### PR TITLE
[politeiad] Ignore non-empty reconcile maps

### DIFF
--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -1348,7 +1348,8 @@ func (g *gitBackEnd) fsck(path string) error {
 		for k := range gitDigests {
 			log.Errorf("unexpected digest: %v", k)
 		}
-		return fmt.Errorf("expected reconcile map to be empty")
+		//return fmt.Errorf("expected reconcile map to be empty")
+		log.Errorf("expected reconcile map to be empty")
 	}
 
 	return nil


### PR DESCRIPTION
There is one remaining corner case where an Anchor confirmation comes
BEFORE some commits that have not been anchored.  This needs to be fixed
but for now work around this issue.