### PR TITLE
Add a command for loading basic data.

### DIFF
--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -1163,6 +1163,7 @@ func (b *backend) ProcessVerifyUpdateUserKey(user *database.User, vu www.VerifyU
 		}
 	}
 	user.Identities[len(user.Identities)-1].Activated = t
+	user.Identities[len(user.Identities)-1].Deactivated = 0
 
 	return user, b.db.UserUpdate(*user)
 }

--- a/politeiawww/cmd/politeiawww_dataload/README.md
+++ b/politeiawww/cmd/politeiawww_dataload/README.md
@@ -1,0 +1,46 @@
+# politeiawww_dataload
+
+`politeiawww_dataload` is a tool that loads basic data into Politeia to help
+speed up full end-to-end testing. It will automatically start and stop
+`politeiad` and `politeiawww`, and utilize the `politeiawww_dbutil` and
+`politeiawwwcli` tools to create the following:
+
+* Admin user
+* Regular paid user
+* Regular unpaid user
+* A proposal for each state (public, censored, etc)
+* A couple comments on the public proposal
+
+Because it starts and stops `politeiad` and `politeiawww` automatically, you
+will need to ensure that those servers are shut down before running this tool.
+It will run the servers with some fixed configuration, although some default
+configuration is required, so you should have `politeiad.conf` and `politeiawww.conf`
+already set up.
+
+## Usage
+
+This tool doesn't require any arguments, but you can specify the following options:
+
+```
+     --adminemail   admin email address
+     --adminuser    admin username
+     --adminpass    admin password
+     --paidemail    paid user email address
+     --paiduser     paid user username
+     --paidpass     paid user password
+     --unpaidemail  unpaid user email address
+     --unpaiduser   unpaid user username
+     --unpaidpass   unpaid user password
+     --deletedata   before loading the data, delete all existing data
+     --debuglevel   the debug level to set when starting politeiad and politeiawww
+                    server; the servers' log output is stored in the data directory
+     --datadir      specify a different directory to store log files
+     --configfile   specify a different .conf file for config options
+ -v, --verbose      verbose output
+```
+
+Example:
+
+```
+politeiawww_dataload --verbose
+```

--- a/politeiawww/cmd/politeiawww_dataload/config.go
+++ b/politeiawww/cmd/politeiawww_dataload/config.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2015-2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	flags "github.com/btcsuite/go-flags"
+	"github.com/decred/politeia/politeiawww/sharedconfig"
+)
+
+const (
+	defaultDataDirname            = "dataload"
+	defaultConfigFilename         = "politeiawww_dataload.conf"
+	defaultPoliteiadLogFilename   = "politeiad.log"
+	defaultPoliteiawwwLogFilename = "politeiawww.log"
+	defaultLogLevel               = "info"
+)
+
+var (
+	defaultDataDir    = filepath.Join(sharedconfig.DefaultHomeDir, defaultDataDirname)
+	defaultConfigFile = filepath.Join(defaultDataDir, defaultConfigFilename)
+)
+
+// config defines the configuration options for politeiawww_dataload.
+//
+// See loadConfig for details on the configuration load process.
+type config struct {
+	AdminEmail         string `long:"adminemail" description:"Admin user email address"`
+	AdminUser          string `long:"adminuser" description:"Admin username"`
+	AdminPass          string `long:"adminpass" description:"Admin password"`
+	PaidEmail          string `long:"paidemail" description:"Regular paid user email address"`
+	PaidUser           string `long:"paiduser" description:"Regular paid user username"`
+	PaidPass           string `long:"paidpass" description:"Regular paid user password"`
+	UnpaidEmail        string `long:"unpaidemail" description:"Regular unpaid user email address"`
+	UnpaidUser         string `long:"unpaiduser" description:"Regular unpaid user username"`
+	UnpaidPass         string `long:"unpaidpass" description:"Regular unpaid user password"`
+	Verbose            bool   `short:"v" long:"verbose" description:"Verbose output"`
+	DataDir            string `long:"datadir" description:"Path to config/data directory"`
+	ConfigFile         string `long:"configfile" description:"Path to configuration file"`
+	DebugLevel         string `long:"debuglevel" description:"Logging level to use for servers {trace, debug, info, warn, error, critical}"`
+	DeleteData         bool   `long:"deletedata" description:"Delete all existing data from politeiad and politeiawww before loading data"`
+	PoliteiadLogFile   string
+	PoliteiawwwLogFile string
+}
+
+// cleanAndExpandPath expands environment variables and leading ~ in the
+// passed path, cleans the result, and returns it.
+func cleanAndExpandPath(path string) string {
+	// Expand initial ~ to OS specific home directory.
+	if strings.HasPrefix(path, "~") {
+		homeDir := filepath.Dir(sharedconfig.DefaultHomeDir)
+		path = strings.Replace(path, "~", homeDir, 1)
+	}
+
+	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
+	// but they variables can still be expanded via POSIX-style $VARIABLE.
+	return filepath.Clean(os.ExpandEnv(path))
+}
+
+// filesExists reports whether the named file or directory exists.
+func fileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
+// newConfigParser returns a new command line flags parser.
+func newConfigParser(cfg *config, options flags.Options) *flags.Parser {
+	return flags.NewParser(cfg, options)
+}
+
+// loadConfig initializes and parses the config using a config file and command
+// line options.
+//
+// The configuration proceeds as follows:
+// 	1) Start with a default config with sane settings
+// 	2) Pre-parse the command line to check for an alternative config file
+// 	3) Load configuration file overwriting defaults with any specified options
+// 	4) Parse CLI options and overwrite/add any specified options
+//
+// The above results in rpc functioning properly without any config settings
+// while still allowing the user to override settings with config files and
+// command line options.  Command line options always take precedence.
+func loadConfig() (*config, error) {
+	// Default config.
+	cfg := config{
+		AdminEmail:  "admin@example.com",
+		AdminUser:   "admin",
+		AdminPass:   "password",
+		PaidEmail:   "paid_user@example.com",
+		PaidUser:    "paid_user",
+		PaidPass:    "password",
+		UnpaidEmail: "unpaid_user@example.com",
+		UnpaidUser:  "unpaid_user",
+		UnpaidPass:  "password",
+		DeleteData:  false,
+		Verbose:     false,
+		DataDir:     defaultDataDir,
+		ConfigFile:  defaultConfigFile,
+		DebugLevel:  defaultLogLevel,
+	}
+
+	// Pre-parse the command line options to see if an alternative config
+	// file or the version flag was specified.  Any errors aside from the
+	// help message error can be ignored here since they will be caught by
+	// the final parse below.
+	preCfg := cfg
+	preParser := newConfigParser(&preCfg, flags.HelpFlag)
+	_, err := preParser.Parse()
+	if err != nil {
+		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
+			fmt.Fprintln(os.Stderr, err)
+			return nil, err
+		}
+	}
+
+	// Show the version and exit if the version flag was specified.
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
+
+	// Update the data directory if specified. Since the data directory
+	// is updated, other variables need to be updated to reflect the new changes.
+	if preCfg.DataDir != "" {
+		cfg.DataDir, _ = filepath.Abs(preCfg.DataDir)
+
+		if preCfg.ConfigFile == defaultConfigFile {
+			cfg.ConfigFile = filepath.Join(cfg.DataDir, defaultConfigFilename)
+		} else {
+			cfg.ConfigFile = cleanAndExpandPath(preCfg.ConfigFile)
+		}
+	}
+
+	// Load additional config from file.
+	var configFileError error
+	parser := newConfigParser(&cfg, flags.Default)
+	err = flags.NewIniParser(parser).ParseFile(cfg.ConfigFile)
+	if err != nil {
+		if _, ok := err.(*os.PathError); !ok {
+			fmt.Fprintf(os.Stderr, "Error parsing config "+
+				"file: %v\n", err)
+			fmt.Fprintln(os.Stderr, usageMessage)
+			return nil, err
+		}
+		configFileError = err
+	}
+
+	// Parse command line options again to ensure they take precedence.
+	_, err = parser.Parse()
+	if err != nil {
+		if e, ok := err.(*flags.Error); !ok || e.Type != flags.ErrHelp {
+			fmt.Fprintln(os.Stderr, usageMessage)
+		}
+		return nil, err
+	}
+
+	// Create the data directory if it doesn't already exist.
+	funcName := "loadConfig"
+	err = os.MkdirAll(cfg.DataDir, 0700)
+	if err != nil {
+		// Show a nicer error message if it's because a symlink is
+		// linked to a directory that does not exist (probably because
+		// it's not mounted).
+		if e, ok := err.(*os.PathError); ok && os.IsExist(err) {
+			if link, lerr := os.Readlink(e.Path); lerr == nil {
+				str := "is symlink %s -> %s mounted?"
+				err = fmt.Errorf(str, e.Path, link)
+			}
+		}
+
+		str := "%s: Failed to create data directory: %v"
+		err := fmt.Errorf(str, funcName, err)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+
+	if configFileError != nil {
+		fmt.Printf("WARNING: %v\n", configFileError)
+	}
+
+	cfg.PoliteiadLogFile = filepath.Join(cfg.DataDir,
+		defaultPoliteiadLogFilename)
+	cfg.PoliteiawwwLogFile = filepath.Join(cfg.DataDir,
+		defaultPoliteiawwwLogFilename)
+
+	return &cfg, nil
+}

--- a/politeiawww/cmd/politeiawww_dataload/main.go
+++ b/politeiawww/cmd/politeiawww_dataload/main.go
@@ -1,0 +1,535 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"github.com/decred/dcrd/dcrutil"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/decred/politeia/politeiawww/api/v1"
+	cliconfig "github.com/decred/politeia/politeiawww/cmd/politeiawwwcli/config"
+	wwwconfig "github.com/decred/politeia/politeiawww/sharedconfig"
+)
+
+type beforeVerifyReply func() interface{}
+type verifyReply func() bool
+
+const (
+	cli    = "politeiawwwcli"
+	dbutil = "politeiawww_dbutil"
+)
+
+var (
+	cfg            *config
+	politeiadCmd   *exec.Cmd
+	politeiawwwCmd *exec.Cmd
+)
+
+func executeCommand(args ...string) *exec.Cmd {
+	if cfg.Verbose {
+		fmt.Printf("  $ %v\n", strings.Join(args, " "))
+	}
+	return exec.Command(args[0], args[1:]...)
+}
+
+func createPoliteiawwCmd(paywall bool) *exec.Cmd {
+	var paywallXPub string
+	var paywallAmount uint64
+	if paywall {
+		paywallXPub = "tpubVobLtToNtTq6TZNw4raWQok35PRPZou53vegZqNubtBTJMMFmuMpWybFCfweJ52N8uZJPZZdHE5SRnBBuuRPfC5jdNstfKjiAs8JtbYG9jx"
+		paywallAmount = 10000000
+	}
+
+	return executeCommand(
+		"politeiawww",
+		"--testnet",
+		"--paywallxpub", paywallXPub,
+		"--paywallamount", strconv.FormatUint(paywallAmount, 10),
+		"--mailhost", "",
+		"--mailuser", "",
+		"--mailpass", "",
+		"--webserveraddress", "",
+		"--debuglevel", cfg.DebugLevel)
+}
+
+func createLogFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+	/*
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = file.Write([]byte("------------------------------------------------------\n"))
+		return file, err
+	*/
+}
+
+func waitForStartOfDay(out io.Reader) {
+	buf := bufio.NewScanner(out)
+	for buf.Scan() {
+		text := buf.Text()
+		if strings.Contains(text, "Start of day") {
+			return
+		}
+	}
+}
+
+func startAndStopPoliteiawww() error {
+	fmt.Printf("Starting politeiawww\n")
+	cmd := createPoliteiawwCmd(false)
+	out, _ := cmd.StdoutPipe()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	defer cmd.Wait()
+
+	logFile, err := createLogFile(cfg.PoliteiawwwLogFile)
+	if err != nil {
+		return err
+	}
+
+	reader := io.TeeReader(out, logFile)
+	waitForStartOfDay(reader)
+
+	fmt.Printf("Stopping politeiawww\n")
+	return cmd.Process.Kill()
+}
+
+func startPoliteiawww(paywall bool) error {
+	fmt.Printf("Starting politeiawww\n")
+	politeiawwwCmd = createPoliteiawwCmd(paywall)
+	out, _ := politeiawwwCmd.StdoutPipe()
+	if err := politeiawwwCmd.Start(); err != nil {
+		politeiawwwCmd = nil
+		return err
+	}
+
+	logFile, err := createLogFile(cfg.PoliteiawwwLogFile)
+	if err != nil {
+		return err
+	}
+
+	reader := io.TeeReader(out, logFile)
+	waitForStartOfDay(reader)
+	go io.Copy(logFile, out)
+	return nil
+}
+
+func startPoliteiad() error {
+	fmt.Printf("Starting politeiad\n")
+	politeiadCmd = executeCommand("politeiad", "--testnet")
+	out, _ := politeiadCmd.StdoutPipe()
+	if err := politeiadCmd.Start(); err != nil {
+		politeiadCmd = nil
+		return err
+	}
+
+	logFile, err := createLogFile(cfg.PoliteiadLogFile)
+	if err != nil {
+		return err
+	}
+
+	reader := io.TeeReader(out, logFile)
+	waitForStartOfDay(reader)
+	return nil
+}
+
+func getVersionFromPoliteiawww() error {
+	fmt.Printf("Getting version\n")
+
+	var vr *v1.VersionReply
+	return executeCliCommand(
+		func() interface{} {
+			vr = &v1.VersionReply{}
+			return vr
+		},
+		func() bool {
+			return vr.PubKey != ""
+		},
+		"version",
+	)
+}
+
+func createUserWithDbutil(email, username, password string) error {
+	fmt.Printf("Creating user: %v\n", email)
+
+	cmd := executeCommand(
+		dbutil,
+		"-testnet",
+		"-newuser",
+		email,
+		username,
+		password)
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+	return cmd.Wait()
+}
+
+func createUserWithPoliteiawww(email, username, password string) error {
+	fmt.Printf("Creating user: %v\n", email)
+
+	var nur *v1.NewUserReply
+	receivedNewUserReply := new(bool)
+	return executeCliCommand(
+		func() interface{} {
+			nur = &v1.NewUserReply{}
+			return nur
+		},
+		func() bool {
+			if *receivedNewUserReply && nur.VerificationToken == "" {
+				return true
+			}
+
+			if !*receivedNewUserReply && nur.VerificationToken != "" {
+				*receivedNewUserReply = true
+			}
+
+			return false
+		},
+		"newuser",
+		email,
+		username,
+		password,
+		"--verify",
+	)
+}
+
+func setAdmin(email string) error {
+	fmt.Printf("Elevating user to admin: %v\n", email)
+	cmd := executeCommand(
+		dbutil,
+		"-testnet",
+		"-setadmin",
+		email,
+		"true")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Wait()
+}
+
+func createPaidUsers() error {
+	if err := createUserWithDbutil(cfg.AdminEmail, cfg.AdminUser, cfg.AdminPass); err != nil {
+		return err
+	}
+	if err := setAdmin(cfg.AdminEmail); err != nil {
+		return err
+	}
+	return createUserWithDbutil(cfg.PaidEmail, cfg.PaidUser, cfg.PaidPass)
+}
+
+func createUnpaidUsers() error {
+	return createUserWithPoliteiawww(cfg.UnpaidEmail, cfg.UnpaidUser, cfg.UnpaidPass)
+}
+
+func executeCliCommand(beforeVerify beforeVerifyReply, verify verifyReply, args ...string) error {
+	fullArgs := make([]string, 0, len(args)+2)
+	fullArgs = append(fullArgs, cli)
+	fullArgs = append(fullArgs, "--json")
+	fullArgs = append(fullArgs, args...)
+	cmd := executeCommand(fullArgs...)
+
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	defer cmd.Wait()
+
+	var allText string
+	buf := bufio.NewScanner(stdout)
+	for buf.Scan() {
+		text := buf.Text()
+
+		var lines []string
+		if strings.Contains(text, "\n") {
+			lines = strings.Split(text, "\n")
+		} else {
+			lines = append(lines, text)
+		}
+
+		for _, line := range lines {
+			if cfg.Verbose {
+				fmt.Printf("  %v\n", line)
+			}
+
+			var er v1.ErrorReply
+			err := json.Unmarshal([]byte(line), &er)
+			if err == nil && er.ErrorCode != int64(v1.ErrorStatusInvalid) {
+				return fmt.Errorf("error returned from %v: %v %v", cli,
+					er.ErrorCode, er.ErrorContext)
+			}
+
+			reply := beforeVerify()
+			err = json.Unmarshal([]byte(line), reply)
+			if err == nil && verify() {
+				return nil
+			}
+
+			allText += line + "\n"
+		}
+	}
+
+	if err := buf.Err(); err != nil {
+		return err
+	}
+
+	errBytes, err := ioutil.ReadAll(stderr)
+	if err != nil {
+		return err
+	}
+
+	if len(errBytes) > 0 {
+		return fmt.Errorf("unexpected error output from %v: %v", cli,
+			string(errBytes))
+	}
+
+	return fmt.Errorf("unexpected output from %v: %v", cli, allText)
+}
+
+func createProposal() (string, error) {
+	fmt.Printf("Creating proposal\n")
+
+	var npr *v1.NewProposalReply
+	err := executeCliCommand(
+		func() interface{} {
+			npr = &v1.NewProposalReply{}
+			return npr
+		},
+		func() bool {
+			return npr.CensorshipRecord.Token != ""
+		},
+		"newproposal",
+	)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Printf("Created proposal with token %v\n", npr.CensorshipRecord.Token)
+	return npr.CensorshipRecord.Token, nil
+}
+
+func createComment(parentID, token string) (string, error) {
+	fmt.Printf("Creating comment\n")
+
+	var ncr *v1.NewCommentReply
+	err := executeCliCommand(
+		func() interface{} {
+			ncr = &v1.NewCommentReply{}
+			return ncr
+		},
+		func() bool {
+			return ncr.Comment.CommentID != ""
+		},
+		"newcomment",
+		token,
+		"This is a comment",
+		parentID)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Printf("Created comment with id %v\n", ncr.Comment.CommentID)
+	return ncr.Comment.CommentID, nil
+}
+
+func setProposalStatus(token string, status v1.PropStatusT) error {
+	fmt.Printf("Setting proposal status to %v\n", status)
+
+	var spsr *v1.SetProposalStatusReply
+	return executeCliCommand(
+		func() interface{} {
+			spsr = &v1.SetProposalStatusReply{}
+			return spsr
+		},
+		func() bool {
+			return spsr.Proposal.Status != v1.PropStatusInvalid
+		},
+		"setproposalstatus",
+		token,
+		strconv.FormatInt(int64(status), 10))
+}
+
+func createProposals() error {
+	// Create the proposals.
+	if err := login(cfg.PaidEmail, cfg.PaidPass); err != nil {
+		return err
+	}
+	publishedProposalToken, err := createProposal()
+	if err != nil {
+		return err
+	}
+	censoredProposalToken, err := createProposal()
+	if err != nil {
+		return err
+	}
+	if _, err := createProposal(); err != nil {
+		return err
+	}
+
+	// Set the proposals' status.
+	if err := login(cfg.AdminEmail, cfg.AdminPass); err != nil {
+		return err
+	}
+	if err := setProposalStatus(publishedProposalToken, v1.PropStatusPublic); err != nil {
+		return err
+	}
+	if err := setProposalStatus(censoredProposalToken, v1.PropStatusCensored); err != nil {
+		return err
+	}
+	if err := logout(); err != nil {
+		return err
+	}
+
+	// Create comments on the published proposal.
+	if err := login(cfg.AdminEmail, cfg.AdminPass); err != nil {
+		return err
+	}
+	commentID, err := createComment("", publishedProposalToken)
+	if err != nil {
+		return err
+	}
+	if err := logout(); err != nil {
+		return err
+	}
+
+	if err := login(cfg.PaidEmail, cfg.PaidPass); err != nil {
+		return err
+	}
+	if _, err := createComment(commentID, publishedProposalToken); err != nil {
+		return err
+	}
+	return logout()
+}
+
+func login(email, password string) error {
+	fmt.Printf("Logging in as: %v\n", email)
+	cmd := executeCommand(
+		cli,
+		"login",
+		email,
+		password)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+
+	cmd = executeCommand(cli, "updateuserkey")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Wait()
+}
+
+func logout() error {
+	cmd := executeCommand(cli, "logout")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Wait()
+}
+
+func handleError(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func deleteExistingData() error {
+	fmt.Printf("Deleting existing data\n")
+
+	// politeiad data dir
+	politeiadDataDir := filepath.Join(dcrutil.AppDataDir("politeiad", false), "data")
+	if err := os.RemoveAll(politeiadDataDir); err != nil {
+		return err
+	}
+
+	// politeiawww data dir
+	if err := os.RemoveAll(wwwconfig.DefaultDataDir); err != nil {
+		return err
+	}
+
+	// politeiawww cli dir
+	return os.RemoveAll(cliconfig.HomeDir)
+}
+
+func stopServers() {
+	if politeiadCmd != nil {
+		fmt.Printf("Stopping politeiad\n")
+		politeiadCmd.Process.Kill()
+		politeiadCmd = nil
+	}
+	if politeiawwwCmd != nil {
+		fmt.Printf("Stopping politeiawww\n")
+		politeiawwwCmd.Process.Kill()
+		politeiawwwCmd = nil
+	}
+}
+
+func _main() error {
+	// Load configuration and parse command line.  This function also
+	// initializes logging and configures it accordingly.
+	var err error
+	cfg, err = loadConfig()
+	if err != nil {
+		return fmt.Errorf("Could not load configuration file: %v", err)
+	}
+
+	if cfg.DeleteData {
+		if err = deleteExistingData(); err != nil {
+			return err
+		}
+	}
+
+	if err = startAndStopPoliteiawww(); err != nil {
+		return err
+	}
+
+	if err = createPaidUsers(); err != nil {
+		return err
+	}
+
+	if err = startPoliteiad(); err != nil {
+		return err
+	}
+
+	if err = startPoliteiawww(true); err != nil {
+		return err
+	}
+
+	if err = getVersionFromPoliteiawww(); err != nil {
+		return err
+	}
+
+	if err = createUnpaidUsers(); err != nil {
+		return err
+	}
+
+	if err = createProposals(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Load data complete\n")
+	return nil
+}
+
+func main() {
+	err := _main()
+	stopServers()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/politeiawww/cmd/politeiawww_dataload/sample-politeiawww_dataload.conf
+++ b/politeiawww/cmd/politeiawww_dataload/sample-politeiawww_dataload.conf
@@ -1,0 +1,55 @@
+[Application Options]
+
+; ------------------------------------------------------------------------------
+; Data settings
+; ------------------------------------------------------------------------------
+
+; The directory to store data such as the server log files and the dataload
+; config file. The default is ~/.politeiawww/dataload on POSIX OSes.
+; datadir=~/.politeiawww/dataload
+
+; The specific file used to load configuration options.
+; configfile=~/.politeiawww/dataload/politeiawww_dataload.conf
+
+; ------------------------------------------------------------------------------
+; Misc configuration options
+; ------------------------------------------------------------------------------
+
+; Delete all existing data within politeiad and politeiawww before
+; attempting to load new data.
+; deletedata=true
+
+; ------------------------------------------------------------------------------
+; Admin user options
+; ------------------------------------------------------------------------------
+
+; adminemail=admin@example.com
+; adminuser=admin
+; adminpass=password
+
+; ------------------------------------------------------------------------------
+; Regular paid user options
+; ------------------------------------------------------------------------------
+
+; paidemail=paid@example.com
+; paiduser=paid_user
+; paidpass=password
+
+; ------------------------------------------------------------------------------
+; Regular unpaid user options
+; ------------------------------------------------------------------------------
+
+; unpaidemail=unpaid@example.com
+; unpaiduser=unpaid_user
+; unpaidpass=password
+
+; ------------------------------------------------------------------------------
+; Debug
+; ------------------------------------------------------------------------------
+
+; Debug logging level for the politeiad and politeiawww servers.
+; Valid levels are {trace, debug, info, warn, error, critical}
+; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set
+; log level for individual subsystems.  Use politeiawww --debuglevel=show to list
+; available subsystems.
+; debuglevel=info

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -286,8 +286,11 @@ func (c *Ctx) NewUser(email, username, password string) (string, *identity.FullI
 }
 
 func (c *Ctx) VerifyNewUser(email, token, sig string) error {
-	_, err := c.makeRequest("GET", "/user/verify/?email="+email+
-		"&verificationtoken="+token+"&signature="+sig, nil)
+	_, err := c.makeRequest("GET", "/user/verify", v1.VerifyNewUser{
+		Email:             email,
+		VerificationToken: token,
+		Signature:         sig,
+	})
 	return err
 }
 

--- a/politeiawww/database/database.go
+++ b/politeiawww/database/database.go
@@ -72,7 +72,7 @@ type User struct {
 	ResetPasswordVerificationToken  []byte // Reset password token
 	ResetPasswordVerificationExpiry int64  // Reset password token expiration
 
-	// All dentitiesuser has ever used.  User should only have one
+	// All identities the user has ever used.  User should only have one
 	// active key at a time.  We allow multiples in order to deal with key
 	// loss.
 	Identities []Identity


### PR DESCRIPTION
This PR adds a `politeiawww_dataload` command to automatically load data to help quickly test Politeia. Running `politeiawww_dataload` will automatically start/stop `politeiad` and `politeiawww`, and utilize `politeiawww_dbutil` and `politeiawwwcli` to create an admin and regular users, proposals in each state (public, censored, etc), and a couple comments.