### PR TITLE
[politeiad] Add inventory command

### DIFF
--- a/politeiad/backend/backend.go
+++ b/politeiad/backend/backend.go
@@ -59,12 +59,20 @@ var (
 	}
 )
 
+// ProposalStorageRecord is the metadata of a proposal.
 type ProposalStorageRecord struct {
-	Version uint              // Iteration count of proposal
-	Status  PSRStatusT        // Current status of the proposal
-	Merkle  [sha256.Size]byte // Merkle root of all files in proposal
-	Name    string            // Short name of proposal
-	Token   []byte            // Proposal authentication token
+	Version   uint              // Iteration count of proposal
+	Status    PSRStatusT        // Current status of the proposal
+	Merkle    [sha256.Size]byte // Merkle root of all files in proposal
+	Name      string            // Short name of proposal
+	Timestamp int64             // Last updated
+	Token     []byte            // Proposal authentication token
+}
+
+// ProposalRecord is a ProposalStorageRecord that includes the files.
+type ProposalRecord struct {
+	ProposalStorageRecord ProposalStorageRecord
+	Files                 []File
 }
 
 type Backend interface {
@@ -72,13 +80,16 @@ type Backend interface {
 	New(string, []File) (*ProposalStorageRecord, error)
 
 	// Get unvetted proposal
-	GetUnvetted([]byte) ([]File, *ProposalStorageRecord, error)
+	GetUnvetted([]byte) (*ProposalRecord, error)
 
 	// Get vetted proposal
-	GetVetted([]byte) ([]File, *ProposalStorageRecord, error)
+	GetVetted([]byte) (*ProposalRecord, error)
 
 	// Set unvetted proposal status
 	SetUnvettedStatus([]byte, PSRStatusT) (PSRStatusT, error)
+
+	// Inventory retrieves various proposal records.
+	Inventory(uint, uint, bool) ([]ProposalRecord, []ProposalRecord, error)
 
 	// Close performs cleanup of the backend.
 	Close()

--- a/politeiad/log.go
+++ b/politeiad/log.go
@@ -95,3 +95,16 @@ func setLogLevels(logLevel string) {
 		setLogLevel(subsystemID, logLevel)
 	}
 }
+
+// LogClosure is a closure that can be printed with %v to be used to
+// generate expensive-to-create data for a detailed log level and avoid doing
+// the work if the data isn't printed.
+type logClosure func() string
+
+func (c logClosure) String() string {
+	return c()
+}
+
+func newLogClosure(c func() string) logClosure {
+	return logClosure(c)
+}


### PR DESCRIPTION
This adds the vetted path of the inventory command.  Inventory should be used once at Start-Of-Day and cached locally (if needed).  It returns an inventory of all vetted and unvetted proposals.  This is an expensive call so use it wisely.