### PR TITLE
[www] Fix bug where users can see unvetted proposals

### DIFF
--- a/politeiawww/backend_proposal_test.go
+++ b/politeiawww/backend_proposal_test.go
@@ -70,7 +70,7 @@ func getProposalDetails(b *backend, token string, t *testing.T) *www.ProposalDet
 	pd := www.ProposalsDetails{
 		Token: token,
 	}
-	pdr, err := b.ProcessProposalDetails(pd)
+	pdr, err := b.ProcessProposalDetails(pd, true)
 	if err != nil {
 		t.Error(err)
 	}

--- a/politeiawww/cmd/politeiawww_refclient/politeiawww_refclient.go
+++ b/politeiawww/cmd/politeiawww_refclient/politeiawww_refclient.go
@@ -545,6 +545,9 @@ func _main() error {
 		return fmt.Errorf("pr1 invalid status got %v wanted %v",
 			pr1.Proposal.Status, v1.PropStatusNotReviewed)
 	}
+	if len(pr1.Proposal.Files) > 0 {
+		return fmt.Errorf("pr1 unexpected proposal data received")
+	}
 
 	pr2, err := c.getProp(myprop2.CensorshipRecord.Token)
 	if err != nil {
@@ -562,8 +565,7 @@ func _main() error {
 
 	_, err = c.allUnvetted()
 	if err == nil {
-		return fmt.Errorf("/unvetted should only be " +
-			"accessible by admin users")
+		return fmt.Errorf("/unvetted should only be accessible by admin users")
 	}
 
 	// Vetted proposals
@@ -578,6 +580,7 @@ func _main() error {
 		return err
 	}
 
+	// Execute routes with admin permissions if the flags are set
 	if *emailFlag != "" {
 		adminEmail := *emailFlag
 		adminPassword := *passwordFlag
@@ -623,6 +626,14 @@ func _main() error {
 
 		// XXX verify response
 		_ = unvetted
+
+		pr1, err := c.getProp(myprop1.CensorshipRecord.Token)
+		if err != nil {
+			return err
+		}
+		if len(pr1.Proposal.Files) == 0 {
+			return fmt.Errorf("pr1 expected proposal data")
+		}
 
 		// Move first proposal to published
 		psr1, err := c.setPropStatus(myprop1.CensorshipRecord.Token,

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -457,7 +457,21 @@ func (p *politeiawww) handleProposalDetails(w http.ResponseWriter, r *http.Reque
 	pathParams := mux.Vars(r)
 	pd.Token = pathParams["token"]
 
-	reply, err := p.backend.ProcessProposalDetails(pd)
+	session, err := p.store.Get(r, v1.CookieSession)
+	if err != nil {
+		RespondInternalError(w, r,
+			"handleProposalDetails: failed to get session: %v", err)
+		return
+	}
+
+	isAdmin, ok := session.Values["admin"].(bool)
+	if !ok {
+		RespondInternalError(w, r,
+			"handleProposalDetails: type assert ok %v", ok)
+		return
+	}
+
+	reply, err := p.backend.ProcessProposalDetails(pd, isAdmin)
 	if err != nil {
 		RespondInternalError(w, r,
 			"handleProposalDetails: %v", err)


### PR DESCRIPTION
This PR changes `/proposals/{token}` to only return full proposal data to admin users. For all other users, it only returns the metadata (censorship data, status, etc). This allows users to see (and show to others) the status of their submitted proposals and know if/when it gets censored.

Fixes #95.