### PR TITLE
[www] Return error when user email is already taken

### DIFF
--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -126,6 +126,7 @@ const (
 	ErrorStatusReviewerAdminEqualsAuthor   ErrorStatusT = 31
 	ErrorStatusMalformedUsername           ErrorStatusT = 32
 	ErrorStatusDuplicateUsername           ErrorStatusT = 33
+	ErrorStatusDuplicateEmail              ErrorStatusT = 34
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid     PropStatusT = 0 // Invalid status
@@ -192,6 +193,7 @@ var (
 		ErrorStatusReviewerAdminEqualsAuthor:   "user cannot change the status of his own proposal",
 		ErrorStatusMalformedUsername:           "malformed username",
 		ErrorStatusDuplicateUsername:           "duplicate username",
+		ErrorStatusDuplicateEmail:              "duplicate email",
 	}
 )
 

--- a/politeiawww/backend_user_test.go
+++ b/politeiawww/backend_user_test.go
@@ -173,16 +173,19 @@ func TestProcessNewUserWithInvalidPublicKey(t *testing.T) {
 	b.db.Close()
 }
 
-// Tests creating a new user with an existing token which still needs to be verified.
-func TestProcessNewUserWithUnverifiedToken(t *testing.T) {
+// Tests creating a new user with an already taken email
+func TestProcessNewUserWithEmailAlreadyTaken(t *testing.T) {
 	b := createBackend(t)
 
 	nu, _ := createNewUserCommandWithIdentity(t)
 	_, err := b.ProcessNewUser(nu)
 	assertSuccess(t, err)
 
-	_, err = b.ProcessNewUser(nu)
-	assertSuccess(t, err)
+	ou, _ := createNewUserCommandWithIdentity(t)
+	ou.Email = nu.Email
+
+	_, oerr := b.ProcessNewUser(nu)
+	assertError(t, oerr, www.ErrorStatusDuplicateEmail)
 
 	b.db.Close()
 }

--- a/politeiawww/backend_user_test.go
+++ b/politeiawww/backend_user_test.go
@@ -190,33 +190,6 @@ func TestProcessNewUserWithEmailAlreadyTaken(t *testing.T) {
 	b.db.Close()
 }
 
-// Tests creating a new user which has an expired token.
-func TestProcessNewUserWithExpiredToken(t *testing.T) {
-	b := createBackend(t)
-
-	b.verificationExpiryTime = time.Duration(100) * time.Nanosecond
-	const sleepTime = time.Duration(2) * time.Second
-
-	nu, _ := createNewUserCommandWithIdentity(t)
-	reply1, err := b.ProcessNewUser(nu)
-	assertSuccess(t, err)
-
-	// Sleep for a longer amount of time than it takes for the verification token to expire.
-	time.Sleep(sleepTime)
-
-	reply2, err := b.ProcessNewUser(nu)
-	assertSuccess(t, err)
-
-	if reply2.VerificationToken == "" {
-		t.Fatalf("ProcessNewUser did not return a verification token.")
-	}
-	if reply1.VerificationToken == reply2.VerificationToken {
-		t.Fatalf("ProcessNewUser did not return a new verification token.")
-	}
-
-	b.db.Close()
-}
-
 // Tests creating a new user with a malformed email.
 func TestProcessNewUserWithMalformedEmail(t *testing.T) {
 	b := createBackend(t)


### PR DESCRIPTION
closes #285 
I've removed the responsibility of checking for expired token from `processNewUser` method and I set it only treat signup policies instead such as returning an error for trying to signup with an already taken email. 
The responsibility of resending verification tokens will be moved to its own code once #287 gets fixed.