### PR TITLE
[www] Fix bugs with GET handlers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -92,6 +92,12 @@
   version = "v1.6.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/gorilla/schema"
+  packages = ["."]
+  revision = "afe77393c53b66afe9212810d9b2013859d04ae6"
+
+[[projects]]
   name = "github.com/gorilla/securecookie"
   packages = ["."]
   revision = "667fe4e3466a040b780561fe9b51a83a3753eefc"
@@ -172,6 +178,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8f16bf83dc83f5a1eb21810e6f978cdf596701e940a3974967eace6f9a641225"
+  inputs-digest = "a0ed3b3e7bb07116cfa9c7f7dac0aead4969ce49a3f52f92b60034df8b504527"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -266,9 +266,7 @@ Return information of the current logged in user.
 
 **Route:** `GET /v1/me`
 
-**Params:**
-
-N/A
+**Params:** none
 
 **Results:**
 
@@ -287,11 +285,8 @@ error codes:
 
 Request:
 
-```json
-  {
-    "email":"26c5687daca2f5d8@example.com",
-    "password":"26c5687daca2f5d8"
-}
+```
+/v1/me
 ```
 
 Reply:
@@ -668,8 +663,10 @@ If the caller is not privileged the unvetted call returns `403 Forbidden`.
 
 Request:
 
-```json
-{}
+The request params should be provided within the URL:
+
+```
+/v1/unvetted?after=f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde
 ```
 
 Reply:
@@ -711,8 +708,10 @@ Retrieve a page of vetted proposals; the number of proposals returned in the pag
 
 Request:
 
-```json
-{}
+The request params should be provided within the URL:
+
+```
+/v1/vetted?after=f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde
 ```
 
 Reply:
@@ -755,10 +754,10 @@ Retrieve a page of proposals submitted by the given user; the number of proposal
 
 Request:
 
-```json
-{
-  "userid": "0"
-}
+The request params should be provided within the URL:
+
+```
+/v1/vetted?userid=15&after=f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde
 ```
 
 Reply:
@@ -786,14 +785,14 @@ SHALL observe.
 
 **Params:** none
 
-**Results:** none
+**Results:** see below
 
 **Example**
 
 Request:
 
-```json
-{}
+```
+/v1/policy
 ```
 
 Reply:
@@ -864,7 +863,7 @@ Reply:
 
 Retrieve proposal and its details.
 
-**Routes:** `POST /v1/proposals/{token}`
+**Routes:** `GET /v1/proposals/{token}`
 
 **Params:** none
 
@@ -882,8 +881,10 @@ error codes:
 
 Request:
 
-```json
-{}
+The request params should be provided within the URL:
+
+```
+/v1/proposals/f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde
 ```
 
 Reply:
@@ -987,8 +988,10 @@ sorted.
 
 Request:
 
-```json
-{}
+The request params should be provided within the URL:
+
+```
+/v1/proposals/f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde/comments
 ```
 
 Reply:

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -274,9 +274,9 @@ type NewUserReply struct {
 // VerifyNewUser is used to perform verification for the user created through
 // the NewUser command using the token provided in NewUserReply.
 type VerifyNewUser struct {
-	Email             string `json:"email"`             // User email address
-	VerificationToken string `json:"verificationtoken"` // Server provided verification token
-	Signature         string `json:"signature"`         // Verification token signature
+	Email             string `schema:"email"`             // User email address
+	VerificationToken string `schema:"verificationtoken"` // Server provided verification token
+	Signature         string `schema:"signature"`         // Verification token signature
 }
 
 // VerifyNewUserReply
@@ -333,9 +333,9 @@ type ResetPasswordReply struct {
 // whose censorship token is provided. If Before is specified, the "page"
 // returned starts before the proposal whose censorship token is provided.
 type UserProposals struct {
-	UserId string `json:"userid"`
-	Before string `json:"before"`
-	After  string `json:"after"`
+	UserId string `schema:"userid"`
+	Before string `schema:"before"`
+	After  string `schema:"after"`
 }
 
 // UserProposalsReply replies to the UserProposals command with
@@ -421,8 +421,8 @@ type SetProposalStatusReply struct {
 //
 // Note: This call requires admin privileges.
 type GetAllUnvetted struct {
-	Before string `json:"before"`
-	After  string `json:"after"`
+	Before string `schema:"before"`
+	After  string `schema:"after"`
 }
 
 // GetAllUnvettedReply is used to reply with a list of all unvetted proposals.
@@ -437,8 +437,8 @@ type GetAllUnvettedReply struct {
 // If Before is specified, the "page" returned starts before the proposal whose
 // censorship token is provided.
 type GetAllVetted struct {
-	Before string `json:"before"`
-	After  string `json:"after"`
+	Before string `schema:"before"`
+	After  string `schema:"after"`
 }
 
 // GetAllVettedReply is used to reply with a list of vetted proposals.

--- a/util/json.go
+++ b/util/json.go
@@ -6,6 +6,7 @@ package util
 
 import (
 	"encoding/json"
+	"github.com/gorilla/schema"
 	"io"
 	"net/http"
 )
@@ -37,4 +38,16 @@ func GetErrorFromJSON(r io.Reader) (interface{}, error) {
 		return nil, err
 	}
 	return e, nil
+}
+
+// ParseGetParams parses the query params from the GET request into
+// a struct. This method requires the struct type to be defined
+// with `schema` tags.
+func ParseGetParams(r *http.Request, dst interface{}) error {
+	err := r.ParseForm()
+	if err != nil {
+		return err
+	}
+
+	return schema.NewDecoder().Decode(dst, r.Form)
 }


### PR DESCRIPTION
The GET handlers are trying to unmarshal the request body
as JSON into a struct, but a payload within a GET request
is not actually defined by the latest HTTP/1.1 spec. This
commit changes the behavior to instead pull values from
the query and store them in the command struct.