### PR TITLE
[politeiad] Fix vetted/unvetted repo creation for Windows

### DIFF
--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -72,6 +72,12 @@ const (
 var (
 	_ backend.Backend = (*gitBackEnd)(nil)
 
+	defaultRepoConfig = map[string]string{
+		// This prevents git from converting CRLF when committing and checking
+		// out files, which helps when running on Windows.
+		"core.autocrlf": "false",
+	}
+
 	errNothingToDo = errors.New("nothing to do")
 )
 
@@ -1600,13 +1606,13 @@ func (g *gitBackEnd) newLocked() error {
 	log.Infof("Git version: %v", version)
 
 	// Init vetted git repo
-	err = g.gitInitRepo(g.vetted)
+	err = g.gitInitRepo(g.vetted, defaultRepoConfig)
 	if err != nil {
 		return err
 	}
 
 	// Clone vetted repo into unvetted
-	err = g.gitClone(g.vetted, g.unvetted)
+	err = g.gitClone(g.vetted, g.unvetted, defaultRepoConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds default config of `core.autocrlf=false` to the vetted and unvetted repos in Politeiad, which prevents Git from converting CRLF character to LF while committing and checking out files.

Having `core.autocrlf` set to anything else can cause issues in Windows if, for example, a proposal is committed with the following text:

    This is a description\n
    \n
    with newline characters.

The same file can get checked out as:

    This is a description\r\n
    \r\n
    with newline characters.

which will result in merkle verification failure when trying to open the proposal details.

Fixes #99.