### PR TITLE
[wwwcli] Add username functionality

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/README.md
+++ b/politeiawww/cmd/politeiawwwcli/README.md
@@ -5,6 +5,7 @@
 ## Available Commands
 ```
 changepassword     change the password for the currently logged in user
+changeusername     change the username for the currently logged in user
 getcomments        fetch a proposal's comments
 getproposal        fetch a proposal
 getunvetted        fetch unvetted proposals
@@ -34,10 +35,10 @@ verifyuserpayment  check if the user has paid their user registration fee
 ## Help Options
 `-h, --help  Show the help message`
 
-View a list of all commands  
+View a list of all commands
 `$ politeiawwwcli -h`
 
-View information about a specific command  
+View information about a specific command
 `$ politeiawwwcli <command> -h`
 
 ## Persisting Data Between Commands
@@ -47,22 +48,22 @@ View information about a specific command
 
 Create a new user and save the user's identity for future use.
 ```
-$ politeiawwwcli -j newuser email@example.com somepassword --save --verify --paywall
+$ politeiawwwcli -j newuser email@example.com username somepassword --save --verify --paywall
 
---save      save the user's identity for future use 
+--save      save the user's identity for future use
 --verify    verify the user's email address
 --paywall   use the testnet faucet to satisfy paywall requirement
 --random    generate a random email address and password
 ```
 
-You can now login with this user.  Session cookies are saved automatically.  
+You can now login with this user.  Session cookies are saved automatically.
 `$ politeiawwwcli login email@example.com somepassword`
 
-Once logged in, you can submit proposals or use any of the other commands that require you to be logged in or require a signature.  
+Once logged in, you can submit proposals or use any of the other commands that require you to be logged in or require a signature.
 `$ politeiawwwcli newproposal`
 
-If you decide to login with a different user, you can use the `updateuserkey` command to update the the user identity that is saved to `AppData/Politeiawww/cli`.  
-Note: This command uses the email as the private key so it should only be used for testing purposes.  
+If you decide to login with a different user, you can use the `updateuserkey` command to update the the user identity that is saved to `AppData/Politeiawww/cli`.
+Note: This command uses the email as the private key so it should only be used for testing purposes.
 ```
 $ politeiawwwcli login newUser@example.com somepassword
 $ politeiawwwcli updateuserkey

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -182,7 +182,7 @@ func idFromString(s string) (*identity.FullIdentity, error) {
 	return id, nil
 }
 
-func (c *Ctx) NewUser(email, password string) (string, *identity.FullIdentity,
+func (c *Ctx) NewUser(email, username, password string) (string, *identity.FullIdentity,
 	string, uint64, error) {
 	id, err := idFromString(email)
 	if err != nil {
@@ -190,6 +190,7 @@ func (c *Ctx) NewUser(email, password string) (string, *identity.FullIdentity,
 	}
 	u := v1.NewUser{
 		Email:     email,
+		Username:  username,
 		Password:  password,
 		PublicKey: hex.EncodeToString(id.Public.Key[:]),
 	}
@@ -263,6 +264,27 @@ func (c *Ctx) Secret() error {
 	return nil
 }
 
+func (c *Ctx) ChangeUsername(password, newUsername string) (
+	*v1.ChangeUsernameReply, error) {
+	cu := v1.ChangeUsername{
+		Password:    password,
+		NewUsername: newUsername,
+	}
+	responseBody, err := c.makeRequest("POST", v1.RouteChangeUsername, cu)
+	if err != nil {
+		return nil, err
+	}
+
+	var cur v1.ChangeUsernameReply
+	err = json.Unmarshal(responseBody, &cur)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal ChangeUsernameReply: %v",
+			err)
+	}
+
+	return &cur, nil
+}
+
 func (c *Ctx) ChangePassword(currentPassword, newPassword string) (
 	*v1.ChangePasswordReply, error) {
 	cp := v1.ChangePassword{
@@ -277,7 +299,7 @@ func (c *Ctx) ChangePassword(currentPassword, newPassword string) (
 	var cpr v1.ChangePasswordReply
 	err = json.Unmarshal(responseBody, &cpr)
 	if err != nil {
-		return nil, fmt.Errorf("Could not unmarshal "+"ChangePasswordReply: %v",
+		return nil, fmt.Errorf("Could not unmarshal ChangePasswordReply: %v",
 			err)
 	}
 

--- a/politeiawww/cmd/politeiawwwcli/commands/changepassword.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/changepassword.go
@@ -1,5 +1,9 @@
 package commands
 
+import (
+	"fmt"
+)
+
 type ChangepasswordCmd struct {
 	Args struct {
 		Password    string `positional-arg-name:"currentPassword"`
@@ -11,6 +15,11 @@ func (cmd *ChangepasswordCmd) Execute(args []string) error {
 	currPass := cmd.Args.Password
 	newPass := cmd.Args.Newpassword
 
-	_, err := Ctx.ChangePassword(currPass, newPass)
-	return err
+	cpr, err := Ctx.ChangePassword(currPass, newPass)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Response: %v", *cpr)
+	return nil
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/changeusername.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/changeusername.go
@@ -1,0 +1,16 @@
+package commands
+
+type ChangeusernameCmd struct {
+	Args struct {
+		Password    string `positional-arg-name:"password"`
+		Newusername string `positional-arg-name:"newusername"`
+	} `positional-args:"true" required:"true"`
+}
+
+func (cmd *ChangeusernameCmd) Execute(args []string) error {
+	password := cmd.Args.Password
+	newUsername := cmd.Args.Newusername
+
+	_, err := Ctx.ChangeUsername(password, newUsername)
+	return err
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
@@ -12,6 +12,7 @@ type Options struct {
 
 	// cli commands
 	ChangePassword    ChangepasswordCmd    `command:"changepassword" description:"change the password for the currently logged in user"`
+	ChangeUsername    ChangeusernameCmd    `command:"changeusername" description:"change the username for the currently logged in user"`
 	GetComments       GetcommentsCmd       `command:"getcomments" description:"fetch a proposal's comments"`
 	GetProposal       GetproposalCmd       `command:"getproposal" description:"fetch a proposal"`
 	GetUnvetted       GetunvettedCmd       `command:"getunvetted" description:"fetch unvetted proposals"`


### PR DESCRIPTION
This PR adds the username parameter to the `newuser` command as well as a new command `changeusername`.