### PR TITLE
enhancement/email-templates#73

### DIFF
--- a/politeiawww/config.go
+++ b/politeiawww/config.go
@@ -28,26 +28,26 @@ import (
 )
 
 const (
-	defaultLogLevel         = "info"
-	defaultLogDirname       = "logs"
-	defaultLogFilename      = "politeiawww.log"
-	defaultIdentityFilename = "identity.json"
+	defaultLogLevel             = "info"
+	defaultLogDirname           = "logs"
+	defaultLogFilename          = "politeiawww.log"
+	defaultIdentityFilename     = "identity.json"
+	defaultTemplateRelativePath = "/templates/email"
 
 	defaultMainnetPort = "4443"
 	defaultTestnetPort = "4443"
 )
 
 var (
+	currentDir           = filepath.Dir(util.Must(os.Executable()))
 	defaultHTTPSKeyFile  = filepath.Join(sharedconfig.DefaultHomeDir, "https.key")
 	defaultHTTPSCertFile = filepath.Join(sharedconfig.DefaultHomeDir, "https.cert")
 	defaultRPCCertFile   = filepath.Join(sharedconfig.DefaultHomeDir, "rpc.cert")
 	defaultCookieKeyFile = filepath.Join(sharedconfig.DefaultHomeDir, "cookie.key")
 	defaultLogDir        = filepath.Join(sharedconfig.DefaultHomeDir, defaultLogDirname)
+	defaultTemplateDir   = filepath.Join(currentDir, defaultTemplateRelativePath)
 
-	templateNewUserEmail = template.Must(
-		template.New("new_user_email_template").Parse(templateNewUserEmailRaw))
-	templateResetPasswordEmail = template.Must(
-		template.New("reset_password_email_template").Parse(templateResetPasswordEmailRaw))
+	templateNewUserEmail, templateResetPasswordEmail *template.Template
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -63,6 +63,7 @@ type config struct {
 	ConfigFile       string   `short:"C" long:"configfile" description:"Path to configuration file"`
 	DataDir          string   `short:"b" long:"datadir" description:"Directory to store data"`
 	LogDir           string   `long:"logdir" description:"Directory to log output."`
+	TemplateDir      string   `long:"templatedir" description:"Directory to the template data"`
 	TestNet          bool     `long:"testnet" description:"Use the test network"`
 	SimNet           bool     `long:"simnet" description:"Use the simulation test network"`
 	Profile          string   `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
@@ -313,6 +314,7 @@ func loadConfig() (*config, []string, error) {
 		DebugLevel:    defaultLogLevel,
 		DataDir:       sharedconfig.DefaultDataDir,
 		LogDir:        defaultLogDir,
+		TemplateDir:   defaultTemplateDir,
 		HTTPSKey:      defaultHTTPSKeyFile,
 		HTTPSCert:     defaultHTTPSCertFile,
 		RPCCert:       defaultRPCCertFile,
@@ -485,6 +487,8 @@ func loadConfig() (*config, []string, error) {
 	cfg.LogDir = cleanAndExpandPath(cfg.LogDir)
 	cfg.LogDir = filepath.Join(cfg.LogDir, netName(activeNetParams))
 
+	cfg.TemplateDir = cleanAndExpandPath(cfg.TemplateDir)
+
 	cfg.HTTPSKey = cleanAndExpandPath(cfg.HTTPSKey)
 	cfg.HTTPSCert = cleanAndExpandPath(cfg.HTTPSCert)
 	cfg.RPCCert = cleanAndExpandPath(cfg.RPCCert)
@@ -636,5 +640,21 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
+	if err := loadEmailTemplates(cfg.TemplateDir); err != nil {
+		return nil, nil, err
+	}
+
 	return &cfg, remainingArgs, nil
+}
+
+// loadEmailTemplates parses the email templates
+func loadEmailTemplates(dir string) error {
+	var err error
+	if templateNewUserEmail, err = template.ParseFiles(filepath.Join(dir, "newuser.html")); err != nil {
+		return err
+	}
+	if templateResetPasswordEmail, err = template.ParseFiles(filepath.Join(dir, "resetpassword.html")); err != nil {
+		return err
+	}
+	return nil
 }

--- a/politeiawww/templates/email/newuser.html
+++ b/politeiawww/templates/email/newuser.html
@@ -1,0 +1,6 @@
+<div>Click the link below to verify your email and complete your registration:</div>
+<div style="margin: 20px 0 0 10px">
+    <a href="{{.Link}}">{{.Link}}</a>
+</div>
+<div style="margin-top: 20px">You are receiving this email because
+    <span style="font-weight: bold">{{.Email}}</span> was used to register for Politeia.</div>

--- a/politeiawww/templates/email/resetpassword.html
+++ b/politeiawww/templates/email/resetpassword.html
@@ -1,0 +1,6 @@
+<div>Click the link below to continue to reset your password:</div>
+<div style="margin: 20px 0 0 10px">
+    <a href="{{.Link}}">{{.Link}}</a>
+</div>
+<div style="margin-top: 20px">You are receiving this email because a password reset was initiated for
+    <span style="font-weight: bold">{{.Email}}</span> on Politeia.</div>

--- a/util/init.go
+++ b/util/init.go
@@ -1,0 +1,12 @@
+package util
+
+// Must is a helper that wraps a call to a function returning (string, error)
+// and panics if the error is non-nil. It is intended for use in variable initializations
+// such as
+//	var str = util.Must(os.Executable())
+func Must(dir string, err error) string {
+	if err != nil {
+		panic(err)
+	}
+	return dir
+}


### PR DESCRIPTION
PR Fixes #73
Logic
- user can provide the location of templates via flag
- default dir is set to /templates/email/ of the repo (relative path)
- removed execution of templates in loadConfig