### PR TITLE
[www] Add paywall enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,21 @@ terminal:
 
 `politeiawww_dbutil -testnet -setadmin <email> <true/false>`
 
+#### 10. Paywall
+* This feature prevents users from submitting new proposals and comments until the paywall amount has been paid.
+* By default, it needs a transaction with 2 confirmations to accept the payment.
+* If running on testnet, it's possible to change the minimum blocks required for accept the payment by setting `minconfirmations` flag for politeiawww:
+
+      politeiawww --minconfirmations=1
+
+##### 10.1 Paywall with politeiawww_refclient
+* When using politeiawww_refclient, the `-use-paywall` flag is true by default. When running the refclient without the paywall, set `-use-paywall=false`, but note that it will not be possible to test new proposals and comments or the `admin` flag.
+* To test the admin flow:
+ * Run the refclient once with paywall enabled and make the payment.
+ * Stop politeiawww.
+ * Set the user created in the first refclient execution as admin with politeiawww_dbutil.
+ * Run refclient again with the `email` and `password` flags set to the user created in the first refclient execution.
+
 ## Integrated Projects / External APIs / Official Development URLs
 * https://faucet.decred.org - instance of [testnetfaucet](https://github.com/decred/testnetfaucet)
   which is used by **politeiawww_refclient** to satisfy paywall requests in an

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -62,6 +62,9 @@ API.  It does not render HTML.
 - [`ErrorStatusInvalidInput`](#ErrorStatusInvalidInput)
 - [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
 - [`ErrorStatusCommentLengthExceededPolicy`](#ErrorStatusCommentLengthExceededPolicy)
+- [`ErrorStatusWrongStatus`](#ErrorStatusWrongStatus)
+- [`ErrorStatusNotLoggedIn`](#ErrorStatusNotLoggedIn)
+- [`ErrorStatusUserNotPaid`](#ErrorStatusUserNotPaid)
 
 **Proposal status codes**
 
@@ -639,6 +642,7 @@ error codes:
 - [`ErrorStatusMaxImageSizeExceededPolicy`](#ErrorStatusMaxImageSizeExceededPolicy)
 - [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
 - [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
+- [`ErrorStatusUserNotPaid`](#ErrorStatusUserNotPaid)
 
 **Example**
 
@@ -975,6 +979,7 @@ On failure the call shall return `400 Bad Request` and one of the following
 error codes:
 
 - [`ErrorStatusCommentLengthExceededPolicy`](#ErrorStatusCommentLengthExceededPolicy)
+- [`ErrorStatusUserNotPaid`](#ErrorStatusUserNotPaid)
 
 **Example**
 
@@ -1420,6 +1425,9 @@ Reply:
 | <a name="ErrorStatusInvalidInput">ErrorStatusInvalidInput</a> | 24 | Invalid input. |
 | <a name="ErrorStatusInvalidSigningKey">ErrorStatusInvalidSigningKey</a> | 25 | Invalid signing key. |
 | <a name="ErrorStatusCommentLengthExceededPolicy">ErrorStatusCommentLengthExceededPolicy</a> | 26 | The submitted comment length is too large. |
+| <a name="ErrorStatusWrongStatus">ErrorStatusWrongStatus</a> | 28 | Wrong Status. |
+| <a name="ErrorStatusNotLoggedIn">ErrorStatusNotLoggedIn</a> | 29 | User not logged in. |
+| <a name="ErrorStatusUserNotPaid">ErrorStatusUserNotPaid</a> | 30 | User not paid paywall. |
 
 ### Proposal status codes
 

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -117,6 +117,7 @@ const (
 	ErrorStatusUserNotFound                ErrorStatusT = 27
 	ErrorStatusWrongStatus                 ErrorStatusT = 28
 	ErrorStatusNotLoggedIn                 ErrorStatusT = 29
+	ErrorStatusUserNotPaid                 ErrorStatusT = 30
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid     PropStatusT = 0 // Invalid status
@@ -173,6 +174,7 @@ var (
 		ErrorStatusUserNotFound:                "user not found",
 		ErrorStatusWrongStatus:                 "wrong status",
 		ErrorStatusNotLoggedIn:                 "user not logged in",
+		ErrorStatusUserNotPaid:                 "user not paid paywall",
 	}
 )
 

--- a/politeiawww/cmd/politeiawww_refclient/client.go
+++ b/politeiawww/cmd/politeiawww_refclient/client.go
@@ -222,6 +222,26 @@ func (c *ctx) verifyNewUser(email, token, sig string) error {
 	return err
 }
 
+func (c *ctx) verifyUserPaymentTx(id *identity.FullIdentity, token, faucetTx string) (*v1.VerifyUserPaymentTxReply, error) {
+	vTx := v1.VerifyUserPaymentTx{
+		TxId: faucetTx,
+	}
+
+	responseBody, err := c.makeRequest("GET", v1.RouteVerifyUserPaymentTx, vTx)
+	if err != nil {
+		return nil, err
+	}
+
+	var vupr v1.VerifyUserPaymentTxReply
+	err = json.Unmarshal(responseBody, &vupr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal verifyUserPaidReply: %v",
+			err)
+	}
+
+	return &vupr, nil
+}
+
 func (c *ctx) login(email, password string) (*v1.LoginReply, error) {
 	l := v1.Login{
 		Email:    email,

--- a/politeiawww/cmd/politeiawww_refclient/main.go
+++ b/politeiawww/cmd/politeiawww_refclient/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/politeia/politeiawww/api/v1"
 	"github.com/decred/politeia/util"
+	"time"
 )
 
 var (
@@ -20,6 +21,11 @@ var (
 	passwordFlag      = flag.String("password", "", "admin password")
 	printJson         = flag.Bool("json", false, "Print JSON")
 	test              = flag.String("test", "all", "only run a subset of tests [all,vote]")
+	usePaywall        = flag.Bool("use-paywall", true, "Run refClient waiting for paywall confimartion")
+)
+
+const (
+	timeToPoll = 3 // time in seconds which will poll for block confirmations
 )
 
 func firstContact() (*ctx, error) {
@@ -188,20 +194,19 @@ func _main() error {
 		return err
 	}
 
+	var faucetTx string
 	if paywallAddress != "" && paywallAmount != 0 {
 		// Use the testnet faucet to satisfy the user paywall fee.
-		faucetTx, err := util.PayWithTestnetFaucet(faucetURL, paywallAddress, paywallAmount,
+		faucetTx, err = util.PayWithTestnetFaucet(faucetURL, paywallAddress, paywallAmount,
 			*overridetokenFlag)
 		if err != nil {
 			return fmt.Errorf("unable to pay with %v with %v faucet: %v",
 				paywallAddress, paywallAmount, err)
 		}
 
-		fmt.Printf("paid %v DCR to %v with faucet tx %v\n",
+		fmt.Printf("paid %v Atom to %v with faucet tx %v\n",
 			paywallAmount, paywallAddress, faucetTx)
 	}
-
-	// TODO need to poll for payment confirmation once enforcement is enabled
 
 	// New proposal
 	_, err = c.newProposal(id)
@@ -260,310 +265,324 @@ func _main() error {
 		return err
 	}
 
-	// New proposal 1
-	myprop1, err := c.newProposal(id)
-	if err != nil {
-		return err
-	}
+	// From here we need to have -use-paywall setted as true
+	// and wait for paywall Confirmations
 
-	// Ensure proposal exists under user
-	upr, err := c.proposalsForUser(me.UserID)
-	if err != nil {
-		return err
-	}
-	if len(upr.Proposals) != 1 {
-		return fmt.Errorf("No proposals returned for user")
-	}
-	if upr.Proposals[0].CensorshipRecord.Token != myprop1.CensorshipRecord.Token {
-		return fmt.Errorf("Proposal tokens don't match")
-	}
+	if *usePaywall {
+		ticker := time.NewTicker(time.Second * timeToPoll)
 
-	// Set new id
-	newId, err := idFromString("alt" + email)
-	if err != nil {
-		return err
-	}
-	err = c.setNewKey(newId)
-	if err != nil {
-		return err
-	}
+		for range ticker.C {
+			verifyUserPaid, err := c.verifyUserPaymentTx(id, token, faucetTx)
+			if err != nil {
+				return fmt.Errorf("ERR: %v", err)
+			}
+			fmt.Printf("Waiting for confirmations\n")
+			if verifyUserPaid.HasPaid {
+				ticker.Stop()
+				break
+			}
+		}
 
-	// New proposal 2
-	_, err = c.newProposal(id)
-	if err == nil {
-		return fmt.Errorf("expected error, user identity should be inactive")
-	}
+		// New proposal 1
+		myprop1, err := c.newProposal(id)
+		if err != nil {
+			return err
+		}
 
-	// New proposal 2
-	myprop2, err := c.newProposal(newId)
-	if err != nil {
-		return err
-	}
+		// Ensure proposal exists under user
+		upr, err := c.proposalsForUser(me.UserID)
+		if err != nil {
+			return err
+		}
+		if len(upr.Proposals) != 1 {
+			return fmt.Errorf("No proposals returned for user")
+		}
+		if upr.Proposals[0].CensorshipRecord.Token != myprop1.CensorshipRecord.Token {
+			return fmt.Errorf("Proposal tokens don't match")
+		}
 
-	// Reset old identity
-	err = c.setNewKey(id)
-	if err != nil {
-		return err
-	}
+		// Set new id
+		newId, err := idFromString("alt" + email)
+		if err != nil {
+			return err
+		}
+		err = c.setNewKey(newId)
+		if err != nil {
+			return err
+		}
 
-	// Get props back out
-	pr1, err := c.getProp(myprop1.CensorshipRecord.Token)
-	if err != nil {
-		return err
-	}
-	if pr1.Proposal.CensorshipRecord.Token != myprop1.CensorshipRecord.Token {
-		return fmt.Errorf("pr1 invalid got %v wanted %v",
-			pr1.Proposal.CensorshipRecord.Token,
-			myprop1.CensorshipRecord.Token)
-	}
-	if pr1.Proposal.Status != v1.PropStatusNotReviewed {
-		return fmt.Errorf("pr1 invalid status got %v wanted %v",
-			pr1.Proposal.Status, v1.PropStatusNotReviewed)
-	}
-	if len(pr1.Proposal.Files) > 0 {
-		return fmt.Errorf("pr1 unexpected proposal data received")
-	}
-
-	pr2, err := c.getProp(myprop2.CensorshipRecord.Token)
-	if err != nil {
-		return err
-	}
-	if pr2.Proposal.CensorshipRecord.Token != myprop2.CensorshipRecord.Token {
-		return fmt.Errorf("pr2 invalid got %v wanted %v",
-			pr2.Proposal.CensorshipRecord.Token,
-			myprop2.CensorshipRecord.Token)
-	}
-	if pr2.Proposal.Status != v1.PropStatusNotReviewed {
-		return fmt.Errorf("pr2 invalid status got %v wanted %v",
-			pr2.Proposal.Status, v1.PropStatusNotReviewed)
-	}
-
-	// Create enough proposals to have 2 pages
-	for i := 0; i < int(pr.ProposalListPageSize); i++ {
+		// New proposal 2
 		_, err = c.newProposal(id)
-		if err != nil {
-			return err
+		if err == nil {
+			return fmt.Errorf("expected error, user identity should be inactive")
 		}
-	}
 
-	_, err = c.allUnvetted("")
-	if err == nil {
-		return fmt.Errorf("/unvetted should only be accessible by admin users")
-	}
-
-	// Vetted proposals
-	err = c.allVetted()
-	if err != nil {
-		return err
-	}
-
-	// Logout
-	err = c.logout()
-	if err != nil {
-		return err
-	}
-
-	// Execute routes with admin permissions if the flags are set
-	if *emailFlag != "" {
-		adminEmail := *emailFlag
-		adminPassword := *passwordFlag
-		adminID, err := idFromString(adminEmail)
+		// New proposal 2
+		myprop2, err := c.newProposal(newId)
 		if err != nil {
 			return err
 		}
 
-		c, err = newClient(true)
-		if err != nil {
-			return err
-		}
-		_, err = c.getCSRF()
-		if err != nil {
-			return err
-		}
-
-		lr, err = c.login(adminEmail, adminPassword)
+		// Reset old identity
+		err = c.setNewKey(id)
 		if err != nil {
 			return err
 		}
 
-		// expect admin == true
-		if !lr.IsAdmin {
-			return fmt.Errorf("expected admin")
-		}
-
-		// Me admin
-		me, err := c.me()
-		if err != nil {
-			return err
-		}
-		if me.Email != adminEmail {
-			return fmt.Errorf("admin email got %v wanted %v",
-				me.Email, adminEmail)
-		}
-		if !me.IsAdmin {
-			return fmt.Errorf("IsAdmin got %v wanted %v",
-				me.IsAdmin, true)
-		}
-
-		// Test unvetted paging
-		unvettedPage1, err := c.allUnvetted("")
-		if err != nil {
-			return err
-		}
-		lastProposal := unvettedPage1.Proposals[len(unvettedPage1.Proposals)-1]
-		unvettedPage2, err := c.allUnvetted(lastProposal.CensorshipRecord.Token)
-		if err != nil {
-			return err
-		}
-		if len(unvettedPage2.Proposals) == 0 {
-			return fmt.Errorf("empty 2nd page of unvetted proposals")
-		}
-
-		// Create test proposal 1
+		// Get props back out
 		pr1, err := c.getProp(myprop1.CensorshipRecord.Token)
 		if err != nil {
 			return err
 		}
-		if len(pr1.Proposal.Files) == 0 {
-			return fmt.Errorf("pr1 expected proposal data")
-		}
-
-		// Move first proposal to published
-		psr1, err := c.setPropStatus(adminID,
-			myprop1.CensorshipRecord.Token, v1.PropStatusPublic)
-		if err != nil {
-			return err
-		}
-		if psr1.Proposal.Status != v1.PropStatusPublic {
-			return fmt.Errorf("invalid status got %v wanted %v",
-				psr1.Proposal.Status,
-				v1.PropStatusPublic)
-		}
-
-		// Move second proposal to censored
-		psr2, err := c.setPropStatus(adminID,
-			myprop2.CensorshipRecord.Token, v1.PropStatusCensored)
-		if err != nil {
-			return err
-		}
-		if psr2.Proposal.Status != v1.PropStatusCensored {
-			return fmt.Errorf("invalid status got %v wanted %v",
-				psr2.Proposal.Status,
-				v1.PropStatusCensored)
-		}
-
-		// Get props back out and check status
-		_pr1, err := c.getProp(myprop1.CensorshipRecord.Token)
-		if err != nil {
-			return err
-		}
-		if _pr1.Proposal.CensorshipRecord.Token !=
-			myprop1.CensorshipRecord.Token {
-			return fmt.Errorf("_pr1 invalid got %v wanted %v",
-				_pr1.Proposal.CensorshipRecord.Token,
+		if pr1.Proposal.CensorshipRecord.Token != myprop1.CensorshipRecord.Token {
+			return fmt.Errorf("pr1 invalid got %v wanted %v",
+				pr1.Proposal.CensorshipRecord.Token,
 				myprop1.CensorshipRecord.Token)
 		}
-		if _pr1.Proposal.Status != v1.PropStatusPublic {
-			return fmt.Errorf("_pr1 invalid status got %v wanted %v",
-				_pr1.Proposal.Status, v1.PropStatusPublic)
+		if pr1.Proposal.Status != v1.PropStatusNotReviewed {
+			return fmt.Errorf("pr1 invalid status got %v wanted %v",
+				pr1.Proposal.Status, v1.PropStatusNotReviewed)
+		}
+		if len(pr1.Proposal.Files) > 0 {
+			return fmt.Errorf("pr1 unexpected proposal data received")
 		}
 
-		_pr2, err := c.getProp(myprop2.CensorshipRecord.Token)
+		pr2, err := c.getProp(myprop2.CensorshipRecord.Token)
 		if err != nil {
 			return err
 		}
-		if _pr2.Proposal.CensorshipRecord.Token !=
-			myprop2.CensorshipRecord.Token {
-			return fmt.Errorf("_pr2 invalid got %v wanted %v",
-				_pr2.Proposal.CensorshipRecord.Token,
+		if pr2.Proposal.CensorshipRecord.Token != myprop2.CensorshipRecord.Token {
+			return fmt.Errorf("pr2 invalid got %v wanted %v",
+				pr2.Proposal.CensorshipRecord.Token,
 				myprop2.CensorshipRecord.Token)
 		}
-		if _pr2.Proposal.Status != v1.PropStatusCensored {
-			return fmt.Errorf("_pr2 invalid status got %v wanted %v",
-				_pr2.Proposal.Status, v1.PropStatusCensored)
+		if pr2.Proposal.Status != v1.PropStatusNotReviewed {
+			return fmt.Errorf("pr2 invalid status got %v wanted %v",
+				pr2.Proposal.Status, v1.PropStatusNotReviewed)
 		}
 
-		// Comment on proposals without a parent
-		cr, err := c.comment(adminID, myprop1.CensorshipRecord.Token,
-			"I like this prop", "")
-		if err != nil {
-			return err
-		}
-		// Comment on original comment
-		cr, err = c.comment(adminID, myprop1.CensorshipRecord.Token,
-			"you are right!", cr.CommentID)
-		if err != nil {
-			return err
-		}
-		// Comment on comment
-		cr, err = c.comment(adminID, myprop1.CensorshipRecord.Token,
-			"you are wrong!", cr.CommentID)
-		if err != nil {
-			return err
+		// Create enough proposals to have 2 pages
+		for i := 0; i < int(pr.ProposalListPageSize); i++ {
+			_, err = c.newProposal(id)
+			if err != nil {
+				return err
+			}
 		}
 
-		// Comment on proposals without a parent
-		cr2, err := c.comment(adminID, myprop1.CensorshipRecord.Token,
-			"I dont like this prop", "")
-		if err != nil {
-			return err
-		}
-		// Comment on original comment
-		cr, err = c.comment(adminID, myprop1.CensorshipRecord.Token,
-			"you are right!", cr2.CommentID)
-		if err != nil {
-			return err
-		}
-		// Comment on original comment
-		cr, err = c.comment(adminID, myprop1.CensorshipRecord.Token,
-			"you are crazy!", cr2.CommentID)
-		if err != nil {
-			return err
+		_, err = c.allUnvetted("")
+		if err == nil {
+			return fmt.Errorf("/unvetted should only be accessible by admin users")
 		}
 
-		// Get comments
-		gcr, err := c.commentGet(myprop1.CensorshipRecord.Token)
+		// Vetted proposals
+		err = c.allVetted()
 		if err != nil {
 			return err
-		}
-		// Expect 6 comments
-		if len(gcr.Comments) != 6 {
-			return fmt.Errorf("expected 6 comments, got %v",
-				len(gcr.Comments))
-		}
-		// Get prop out again and check comments num
-		_pr1, err = c.getProp(myprop1.CensorshipRecord.Token)
-		if err != nil {
-			return err
-		}
-		if _pr1.Proposal.NumComments != uint(len(gcr.Comments)) {
-			return fmt.Errorf("expected %v comments, got %v",
-				len(gcr.Comments), _pr1.Proposal.NumComments)
-		}
-
-		gcr2, err := c.commentGet(myprop2.CensorshipRecord.Token)
-		if err != nil {
-			return err
-		}
-		// Expect nothing
-		if len(gcr2.Comments) != 0 {
-			return fmt.Errorf("expected 0 comments, got %v",
-				len(gcr2.Comments))
-		}
-		// Get prop out again and check comments num
-		_pr2, err = c.getProp(myprop2.CensorshipRecord.Token)
-		if err != nil {
-			return err
-		}
-		if _pr2.Proposal.NumComments != uint(len(gcr2.Comments)) {
-			return fmt.Errorf("expected %v comments, got %v",
-				len(gcr2.Comments), _pr2.Proposal.NumComments)
 		}
 
 		// Logout
 		err = c.logout()
 		if err != nil {
 			return err
+		}
+
+		// Execute routes with admin permissions if the flags are set
+		if *emailFlag != "" {
+			adminEmail := *emailFlag
+			adminPassword := *passwordFlag
+			adminID, err := idFromString(adminEmail)
+			if err != nil {
+				return err
+			}
+
+			c, err = newClient(true)
+			if err != nil {
+				return err
+			}
+			_, err = c.getCSRF()
+			if err != nil {
+				return err
+			}
+
+			lr, err = c.login(adminEmail, adminPassword)
+			if err != nil {
+				return err
+			}
+
+			// expect admin == true
+			if !lr.IsAdmin {
+				return fmt.Errorf("expected admin")
+			}
+
+			// Me admin
+			me, err := c.me()
+			if err != nil {
+				return err
+			}
+			if me.Email != adminEmail {
+				return fmt.Errorf("admin email got %v wanted %v",
+					me.Email, adminEmail)
+			}
+			if !me.IsAdmin {
+				return fmt.Errorf("IsAdmin got %v wanted %v",
+					me.IsAdmin, true)
+			}
+
+			// Test unvetted paging
+			unvettedPage1, err := c.allUnvetted("")
+			if err != nil {
+				return err
+			}
+			lastProposal := unvettedPage1.Proposals[len(unvettedPage1.Proposals)-1]
+			unvettedPage2, err := c.allUnvetted(lastProposal.CensorshipRecord.Token)
+			if err != nil {
+				return err
+			}
+			if len(unvettedPage2.Proposals) == 0 {
+				return fmt.Errorf("empty 2nd page of unvetted proposals")
+			}
+
+			// Create test proposal 1
+			pr1, err := c.getProp(myprop1.CensorshipRecord.Token)
+			if err != nil {
+				return err
+			}
+			if len(pr1.Proposal.Files) == 0 {
+				return fmt.Errorf("pr1 expected proposal data")
+			}
+
+			// Move first proposal to published
+			psr1, err := c.setPropStatus(adminID,
+				myprop1.CensorshipRecord.Token, v1.PropStatusPublic)
+			if err != nil {
+				return err
+			}
+			if psr1.Proposal.Status != v1.PropStatusPublic {
+				return fmt.Errorf("invalid status got %v wanted %v",
+					psr1.Proposal.Status,
+					v1.PropStatusPublic)
+			}
+
+			// Move second proposal to censored
+			psr2, err := c.setPropStatus(adminID,
+				myprop2.CensorshipRecord.Token, v1.PropStatusCensored)
+			if err != nil {
+				return err
+			}
+			if psr2.Proposal.Status != v1.PropStatusCensored {
+				return fmt.Errorf("invalid status got %v wanted %v",
+					psr2.Proposal.Status,
+					v1.PropStatusCensored)
+			}
+
+			// Get props back out and check status
+			_pr1, err := c.getProp(myprop1.CensorshipRecord.Token)
+			if err != nil {
+				return err
+			}
+			if _pr1.Proposal.CensorshipRecord.Token !=
+				myprop1.CensorshipRecord.Token {
+				return fmt.Errorf("_pr1 invalid got %v wanted %v",
+					_pr1.Proposal.CensorshipRecord.Token,
+					myprop1.CensorshipRecord.Token)
+			}
+			if _pr1.Proposal.Status != v1.PropStatusPublic {
+				return fmt.Errorf("_pr1 invalid status got %v wanted %v",
+					_pr1.Proposal.Status, v1.PropStatusPublic)
+			}
+
+			_pr2, err := c.getProp(myprop2.CensorshipRecord.Token)
+			if err != nil {
+				return err
+			}
+			if _pr2.Proposal.CensorshipRecord.Token !=
+				myprop2.CensorshipRecord.Token {
+				return fmt.Errorf("_pr2 invalid got %v wanted %v",
+					_pr2.Proposal.CensorshipRecord.Token,
+					myprop2.CensorshipRecord.Token)
+			}
+			if _pr2.Proposal.Status != v1.PropStatusCensored {
+				return fmt.Errorf("_pr2 invalid status got %v wanted %v",
+					_pr2.Proposal.Status, v1.PropStatusCensored)
+			}
+
+			// Comment on proposals without a parent
+			cr, err := c.comment(adminID, myprop1.CensorshipRecord.Token,
+				"I like this prop", "")
+			if err != nil {
+				return err
+			}
+			// Comment on original comment
+			cr, err = c.comment(adminID, myprop1.CensorshipRecord.Token,
+				"you are right!", cr.CommentID)
+			if err != nil {
+				return err
+			}
+			// Comment on comment
+			cr, err = c.comment(adminID, myprop1.CensorshipRecord.Token,
+				"you are wrong!", cr.CommentID)
+			if err != nil {
+				return err
+			}
+
+			// Comment on proposals without a parent
+			cr2, err := c.comment(adminID, myprop1.CensorshipRecord.Token,
+				"I dont like this prop", "")
+			if err != nil {
+				return err
+			}
+			// Comment on original comment
+			cr, err = c.comment(adminID, myprop1.CensorshipRecord.Token,
+				"you are right!", cr2.CommentID)
+			if err != nil {
+				return err
+			}
+			// Comment on original comment
+			cr, err = c.comment(adminID, myprop1.CensorshipRecord.Token,
+				"you are crazy!", cr2.CommentID)
+			if err != nil {
+				return err
+			}
+
+			// Get comments
+			gcr, err := c.commentGet(myprop1.CensorshipRecord.Token)
+			if err != nil {
+				return err
+			}
+			// Expect 6 comments
+			if len(gcr.Comments) != 6 {
+				return fmt.Errorf("expected 6 comments, got %v",
+					len(gcr.Comments))
+			}
+			// Get prop out again and check comments num
+			_pr1, err = c.getProp(myprop1.CensorshipRecord.Token)
+			if err != nil {
+				return err
+			}
+			if _pr1.Proposal.NumComments != uint(len(gcr.Comments)) {
+				return fmt.Errorf("expected %v comments, got %v",
+					len(gcr.Comments), _pr1.Proposal.NumComments)
+			}
+
+			gcr2, err := c.commentGet(myprop2.CensorshipRecord.Token)
+			if err != nil {
+				return err
+			}
+			// Expect nothing
+			if len(gcr2.Comments) != 0 {
+				return fmt.Errorf("expected 0 comments, got %v",
+					len(gcr2.Comments))
+			}
+			// Get prop out again and check comments num
+			_pr2, err = c.getProp(myprop2.CensorshipRecord.Token)
+			if err != nil {
+				return err
+			}
+			if _pr2.Proposal.NumComments != uint(len(gcr2.Comments)) {
+				return fmt.Errorf("expected %v comments, got %v",
+					len(gcr2.Comments), _pr2.Proposal.NumComments)
+			}
+
 		}
 	}
 
@@ -573,6 +592,12 @@ func _main() error {
 	//if err != nil {
 	//	return err
 	//}
+
+	// Logout
+	err = c.logout()
+	if err != nil {
+		return err
+	}
 
 	// Secret once more that should fail
 	err = c.secret()

--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -10,8 +10,9 @@ import (
 // meets the minimum requirements to mark the user as paid, and then does
 // that in the user database.
 func (b *backend) ProcessVerifyUserPaymentTx(user *database.User, vupt www.VerifyUserPaymentTx) (*www.VerifyUserPaymentTxReply, error) {
+	minConfirmations := b.cfg.MinConfirmationsRequired
 	verified, err := util.VerifyTxWithBlockExplorers(user.NewUserPaywallAddress,
-		user.NewUserPaywallAmount, vupt.TxId, user.NewUserPaywallTxNotBefore)
+		user.NewUserPaywallAmount, vupt.TxId, user.NewUserPaywallTxNotBefore, minConfirmations)
 	if err != nil {
 		return nil, err
 	}
@@ -28,4 +29,12 @@ func (b *backend) ProcessVerifyUserPaymentTx(user *database.User, vupt www.Verif
 	}
 
 	return &reply, nil
+}
+
+// VerifyUserPaid checks that a user has paid the paywall
+func (b *backend) VerifyUserPaid(user *database.User) bool {
+	if b.test {
+		return true
+	}
+	return user.NewUserPaywallTx != ""
 }

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -912,6 +912,9 @@ func _main() error {
 	log.Infof("Network : %v", activeNetParams.Params.Name)
 	log.Infof("Home dir: %v", loadedCfg.HomeDir)
 
+	paywallAmountInDcr := float64(loadedCfg.PaywallAmount) / 1e8
+	log.Infof("Paywall : %v DCR", paywallAmountInDcr)
+
 	// Create the data directory in case it does not exist.
 	err = os.MkdirAll(loadedCfg.DataDir, 0700)
 	if err != nil {


### PR DESCRIPTION
This PR closes #217 

I added a flag `-use-paywall` to the politeiawww_refclient. In case we do not want to wait for the paywall payment confirmation, we just need to set it to false, but because of that, is not possible to test new proposals and comments. I let default as true.

I also added a flag `--minConfirmations` to politeiawww, so we can change the minimum amount of blocks needed when in testnet. I setted mainnet as 2 blocks and it is not configurable. Should I left like that?

~~Tests are failing because of paywall enformecement, should I add 0 confirmations block in case of tests?~~

Right now we have two URLs for confirming payments

```
primaryURL = "https://testnet.dcrdata.org/api/address/" + address + "/raw"
backupURL = "https://testnet.decred.org/api/addr/" + address + "/utxo?noCache=1"
```

But the dcrdata API looks like is returning 0 confirmations and no timestamp until it has 2 confirmations, so even when setting `--minConfirmations=0` or `--minConfirmations=1` it does not work, because we always receive 0.
~~Should I change our primary url and backup url with each other?~~
We have an issue for that at dcrdata

I'd like @marcopeereboom and @sndurkin to take a look on where I am heading with this PR to see if you guys have any suggestions.

Thanks