### PR TITLE
[politeiad] Remove proposal name from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,13 @@ Identity saved to: /Users/marco/Library/Application Support/Politeia/identity.js
 
 Send proposal:
 ```
-politeia -v -testnet -rpchost 127.0.0.1 new "My awesome proposal" proposal.txt spec.txt
+politeia -v -testnet -rpchost 127.0.0.1 new proposal.txt spec.txt
 ```
 
 Result will look something like:
 ```
 00: 331ea9090db0c9f6f597bd9840fd5b171830f6e0b3ba1cb24dfa91f0c95aedc1 proposal.txt text/plain; charset=utf-8
 01: be0997732fa648fd083baa85e782d9e4768602dbe8a0a431ba17a01000ba93db spec.txt text/plain; charset=utf-8
-Submitted proposal name: My awesome proposal
 Censorship record:
   Merkle   : 8e125a9c791634f6f68672c7bc3b71dc50f986a0525e3e7361ad180cadbf6347
   Token    : 6284c5f8fba5665373b8e6651ebc8747b289fed242d2f880f64a284496bb4ca8

--- a/politeiad/api/v1/v1.go
+++ b/politeiad/api/v1/v1.go
@@ -187,7 +187,6 @@ type File struct {
 
 // ProposalRecord is an entire proposal and it's content.
 type ProposalRecord struct {
-	Name      string      `json:"name"`      // Suggested short proposal name
 	Status    PropStatusT `json:"status"`    // Current status of proposal
 	Timestamp int64       `json:"timestamp"` // Last update of proposal
 	Files     []File      `json:"files"`     // Files that make up the proposal
@@ -199,7 +198,6 @@ type ProposalRecord struct {
 // the proposal.  The only acceptable file types are text, markdown and PNG.
 type New struct {
 	Challenge string `json:"challenge"` // Random challenge
-	Name      string `json:"name"`      // Suggested short proposal name
 	Files     []File `json:"files"`     // Files that make up the proposal
 }
 

--- a/politeiad/backend/backend.go
+++ b/politeiad/backend/backend.go
@@ -68,7 +68,6 @@ type ProposalStorageRecord struct {
 	Version   uint              // Iteration count of proposal
 	Status    PSRStatusT        // Current status of the proposal
 	Merkle    [sha256.Size]byte // Merkle root of all files in proposal
-	Name      string            // Short name of proposal
 	Timestamp int64             // Last updated
 	Token     []byte            // Proposal authentication token
 }
@@ -81,7 +80,7 @@ type ProposalRecord struct {
 
 type Backend interface {
 	// Create new proposal
-	New(string, []File) (*ProposalStorageRecord, error)
+	New([]File) (*ProposalStorageRecord, error)
 
 	// Get unvetted proposal
 	GetUnvetted([]byte) (*ProposalRecord, error)

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -322,10 +322,9 @@ func loadPSR(path, id string) (*backend.ProposalStorageRecord, error) {
 // unvetted/id or vetted/id.
 //
 // This function should be called with the lock held.
-func createPSR(path, id, name string, status backend.PSRStatusT, version uint, hashes []*[sha256.Size]byte, token []byte) (*backend.ProposalStorageRecord, error) {
+func createPSR(path, id string, status backend.PSRStatusT, version uint, hashes []*[sha256.Size]byte, token []byte) (*backend.ProposalStorageRecord, error) {
 	// Create proposal storage record
 	psr := backend.ProposalStorageRecord{
-		Name:      name,
 		Version:   version,
 		Status:    status,
 		Merkle:    *merkle.Root(hashes),
@@ -943,7 +942,7 @@ func (g *gitBackEnd) verifyAnchor(digest string) (*v1.VerifyDigest, error) {
 // function returns a ProposaltorageRecord.
 //
 // New satisfies the backend interface.
-func (g *gitBackEnd) New(name string, files []backend.File) (*backend.ProposalStorageRecord, error) {
+func (g *gitBackEnd) New(files []backend.File) (*backend.ProposalStorageRecord, error) {
 	fa, err := verifyContent(files)
 	if err != nil {
 		return nil, err
@@ -1035,7 +1034,7 @@ func (g *gitBackEnd) New(name string, files []backend.File) (*backend.ProposalSt
 	}
 
 	// Save Proposal Storage Record
-	psr, err := createPSR(g.unvetted, id, name, backend.PSRStatusUnvetted, 1,
+	psr, err := createPSR(g.unvetted, id, backend.PSRStatusUnvetted, 1,
 		hashes, token)
 	if err != nil {
 		return nil, err

--- a/politeiad/backend/gitbe/gitbe_test.go
+++ b/politeiad/backend/gitbe/gitbe_test.go
@@ -30,7 +30,6 @@ func validatePSR(got, want *backend.ProposalStorageRecord) error {
 		got.Status != backend.PSRStatusVetted ||
 		want.Status != backend.PSRStatusUnvetted ||
 		got.Merkle != want.Merkle ||
-		got.Name != want.Name ||
 		!bytes.Equal(got.Token, want.Token) {
 		return fmt.Errorf("unexpected psr got %v, wanted %v",
 			spew.Sdump(*got), spew.Sdump(*want))
@@ -100,7 +99,7 @@ func TestAnchorWithCommits(t *testing.T) {
 		}
 		allFiles[i] = files
 
-		psr[i], err = g.New(name, files)
+		psr[i], err = g.New(files)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -234,8 +234,8 @@ func newProposal() error {
 	flags := flag.Args()[1:] // Chop off action.
 
 	// Make sure we have name and at least one file.
-	if len(flags) < 2 {
-		return fmt.Errorf("must provide name and at least one file")
+	if len(flags) < 1 {
+		return fmt.Errorf("must provide at least one file")
 	}
 
 	// Fetch remote identity
@@ -251,12 +251,12 @@ func newProposal() error {
 	}
 	n := v1.New{
 		Challenge: hex.EncodeToString(challenge),
-		Files:     make([]v1.File, 0, len(flags[1:])),
+		Files:     make([]v1.File, 0, len(flags)),
 	}
 
 	// Open all files, validate MIME type and digest them.
-	hashes := make([]*[sha256.Size]byte, 0, len(flags[1:]))
-	for i, a := range flags[1:] {
+	hashes := make([]*[sha256.Size]byte, 0, len(flags))
+	for i, a := range flags {
 		file := v1.File{
 			Name: filepath.Base(a),
 		}
@@ -280,7 +280,6 @@ func newProposal() error {
 		fmt.Printf("%02v: %v %v %v\n",
 			i, file.Digest, file.Name, file.MIME)
 	}
-	fmt.Printf("Submitted proposal name: %v\n", flags[0])
 
 	// Convert Verify to JSON
 	b, err := json.Marshal(n)

--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -134,7 +134,6 @@ func printProposalRecord(header string, pr v1.ProposalRecord) {
 		status = v1.PropStatus[v1.PropStatusInvalid]
 	}
 	fmt.Printf("%v:\n", header)
-	fmt.Printf("  Name       : %v\n", pr.Name)
 	fmt.Printf("  Status     : %v\n", status)
 	fmt.Printf("  Timestamp  : %v\n", time.Unix(pr.Timestamp, 0).UTC())
 	printCensorshipRecord(pr.CensorshipRecord)
@@ -251,7 +250,6 @@ func newProposal() error {
 		return err
 	}
 	n := v1.New{
-		Name:      flags[0],
 		Challenge: hex.EncodeToString(challenge),
 		Files:     make([]v1.File, 0, len(flags[1:])),
 	}
@@ -282,7 +280,7 @@ func newProposal() error {
 		fmt.Printf("%02v: %v %v %v\n",
 			i, file.Digest, file.Name, file.MIME)
 	}
-	fmt.Printf("Submitted proposal name: %v\n", n.Name)
+	fmt.Printf("Submitted proposal name: %v\n", flags[0])
 
 	// Convert Verify to JSON
 	b, err := json.Marshal(n)

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -100,6 +100,9 @@ const (
 	PropStatusNotReviewed PropStatusT = 2 // Proposal has not been reviewed
 	PropStatusCensored    PropStatusT = 3 // Proposal has been censored
 	PropStatusPublic      PropStatusT = 4 // Proposal is publicly visible
+
+	// IndexFileName contains the file name of the index file
+	IndexFileName = "index.md"
 )
 
 var (

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -26,11 +26,6 @@ import (
 	"github.com/decred/politeia/util"
 )
 
-const (
-	// indexFile contains the file name of the index file
-	indexFile = "index.md"
-)
-
 // politeiawww backend construct
 type backend struct {
 	sync.RWMutex // lock for inventory and comments
@@ -259,7 +254,7 @@ func (b *backend) validateProposal(np www.NewProposal) error {
 		} else {
 			numMDs++
 
-			if v.Name == indexFile {
+			if v.Name == www.IndexFileName {
 				numIndexFiles++
 			}
 
@@ -293,7 +288,7 @@ func (b *backend) validateProposal(np www.NewProposal) error {
 	if numIndexFiles == 0 {
 		return www.UserError{
 			ErrorCode:    www.ErrorStatusProposalMissingFiles,
-			ErrorContext: []string{indexFile},
+			ErrorContext: []string{www.IndexFileName},
 		}
 	}
 
@@ -322,7 +317,7 @@ func (b *backend) validateProposal(np www.NewProposal) error {
 	}
 
 	// proposal title validation
-	name, err := getProposalName(np.Files)
+	name, err := util.RecoverProposalName(np.Files)
 	if err != nil {
 		return err
 	}
@@ -856,7 +851,7 @@ func (b *backend) ProcessNewProposal(np www.NewProposal) (*www.NewProposalReply,
 		return nil, err
 	}
 
-	name, err := getProposalName(np.Files)
+	name, err := util.RecoverProposalName(np.Files)
 	if err != nil {
 		return nil, err
 	}
@@ -1173,14 +1168,4 @@ func NewBackend(cfg *config) (*backend, error) {
 	}
 
 	return b, nil
-}
-
-// getProposalName returns the proposal name based on the index markdown file.
-func getProposalName(files []www.File) (string, error) {
-	for _, file := range files {
-		if file.Name == indexFile {
-			return util.GetProposalName(file.Payload)
-		}
-	}
-	return "", nil
 }

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -862,7 +862,6 @@ func (b *backend) ProcessNewProposal(np www.NewProposal) (*www.NewProposalReply,
 	}
 
 	n := pd.New{
-		Name:      name,
 		Challenge: hex.EncodeToString(challenge),
 		Files:     convertPropFilesFromWWW(np.Files),
 	}
@@ -897,7 +896,7 @@ func (b *backend) ProcessNewProposal(np www.NewProposal) (*www.NewProposalReply,
 			return nil, err
 		}
 
-		log.Infof("Submitted proposal name: %v\n", n.Name)
+		log.Infof("Submitted proposal name: %v\n", name)
 		for k, f := range n.Files {
 			fmt.Printf("%02v: %v %v\n", k, f.Name, f.Digest)
 		}

--- a/politeiawww/backend_proposal_test.go
+++ b/politeiawww/backend_proposal_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/base64"
-	"github.com/decred/politeia/util"
 	"testing"
 	"time"
+
+	"github.com/decred/politeia/util"
 
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	www "github.com/decred/politeia/politeiawww/api/v1"
@@ -28,7 +29,7 @@ func createNewProposalWithFileSizes(b *backend, t *testing.T, numMDFiles, numIma
 
 		// @rgeraldes - add at least one index file
 		if i == 0 {
-			name = indexFile
+			name = www.IndexFileName
 		} else {
 			name = generateRandomString(5) + ".md"
 		}
@@ -69,7 +70,7 @@ func createNewProposalWithInvalidTitle(b *backend, t *testing.T) (*www.NewPropos
 		invalidTitle = "$%&/)Title<<>>"
 	)
 	files := make([]pd.File, 0, 2)
-	filename := indexFile
+	filename := www.IndexFileName
 
 	payload := base64.StdEncoding.EncodeToString([]byte(invalidTitle))
 
@@ -91,7 +92,7 @@ func createNewProposalTitleSize(b *backend, t *testing.T, nameLength int) (*www.
 
 	invalidTitle := generateRandomString(nameLength)
 	files := make([]pd.File, 0, 2)
-	filename := indexFile
+	filename := www.IndexFileName
 
 	payload := base64.StdEncoding.EncodeToString([]byte(invalidTitle))
 
@@ -111,7 +112,7 @@ func createNewProposalTitleSize(b *backend, t *testing.T, nameLength int) (*www.
 
 func createNewProposalWithDuplicateFiles(b *backend, t *testing.T) (*www.NewProposal, *www.NewProposalReply, error) {
 	files := make([]pd.File, 0, 2)
-	filename := indexFile
+	filename := www.IndexFileName
 	payload := base64.StdEncoding.EncodeToString([]byte(generateRandomString(int(64))))
 
 	files = append(files, pd.File{
@@ -252,10 +253,10 @@ func TestNewProposalPolicyRestrictions(t *testing.T) {
 	assertErrorWithContext(t, err, www.ErrorStatusProposalInvalidTitle, []string{util.CreateProposalTitleRegex()})
 
 	_, _, err = createNewProposalWithDuplicateFiles(b, t)
-	assertErrorWithContext(t, err, www.ErrorStatusProposalDuplicateFilenames, []string{indexFile})
+	assertErrorWithContext(t, err, www.ErrorStatusProposalDuplicateFilenames, []string{www.IndexFileName})
 
 	_, _, err = createNewProposalWithoutIndexFile(b, t)
-	assertErrorWithContext(t, err, www.ErrorStatusProposalMissingFiles, []string{indexFile})
+	assertErrorWithContext(t, err, www.ErrorStatusProposalMissingFiles, []string{www.IndexFileName})
 }
 
 // Tests fetching an unreviewed proposal's details.

--- a/politeiawww/backend_proposal_test.go
+++ b/politeiawww/backend_proposal_test.go
@@ -192,9 +192,6 @@ func verifyProposalDetails(np *www.NewProposal, p www.ProposalRecord, t *testing
 }
 
 func verifyProposals(p1 www.ProposalRecord, p2 www.ProposalRecord, t *testing.T) {
-	if p1.Name != p2.Name {
-		t.Fatalf("proposal names do not match: %v, %v", p1.Name, p2.Name)
-	}
 	if p1.Files[0].Payload != p2.Files[0].Payload {
 		t.Fatalf("proposal descriptions do not match")
 	}

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -3,6 +3,7 @@ package main
 import (
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	www "github.com/decred/politeia/politeiawww/api/v1"
+	"github.com/decred/politeia/util"
 )
 
 func convertPropStatusFromWWW(s www.PropStatusT) pd.PropStatusT {
@@ -102,12 +103,18 @@ func convertPropCensorFromPD(f pd.CensorshipRecord) www.CensorshipRecord {
 }
 
 func convertPropFromPD(p pd.ProposalRecord) www.ProposalRecord {
-	return www.ProposalRecord{
+	pr := www.ProposalRecord{
 		Status:           convertPropStatusFromPD(p.Status),
 		Timestamp:        p.Timestamp,
 		Files:            convertPropFilesFromPD(p.Files),
 		CensorshipRecord: convertPropCensorFromPD(p.CensorshipRecord),
 	}
+	name, err := util.RecoverProposalName(pr.Files)
+	if err != nil {
+		name = ""
+	}
+	pr.Name = name
+	return pr
 }
 
 func convertPropsFromPD(p []pd.ProposalRecord) []www.ProposalRecord {

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -46,7 +46,6 @@ func convertPropCensorFromWWW(f www.CensorshipRecord) pd.CensorshipRecord {
 
 func convertPropFromWWW(p www.ProposalRecord) pd.ProposalRecord {
 	return pd.ProposalRecord{
-		Name:             p.Name,
 		Status:           convertPropStatusFromWWW(p.Status),
 		Timestamp:        p.Timestamp,
 		Files:            convertPropFilesFromWWW(p.Files),
@@ -104,7 +103,6 @@ func convertPropCensorFromPD(f pd.CensorshipRecord) www.CensorshipRecord {
 
 func convertPropFromPD(p pd.ProposalRecord) www.ProposalRecord {
 	return www.ProposalRecord{
-		Name:             p.Name,
 		Status:           convertPropStatusFromPD(p.Status),
 		Timestamp:        p.Timestamp,
 		Files:            convertPropFilesFromPD(p.Files),

--- a/util/proposal.go
+++ b/util/proposal.go
@@ -33,6 +33,17 @@ func GetProposalName(payload string) (string, error) {
 	return string(proposalName), nil
 }
 
+// RecoverProposalName iterates over the files in a proposal
+// and extracts the proposal name from the index file
+func RecoverProposalName(files []www.File) (string, error) {
+	for _, file := range files {
+		if file.Name == www.IndexFileName {
+			return GetProposalName(file.Payload)
+		}
+	}
+	return "", nil
+}
+
 // IsValidProposalName reports whether str is a valid proposal name
 func IsValidProposalName(str string) bool {
 	return validProposalName.MatchString(str)


### PR DESCRIPTION
@marcopeereboom @sndurkin Reopening this in place of PR https://github.com/decred/politeia/pull/138. This addresses issue https://github.com/decred/politeia/issues/132 and removes the idea of a proposal name from the backend

In the future, we may want to add a common util to extract a proposal name from its files, as www does right now, so it can also be recovered by the backend too, if required. I can open an issue for this if you think it's a good idea.