### PR TITLE
[wwwcli] Add version command and persist CSRF token

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/README.md
+++ b/politeiawww/cmd/politeiawwwcli/README.md
@@ -24,6 +24,7 @@ updateuserkey      update the user identity saved to appDataDir
 userproposals      fetch all proposals submitted by a specific user
 verifyuser         verify user's email address
 verifyuserpayment  check if the user has paid their user registration fee
+version            fetch version info and CSRF token 
 ```
 
 ## Application Options
@@ -42,9 +43,14 @@ View information about a specific command
 `$ politeiawwwcli <command> -h`
 
 ## Persisting Data Between Commands
-`politeiawwwcli` stores  user identity data (user's public/private key pair) and session cookies in the `AppData/Politeiawww/cli/` directory.  This allows you to login with a user and remain logged in between commands.  The user identity data and cookies are segmented by host, allowing you to login and interact with multiple hosts simultaneously.
+`politeiawwwcli` stores  user identity data (user's public/private key pair), session cookies, and CSRF tokens in the `AppData/Politeiawww/cli/` directory.  This allows you to login with a user and remain logged in between commands.  The user identity data and cookies are segmented by host, allowing you to login and interact with multiple hosts simultaneously.
 
 ## Usage
+
+You need to first obtain a CSRF token from the Politeiawww server in order to interact with the API.  The `version` command fetches a CSRF token and saves it for future use.
+```
+$ politeiawwwcli version
+```
 
 Create a new user and save the user's identity for future use.
 ```

--- a/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
@@ -31,6 +31,7 @@ type Options struct {
 	UserProposals     UserproposalsCmd     `command:"userproposals" description:"fetch all proposals submitted by a specific user"`
 	VerifyUser        VerifyuserCmd        `command:"verifyuser" description:"verify user's email address"`
 	VerifyUserPayment VerifyuserpaymentCmd `command:"verifyuserpayment" description:"check if the user has paid their user registration fee"`
+	Version           VersionCmd           `command:"version" description:"fetch server info and CSRF token"`
 }
 
 // registers callbacks for cli flags

--- a/politeiawww/cmd/politeiawwwcli/commands/version.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/version.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"github.com/decred/politeia/politeiawww/cmd/politeiawwwcli/config"
+)
+
+type VersionCmd struct{}
+
+func (cmd *VersionCmd) Execute(args []string) error {
+	_, err := Ctx.Version()
+	if err != nil {
+		return err
+	}
+
+	// CSRF protection works via double-submit method. One token is stored in the
+	// cookie. A different token is sent via the header. Both tokens must be
+	// persisted between cli commands.
+
+	// persist CSRF header token
+	config.SaveCsrf(Ctx.Csrf())
+
+	// persist session cookie
+	ck, err := Ctx.Cookies(config.Host)
+	if err != nil {
+		return err
+	}
+	err = config.SaveCookies(ck)
+
+	return err
+}

--- a/politeiawww/cmd/politeiawwwcli/main.go
+++ b/politeiawww/cmd/politeiawwwcli/main.go
@@ -25,10 +25,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	// configure client to use any previously saved cookies
+	// configure client
 	if len(config.Cookies) != 0 {
 		commands.Ctx.SetCookies(config.Host, config.Cookies)
 	}
+	commands.Ctx.SetCsrf(config.CsrfToken)
 
 	// setup and run cli parser
 	commands.RegisterCallbacks()


### PR DESCRIPTION
Fixes #293.
The `version` command sends a GET request to `/version` and receives a response containing the server's version, route info, signing identity, and a CSRF token.  The CSRF cookie and header token are automatically stored for future use.