### PR TITLE
Make the curve type a settable option for cert gen.

### DIFF
--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"crypto/elliptic"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
@@ -527,8 +528,8 @@ func _main() error {
 		!fileExists(loadedCfg.HTTPSCert) {
 		log.Infof("Generating HTTPS keypair...")
 
-		err := util.GenCertPair("politeiad", loadedCfg.HTTPSCert,
-			loadedCfg.HTTPSKey)
+		err := util.GenCertPair(elliptic.P521(), "politeiad",
+			loadedCfg.HTTPSCert, loadedCfg.HTTPSKey)
 		if err != nil {
 			return fmt.Errorf("unable to create https keypair: %v",
 				err)

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/elliptic"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -186,8 +187,8 @@ func _main() error {
 		!fileExists(loadedCfg.HTTPSCert) {
 		log.Infof("Generating HTTPS keypair...")
 
-		err := util.GenCertPair("politeiadwww", loadedCfg.HTTPSCert,
-			loadedCfg.HTTPSKey)
+		err := util.GenCertPair(elliptic.P256(), "politeiadwww",
+			loadedCfg.HTTPSCert, loadedCfg.HTTPSKey)
 		if err != nil {
 			return fmt.Errorf("unable to create https keypair: %v",
 				err)
@@ -254,7 +255,9 @@ func _main() error {
 		go func() {
 			cfg := &tls.Config{
 				MinVersion: tls.VersionTLS12,
-				CurvePreferences: []tls.CurveID{tls.CurveP521,
+				CurvePreferences: []tls.CurveID{
+					tls.CurveP256, // BLAME CHROME, NOT ME!
+					tls.CurveP521,
 					tls.X25519},
 				PreferServerCipherSuites: true,
 				CipherSuites: []uint16{

--- a/util/cert.go
+++ b/util/cert.go
@@ -14,10 +14,9 @@ import (
 )
 
 // GenCertPair generates a key/cert pair to the paths provided.
-func GenCertPair(org, certFile, keyFile string) error {
+func GenCertPair(curve elliptic.Curve, org, certFile, keyFile string) error {
 	validUntil := time.Now().Add(10 * 365 * 24 * time.Hour)
-	cert, key, err := dcrutil.NewTLSCertPair(elliptic.P521(), org,
-		validUntil, nil)
+	cert, key, err := dcrutil.NewTLSCertPair(curve, org, validUntil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We have to debase the elliptic curve used in politeiawww to P256 because
chrome thinks P521 is not a good idea and therefore refuses to work with
it.  Blame them, not me.  I tried.