### PR TITLE
routes: modified 'setstatus' to 'status #76

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -1070,7 +1070,7 @@ Reply:
 Set status of proposal to `PropStatusPublic` or `PropStatusCensored`.  This call requires admin
 privileges.
 
-**Route:** `POST /v1/proposals/{token}/setstatus`
+**Route:** `POST /v1/proposals/{token}/status`
 
 **Params:**
 

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -27,7 +27,7 @@ const (
 	RouteAllUnvetted          = "/proposals/unvetted"
 	RouteNewProposal          = "/proposals/new"
 	RouteProposalDetails      = "/proposals/{token:[A-z0-9]{64}}"
-	RouteSetProposalStatus    = "/proposals/{token:[A-z0-9]{64}}/setstatus"
+	RouteSetProposalStatus    = "/proposals/{token:[A-z0-9]{64}}/status"
 	RoutePolicy               = "/policy"
 	RouteNewComment           = "/comments/new"
 	RouteCommentsGet          = "/proposals/{token:[A-z0-9]{64}}/comments"

--- a/politeiawww/cmd/politeiawww_refclient/politeiawww_refclient.go
+++ b/politeiawww/cmd/politeiawww_refclient/politeiawww_refclient.go
@@ -349,7 +349,7 @@ func (c *ctx) setPropStatus(token string, status v1.PropStatusT) (*v1.SetProposa
 		ProposalStatus: status,
 	}
 	responseBody, err := c.makeRequest("POST",
-		"/proposals/"+token+"/setstatus", /*v1.RouteSetProposalStatus*/
+		"/proposals/"+token+"/status", /*v1.RouteSetProposalStatus*/
 		ps)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As discussed: covers the api doc, api route and client.
PR GUI: decred/politeiagui#93