### PR TITLE
[www] Add logic to email the verification code for new user registration

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 62072084e490ff73ecca57cfc466b3596788b90c4af5cac75d84af8063e46434
-updated: 2017-09-12T15:56:53.1800663-04:00
+hash: 0ce8ddcd6a55b6a18c7a7ce64b40a0819f6d8ab0919008c728c9e86a612b44d6
+updated: 2017-09-13T09:39:25.2063185-04:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
@@ -14,6 +14,8 @@ imports:
   version: 6c288d648c1cc1befcb90cb5511dcacf64ae8e61
 - name: github.com/btcsuite/seelog
   version: ae8891d029dd3c269dcfd6f261ad23e761acd99f
+- name: github.com/dajohi/goemail
+  version: 40fa6c958abc97b72d3ff95998228b05dc21a1db
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -37,3 +37,4 @@ import:
 - package: github.com/gorilla/sessions
   version: ^1.1.0
 - package: github.com/badoux/checkmail
+- package: github.com/dajohi/goemail

--- a/politeiawww/backend_test.go
+++ b/politeiawww/backend_test.go
@@ -80,7 +80,7 @@ func TestProcessNewUserWithExpiredToken(t *testing.T) {
 		Password: generateRandomPassword(),
 	}
 
-	_, err := b.ProcessNewUser(u)
+	reply1, err := b.ProcessNewUser(u)
 	if err != nil {
 		t.Error(err)
 	}
@@ -88,9 +88,16 @@ func TestProcessNewUserWithExpiredToken(t *testing.T) {
 	// Sleep for a longer amount of time than it takes for the verification token to expire.
 	time.Sleep(sleepTime)
 
-	_, err = b.ProcessNewUser(u)
+	reply2, err := b.ProcessNewUser(u)
 	if err != nil {
 		t.Error(err)
+	}
+
+	if reply2.VerificationToken == "" {
+		t.Errorf("ProcessNewUser did not return a verification token.")
+	}
+	if reply1.VerificationToken == reply2.VerificationToken {
+		t.Errorf("ProcessNewUser did not return a new verification token.")
 	}
 
 	b.db.Close()


### PR DESCRIPTION
This PR adds logic to email the verification code for new user registration when all of the following properties are populated in `politeiawww.conf`:

    mailserveraddress=XXX
    mailserveruser=YYY
    mailserverpass=ZZZ


It sends an email like this:

> From: noreply@decred.org
> Subject: Politeia Registration - Verify Your Email

> You must verify your email to complete your registration for Politeia.
> 
> Enter this code to verify your email: **a748a1b1fd29b29d9ee81e443f8f063d2303a655b840ff7f372e8242ef603cf8**
> 
> You are receiving this email because this email address was used to register for Politeia.

Closes #11.