### PR TITLE
[www] Fix a bug with resolving routes

### DIFF
--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -12,16 +12,16 @@ const (
 
 	CsrfToken = "X-CSRF-Token" // CSRF token for replies
 
-	RouteNewUser           = "/user/new/"
-	RouteVerifyNewUser     = "/user/verify/"
-	RouteLogin             = "/login/"
-	RouteLogout            = "/logout/"
-	RouteSecret            = "/secret/"
-	RouteAllVetted         = "/proposals/vetted/"
-	RouteAllUnvetted       = "/proposals/unvetted/"
-	RouteNewProposal       = "/proposals/new/"
-	RouteProposalDetails   = "/proposals/{token}/"
-	RouteSetProposalStatus = "/proposals/{token}/setstatus"
+	RouteNewUser           = "/user/new"
+	RouteVerifyNewUser     = "/user/verify"
+	RouteLogin             = "/login"
+	RouteLogout            = "/logout"
+	RouteSecret            = "/secret"
+	RouteAllVetted         = "/proposals/vetted"
+	RouteAllUnvetted       = "/proposals/unvetted"
+	RouteNewProposal       = "/proposals/new"
+	RouteProposalDetails   = "/proposals/{token:[A-z0-9]{64}}"
+	RouteSetProposalStatus = "/proposals/{token:[A-z0-9]{64}}/setstatus"
 
 	// Size of verification token in bytes
 	VerificationTokenSize = 32
@@ -99,12 +99,7 @@ type NewProposalReply struct {
 	CensorshipRecord v1d.CensorshipRecord `json:"censorshiprecord"`
 }
 
-// ProposalDetails is used to request the full details of a proposal.
-type ProposalDetails struct {
-	Token string `json:"token"` // Censorship token
-}
-
-// ProposalDetailsReply is used to reply to a ProposalDetails command.
+// ProposalDetailsReply is used to reply to a proposal details command.
 type ProposalDetailsReply struct {
 	Proposal v1d.ProposalRecord `json:"proposal"`
 }

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -473,7 +473,7 @@ func (b *backend) ProcessSetProposalStatus(sps v1w.SetProposalStatus) (*v1w.SetP
 }
 
 // ProcessProposalDetails tries to fetch the full details of a proposal from politeiad.
-func (b *backend) ProcessProposalDetails(pd v1w.ProposalDetails) (*v1w.ProposalDetailsReply, error) {
+func (b *backend) ProcessProposalDetails(token string) (*v1w.ProposalDetailsReply, error) {
 	challenge, err := util.Random(v1d.ChallengeSize)
 	if err != nil {
 		return nil, err
@@ -481,7 +481,7 @@ func (b *backend) ProcessProposalDetails(pd v1w.ProposalDetails) (*v1w.ProposalD
 
 	var cachedProposal *v1d.ProposalRecord
 	for _, v := range b.inventory {
-		if v.CensorshipRecord.Token == pd.Token {
+		if v.CensorshipRecord.Token == token {
 			cachedProposal = &v
 			break
 		}
@@ -495,13 +495,13 @@ func (b *backend) ProcessProposalDetails(pd v1w.ProposalDetails) (*v1w.ProposalD
 	if cachedProposal.Status == v1d.StatusPublic {
 		isVettedProposal = true
 		requestObject = v1d.GetVetted{
-			Token:     pd.Token,
+			Token:     token,
 			Challenge: hex.EncodeToString(challenge),
 		}
 	} else {
 		isVettedProposal = false
 		requestObject = v1d.GetUnvetted{
-			Token:     pd.Token,
+			Token:     token,
 			Challenge: hex.EncodeToString(challenge),
 		}
 	}


### PR DESCRIPTION
The proposal details route is not correctly resolving in Chrome
because it is sometimes removing the trailing `/` character
from the request, even when it's present in the address bar.

For example, `/v1/proposals/{token}/` sends `/v1/proposals/{token}`.

Also:

* The trailing `/` character is untypical so remove it.
* Move redundant route-adding logic to a function.
* Fix a bug with path param resolution for `/proposals/{token}`.