### PR TITLE
[www] Add username implementation

### DIFF
--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -20,6 +20,7 @@ const (
 	RouteVerifyNewUser       = "/user/verify"
 	RouteUpdateUserKey       = "/user/key"
 	RouteVerifyUpdateUserKey = "/user/key/verify"
+	RouteChangeUsername      = "/user/username/change"
 	RouteChangePassword      = "/user/password/change"
 	RouteResetPassword       = "/user/password/reset"
 	RouteUserProposals       = "/user/proposals"
@@ -66,16 +67,20 @@ const (
 	// accepted when creating a new proposal
 	PolicyMaxMDSize = 512 * 1024
 
-	// PolicyPasswordMinChars is the minimum number of characters
+	// PolicyMinPasswordLength is the minimum number of characters
 	// accepted for user passwords
-	PolicyPasswordMinChars = 8
+	PolicyMinPasswordLength = 8
+
+	// PolicyMaxUsernameLength is the max length of a username
+	PolicyMaxUsernameLength = 30
+
+	// PolicyMinUsernameLength is the min length of a username
+	PolicyMinUsernameLength = 3
 
 	// PolicyMaxProposalNameLength is the max length of a proposal name
-	// proposal name
 	PolicyMaxProposalNameLength = 80
 
 	// PolicyMinProposalNameLength is the min length of a proposal name
-	// proposal name
 	PolicyMinProposalNameLength = 8
 
 	// PolicyMaxCommentLength is the maximum number of characters
@@ -119,6 +124,8 @@ const (
 	ErrorStatusNotLoggedIn                 ErrorStatusT = 29
 	ErrorStatusUserNotPaid                 ErrorStatusT = 30
 	ErrorStatusReviewerAdminEqualsAuthor   ErrorStatusT = 31
+	ErrorStatusMalformedUsername           ErrorStatusT = 32
+	ErrorStatusDuplicateUsername           ErrorStatusT = 33
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid     PropStatusT = 0 // Invalid status
@@ -130,11 +137,17 @@ const (
 )
 
 var (
-	// PolicyProposalNameSupportedCharacters is the regular expression of a valid
+	// PolicyProposalNameSupportedChars is the regular expression of a valid
 	// proposal name
-	PolicyProposalNameSupportedCharacters = []string{
+	PolicyProposalNameSupportedChars = []string{
 		"A-z", "0-9", "&", ".", ",", ":", ";", "-", " ", "@", "+", "#", "/",
 		"(", ")", "!"}
+
+	// PolicyUsernameSupportedChars is the regular expression of a valid
+	// username
+	PolicyUsernameSupportedChars = []string{
+		"A-z", "0-9", ".", ",", ":", ";", "-", " ", "@", "+",
+		"(", ")"}
 
 	// PoliteiaWWWAPIRoute is the prefix to the API route
 	PoliteiaWWWAPIRoute = fmt.Sprintf("/v%v", PoliteiaWWWAPIVersion)
@@ -175,8 +188,10 @@ var (
 		ErrorStatusUserNotFound:                "user not found",
 		ErrorStatusWrongStatus:                 "wrong status",
 		ErrorStatusNotLoggedIn:                 "user not logged in",
-		ErrorStatusUserNotPaid:                 "user not paid paywall",
+		ErrorStatusUserNotPaid:                 "user hasn't paid paywall",
 		ErrorStatusReviewerAdminEqualsAuthor:   "user cannot change the status of his own proposal",
+		ErrorStatusMalformedUsername:           "malformed username",
+		ErrorStatusDuplicateUsername:           "duplicate username",
 	}
 )
 
@@ -212,6 +227,7 @@ type ProposalRecord struct {
 	Status      PropStatusT `json:"status"`      // Current status of proposal
 	Timestamp   int64       `json:"timestamp"`   // Last update of proposal
 	UserId      string      `json:"userid"`      // ID of user who submitted proposal
+	Username    string      `json:"username"`    // Username of user who submitted proposal
 	PublicKey   string      `json:"publickey"`   // Key used for signature.
 	Signature   string      `json:"signature"`   // Signature of merkle root
 	Files       []File      `json:"files"`       // Files that make up the proposal
@@ -282,6 +298,7 @@ type NewUser struct {
 	Email     string `json:"email"`
 	Password  string `json:"password"`
 	PublicKey string `json:"publickey"`
+	Username  string `json:"username"`
 }
 
 // NewUserReply is used to reply to the NewUser command with an error
@@ -322,6 +339,17 @@ type VerifyUpdateUserKey struct {
 
 // VerifyUpdateUserKeyReply replies to the VerifyUpdateUserKey command.
 type VerifyUpdateUserKeyReply struct{}
+
+// ChangeUsername is used to perform a username change while the user
+// is logged in.
+type ChangeUsername struct {
+	Password    string `json:"password"`
+	NewUsername string `json:"newusername"`
+}
+
+// ChangeUsernameReply is used to perform a username change while the user
+// is logged in.
+type ChangeUsernameReply struct{}
 
 // ChangePassword is used to perform a password change while the user
 // is logged in.
@@ -389,6 +417,7 @@ type LoginReply struct {
 	IsAdmin            bool   `json:"isadmin"`            // Set if user is an admin
 	UserID             string `json:"userid"`             // User id
 	Email              string `json:"email"`              // User email
+	Username           string `json:"username"`           // Username
 	PublicKey          string `json:"publickey"`          // Active public key
 	PaywallAddress     string `json:"paywalladdress"`     // Registration paywall address
 	PaywallAmount      uint64 `json:"paywallamount"`      // Registration paywall amount in atoms
@@ -484,18 +513,21 @@ type Policy struct{}
 // PolicyReply is used to reply to the policy command. It returns
 // the file upload restrictions set for Politeia.
 type PolicyReply struct {
-	PasswordMinChars     uint     `json:"passwordminchars"`
-	ProposalListPageSize uint     `json:"proposallistpagesize"`
-	MaxImages            uint     `json:"maximages"`
-	MaxImageSize         uint     `json:"maximagesize"`
-	MaxMDs               uint     `json:"maxmds"`
-	MaxMDSize            uint     `json:"maxmdsize"`
-	ValidMIMETypes       []string `json:"validmimetypes"`
-	MaxNameLength        uint     `json:"maxnamelength"`
-	MinNameLength        uint     `json:"minnamelength"`
-	SupportedCharacters  []string `json:"supportedcharacters"`
-	MaxCommentLength     uint     `json:"maxcommentlength"`
-	BackendPublicKey     string   `json:"backendpublickey"`
+	MinPasswordLength          uint     `json:"minpasswordlength"`
+	MinUsernameLength          uint     `json:"minusernamelength"`
+	MaxUsernameLength          uint     `json:"maxusernamelength"`
+	UsernameSupportedChars     []string `json:"usernamesupportedchars"`
+	ProposalListPageSize       uint     `json:"proposallistpagesize"`
+	MaxImages                  uint     `json:"maximages"`
+	MaxImageSize               uint     `json:"maximagesize"`
+	MaxMDs                     uint     `json:"maxmds"`
+	MaxMDSize                  uint     `json:"maxmdsize"`
+	ValidMIMETypes             []string `json:"validmimetypes"`
+	MinProposalNameLength      uint     `json:"minproposalnamelength"`
+	MaxProposalNameLength      uint     `json:"maxproposalnamelength"`
+	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
+	MaxCommentLength           uint     `json:"maxcommentlength"`
+	BackendPublicKey           string   `json:"backendpublickey"`
 }
 
 // NewComment sends a comment from a user to a specific proposal.  Note that

--- a/politeiawww/backend_proposal_test.go
+++ b/politeiawww/backend_proposal_test.go
@@ -342,13 +342,13 @@ func TestNewProposalPolicyRestrictions(t *testing.T) {
 	assertError(t, err, www.ErrorStatusMaxImageSizeExceededPolicy)
 
 	_, _, err = createNewProposalWithInvalidTitle(b, t, user, id)
-	assertErrorWithContext(t, err, www.ErrorStatusProposalInvalidTitle, []string{util.CreateProposalTitleRegex()})
+	assertErrorWithContext(t, err, www.ErrorStatusProposalInvalidTitle, []string{util.CreateProposalNameRegex()})
 
 	_, _, err = createNewProposalTitleSize(b, t, user, id, www.PolicyMaxProposalNameLength+1)
-	assertErrorWithContext(t, err, www.ErrorStatusProposalInvalidTitle, []string{util.CreateProposalTitleRegex()})
+	assertErrorWithContext(t, err, www.ErrorStatusProposalInvalidTitle, []string{util.CreateProposalNameRegex()})
 
 	_, _, err = createNewProposalTitleSize(b, t, user, id, www.PolicyMinProposalNameLength-1)
-	assertErrorWithContext(t, err, www.ErrorStatusProposalInvalidTitle, []string{util.CreateProposalTitleRegex()})
+	assertErrorWithContext(t, err, www.ErrorStatusProposalInvalidTitle, []string{util.CreateProposalNameRegex()})
 
 	_, _, err = createNewProposalWithDuplicateFiles(b, t, user, id)
 	assertErrorWithContext(t, err, www.ErrorStatusProposalDuplicateFilenames, []string{indexFile})

--- a/politeiawww/cmd/politeiawww_refclient/main.go
+++ b/politeiawww/cmd/politeiawww_refclient/main.go
@@ -173,7 +173,7 @@ func _main() error {
 		return err
 	}
 
-	b, err := util.Random(int(pr.PasswordMinChars))
+	b, err := util.Random(int(pr.MinPasswordLength))
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func _main() error {
 		return fmt.Errorf("/new should only be accessible by logged in users")
 	}
 
-	b, err = util.Random(int(pr.PasswordMinChars))
+	b, err = util.Random(int(pr.MinPasswordLength))
 	if err != nil {
 		return err
 	}

--- a/politeiawww/database/database.go
+++ b/politeiawww/database/database.go
@@ -58,6 +58,7 @@ func ActiveIdentityString(i []Identity) (string, bool) {
 type User struct {
 	ID                              uint64 // Unique id
 	Email                           string // Email address + lookup key.
+	Username                        string // Unique username
 	HashedPassword                  []byte // Blowfish hash
 	Admin                           bool   // Is user an admin
 	NewUserPaywallAddress           string // Address the user needs to send to
@@ -81,6 +82,8 @@ type User struct {
 type Database interface {
 	// User functions
 	UserGet(string) (*User, error)           // Return user record, key is email
+	UserGetByUsername(string) (*User, error) // Return user record given the username
+	UserGetById(uint64) (*User, error)       // Return user record given its id
 	UserNew(User) error                      // Add new user
 	UserUpdate(User) error                   // Update existing user
 	AllUsers(callbackFn func(u *User)) error // Iterate all users

--- a/politeiawww/inventory.go
+++ b/politeiawww/inventory.go
@@ -250,10 +250,12 @@ func (b *backend) getProposals(pr proposalsRequest) []www.ProposalRecord {
 		// Set the number of comments.
 		v.NumComments = uint(len(vv.comments))
 
-		// Look up and set the user id.
+		// Look up and set the user id and username.
 		var ok bool
 		v.UserId, ok = b.userPubkeys[v.PublicKey]
-		if !ok {
+		if ok {
+			v.Username = b.getUsernameById(v.UserId)
+		} else {
 			log.Infof("%v", spew.Sdump(b.userPubkeys))
 			log.Errorf("user not found for public key %v, for proposal %v",
 				v.PublicKey, v.CensorshipRecord.Token)

--- a/util/proposal.go
+++ b/util/proposal.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	validProposalName = regexp.MustCompile(CreateProposalTitleRegex())
+	validProposalName = regexp.MustCompile(CreateProposalNameRegex())
 )
 
 // ProposalName returns a proposal name
@@ -38,12 +38,12 @@ func IsValidProposalName(str string) bool {
 	return validProposalName.MatchString(str)
 }
 
-// CreateProposalTitleRegex returns a regex string for matching the proposal name
-func CreateProposalTitleRegex() string {
+// CreateProposalNameRegex returns a regex string for matching the proposal name
+func CreateProposalNameRegex() string {
 	var validProposalNameBuffer bytes.Buffer
 	validProposalNameBuffer.WriteString("^[")
 
-	for _, supportedChar := range www.PolicyProposalNameSupportedCharacters {
+	for _, supportedChar := range www.PolicyProposalNameSupportedChars {
 		if len(supportedChar) > 1 {
 			validProposalNameBuffer.WriteString(supportedChar)
 		} else {


### PR DESCRIPTION
This PR adds support for usernames, which are unique (case-insensitive). It adds a parameter to the `/user/new` route for supplying a username (required), and a `/user/username/change` route which allows an already-logged-in user to change his existing username by supplying his current password.

Unrelated to the usernames feature, this PR also adds a `-clearpaywall <email>` flag to `politeiawww_dbutil`.