### PR TITLE
force lowercase when creating and getting a user

### DIFF
--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -773,7 +773,7 @@ func (b *backend) ProcessNewUser(u www.NewUser) (*www.NewUserReply, error) {
 
 		// Add the user and hashed password to the db.
 		newUser := database.User{
-			Email:          u.Email,
+			Email:          strings.ToLower(u.Email),
 			HashedPassword: hashedPassword,
 			Admin:          false,
 			NewUserVerificationToken:  token,

--- a/politeiawww/backend_user_test.go
+++ b/politeiawww/backend_user_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,7 +140,7 @@ func createAndVerifyUser(t *testing.T, b *backend) (www.NewUser, *identity.FullI
 
 	signature := id.SignMessage([]byte(nur.VerificationToken))
 	v := www.VerifyNewUser{
-		Email:             nu.Email,
+		Email:             strings.ToUpper(nu.Email),
 		VerificationToken: nur.VerificationToken,
 		Signature:         hex.EncodeToString(signature[:]),
 	}
@@ -484,7 +485,7 @@ func TestProcessResetPassword(t *testing.T) {
 
 	// Reset password verify
 	rp = www.ResetPassword{
-		Email:             u.Email,
+		Email:             strings.ToUpper(u.Email),
 		VerificationToken: rpr.VerificationToken,
 		NewPassword:       generateRandomPassword(),
 	}

--- a/politeiawww/database/localdb/localdb.go
+++ b/politeiawww/database/localdb/localdb.go
@@ -3,6 +3,7 @@ package localdb
 import (
 	"encoding/binary"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/decred/politeia/politeiawww/database"
@@ -95,7 +96,7 @@ func (l *localdb) UserGet(email string) (*database.User, error) {
 	}
 
 	log.Debugf("UserGet: %v", email)
-	payload, err := l.userdb.Get([]byte(email), nil)
+	payload, err := l.userdb.Get([]byte(strings.ToLower(email)), nil)
 	if err == leveldb.ErrNotFound {
 		return nil, database.ErrUserNotFound
 	} else if err != nil {


### PR DESCRIPTION
Fixes #188.

This breaks the tests by adding ToUpper and then uses ToLower in the right spots to fix the issue.