### PR TITLE
enhancement/derive-title-from-index#115#128

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -110,12 +110,6 @@
   revision = "a93b200c26cbae3bb09dd0dc2c7c7fe1468a034a"
 
 [[projects]]
-  name = "github.com/kennygrant/sanitize"
-  packages = ["."]
-  revision = "6a0bfdde8629a3a3a7418a7eae45c54154692514"
-  version = "v1.2"
-
-[[projects]]
   branch = "master"
   name = "github.com/marcopeereboom/lockfile"
   packages = ["."]
@@ -154,7 +148,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["html","html/atom","idna","publicsuffix"]
+  packages = ["idna","publicsuffix"]
   revision = "0a9397675ba34b2845f758fe3cd68828369c6517"
 
 [[projects]]
@@ -166,6 +160,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f7fb71a9b6a1287415654c63b76f1092b8b39e5c53298feef4ac3073c9742561"
+  inputs-digest = "238cd7a8a72b3ba6c65ac46fecc635d3a7b0575bdb5c51d6e7977bf26b6e83b7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -24,7 +24,6 @@ import (
 	"github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/util"
-	"github.com/kennygrant/sanitize"
 )
 
 var (
@@ -252,7 +251,7 @@ func newProposal() error {
 		return err
 	}
 	n := v1.New{
-		Name:      sanitize.Name(flags[0]),
+		Name:      flags[0],
 		Challenge: hex.EncodeToString(challenge),
 		Files:     make([]v1.File, 0, len(flags[1:])),
 	}

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -25,7 +25,6 @@ import (
 	"github.com/decred/politeia/politeiad/backend/gitbe"
 	"github.com/decred/politeia/util"
 	"github.com/gorilla/mux"
-	"github.com/kennygrant/sanitize"
 )
 
 // politeia application context.
@@ -161,8 +160,6 @@ func (p *politeia) newProposal(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	// Sanitize name
-	t.Name = sanitize.Name(t.Name)
 	if len(t.Name) > 80 {
 		log.Errorf("%v New proposal: invalid name", remoteAddr(r))
 		p.respondWithUserError(w, v1.ErrorStatusInvalidProposalName, nil)

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -31,9 +31,10 @@ API.  It does not render HTML.
 - [`ErrorStatusMalformedEmail`](#ErrorStatusMalformedEmail)
 - [`ErrorStatusVerificationTokenInvalid`](#ErrorStatusVerificationTokenInvalid)
 - [`ErrorStatusVerificationTokenExpired`](#ErrorStatusVerificationTokenExpired)
-- [`ErrorStatusProposalMissingName`](#ErrorStatusProposalMissingName)
-- [`ErrorStatusProposalMissingDescription`](#ErrorStatusProposalMissingDescription)
+- [`ErrorStatusProposalMissingFiles`](#ErrorStatusProposalMissingFiles)
 - [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
+- [`ErrorStatusProposalDuplicateFilenames`](#ErrorStatusProposalDuplicateFilenames)
+- [`ErrorStatusProposalInvalidTitle`](#ErrorStatusProposalInvalidTitle)
 - [`ErrorStatusMaxMDsExceededPolicy`](#ErrorStatusMaxMDsExceededPolicy)
 - [`ErrorStatusMaxImagesExceededPolicy`](#ErrorStatusMaxImagesExceededPolicy)
 - [`ErrorStatusMaxMDSizeExceededPolicy`](#ErrorStatusMaxMDSizeExceededPolicy)
@@ -624,7 +625,8 @@ Reply:
 
 ### `New proposal`
 
-Submit a new proposal to the politeiawww server.
+Submit a new proposal to the politeiawww server. 
+The proposal name is derived from the first line of the markdown file - index.md.
 
 **Route:** `POST /v1/proposal/new`
 
@@ -639,20 +641,11 @@ Submit a new proposal to the politeiawww server.
       <th>Required</th>
     </tr>
     <tr>
-      <td><code>name</code></td>
-      <td>String</td>
-      <td>
-        Name of the proposal.  This should be a reasonably small title that
-        describes the proposal.
-      </td>
-      <td>Yes</td>
-    </tr>
-    <tr>
       <td><code>files</code></td>
       <td>Array of Objects</td>
       <td>
         <p>Files are the body of the proposal.  It should consist of one markdown
-        file and up to five pictures.  The structure of the file is as follows:</p>
+        file - named "index.md" - and up to five pictures.   The structure of the file is as follows:</p>
         <table>
           <tbody>
             <tr>
@@ -729,8 +722,9 @@ Submit a new proposal to the politeiawww server.
 
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
-- [`ErrorStatusProposalMissingName`](#ErrorStatusProposalMissingName)
-- [`ErrorStatusProposalMissingDescription`](#ErrorStatusProposalMissingDescription)
+- [`ErrorStatusProposalMissingFiles`](#ErrorStatusProposalMissingFiles)
+- [`ErrorStatusProposalDuplicateFilenames`](#ErrorStatusProposalDuplicateFilenames)
+- [`ErrorStatusProposalInvalidTitle`](#ErrorStatusProposalInvalidTitle)
 - [`ErrorStatusMaxMDsExceededPolicy`](#ErrorStatusMaxMDsExceededPolicy)
 - [`ErrorStatusMaxImagesExceededPolicy`](#ErrorStatusMaxImagesExceededPolicy)
 - [`ErrorStatusMaxMDSizeExceededPolicy`](#ErrorStatusMaxMDSizeExceededPolicy)
@@ -1188,23 +1182,15 @@ Reply:
       <td>4</td>
       <td>The provided user activation token is expired.</td>
     </tr>
-    <tr>
-      <td>
-        <a name="ErrorStatusProposalMissingName">
-          <code>ErrorStatusProposalMissingName</code>
-        </a>
-      </td>
-      <td>5</td>
-      <td>The provided proposal does not have a short name.</td>
     </tr>
     <tr>
       <td>
-        <a name="ErrorStatusProposalMissingDescription">
-          <code>ErrorStatusProposalMissingDescription</code>
+        <a name="ErrorStatusProposalMissingFiles">
+          <code>ErrorStatusProposalMissingFiles</code>
         </a>
       </td>
-      <td>6</td>
-      <td>The provided proposal does not have a description.</td>
+      <td>5</td>
+      <td>The provided proposal does not have files.</td>
     </tr>
     <tr>
       <td>
@@ -1212,8 +1198,26 @@ Reply:
           <code>ErrorStatusProposalNotFound</code>
         </a>
       </td>
-      <td>7</td>
+      <td>6</td>
       <td>The requested proposal does not exist.</td>
+    </tr>
+    <tr>
+      <td>
+        <a name="ErrorStatusProposalDuplicateFilenames">
+          <code>ErrorStatusProposalDuplicateFilenames</code>
+        </a>
+      </td>
+      <td>7</td>
+      <td>The provided proposal has duplicate files. </td>
+    </tr>
+    <tr>
+      <td>
+        <a name="ErrorStatusProposalInvalidTitle">
+          <code>ErrorStatusProposalInvalidTitle</code>
+        </a>
+      </td>
+      <td>8</td>
+      <td>The provided proposal title is invalid. </td>
     </tr>
     <tr>
       <td>
@@ -1221,7 +1225,7 @@ Reply:
           <code>ErrorStatusMaxMDsExceededPolicy</code>
         </a>
       </td>
-      <td>8</td>
+      <td>9</td>
       <td>
         The submitted proposal has too many markdown files.  Limits can be obtained
         by issuing the <a href="#Policy">Policy</a> command.
@@ -1233,7 +1237,7 @@ Reply:
           <code>ErrorStatusMaxImagesExceededPolicy</code>
         </a>
       </td>
-      <td>9</td>
+      <td>10</td>
       <td>
         The submitted proposal has too many images.  Limits can be obtained by
         issuing the <a href="#Policy">Policy</a> command.
@@ -1245,7 +1249,7 @@ Reply:
           <code>ErrorStatusMaxMDSizeExceededPolicy</code>
         </a>
       </td>
-      <td>10</td>
+      <td>11</td>
       <td>
         The submitted proposal markdown is too large.  Limits can be obtained by
         issuing the <a href="#Policy">Policy</a> command.
@@ -1257,7 +1261,7 @@ Reply:
           <code>ErrorStatusMaxImageSizeExceededPolicy</code>
         </a>
       </td>
-      <td>11</td>
+      <td>12</td>
       <td>
         The submitted proposal has one or more images that are too large.  Limits can
         be obtained by issuing the <a href="#Policy">Policy</a> command.
@@ -1269,7 +1273,7 @@ Reply:
           <code>ErrorStatusMalformedPassword</code>
         </a>
       </td>
-      <td>12</td>
+      <td>13</td>
       <td>The provided password was malformed.</td>
     </tr>
     <tr>
@@ -1278,7 +1282,7 @@ Reply:
           <code>ErrorStatusCommentNotFound</code>
         </a>
       </td>
-      <td>13</td>
+      <td>14</td>
       <td>The requested comment does not exist.</td>
     </tr>
     <tr>
@@ -1287,7 +1291,7 @@ Reply:
           <code>ErrorStatusInvalidProposalName</code>
         </a>
       </td>
-      <td>14</td>
+      <td>15</td>
       <td>The proposal's name was invalid.</td>
     </tr>
     <tr>
@@ -1296,7 +1300,7 @@ Reply:
           <code>ErrorStatusInvalidFileDigest</code>
         </a>
       </td>
-      <td>15</td>
+      <td>16</td>
       <td>
         The digest (SHA-256 checksum) provided for one of the proposal files
         was incorrect. This error is provided with additional information inside
@@ -1322,7 +1326,7 @@ Reply:
           <code>ErrorStatusInvalidBase64</code>
         </a>
       </td>
-      <td>16</td>
+      <td>17</td>
       <td>
         The Base64 encoding provided for one of the proposal files
         was incorrect. This error is provided with additional information inside
@@ -1348,7 +1352,7 @@ Reply:
           <code>ErrorStatusInvalidMIMEType</code>
         </a>
       </td>
-      <td>17</td>
+      <td>18</td>
       <td>
         The MIME type provided for one of the proposal files was not
         the same as the one derived from the file's content. This error
@@ -1380,7 +1384,7 @@ Reply:
           <code>ErrorStatusUnsupportedMIMEType</code>
         </a>
       </td>
-      <td>18</td>
+      <td>19</td>
       <td>
         The MIME type provided for one of the proposal files is
         not supported. This error is provided with additional information
@@ -1411,7 +1415,7 @@ Reply:
           <code>ErrorStatusInvalidPropStatusTransition</code>
         </a>
       </td>
-      <td>19</td>
+      <td>20</td>
       <td>
         The provided proposal cannot be changed to the given status.
       </td>

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -59,27 +59,32 @@ const (
 	// accepted for user passwords
 	PolicyPasswordMinChars = 8
 
+	// ValidProposalNameRegExp is the regular expression of a valid
+	// proposal name
+	ValidProposalNameRegExp = `^[[:alnum:]\.\:\;\,\- \@\+\#]{8,}$`
+
 	// Error status codes
 	ErrorStatusInvalid                     ErrorStatusT = 0
 	ErrorStatusInvalidEmailOrPassword      ErrorStatusT = 1
 	ErrorStatusMalformedEmail              ErrorStatusT = 2
 	ErrorStatusVerificationTokenInvalid    ErrorStatusT = 3
 	ErrorStatusVerificationTokenExpired    ErrorStatusT = 4
-	ErrorStatusProposalMissingName         ErrorStatusT = 5
-	ErrorStatusProposalMissingDescription  ErrorStatusT = 6
-	ErrorStatusProposalNotFound            ErrorStatusT = 7
-	ErrorStatusMaxMDsExceededPolicy        ErrorStatusT = 8
-	ErrorStatusMaxImagesExceededPolicy     ErrorStatusT = 9
-	ErrorStatusMaxMDSizeExceededPolicy     ErrorStatusT = 10
-	ErrorStatusMaxImageSizeExceededPolicy  ErrorStatusT = 11
-	ErrorStatusMalformedPassword           ErrorStatusT = 12
-	ErrorStatusCommentNotFound             ErrorStatusT = 13
-	ErrorStatusInvalidProposalName         ErrorStatusT = 14
-	ErrorStatusInvalidFileDigest           ErrorStatusT = 15
-	ErrorStatusInvalidBase64               ErrorStatusT = 16
-	ErrorStatusInvalidMIMEType             ErrorStatusT = 17
-	ErrorStatusUnsupportedMIMEType         ErrorStatusT = 18
-	ErrorStatusInvalidPropStatusTransition ErrorStatusT = 19
+	ErrorStatusProposalMissingFiles        ErrorStatusT = 5
+	ErrorStatusProposalNotFound            ErrorStatusT = 6
+	ErrorStatusProposalDuplicateFilenames  ErrorStatusT = 7
+	ErrorStatusProposalInvalidTitle        ErrorStatusT = 8
+	ErrorStatusMaxMDsExceededPolicy        ErrorStatusT = 9
+	ErrorStatusMaxImagesExceededPolicy     ErrorStatusT = 10
+	ErrorStatusMaxMDSizeExceededPolicy     ErrorStatusT = 11
+	ErrorStatusMaxImageSizeExceededPolicy  ErrorStatusT = 12
+	ErrorStatusMalformedPassword           ErrorStatusT = 13
+	ErrorStatusCommentNotFound             ErrorStatusT = 14
+	ErrorStatusInvalidProposalName         ErrorStatusT = 15
+	ErrorStatusInvalidFileDigest           ErrorStatusT = 16
+	ErrorStatusInvalidBase64               ErrorStatusT = 17
+	ErrorStatusInvalidMIMEType             ErrorStatusT = 18
+	ErrorStatusUnsupportedMIMEType         ErrorStatusT = 19
+	ErrorStatusInvalidPropStatusTransition ErrorStatusT = 20
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid     PropStatusT = 0 // Invalid status
@@ -87,6 +92,9 @@ const (
 	PropStatusNotReviewed PropStatusT = 2 // Proposal has not been reviewed
 	PropStatusCensored    PropStatusT = 3 // Proposal has been censored
 	PropStatusPublic      PropStatusT = 4 // Proposal is publicly visible
+
+	// Error contexts
+	ErrorContextProposalInvalidTitle = ValidProposalNameRegExp
 )
 
 var (
@@ -134,7 +142,8 @@ type ProposalRecord struct {
 // UserError represents an error that is caused by something that the user
 // did (malformed input, bad timing, etc).
 type UserError struct {
-	ErrorCode ErrorStatusT
+	ErrorCode    ErrorStatusT
+	ErrorContext []string
 }
 
 // Error satisfies the error interface.
@@ -263,7 +272,6 @@ type MeReply struct {
 
 // NewProposal attempts to submit a new proposal.
 type NewProposal struct {
-	Name  string `json:"name"`  // Proposal name
 	Files []File `json:"files"` // XXX layer violation.
 }
 

--- a/politeiawww/backend_user_test.go
+++ b/politeiawww/backend_user_test.go
@@ -65,11 +65,24 @@ func assertSuccess(t *testing.T, err error) {
 }
 
 func assertError(t *testing.T, err error, expectedStatus www.ErrorStatusT) {
+	assertErrorWithContext(t, err, expectedStatus, []string{})
+}
+
+func assertErrorWithContext(t *testing.T, err error, expectedStatus www.ErrorStatusT, expectedContext []string) {
 	if err != nil {
 		userErr, ok := err.(www.UserError)
 		if ok {
 			if userErr.ErrorCode != expectedStatus {
 				t.Fatalf("expected error code %v, was %v\n\n%s", expectedStatus, userErr.ErrorCode, debug.Stack())
+			}
+			if len(userErr.ErrorContext) == len(expectedContext) {
+				for i, context := range userErr.ErrorContext {
+					if context != expectedContext[i] {
+						t.Fatalf("expected context %s, was %s\n\n%s", expectedContext, userErr.ErrorContext, debug.Stack())
+					}
+				}
+			} else {
+				t.Fatalf("expected context %v, was %v\n\n%s", expectedContext, userErr.ErrorContext, debug.Stack())
 			}
 		} else {
 			t.Fatalf("unexpected error: %v\n\n%s", err, debug.Stack())

--- a/politeiawww/cmd/politeiawww_refclient/politeiawww_refclient.go
+++ b/politeiawww/cmd/politeiawww_refclient/politeiawww_refclient.go
@@ -265,7 +265,6 @@ func (c *ctx) me() (*v1.MeReply, error) {
 
 func (c *ctx) newProposal() (*v1.NewProposalReply, error) {
 	np := v1.NewProposal{
-		Name:  "test",
 		Files: make([]v1.File, 0),
 	}
 

--- a/util/proposal.go
+++ b/util/proposal.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"regexp"
+
+	www "github.com/decred/politeia/politeiawww/api/v1"
+)
+
+var (
+	validProposalName = regexp.MustCompile(www.ValidProposalNameRegExp)
+)
+
+// ProposalName returns a proposal name
+func GetProposalName(payload string) (string, error) {
+	// decode payload (base64)
+	rawPayload, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return "", err
+	}
+	// @rgeraldes - used reader instead of scanner
+	// due to the size of the input (scanner > token too long)
+	// get the first line from the payload
+	reader := bufio.NewReader(bytes.NewReader(rawPayload))
+	proposalName, _, err := reader.ReadLine()
+	if err != nil {
+		return "", err
+	}
+
+	return string(proposalName), nil
+}
+
+// IsValidProposalName reports whether str is a valid proposal name
+func IsValidProposalName(str string) bool {
+	return validProposalName.MatchString(str)
+}

--- a/util/proposal_test.go
+++ b/util/proposal_test.go
@@ -1,0 +1,108 @@
+package util_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/decred/politeia/util"
+)
+
+func TestGetProposalName(t *testing.T) {
+	testCases := []struct {
+		input         string
+		output        string
+		expectedError error
+	}{
+		{
+			base64.StdEncoding.EncodeToString([]byte("this is-the-title")),
+			"this is-the-title",
+			nil,
+		},
+		{
+			base64.StdEncoding.EncodeToString([]byte("this-is-the title\nbody")),
+			"this-is-the title",
+			nil,
+		},
+		// payload does not have a title
+		{
+			base64.StdEncoding.EncodeToString([]byte("\n\nbody")),
+			"",
+			nil,
+		},
+	}
+
+	// test
+	for _, testCase := range testCases {
+		result, err := util.GetProposalName(testCase.input)
+		if err != testCase.expectedError {
+			t.Errorf("Expected %v, got %v.", testCase.expectedError, err)
+		}
+		if err == nil {
+			if result != testCase.output {
+				t.Errorf("Expected %s, got %s.", testCase.output, result)
+			}
+		}
+	}
+}
+
+func TestIsValidProposalName(t *testing.T) {
+	testCases := []struct {
+		input  string // @rgeraldes - valid input is a string without new lines
+		output bool
+	}{
+		// empty test
+		{
+			"",
+			false,
+		},
+		// 7 characters
+		{
+			"1234567",
+			false,
+		},
+
+		// 8 characters
+		{
+			"12345678",
+			true,
+		},
+		{
+			"valid title",
+			true,
+		},
+		{
+			" - title: is valid; title.   ",
+			true,
+		},
+		{
+			"\n\n#This-is MY tittle###",
+			false,
+		},
+		{
+			"{this-is-the-title}",
+			false,
+		},
+		{
+			"\t<this- is-the title>",
+			false,
+		},
+		{
+			"{this   -is-the-title}   ",
+			false,
+		},
+		{
+			"###this is the title***",
+			false,
+		},
+		{
+			"###this is the title@+",
+			true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		if result := util.IsValidProposalName(testCase.input); result != testCase.output {
+			t.Errorf("Expected %t, got %t.", testCase.output, result)
+		}
+	}
+}


### PR DESCRIPTION
PR Fixes #115 and Fixes #128:
(www)
- proposal name derived from index.md
- reworked error codes (128) & modified api docs.
- reworked validations (duplicate files / index file / no files) 
- added tests for missing validations

(pd)
- removed sanitize.Name() calls 

(all)
dep ensure (sanitize removed)

POST - 
create gui issue to update error codes and do regex `^[[:alnum:]\.\:\;\,\- \@\+\#]{8,}$`
politiead - the new proposal validation looks to be imcomplete > create issue?


