### PR TITLE
[www] Add usernames-by-id route.

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -33,6 +33,7 @@ API.  It does not render HTML.
 - [`Active votes`](#active-votes)
 - [`Cast votes`](#cast-votes)
 - [`Proposal votes`](#proposal-votes)
+- [`Usernames by id`](#usernames-by-id)
 
 **Error status codes**
 
@@ -1446,6 +1447,42 @@ Reply:
     "votebit":"2",
     "signature":"1f8b3c8207fa67d91a65d8742e5026044ccebd6b4865579a1f75d6e9a40a56f9a96e091397d2ec9f8fca773c68e961b93fe380a694aceecfd8f9b972f1e4d59db9"
   }]
+}
+```
+
+### `Usernames by id`
+
+Retrieve usernames given an array of user ids.
+
+**Route:** `POST /v1/usernames`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| userids | array of strings | User ids | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| usernames | array of strings  | Array of usernames, in the same order of the provided user ids |
+
+**Example**
+
+Request:
+
+``` json
+{
+  "userids": ["0"]
+}
+```
+
+Reply:
+
+```json
+{
+  "usernames": ["foobar"]
 }
 ```
 

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -43,6 +43,7 @@ const (
 	// XXX should we use a fancy route like the one underneath?
 	//RouteProposalVotes    = "/proposals/{token:[A-z0-9]{64}}/votes"
 	RouteProposalVotes = "/proposals/voteresults"
+	RouteUsernamesById = "/usernames"
 
 	// VerificationTokenSize is the size of verification token in bytes
 	VerificationTokenSize = 32
@@ -618,4 +619,15 @@ type ProposalVotes struct {
 type ProposalVotesReply struct {
 	Vote      decredplugin.Vote       `json:"vote"`      // Original vote
 	CastVotes []decredplugin.CastVote `json:"castvotes"` // Vote results
+}
+
+// UsernamesById is a command to fetch all usernames by their ids.
+type UsernamesById struct {
+	UserIds []string `json:"userids"`
+}
+
+// UsernamesByIdReply is a reply with all the usernames that correspond
+// to the given ids.
+type UsernamesByIdReply struct {
+	Usernames []string `json:"usernames"`
 }

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2029,6 +2029,31 @@ func (b *backend) ProcessProposalVotes(gpv *www.ProposalVotes) (*www.ProposalVot
 	}, nil
 }
 
+// ProcessUsernamesById returns the corresponding usernames for all given
+// user ids.
+func (b *backend) ProcessUsernamesById(ubi www.UsernamesById) *www.UsernamesByIdReply {
+	var usernames []string
+	for _, userIdStr := range ubi.UserIds {
+		userId, err := strconv.ParseUint(userIdStr, 10, 64)
+		if err != nil {
+			usernames = append(usernames, "")
+			continue
+		}
+
+		user, err := b.db.UserGetById(userId)
+		if err != nil {
+			usernames = append(usernames, "")
+			continue
+		}
+
+		usernames = append(usernames, user.Username)
+	}
+
+	return &www.UsernamesByIdReply{
+		Usernames: usernames,
+	}
+}
+
 // ProcessPolicy returns the details of Politeia's restrictions on file uploads.
 func (b *backend) ProcessPolicy(p www.Policy) *www.PolicyReply {
 	return &www.PolicyReply{

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -683,3 +683,22 @@ func (c *Ctx) VerifyUserPayment(txid string) (*v1.VerifyUserPaymentTxReply,
 
 	return &vr, nil
 }
+
+func (c *Ctx) UsernamesById(userIds []string) (*v1.UsernamesByIdReply, error) {
+	ubi := v1.UsernamesById{
+		UserIds: userIds,
+	}
+	responseBody, err := c.makeRequest("POST", v1.RouteUsernamesById, ubi)
+	if err != nil {
+		return nil, err
+	}
+
+	var ubir v1.UsernamesByIdReply
+	err = json.Unmarshal(responseBody, &ubir)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal UsernamesByIdReply: %v",
+			err)
+	}
+
+	return &ubir, nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
@@ -32,6 +32,7 @@ type Options struct {
 	VerifyUser        VerifyuserCmd        `command:"verifyuser" description:"verify user's email address"`
 	VerifyUserPayment VerifyuserpaymentCmd `command:"verifyuserpayment" description:"check if the user has paid their user registration fee"`
 	Version           VersionCmd           `command:"version" description:"fetch server info and CSRF token"`
+	UsernamesById     UsernamesbyidCmd     `command:"usernamesbyid" description:"fetch usernames by their user ids"`
 }
 
 // registers callbacks for cli flags

--- a/politeiawww/cmd/politeiawwwcli/commands/usernamesbyid.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/usernamesbyid.go
@@ -1,0 +1,13 @@
+package commands
+
+type UsernamesbyidCmd struct {
+	Args struct {
+		UserIds []string `positional-arg-name:"userids"`
+	} `positional-args:"true" required:"true"`
+}
+
+func (cmd *UsernamesbyidCmd) Execute(args []string) error {
+	userIds := cmd.Args.UserIds
+	_, err := Ctx.UsernamesById(userIds)
+	return err
+}

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -615,6 +615,23 @@ func (p *politeiawww) handleProposalDetails(w http.ResponseWriter, r *http.Reque
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
 
+func (p *politeiawww) handleUsernamesById(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleUsernamesById")
+
+	// Get the UsernamesById command.
+	var ubi v1.UsernamesById
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&ubi); err != nil {
+		RespondWithError(w, r, 0, "handleUsernamesById: unmarshal", v1.UserError{
+			ErrorCode: v1.ErrorStatusInvalidInput,
+		})
+		return
+	}
+
+	// Reply with the usernames.
+	util.RespondWithJSON(w, http.StatusOK, p.backend.ProcessUsernamesById(ubi))
+}
+
 func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 	// Get the policy command.
 	log.Tracef("handlePolicy")
@@ -1075,6 +1092,8 @@ func _main() error {
 		permissionPublic, true)
 	p.addRoute(http.MethodPost, v1.RouteProposalVotes,
 		p.handleProposalVotes, permissionPublic, true)
+	p.addRoute(http.MethodPost, v1.RouteUsernamesById, p.handleUsernamesById,
+		permissionPublic, false)
 
 	// Routes that require being logged in.
 	p.addRoute(http.MethodPost, v1.RouteSecret, p.handleSecret,


### PR DESCRIPTION
Because www does not send usernames with comments for a proposal details request, this PR adds a route which allows the client to fetch usernames given their user ids.