### PR TITLE
Minor UX fixes to the new identity flow

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -70,6 +70,7 @@ API.  It does not render HTML.
 - [`ErrorStatusReviewerAdminEqualsAuthor`](#ErrorStatusReviewerAdminEqualsAuthor)
 - [`ErrorStatusMalformedUsername`](#ErrorStatusMalformedUsername)
 - [`ErrorStatusDuplicateUsername`](#ErrorStatusDuplicateUsername)
+- [`ErrorStatusVerificationTokenUnexpired`](#ErrorStatusVerificationTokenUnexpired)
 
 **Proposal status codes**
 
@@ -435,6 +436,7 @@ Updates the user's active key pair.
 This call can return one of the following error codes:
 
 - [`ErrorStatusInvalidPublicKey`](#ErrorStatusInvalidPublicKey)
+- [`ErrorStatusVerificationTokenUnexpired`](#ErrorStatusVerificationTokenUnexpired)
 
 The email shall include a link in the following format:
 
@@ -1485,6 +1487,7 @@ Reply:
 | <a name="ErrorStatusReviewerAdminEqualsAuthor">ErrorStatusReviewerAdminEqualsAuthor</a> | 31 | The user cannot change the status of his own proposal. |
 | <a name="ErrorStatusMalformedUsername">ErrorStatusMalformedUsername</a> | 32 | The provided username was malformed. |
 | <a name="ErrorStatusDuplicateUsername">ErrorStatusDuplicateUsername</a> | 33 | The provided username was a duplicate of another username. |
+| <a name="ErrorStatusVerificationTokenUnexpired">ErrorStatusVerificationTokenUnexpired</a> | 34 | A verification token has already been generated and hasn't expired yet. |
 
 ### Proposal status codes
 

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -126,6 +126,7 @@ const (
 	ErrorStatusReviewerAdminEqualsAuthor   ErrorStatusT = 31
 	ErrorStatusMalformedUsername           ErrorStatusT = 32
 	ErrorStatusDuplicateUsername           ErrorStatusT = 33
+	ErrorStatusVerificationTokenUnexpired  ErrorStatusT = 34
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid     PropStatusT = 0 // Invalid status

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -362,7 +362,7 @@ func (b *backend) emailUpdateUserKeyVerificationLink(email, publicKey, token str
 		return err
 	}
 	from := "noreply@decred.org"
-	subject := "Set New Key Pair"
+	subject := "Verify Your New Identity"
 	body := buf.String()
 
 	msg := goemail.NewHTMLMessage(from, subject, body)
@@ -1062,8 +1062,14 @@ func (b *backend) ProcessUpdateUserKey(user *database.User, u www.UpdateUserKey)
 
 	// Check if the verification token hasn't expired yet.
 	if user.UpdateKeyVerificationToken != nil {
-		if currentTime := time.Now().Unix(); currentTime < user.UpdateKeyVerificationExpiry {
-			return &reply, nil
+		currentTime := time.Now().Unix()
+		if currentTime < user.UpdateKeyVerificationExpiry {
+			return nil, www.UserError{
+				ErrorCode: www.ErrorStatusVerificationTokenUnexpired,
+				ErrorContext: []string{
+					strconv.FormatInt(user.UpdateKeyVerificationExpiry, 10),
+				},
+			}
 		}
 	}
 

--- a/politeiawww/templates.go
+++ b/politeiawww/templates.go
@@ -8,20 +8,23 @@ const templateNewUserEmailRaw = `
 <div>Click the link below to verify your email and complete your registration:</div>
 <div style="margin: 20px 0 0 10px"><a href="{{.Link}}">{{.Link}}</a></div>
 <div style="margin-top: 20px">You are receiving this email because
-<span style="font-weight: bold">{{.Email}}</span> was used to register for Politeia.</div>
+<span style="font-weight: bold">{{.Email}}</span> was used to register for Politeia.
+If you did not perform this action, please ignore this email.</div>
 `
 
 const templateResetPasswordEmailRaw = `
 <div>Click the link below to continue resetting your password:</div>
 <div style="margin: 20px 0 0 10px"><a href="{{.Link}}">{{.Link}}</a></div>
 <div style="margin-top: 20px">You are receiving this email because a password reset
-was initiated for <span style="font-weight: bold">{{.Email}}</span> on Politeia.</div>
+was initiated for <span style="font-weight: bold">{{.Email}}</span> on Politeia.
+If you did not perform this action, please contact Politeia administrators.</div>
 `
 
 const templateUpdateUserKeyEmailRaw = `
-<div>Click the link below to continue setting a new key pair:</div>
+<div>Click the link below to verify your new identity:</div>
 <div style="margin: 20px 0 0 10px"><a href="{{.Link}}">{{.Link}}</a></div>
-<div style="margin-top: 20px">You are receiving this email because a new key pair
+<div style="margin-top: 20px">You are receiving this email because a new identity
 (public key: {{.PublicKey}}) was generated for
-<span style="font-weight: bold">{{.Email}}</span> on Politeia.</div>
+<span style="font-weight: bold">{{.Email}}</span> on Politeia. If you did not perform
+this action, please contact Politeia administrators.</div>
 `

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -180,7 +180,8 @@ func RespondWithError(w http.ResponseWriter, r *http.Request, userHttpCode int, 
 
 		util.RespondWithJSON(w, userHttpCode,
 			v1.ErrorReply{
-				ErrorCode: int64(userErr.ErrorCode),
+				ErrorCode:    int64(userErr.ErrorCode),
+				ErrorContext: userErr.ErrorContext,
 			})
 		return
 	}


### PR DESCRIPTION
This PR adds a new `ErrorStatusVerificationTokenUnexpired` error which allows us to inform the user when an email has already been generated, which is used for when a verification email is generated for generating a new identity.