### PR TITLE
[wwwcli] Add --verbose flag and update --json flag

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/agl/ed25519"
 	"github.com/decred/politeia/decredplugin"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiawww/api/v1"
@@ -74,11 +73,19 @@ func (c *Ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 	}
 
 	fullRoute := config.Host + v1.PoliteiaWWWAPIRoute + route + queryParams
-	fmt.Printf("Request: %v %v\n", method,
-		v1.PoliteiaWWWAPIRoute+route+queryParams)
 
-	if config.PrintJson {
-		fmt.Println("  " + string(requestBody))
+	// if --verbose flag is used, print everything and pretty print json
+	// if --json flag is used, only print the raw json from req and resp bodies
+	// if neither flags are used, only print request method and route
+	if !config.PrintJSON {
+		fmt.Printf("Request: %v %v\n", method,
+			v1.PoliteiaWWWAPIRoute+route+queryParams)
+	}
+	if config.Verbose && method != http.MethodGet {
+		prettyPrintJSON(b)
+	}
+	if config.PrintJSON && method != http.MethodGet {
+		fmt.Printf("%v\n", string(requestBody))
 	}
 
 	req, err := http.NewRequest(method, fullRoute, bytes.NewReader(requestBody))
@@ -95,10 +102,6 @@ func (c *Ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 	}()
 
 	responseBody := util.ConvertBodyToByteArray(r.Body, false)
-
-	if config.PrintJson {
-		fmt.Printf("Response: %v %v\n\n", r.StatusCode, string(responseBody))
-	}
 	if r.StatusCode != http.StatusOK {
 		var ue v1.UserError
 		err = json.Unmarshal(responseBody, &ue)
@@ -108,6 +111,13 @@ func (c *Ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 		}
 
 		return nil, fmt.Errorf("%v", r.StatusCode)
+	}
+
+	if config.Verbose {
+		fmt.Printf("Response: %v\n", r.StatusCode)
+	}
+	if config.PrintJSON {
+		fmt.Printf("%v\n", string(responseBody))
 	}
 
 	return responseBody, nil
@@ -146,10 +156,10 @@ func (c *Ctx) Version() (*v1.VersionReply, error) {
 	}
 
 	fullRoute := config.Host + v1.PoliteiaWWWAPIRoute + v1.RouteVersion
-	fmt.Printf("Request: GET %v\n", v1.PoliteiaWWWAPIRoute+v1.RouteVersion)
 
-	if config.PrintJson {
-		fmt.Println("  " + string(requestBody))
+	// if --json flag is used, only print the raw json from req and resp bodies
+	if !config.PrintJSON {
+		fmt.Printf("Request: GET %v\n", v1.PoliteiaWWWAPIRoute+v1.RouteVersion)
 	}
 
 	// create new http request instead of using makeRequest() so that we can
@@ -169,9 +179,6 @@ func (c *Ctx) Version() (*v1.VersionReply, error) {
 
 	responseBody := util.ConvertBodyToByteArray(r.Body, false)
 
-	if config.PrintJson {
-		fmt.Println("Response: " + string(responseBody) + "\n")
-	}
 	if r.StatusCode != http.StatusOK {
 		var ue v1.UserError
 		err = json.Unmarshal(responseBody, &ue)
@@ -187,6 +194,14 @@ func (c *Ctx) Version() (*v1.VersionReply, error) {
 	err = json.Unmarshal(responseBody, &v)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal version: %v", err)
+	}
+
+	if config.Verbose {
+		fmt.Printf("Response: %v\n", r.StatusCode)
+		prettyPrintJSON(v)
+	}
+	if config.PrintJSON {
+		fmt.Printf("%v\n", string(responseBody))
 	}
 
 	// store CSRF tokens
@@ -213,6 +228,10 @@ func (c *Ctx) Login(email, password string) (*v1.LoginReply, error) {
 		return nil, fmt.Errorf("Could not unmarshal LoginReply: %v", err)
 	}
 
+	if config.Verbose {
+		prettyPrintJSON(lr)
+	}
+
 	return &lr, nil
 }
 
@@ -228,23 +247,11 @@ func (c *Ctx) Policy() (*v1.PolicyReply, error) {
 		return nil, fmt.Errorf("Could not unmarshal PolicyReply: %v", err)
 	}
 
-	return &pr, nil
-}
-
-func idFromString(s string) (*identity.FullIdentity, error) {
-	// super hack alert, we are going to use the email address as the
-	// privkey.  We do this in order to sign things as an admin later.
-	buf := [32]byte{}
-	copy(buf[:], []byte(s))
-	r := bytes.NewReader(buf[:])
-	pub, priv, err := ed25519.GenerateKey(r)
-	if err != nil {
-		return nil, err
+	if config.Verbose {
+		prettyPrintJSON(pr)
 	}
-	id := &identity.FullIdentity{}
-	copy(id.Public.Key[:], pub[:])
-	copy(id.PrivateKey[:], priv[:])
-	return id, nil
+
+	return &pr, nil
 }
 
 func (c *Ctx) NewUser(email, username, password string) (string, *identity.FullIdentity,
@@ -272,20 +279,11 @@ func (c *Ctx) NewUser(email, username, password string) (string, *identity.FullI
 			err)
 	}
 
-	return nur.VerificationToken, id, nur.PaywallAddress, nur.PaywallAmount, nil
-}
+	if config.Verbose {
+		prettyPrintJSON(nur)
+	}
 
-func checkNotLoggedInErr(response []byte) error {
-	var ue v1.UserError
-	err := json.Unmarshal(response, &ue)
-	if ue.ErrorCode == v1.ErrorStatusNotLoggedIn {
-		return fmt.Errorf("User not logged in: %v",
-			v1.ErrorStatusNotLoggedIn)
-	}
-	if err != nil {
-		return err
-	}
-	return nil
+	return nur.VerificationToken, id, nur.PaywallAddress, nur.PaywallAmount, nil
 }
 
 func (c *Ctx) VerifyNewUser(email, token, sig string) error {
@@ -301,15 +299,15 @@ func (c *Ctx) Me() (*v1.LoginReply, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = checkNotLoggedInErr(responseBody)
-	if err != nil {
-		return nil, err
-	}
 
 	var lr v1.LoginReply
 	err = json.Unmarshal(responseBody, &lr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal LoginReply: %v", err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(lr)
 	}
 
 	return &lr, nil
@@ -318,14 +316,17 @@ func (c *Ctx) Me() (*v1.LoginReply, error) {
 func (c *Ctx) Secret() error {
 	l := v1.Login{}
 	responseBody, err := c.makeRequest("POST", v1.RouteSecret, l)
+
 	var ue v1.UserError
 	json.Unmarshal(responseBody, &ue)
-	if ue.ErrorCode == v1.ErrorStatusNotLoggedIn {
-		return fmt.Errorf("User not logged in: %v", v1.ErrorStatusNotLoggedIn)
-	}
 	if err != nil {
 		return err
 	}
+
+	if config.Verbose {
+		prettyPrintJSON(ue)
+	}
+
 	return nil
 }
 
@@ -347,6 +348,10 @@ func (c *Ctx) ChangeUsername(password, newUsername string) (
 			err)
 	}
 
+	if config.Verbose {
+		prettyPrintJSON(cur)
+	}
+
 	return &cur, nil
 }
 
@@ -366,6 +371,10 @@ func (c *Ctx) ChangePassword(currentPassword, newPassword string) (
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal ChangePasswordReply: %v",
 			err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(cpr)
 	}
 
 	return &cpr, nil
@@ -397,6 +406,10 @@ func (c *Ctx) ResetPassword(email, password, newPassword string) error {
 	err = json.Unmarshal(responseBody, &rpr)
 	if err != nil {
 		return fmt.Errorf("Could not unmarshal ResetPasswordReply: %v", err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(rpr)
 	}
 
 	return nil
@@ -434,18 +447,17 @@ func (c *Ctx) NewProposal(id *identity.FullIdentity) (*v1.NewProposalReply, erro
 		return nil, err
 	}
 
-	err = checkNotLoggedInErr(responseBody)
-	if err != nil {
-		return nil, err
-	}
-
-	var vr v1.NewProposalReply
-	err = json.Unmarshal(responseBody, &vr)
+	var npr v1.NewProposalReply
+	err = json.Unmarshal(responseBody, &npr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal NewProposalReply: %v", err)
 	}
 
-	return &vr, nil
+	if config.Verbose {
+		prettyPrintJSON(npr)
+	}
+
+	return &npr, nil
 }
 
 func (c *Ctx) GetProp(token string) (*v1.ProposalDetailsReply, error) {
@@ -458,6 +470,10 @@ func (c *Ctx) GetProp(token string) (*v1.ProposalDetailsReply, error) {
 	err = json.Unmarshal(responseBody, &pr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal GetProposalReply: %v", err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(pr)
 	}
 
 	return &pr, nil
@@ -476,6 +492,10 @@ func (c *Ctx) ProposalsForUser(userId string) (*v1.UserProposalsReply, error) {
 	err = json.Unmarshal(responseBody, &upr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal UserProposalsReply: %v", err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(upr)
 	}
 
 	return &upr, nil
@@ -507,6 +527,10 @@ func (c *Ctx) SetPropStatus(id *identity.FullIdentity, token string,
 			"SetProposalStatusReply: %v", err)
 	}
 
+	if config.Verbose {
+		prettyPrintJSON(psr)
+	}
+
 	return &psr, nil
 }
 
@@ -520,6 +544,10 @@ func (c *Ctx) GetVetted(v v1.GetAllVetted) (*v1.GetAllVettedReply, error) {
 	err = json.Unmarshal(responseBody, &vr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal GetAllVettedReply: %v", err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(vr)
 	}
 
 	return &vr, nil
@@ -536,6 +564,10 @@ func (c *Ctx) GetUnvetted(u v1.GetAllUnvetted) (*v1.GetAllUnvettedReply,
 	err = json.Unmarshal(responseBody, &ur)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal GetAllUnvettedReply: %v", err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(ur)
 	}
 
 	return &ur, nil
@@ -566,6 +598,10 @@ func (c *Ctx) Comment(id *identity.FullIdentity, token, comment,
 		return nil, fmt.Errorf("Could not unmarshal CommentReply: %v", err)
 	}
 
+	if config.Verbose {
+		prettyPrintJSON(cr)
+	}
+
 	return &cr, nil
 }
 
@@ -580,6 +616,10 @@ func (c *Ctx) CommentGet(token string) (*v1.GetCommentsReply, error) {
 	err = json.Unmarshal(responseBody, &gcr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal GetCommentReply: %v", err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(gcr)
 	}
 
 	return &gcr, nil
@@ -621,6 +661,10 @@ func (c *Ctx) StartVote(id *identity.FullIdentity, token string) (
 		return nil, fmt.Errorf("Could not unmarshal StartVoteReply: %v", err)
 	}
 
+	if config.Verbose {
+		prettyPrintJSON(svr)
+	}
+
 	return &svr, nil
 }
 
@@ -643,6 +687,10 @@ func (c *Ctx) CreateNewKey(email string) (*identity.FullIdentity, error) {
 		return nil, fmt.Errorf("Could not unmarshal UpdateUserKeyReply: %v", err)
 	}
 
+	if config.Verbose {
+		prettyPrintJSON(uukr)
+	}
+
 	sig := id.SignMessage([]byte(uukr.VerificationToken))
 	vuuk := v1.VerifyUpdateUserKey{
 		VerificationToken: uukr.VerificationToken,
@@ -659,6 +707,10 @@ func (c *Ctx) CreateNewKey(email string) (*identity.FullIdentity, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal VerifyUpdateUserKeyReply: %v",
 			err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(vuukr)
 	}
 
 	return id, nil
@@ -679,6 +731,10 @@ func (c *Ctx) VerifyUserPaymentTx(txid string) (*v1.VerifyUserPaymentTxReply,
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal VerifyUserPaymentTxReply: %v",
 			err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(vr)
 	}
 
 	return &vr, nil

--- a/politeiawww/cmd/politeiawwwcli/client/util.go
+++ b/politeiawww/cmd/politeiawwwcli/client/util.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/agl/ed25519"
+	"github.com/decred/politeia/politeiad/api/v1/identity"
+)
+
+func idFromString(s string) (*identity.FullIdentity, error) {
+	// super hack alert, we are going to use the email address as the
+	// privkey.  We do this in order to sign things as an admin later.
+	buf := [32]byte{}
+	copy(buf[:], []byte(s))
+	r := bytes.NewReader(buf[:])
+	pub, priv, err := ed25519.GenerateKey(r)
+	if err != nil {
+		return nil, err
+	}
+	id := &identity.FullIdentity{}
+	copy(id.Public.Key[:], pub[:])
+	copy(id.PrivateKey[:], priv[:])
+	return id, nil
+}
+
+func prettyPrintJSON(v interface{}) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Could not marshal JSON: %v\n", err)
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", b)
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/changepassword.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/changepassword.go
@@ -1,9 +1,5 @@
 package commands
 
-import (
-	"fmt"
-)
-
 type ChangepasswordCmd struct {
 	Args struct {
 		Password    string `positional-arg-name:"currentPassword"`
@@ -15,11 +11,6 @@ func (cmd *ChangepasswordCmd) Execute(args []string) error {
 	currPass := cmd.Args.Password
 	newPass := cmd.Args.Newpassword
 
-	cpr, err := Ctx.ChangePassword(currPass, newPass)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Response: %v", *cpr)
-	return nil
+	_, err := Ctx.ChangePassword(currPass, newPass)
+	return err
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
@@ -7,8 +7,9 @@ import (
 
 type Options struct {
 	// cli flags
-	Host func(string) error `long:"host" description:"politeiawww host"`
-	Json func()             `short:"j" long:"json" description:"Print JSON"`
+	Host    func(string) error `long:"host" description:"politeiawww host"`
+	Json    func()             `short:"j" long:"json" description:"Print JSON"`
+	Verbose func()             `short:"v" long:"verbose" description:"Print request and response details"`
 
 	// cli commands
 	ChangePassword    ChangepasswordCmd    `command:"changepassword" description:"change the password for the currently logged in user"`
@@ -47,7 +48,11 @@ func RegisterCallbacks() {
 	}
 
 	Opts.Json = func() {
-		config.PrintJson = true
+		config.PrintJSON = true
+	}
+
+	Opts.Verbose = func() {
+		config.Verbose = true
 	}
 }
 

--- a/politeiawww/cmd/politeiawwwcli/commands/updateuserkey.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/updateuserkey.go
@@ -23,7 +23,9 @@ func (cmd *UpdateuserkeyCmd) Execute(args []string) error {
 
 	// save user identity to HomeDir
 	id.Save(config.UserIdentityFile)
-	fmt.Printf("User identity saved to: %v\n", config.UserIdentityFile)
+	if config.Verbose {
+		fmt.Printf("User identity saved to: %v\n", config.UserIdentityFile)
+	}
 
 	return nil
 }

--- a/politeiawww/cmd/politeiawwwcli/config/config.go
+++ b/politeiawww/cmd/politeiawwwcli/config/config.go
@@ -32,10 +32,12 @@ var (
 	cookieFile       string
 	csrfFile         string
 	CsrfToken        string
-	PrintJson        bool
+	PrintJSON        bool
 	UserIdentityFile string
-	UserIdentity     *identity.FullIdentity
-	Cookies          []*http.Cookie
+	Verbose          bool
+
+	Cookies      []*http.Cookie
+	UserIdentity *identity.FullIdentity
 )
 
 func stringToHash(s string) string {
@@ -167,7 +169,11 @@ func SaveCookies(cookies []*http.Cookie) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Cookies saved to: %v\n", cookieFile)
+
+	if Verbose {
+		fmt.Printf("Cookies saved to: %v\n", cookieFile)
+	}
+
 	return nil
 }
 
@@ -191,7 +197,11 @@ func SaveCsrf(csrf string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("CSRF token saved to: %v\n", csrfFile)
+
+	if Verbose {
+		fmt.Printf("CSRF token saved to: %v\n", csrfFile)
+	}
+
 	return nil
 }
 

--- a/politeiawww/cmd/politeiawwwtest/main.go
+++ b/politeiawww/cmd/politeiawwwtest/main.go
@@ -29,7 +29,7 @@ type Options struct {
 	Admin         AdminOptions `group:"Admin Options"`
 	Host          string       `long:"host" short:"h" default:"https://127.0.0.1:4443" description:"Host"`
 	OverrideToken string       `long:"overridetoken" short:"o" description:"Override token for faucet"`
-	PrintJson     bool         `long:"json" short:"j" description:"Print JSON"`
+	Json          bool         `long:"json" short:"j" description:"Print JSON"`
 	SkipPaywall   bool         `long:"skip-paywall" short:"s" description:"Don't wait for paywall confirmations during test run"`
 	Vote          bool         `long:"vote" short:"v" description:"Run vote routes"`
 }
@@ -122,7 +122,7 @@ func main() {
 
 	// Setup CLI options
 	config.Host = opts.Host
-	config.PrintJson = opts.PrintJson
+	config.PrintJSON = opts.Json
 
 	// Exit if admin email is given without password or vise versa
 	if opts.Admin.Email != "" || opts.Admin.Password != "" {


### PR DESCRIPTION
Fixes #296 

This PR adds a `--verbose` flag to `politeiawwwcli` and updates the `--json` flag.  The new printing functionality is as follows:

No flags - print request method and route.
```
$ politeiawwwcli login 4d5ae35feee0ed43@example.com 4d5ae35feee0ed43
Request: POST /v1/login
```

Verbose flag `--verbose, -v`
Print request method and route, pretty print request body, print response status code, pretty print response body, and print a message when a cookie or identity is saved to the filesystem.
```
$ politeiawwwcli login -v 4d5ae35feee0ed43@example.com 4d5ae35feee0ed43
Request: POST /v1/login
{
  "email": "4d5ae35feee0ed43@example.com",
  "password": "4d5ae35feee0ed43"
}
Response: 200
{
  "isadmin": true,
  "userid": "0",
  "email": "4d5ae35feee0ed43@example.com",
  "username": "4d5ae35feee0ed43",
  "publickey": "6cf7d7d721e0d8e3d6e26d929592332dbf4103313d3b10ad5c110d0f218f4693",
  "paywalladdress": "",
  "paywallamount": 0,
  "paywalltxnotbefore": 1527178185
}
Cookies saved to: /Users/luke/Library/Application Support/Politeiawww/cli/cookie_3078956250.json
```

JSON flag `--json, -j`
Print only the raw JSON of request and response bodies.
```
$ politeiawwwcli login -j 4d5ae35feee0ed43@example.com 4d5ae35feee0ed43
{"email":"4d5ae35feee0ed43@example.com","password":"4d5ae35feee0ed43"}
{"isadmin":true,"userid":"0","email":"4d5ae35feee0ed43@example.com","username":"4d5ae35feee0ed43","publickey":"6cf7d7d721e0d8e3d6e26d929592332dbf4103313d3b10ad5c110d0f218f4693","paywalladdress":"","paywallamount":0,"paywalltxnotbefore":1527178185}
```