### PR TITLE
[www] Merge voting details to proposal vote results

### DIFF
--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -611,9 +611,9 @@ type VoteResults struct {
 // VoteResultsReply returns the original proposal vote and the associated cast
 // votes.
 type VoteResultsReply struct {
-	Vote           Vote           `json:"vote"`          // Original vote
-	CastVotes      []CastVote     `json:"castvotes"`     // Vote results
-	StartVoteReply StartVoteReply `json:"startvotereply` // Eligible tickets and other details
+	Vote           Vote           `json:"vote"`           // Original vote
+	CastVotes      []CastVote     `json:"castvotes"`      // Vote results
+	StartVoteReply StartVoteReply `json:"startvotereply"` // Eligible tickets and other details
 }
 
 // Comment is the structure that describes the full server side content.  It

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -611,8 +611,9 @@ type VoteResults struct {
 // VoteResultsReply returns the original proposal vote and the associated cast
 // votes.
 type VoteResultsReply struct {
-	Vote      Vote       `json:"vote"`      // Original vote
-	CastVotes []CastVote `json:"castvotes"` // Vote results
+	Vote           Vote           `json:"vote"`          // Original vote
+	CastVotes      []CastVote     `json:"castvotes"`     // Vote results
+	StartVoteReply StartVoteReply `json:"startvotereply` // Eligible tickets and other details
 }
 
 // Comment is the structure that describes the full server side content.  It

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2130,7 +2130,22 @@ func (b *backend) ProcessVoteResults(vr *www.VoteResults) (*www.VoteResultsReply
 	if err != nil {
 		return nil, err
 	}
-	wvrr := convertVoteResultsReplyFromDecredplugin(*vrr)
+
+	// Fetch record from inventory in order to
+	// get the voting details (StartVoteReply)
+	ir, err := b._getInventoryRecord(vr.Token)
+	if err != nil {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusProposalNotFound,
+		}
+	}
+	if ir.record.Status != pd.RecordStatusPublic {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusWrongStatus,
+		}
+	}
+
+	wvrr := convertVoteResultsReplyFromDecredplugin(*vrr, ir)
 	return &wvrr, nil
 }
 

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -142,10 +142,11 @@ func convertCastVotesFromDecredplugin(cv []decredplugin.CastVote) []www.CastVote
 	return cvr
 }
 
-func convertVoteResultsReplyFromDecredplugin(vrr decredplugin.VoteResultsReply) www.VoteResultsReply {
+func convertVoteResultsReplyFromDecredplugin(vrr decredplugin.VoteResultsReply, ir inventoryRecord) www.VoteResultsReply {
 	return www.VoteResultsReply{
-		Vote:      convertVoteFromDecredplugin(vrr.Vote),
-		CastVotes: convertCastVotesFromDecredplugin(vrr.CastVotes),
+		Vote:           convertVoteFromDecredplugin(vrr.Vote),
+		CastVotes:      convertCastVotesFromDecredplugin(vrr.CastVotes),
+		StartVoteReply: ir.voting,
 	}
 }
 


### PR DESCRIPTION
closes #270

I've added the vote Details info within vote Results returned data. With that, is possible to tell a proposal status (on-voting, finshed, not-started-voting) by simply calling the vote Results for a given proposal token. 