### PR TITLE
[www] Change paywall logic to continuously poll.

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -14,7 +14,7 @@ API.  It does not render HTML.
 - [`Me`](#me)
 - [`Login`](#login)
 - [`Logout`](#logout)
-- [`Verify user payment tx`](#verify-user-payment-tx)
+- [`Verify user payment`](#verify-user-payment)
 - [`Update user key`](#update-user-key)
 - [`Verify update user key`](#verify-update-user-key)
 - [`Change username`](#change-username)
@@ -73,6 +73,7 @@ API.  It does not render HTML.
 - [`ErrorStatusMalformedUsername`](#ErrorStatusMalformedUsername)
 - [`ErrorStatusDuplicateUsername`](#ErrorStatusDuplicateUsername)
 - [`ErrorStatusVerificationTokenUnexpired`](#ErrorStatusVerificationTokenUnexpired)
+- [`ErrorStatusCannotVerifyPayment`](#ErrorStatusCannotVerifyPayment)
 
 
 **Proposal status codes**
@@ -351,33 +352,30 @@ Reply:
 {}
 ```
 
-### `Verify user payment tx`
+### `Verify user payment`
 
-Checks that a user has paid his user registration fee by verifying the given
-transaction on the blockchain.
+Checks that a user has paid his user registration fee.
 
-**Route:** `GET /v1/user/verifypaymenttx`
+**Route:** `GET /v1/user/verifypayment`
 
-**Params:**
-
-| Parameter | Type | Description | Required |
-|-|-|-|-|
-| txid | string | The id of the transaction on the blockchain that was sent to the `paywalladdress` (which is provided on [`New user`](#new-user) and the [`Login reply`](#login-reply). | Yes |
+**Params:** none
 
 **Results:**
 
 | Parameter | Type | Description |
 |-|-|-|
-| haspaid | boolean | Whether or not the transaction is verified. |
+| haspaid | boolean | Whether or not a transaction on the blockchain that was sent to the `paywalladdress` (which is provided on [`New user`](#new-user) and the [`Login reply`](#login-reply) could be found and verified. |
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusCannotVerifyPayment`](#ErrorStatusCannotVerifyPayment)
 
 **Example**
 
 Request:
 
-The request params should be provided within the URL:
-
 ```
-/v1/user/verifypaymenttx?txid=11b0693e68d6e129f0f1898e57b121c3ac323c2bcb94ad9d8da2c15cf935bbc5
+/v1/user/verifypayment
 ```
 
 Reply:
@@ -572,7 +570,7 @@ Allows a user to reset his password without being logged in.
 | verificationtoken | string | The verification token which is sent to the user's email address. | Yes |
 | newpassword | String | The new password for the user. | Yes |
 
-**Results:** 
+**Results:**
 
 | Parameter | Type | Description |
 |-|-|-|
@@ -854,7 +852,7 @@ SHALL observe.
 
 **Params:** none
 
-**Results:** 
+**Results:**
 
 | | Type | Description |
 |-|-|-|
@@ -910,7 +908,7 @@ Reply:
   "maxcommentlength": 8000,
   "backendpublickey": "",
   "minproposalnamelength": 8,
-  "maxproposalnamelength": 80  
+  "maxproposalnamelength": 80
 }
 ```
 
@@ -930,7 +928,7 @@ call requires admin privileges.
 | signature | string | Signature of token+string(status). | Yes |
 | publickey | string | Public key from the client side, sent to politeiawww for verification | Yes |
 
-**Results:** 
+**Results:**
 
 | Parameter | Type | Description |
 |-|-|-|-|
@@ -982,7 +980,7 @@ Retrieve proposal and its details.
 
 **Routes:** `GET /v1/proposals/{token}`
 
-**Params:** 
+**Params:**
 
 | Parameter | Type | Description | Required |
 |-|-|-|-|
@@ -1594,6 +1592,7 @@ Reply:
 | <a name="ErrorStatusMalformedUsername">ErrorStatusMalformedUsername</a> | 32 | The provided username was malformed. |
 | <a name="ErrorStatusDuplicateUsername">ErrorStatusDuplicateUsername</a> | 33 | The provided username was a duplicate of another username. |
 | <a name="ErrorStatusVerificationTokenUnexpired">ErrorStatusVerificationTokenUnexpired</a> | 34 | A verification token has already been generated and hasn't expired yet. |
+| <a name="ErrorStatusCannotVerifyPayment">ErrorStatusCannotVerifyPayment</a> | 35 | The server cannot verify the payment at this time, please try again later. |
 
 
 ### Proposal status codes

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -22,7 +22,7 @@ const (
 	RouteChangePassword      = "/user/password/change"
 	RouteResetPassword       = "/user/password/reset"
 	RouteUserProposals       = "/user/proposals"
-	RouteVerifyUserPaymentTx = "/user/verifypaymenttx"
+	RouteVerifyUserPayment   = "/user/verifypayment"
 	RouteLogin               = "/login"
 	RouteLogout              = "/logout"
 	RouteSecret              = "/secret"
@@ -128,6 +128,7 @@ const (
 	ErrorStatusMalformedUsername           ErrorStatusT = 32
 	ErrorStatusDuplicateUsername           ErrorStatusT = 33
 	ErrorStatusVerificationTokenUnexpired  ErrorStatusT = 34
+	ErrorStatusCannotVerifyPayment         ErrorStatusT = 35
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid     PropStatusT = 0 // Invalid status
@@ -195,6 +196,7 @@ var (
 		ErrorStatusMalformedUsername:           "malformed username",
 		ErrorStatusDuplicateUsername:           "duplicate username",
 		ErrorStatusVerificationTokenUnexpired:  "verification token not yet expired",
+		ErrorStatusCannotVerifyPayment:         "cannot verify payment at this time",
 	}
 )
 
@@ -397,15 +399,17 @@ type UserProposalsReply struct {
 	Proposals []ProposalRecord `json:"proposals"`
 }
 
-// VerifyUserPaymentTx is used to request the server to check for the
+// VerifyUserPayment is used to request the server to check for the
 // provided transaction on the Decred blockchain and verify that it
 // satisfies the requirements for a user to pay his registration fee.
-type VerifyUserPaymentTx struct {
-	TxId string `schema:"txid"`
+type VerifyUserPayment struct {
 }
 
-type VerifyUserPaymentTxReply struct {
-	HasPaid bool `json:"haspaid"`
+type VerifyUserPaymentReply struct {
+	HasPaid            bool   `json:"haspaid"`
+	PaywallAddress     string `json:"paywalladdress"`     // Registration paywall address
+	PaywallAmount      uint64 `json:"paywallamount"`      // Registration paywall amount in atoms
+	PaywallTxNotBefore int64  `json:"paywalltxnotbefore"` // Minimum timestamp for paywall tx
 }
 
 // Login attempts to login the user.  Note that by necessity the password

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -54,13 +54,14 @@ type MDStreamChanges struct {
 
 // politeiawww backend construct
 type backend struct {
-	sync.RWMutex // lock for inventory and comments
+	sync.RWMutex // lock for inventory and comments and caches
 
-	db          database.Database
-	cfg         *config
-	params      *chaincfg.Params
-	client      *http.Client      // politeiad client
-	userPubkeys map[string]string // [pubkey][userid]
+	db           database.Database
+	cfg          *config
+	params       *chaincfg.Params
+	client       *http.Client           // politeiad client
+	userPubkeys  map[string]string      // [pubkey][userid]
+	paywallUsers map[uint64]paywallInfo // [userid][paywallInfo]
 
 	// These properties are only used for testing.
 	test                   bool

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -750,7 +750,7 @@ func (b *backend) loadInventory() (*pd.InventoryReply, error) {
 	return nil, fmt.Errorf("use inventory")
 }
 
-func (b *backend) CreateLoginReply(user *database.User) *www.LoginReply {
+func (b *backend) CreateLoginReply(user *database.User) (*www.LoginReply, error) {
 	activeIdentity, ok := database.ActiveIdentityString(user.Identities)
 	if !ok {
 		activeIdentity = ""
@@ -764,13 +764,18 @@ func (b *backend) CreateLoginReply(user *database.User) *www.LoginReply {
 		PublicKey: activeIdentity,
 	}
 
-	if user.NewUserPaywallTx == "" {
+	if !b.HasUserPaid(user) {
+		err := b.GenerateNewUserPaywall(user)
+		if err != nil {
+			return nil, err
+		}
+
 		reply.PaywallAddress = user.NewUserPaywallAddress
 		reply.PaywallAmount = user.NewUserPaywallAmount
 		reply.PaywallTxNotBefore = user.NewUserPaywallTxNotBefore
 	}
 
-	return &reply
+	return &reply, nil
 }
 
 // LoadInventory fetches the entire inventory of proposals from politeiad and
@@ -917,33 +922,15 @@ func (b *backend) ProcessNewUser(u www.NewUser) (*www.NewUserReply, error) {
 		// Associate the user id with the new public key.
 		b.setUserPubkeyAssociaton(user, u.PublicKey)
 
-		// Derive a paywall address for this user if the paywall is enabled.
-		paywallAddress := ""
-		paywallAmount := uint64(0)
-		if b.cfg.PaywallAmount != 0 && b.cfg.PaywallXpub != "" {
-			paywallAddress, err = util.DerivePaywallAddress(b.params,
-				b.cfg.PaywallXpub, uint32(user.ID))
-			if err != nil {
-				return nil, fmt.Errorf("Unable to derive paywall address #%v "+
-					"for %v: %v", uint32(user.ID), u.Email, err)
-			}
-			paywallAmount = b.cfg.PaywallAmount
-		}
-
-		txNotBeforeTimestamp := time.Now().Unix()
-
-		reply.PaywallAddress = paywallAddress
-		reply.PaywallAmount = paywallAmount
-		reply.PaywallTxNotBefore = txNotBeforeTimestamp
-
-		user.NewUserPaywallAddress = paywallAddress
-		user.NewUserPaywallAmount = paywallAmount
-		user.NewUserPaywallTxNotBefore = txNotBeforeTimestamp
-
-		err = b.db.UserUpdate(*user)
+		// Derive paywall information for this user if the paywall is enabled.
+		err = b.GenerateNewUserPaywall(user)
 		if err != nil {
 			return nil, err
 		}
+
+		reply.PaywallAddress = user.NewUserPaywallAddress
+		reply.PaywallAmount = user.NewUserPaywallAmount
+		reply.PaywallTxNotBefore = user.NewUserPaywallTxNotBefore
 	}
 
 	if !b.test {
@@ -1029,7 +1016,14 @@ func (b *backend) ProcessVerifyNewUser(u www.VerifyNewUser) (*database.User, err
 	// Clear out the verification token fields in the db.
 	user.NewUserVerificationToken = nil
 	user.NewUserVerificationExpiry = 0
-	return user, b.db.UserUpdate(*user)
+	err = b.db.UserUpdate(*user)
+	if err != nil {
+		return nil, err
+	}
+
+	b.AddUserToPaywallPool(user)
+
+	return user, nil
 }
 
 // ProcessUpdateUserKey sets a verification token and expiry to allow the user to
@@ -1200,7 +1194,7 @@ func (b *backend) ProcessLogin(l www.Login) (*www.LoginReply, error) {
 		}
 	}
 
-	return b.CreateLoginReply(user), nil
+	return b.CreateLoginReply(user)
 }
 
 // ProcessChangeUsername checks that the password matches the one
@@ -1351,7 +1345,7 @@ func (b *backend) ProcessAllUnvetted(u www.GetAllUnvetted) *www.GetAllUnvettedRe
 func (b *backend) ProcessNewProposal(np www.NewProposal, user *database.User) (*www.NewProposalReply, error) {
 	log.Tracef("ProcessNewProposal")
 
-	if !b.VerifyUserPaid(user) {
+	if !b.HasUserPaid(user) {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusUserNotPaid,
 		}
@@ -1687,7 +1681,7 @@ func (b *backend) ProcessComment(c www.NewComment, user *database.User) (*www.Ne
 	log.Debugf("ProcessComment: %v %v", c.Token, user.ID)
 
 	// Pay up sucker!
-	if !b.VerifyUserPaid(user) {
+	if !b.HasUserPaid(user) {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusUserNotPaid,
 		}
@@ -1765,7 +1759,7 @@ func (b *backend) ProcessLikeComment(lc www.LikeComment, user *database.User) (*
 	log.Debugf("ProcessLikeComment: %v %v", lc.Token, user.ID)
 
 	// Pay up sucker!
-	if !b.VerifyUserPaid(user) {
+	if !b.HasUserPaid(user) {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusUserNotPaid,
 		}
@@ -2288,6 +2282,9 @@ func NewBackend(cfg *config) (*backend, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Set up the code that checks for paywall payments.
+	b.InitPaywallCheck()
 
 	return b, nil
 }

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -211,7 +211,7 @@ func clearPaywallAction() error {
 		return err
 	}
 
-	u.NewUserPaywallAddress = ""
+	u.NewUserPaywallPollExpiry = 0
 	u.NewUserPaywallTx = "cleared_by_dbutil"
 
 	b, err = localdb.EncodeUser(*u)

--- a/politeiawww/cmd/politeiawww_refclient/client.go
+++ b/politeiawww/cmd/politeiawww_refclient/client.go
@@ -238,17 +238,14 @@ func (c *ctx) getUserCommentsVotes(token string) (*v1.UserCommentsVotesReply, er
 	return &ucvr, nil
 }
 
-func (c *ctx) verifyUserPaymentTx(id *identity.FullIdentity, token, faucetTx string) (*v1.VerifyUserPaymentTxReply, error) {
-	vTx := v1.VerifyUserPaymentTx{
-		TxId: faucetTx,
-	}
-
-	responseBody, err := c.makeRequest("GET", v1.RouteVerifyUserPaymentTx, vTx)
+func (c *ctx) verifyUserPayment(id *identity.FullIdentity, token string) (*v1.VerifyUserPaymentReply, error) {
+	vup := v1.VerifyUserPayment{}
+	responseBody, err := c.makeRequest("GET", v1.RouteVerifyUserPayment, vup)
 	if err != nil {
 		return nil, err
 	}
 
-	var vupr v1.VerifyUserPaymentTxReply
+	var vupr v1.VerifyUserPaymentReply
 	err = json.Unmarshal(responseBody, &vupr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal verifyUserPaidReply: %v",

--- a/politeiawww/cmd/politeiawww_refclient/main.go
+++ b/politeiawww/cmd/politeiawww_refclient/main.go
@@ -455,7 +455,7 @@ func createUser(c *ctx) (*UserCredentials, error) {
 	ticker := time.NewTicker(time.Second * timeToPoll)
 
 	for range ticker.C {
-		verifyUserPaid, err := c.verifyUserPaymentTx(id, token, faucetTx)
+		verifyUserPaid, err := c.verifyUserPayment(id, token)
 		if err != nil {
 			return nil, fmt.Errorf("ERR: %v", err)
 		}
@@ -589,14 +589,14 @@ func _main() error {
 		return err
 	}
 
-	// From here we need to have -use-paywall setted as true
+	// From here we need to have -use-paywall set to true
 	// and wait for paywall Confirmations
 
 	if *usePaywall {
 		ticker := time.NewTicker(time.Second * timeToPoll)
 
 		for range ticker.C {
-			verifyUserPaid, err := c.verifyUserPaymentTx(id, token, faucetTx)
+			verifyUserPaid, err := c.verifyUserPayment(id, token)
 			if err != nil {
 				return fmt.Errorf("ERR: %v", err)
 			}

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -769,20 +769,18 @@ func (c *Ctx) CreateNewKey(email string) (*identity.FullIdentity, error) {
 	return id, nil
 }
 
-func (c *Ctx) VerifyUserPaymentTx(txid string) (*v1.VerifyUserPaymentTxReply,
+func (c *Ctx) VerifyUserPayment() (*v1.VerifyUserPaymentReply,
 	error) {
-	v := v1.VerifyUserPaymentTx{
-		TxId: txid,
-	}
-	responseBody, err := c.makeRequest("GET", v1.RouteVerifyUserPaymentTx, v)
+	v := v1.VerifyUserPayment{}
+	responseBody, err := c.makeRequest("GET", v1.RouteVerifyUserPayment, v)
 	if err != nil {
 		return nil, err
 	}
 
-	var vr v1.VerifyUserPaymentTxReply
+	var vr v1.VerifyUserPaymentReply
 	err = json.Unmarshal(responseBody, &vr)
 	if err != nil {
-		return nil, fmt.Errorf("Could not unmarshal VerifyUserPaymentTxReply: %v",
+		return nil, fmt.Errorf("Could not unmarshal VerifyUserPaymentReply: %v",
 			err)
 	}
 

--- a/politeiawww/cmd/politeiawwwcli/commands/verifyuserpayment.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/verifyuserpayment.go
@@ -1,12 +1,8 @@
 package commands
 
-type VerifyuserpaymentCmd struct {
-	Args struct {
-		Txid string `positional-arg-name:"txid" description:"The id of the transaction on the blockchain that was sent to the paywall address"`
-	} `positional-args:"true" required:"true"`
-}
+type VerifyuserpaymentCmd struct{}
 
 func (cmd *VerifyuserpaymentCmd) Execute(args []string) error {
-	_, err := Ctx.VerifyUserPaymentTx(cmd.Args.Txid)
+	_, err := Ctx.VerifyUserPayment()
 	return err
 }

--- a/politeiawww/cmd/politeiawwwtest/main.go
+++ b/politeiawww/cmd/politeiawwwtest/main.go
@@ -243,7 +243,7 @@ func main() {
 		ticker := time.NewTicker(time.Second * timeToPoll)
 
 		for range ticker.C {
-			verifyUserPaid, err := c.VerifyUserPaymentTx(faucetTx)
+			verifyUserPaid, err := c.VerifyUserPayment()
 			handleError(err)
 			fmt.Printf("Waiting for confirmations...\n")
 			if verifyUserPaid.HasPaid {

--- a/politeiawww/database/database.go
+++ b/politeiawww/database/database.go
@@ -65,6 +65,7 @@ type User struct {
 	NewUserPaywallAmount            uint64 // Amount the user needs to send
 	NewUserPaywallTx                string // Paywall transaction id
 	NewUserPaywallTxNotBefore       int64  // Transactions occurring before this time will not be valid.
+	NewUserPaywallPollExpiry        int64  // After this time, the user's paywall address will not be continuously polled
 	NewUserVerificationToken        []byte // Verification token during signup
 	NewUserVerificationExpiry       int64  // Verification expiration
 	UpdateKeyVerificationToken      []byte // Verification token for updating keypair

--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -84,13 +84,13 @@ func (b *backend) createUserPaywallPoolCopy() map[uint64]paywallPoolMember {
 	b.RLock()
 	defer b.RUnlock()
 
-	copy := make(map[uint64]paywallPoolMember, len(b.userPaywallPool))
+	poolCopy := make(map[uint64]paywallPoolMember, len(b.userPaywallPool))
 
 	for k, v := range b.userPaywallPool {
-		copy[k] = v
+		poolCopy[k] = v
 	}
 
-	return copy
+	return poolCopy
 }
 
 func (b *backend) checkForUserPayments(pool map[uint64]paywallPoolMember) (bool, []uint64) {

--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -1,47 +1,256 @@
 package main
 
 import (
-	www "github.com/decred/politeia/politeiawww/api/v1"
+	"fmt"
+	"sync"
+	"time"
+
+	v1 "github.com/decred/politeia/politeiawww/api/v1"
 	"github.com/decred/politeia/politeiawww/database"
 	"github.com/decred/politeia/util"
 )
 
-// ProcessVerifyUserPaymentTx verifies that the provided transaction
+type paywallInfo struct {
+	address     string
+	amount      uint64
+	txNotBefore int64
+}
+
+const (
+	// paywallExpiry is the amount of time the server will watch a paywall address
+	// for transactions. It gets reset when the user logs in or makes a call to
+	// RouteVerifyUserPayment.
+	paywallExpiry = time.Hour * 24
+
+	// paywallCheckGap is the amount of time the server sleeps after polling for
+	// a paywall address.
+	paywallCheckGap = time.Second * 1
+)
+
+var (
+	paywallUsers map[uint64]paywallInfo
+	mutex        sync.RWMutex
+)
+
+func paywallHasExpired(txNotBefore int64) bool {
+	expiryTime := time.Unix(txNotBefore, 0).Add(paywallExpiry)
+	return time.Now().After(expiryTime)
+}
+
+func addUser(user *database.User) {
+	paywallUsers[user.ID] = paywallInfo{
+		address:     user.NewUserPaywallAddress,
+		amount:      user.NewUserPaywallAmount,
+		txNotBefore: user.NewUserPaywallTxNotBefore,
+	}
+}
+
+func (b *backend) derivePaywallInfo(user *database.User) (string, uint64, int64, error) {
+	address, err := util.DerivePaywallAddress(b.params,
+		b.cfg.PaywallXpub, uint32(user.ID))
+	if err != nil {
+		err = fmt.Errorf("Unable to derive paywall address #%v "+
+			"for %v: %v", uint32(user.ID), user.Email, err)
+	}
+
+	return address, b.cfg.PaywallAmount, time.Now().Unix(), err
+}
+
+func (b *backend) checkForPayments() {
+	minConfirmations := b.cfg.MinConfirmationsRequired
+
+	// Check new user payments.
+	for {
+		mutex.RLock()
+		for k, v := range paywallUsers {
+			user, err := b.db.UserGetById(k)
+			if err != nil {
+				log.Errorf("cannot fetch user by id %v: %v\n", k, err)
+				continue
+			}
+
+			if b.HasUserPaid(user) {
+				// The user could have been marked as paid by RouteVerifyUserPayment,
+				// so just remove him from the in-memory pool.
+				mutex.Lock()
+				delete(paywallUsers, k)
+				mutex.Unlock()
+				continue
+			}
+
+			if paywallHasExpired(user.NewUserPaywallTxNotBefore) {
+				return
+			}
+
+			tx, err := util.FetchTxWithBlockExplorers(v.address, v.amount,
+				v.txNotBefore, minConfirmations)
+			if err != nil {
+				log.Errorf("cannot fetch tx: %v\n", err)
+				continue
+			}
+
+			if tx != "" {
+				// Update the user in the database.
+				user.NewUserPaywallTx = tx
+				err := b.db.UserUpdate(*user)
+				if err != nil {
+					log.Errorf("cannot update user with id %v: %v", user.ID, err)
+					continue
+				}
+
+				// Remove this user from the in-memory pool.
+				mutex.RUnlock()
+				mutex.Lock()
+				delete(paywallUsers, k)
+				mutex.Unlock()
+				mutex.RLock()
+			}
+
+			time.Sleep(paywallCheckGap)
+		}
+		mutex.RUnlock()
+	}
+
+	// TODO: Check proposal payments within the above loop.
+}
+
+// GenerateNewUserPaywall generates new paywall info, if necessary, and saves
+// it in the database.
+func (b *backend) GenerateNewUserPaywall(user *database.User) error {
+	// Check that the paywall is enabled.
+	if !b.PaywallIsEnabled() {
+		return nil
+	}
+
+	// Check that the user either hasn't had paywall information set yet,
+	// or it has expired.
+	if user.NewUserPaywallAddress != "" &&
+		!paywallHasExpired(user.NewUserPaywallTxNotBefore) {
+		return nil
+	}
+
+	address, amount, txNotBefore, err := b.derivePaywallInfo(user)
+	if err != nil {
+		return err
+	}
+
+	user.NewUserPaywallAddress = address
+	user.NewUserPaywallAmount = amount
+	user.NewUserPaywallTxNotBefore = txNotBefore
+	err = b.db.UserUpdate(*user)
+	if err != nil {
+		return err
+	}
+
+	b.AddUserToPaywallPool(user)
+	return nil
+}
+
+// ProcessVerifyUserPayment verifies that the provided transaction
 // meets the minimum requirements to mark the user as paid, and then does
 // that in the user database.
-func (b *backend) ProcessVerifyUserPaymentTx(user *database.User, vupt www.VerifyUserPaymentTx) (*www.VerifyUserPaymentTxReply, error) {
+func (b *backend) ProcessVerifyUserPayment(user *database.User, vupt v1.VerifyUserPayment) (*v1.VerifyUserPaymentReply, error) {
+	var reply v1.VerifyUserPaymentReply
+	if b.HasUserPaid(user) {
+		reply.HasPaid = true
+		return &reply, nil
+	}
+
+	if paywallHasExpired(user.NewUserPaywallTxNotBefore) {
+		b.GenerateNewUserPaywall(user)
+
+		reply.PaywallAddress = user.NewUserPaywallAddress
+		reply.PaywallAmount = user.NewUserPaywallAmount
+		reply.PaywallTxNotBefore = user.NewUserPaywallTxNotBefore
+		return &reply, nil
+	}
+
 	minConfirmations := b.cfg.MinConfirmationsRequired
-	verified, err := util.VerifyTxWithBlockExplorers(user.NewUserPaywallAddress,
-		user.NewUserPaywallAmount, vupt.TxId, user.NewUserPaywallTxNotBefore, minConfirmations)
+	txId, err := util.FetchTxWithBlockExplorers(user.NewUserPaywallAddress,
+		user.NewUserPaywallAmount, user.NewUserPaywallTxNotBefore, minConfirmations)
 	if err != nil {
+		if err == util.ErrCannotVerifyPayment {
+			return nil, v1.UserError{
+				ErrorCode: v1.ErrorStatusCannotVerifyPayment,
+			}
+		}
 		return nil, err
 	}
 
-	var reply www.VerifyUserPaymentTxReply
-	if verified {
+	if txId != "" {
 		reply.HasPaid = true
 
-		user.NewUserPaywallTx = vupt.TxId
+		user.NewUserPaywallTx = txId
 		err = b.db.UserUpdate(*user)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		// Add the user to the in-memory pool.
 	}
 
 	return &reply, nil
 }
 
-// VerifyUserPaid checks that a user has paid the paywall
-func (b *backend) VerifyUserPaid(user *database.User) bool {
+// HasUserPaid checks that a user has paid the paywall
+func (b *backend) HasUserPaid(user *database.User) bool {
 	// Return true when running unit tests
 	if b.test {
 		return true
 	}
 
 	// Return true if paywall is disabled
-	if b.cfg.PaywallAmount == 0 && b.cfg.PaywallXpub == "" {
+	if !b.PaywallIsEnabled() {
 		return true
 	}
 
 	return user.NewUserPaywallTx != ""
+}
+
+// AddUserToPaywallPool adds a user and its paywall info to the in-memory pool.
+func (b *backend) AddUserToPaywallPool(user *database.User) {
+	mutex.Lock()
+	addUser(user)
+	mutex.Unlock()
+}
+
+// InitPaywallCheck is intended to be called
+func (b *backend) InitPaywallCheck() error {
+	if b.cfg.PaywallAmount == 0 {
+		// Paywall not configured.
+		return nil
+	}
+
+	paywallUsers = make(map[uint64]paywallInfo)
+
+	// Create the in-memory pool of all users who need to pay the paywall.
+	mutex.Lock()
+	err := b.db.AllUsers(func(user *database.User) {
+		if b.HasUserPaid(user) {
+			return
+		}
+		if user.NewUserVerificationToken != nil {
+			return
+		}
+		if paywallHasExpired(user.NewUserPaywallTxNotBefore) {
+			return
+		}
+
+		addUser(user)
+	})
+	mutex.Unlock()
+
+	if err != nil {
+		return err
+	}
+
+	// Initiate the thread that checks for payments.
+	go b.checkForPayments()
+	return nil
+}
+
+// PaywallIsEnabled returns true if paywall is enabled for the server, false
+// otherwise.
+func (b *backend) PaywallIsEnabled() bool {
+	return b.cfg.PaywallAmount != 0 && b.cfg.PaywallXpub != ""
 }

--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -9,37 +9,64 @@ import (
 	"github.com/decred/politeia/util"
 )
 
-type paywallInfo struct {
+type paywallPoolMember struct {
 	address     string
 	amount      uint64
 	txNotBefore int64
+	pollExpiry  int64
 }
 
 const (
-	// paywallExpiry is the amount of time the server will watch a paywall address
+	// paywallExpiryDuration is the amount of time the server will watch a paywall address
 	// for transactions. It gets reset when the user logs in or makes a call to
 	// RouteVerifyUserPayment.
-	paywallExpiry = time.Hour * 24
+	paywallExpiryDuration = time.Hour * 24
 
 	// paywallCheckGap is the amount of time the server sleeps after polling for
 	// a paywall address.
-	paywallCheckGap = time.Second * 10
+	paywallCheckGap = time.Second * 5
 )
 
-func paywallHasExpired(txNotBefore int64) bool {
-	expiryTime := time.Unix(txNotBefore, 0).Add(paywallExpiry)
-	return time.Now().After(expiryTime)
+func paywallHasExpired(pollExpiry int64) bool {
+	return time.Now().After(time.Unix(pollExpiry, 0))
 }
 
-// addUser adds a database user to the paywall pool.
+// paywallIsEnabled returns true if paywall is enabled for the server, false
+// otherwise.
+func (b *backend) paywallIsEnabled() bool {
+	return b.cfg.PaywallAmount != 0 && b.cfg.PaywallXpub != ""
+}
+
+// addUserToPaywallPoolWithLock adds a database user to the paywall pool.
 //
 // This function must be called WITH the mutex held.
-func (b *backend) addUser(user *database.User) {
-	b.paywallUsers[user.ID] = paywallInfo{
+func (b *backend) addUserToPaywallPoolWithLock(user *database.User) {
+	b.userPaywallPool[user.ID] = paywallPoolMember{
 		address:     user.NewUserPaywallAddress,
 		amount:      user.NewUserPaywallAmount,
 		txNotBefore: user.NewUserPaywallTxNotBefore,
+		pollExpiry:  user.NewUserPaywallPollExpiry,
 	}
+}
+
+// addUserToPaywallPool adds a user and its paywall info to the in-memory pool.
+//
+// This function must be called WITHOUT the mutex held.
+func (b *backend) addUserToPaywallPool(user *database.User) {
+	if !b.paywallIsEnabled() {
+		return
+	}
+
+	b.Lock()
+	defer b.Unlock()
+
+	b.addUserToPaywallPoolWithLock(user)
+}
+
+func (b *backend) updateUserAsPaid(user *database.User, tx string) error {
+	user.NewUserPaywallTx = tx
+	user.NewUserPaywallPollExpiry = 0
+	return b.db.UserUpdate(*user)
 }
 
 func (b *backend) derivePaywallInfo(user *database.User) (string, uint64, int64, error) {
@@ -53,28 +80,23 @@ func (b *backend) derivePaywallInfo(user *database.User) (string, uint64, int64,
 	return address, b.cfg.PaywallAmount, time.Now().Unix(), err
 }
 
-func (b *backend) checkForPayments() {
-	// Check new user payments.
-	for {
-		shouldContinue, userIDsToRemove := b.checkForPaymentsAux()
-		if !shouldContinue {
-			return
-		}
-		b.removeUsers(userIDsToRemove)
-	}
-
-	// TODO: Check proposal payments within the above loop.
-}
-
-func (b *backend) checkForPaymentsAux() (bool, []uint64) {
-	var userIDsToRemove []uint64
-
+func (b *backend) createUserPaywallPoolCopy() map[uint64]paywallPoolMember {
 	b.RLock()
 	defer b.RUnlock()
 
-	for userID, paywall := range b.paywallUsers {
-		time.Sleep(paywallCheckGap)
+	copy := make(map[uint64]paywallPoolMember, len(b.userPaywallPool))
 
+	for k, v := range b.userPaywallPool {
+		copy[k] = v
+	}
+
+	return copy
+}
+
+func (b *backend) checkForUserPayments(pool map[uint64]paywallPoolMember) (bool, []uint64) {
+	var userIDsToRemove []uint64
+
+	for userID, poolMember := range pool {
 		user, err := b.db.UserGetById(userID)
 		if err != nil {
 			if err == database.ErrShutdown {
@@ -86,19 +108,24 @@ func (b *backend) checkForPaymentsAux() (bool, []uint64) {
 			continue
 		}
 
+		log.Tracef("Checking the paywall address for user %v...", user.Email)
+
 		if b.HasUserPaid(user) {
 			// The user could have been marked as paid by RouteVerifyUserPayment,
 			// so just remove him from the in-memory pool.
 			userIDsToRemove = append(userIDsToRemove, userID)
+			log.Tracef("  removing from polling, user already paid")
 			continue
 		}
 
-		if paywallHasExpired(user.NewUserPaywallTxNotBefore) {
+		if paywallHasExpired(user.NewUserPaywallPollExpiry) {
+			userIDsToRemove = append(userIDsToRemove, userID)
+			log.Tracef("  removing from polling, poll has expired")
 			continue
 		}
 
-		tx, err := util.FetchTxWithBlockExplorers(paywall.address, paywall.amount,
-			paywall.txNotBefore, b.cfg.MinConfirmationsRequired)
+		tx, err := util.FetchTxWithBlockExplorers(poolMember.address, poolMember.amount,
+			poolMember.txNotBefore, b.cfg.MinConfirmationsRequired)
 		if err != nil {
 			log.Errorf("cannot fetch tx: %v\n", err)
 			continue
@@ -106,8 +133,7 @@ func (b *backend) checkForPaymentsAux() (bool, []uint64) {
 
 		if tx != "" {
 			// Update the user in the database.
-			user.NewUserPaywallTx = tx
-			err := b.db.UserUpdate(*user)
+			err = b.updateUserAsPaid(user, tx)
 			if err != nil {
 				if err == database.ErrShutdown {
 					// The database is shutdown, so stop the thread.
@@ -120,18 +146,35 @@ func (b *backend) checkForPaymentsAux() (bool, []uint64) {
 
 			// Remove this user from the in-memory pool.
 			userIDsToRemove = append(userIDsToRemove, userID)
+			log.Tracef("  removing from polling, user just paid")
 		}
+
+		time.Sleep(paywallCheckGap)
 	}
 
 	return true, userIDsToRemove
 }
 
-func (b *backend) removeUsers(userIDsToRemove []uint64) {
+func (b *backend) removeUsersFromPool(userIDsToRemove []uint64) {
 	b.Lock()
 	defer b.Unlock()
 
 	for _, userID := range userIDsToRemove {
-		delete(b.paywallUsers, userID)
+		delete(b.userPaywallPool, userID)
+	}
+}
+
+func (b *backend) checkForPayments() {
+	for {
+		// Check new user payments.
+		userPaywallsToCheck := b.createUserPaywallPoolCopy()
+		shouldContinue, userIDsToRemove := b.checkForUserPayments(userPaywallsToCheck)
+		if !shouldContinue {
+			return
+		}
+		b.removeUsersFromPool(userIDsToRemove)
+
+		// TODO: Check for proposal payments.
 	}
 }
 
@@ -139,31 +182,35 @@ func (b *backend) removeUsers(userIDsToRemove []uint64) {
 // it in the database.
 func (b *backend) GenerateNewUserPaywall(user *database.User) error {
 	// Check that the paywall is enabled.
-	if !b.PaywallIsEnabled() {
+	if !b.paywallIsEnabled() {
 		return nil
 	}
 
 	// Check that the user either hasn't had paywall information set yet,
 	// or it has expired.
 	if user.NewUserPaywallAddress != "" &&
-		!paywallHasExpired(user.NewUserPaywallTxNotBefore) {
+		!paywallHasExpired(user.NewUserPaywallPollExpiry) {
 		return nil
 	}
 
-	address, amount, txNotBefore, err := b.derivePaywallInfo(user)
+	if user.NewUserPaywallAddress == "" {
+		address, amount, txNotBefore, err := b.derivePaywallInfo(user)
+		if err != nil {
+			return err
+		}
+
+		user.NewUserPaywallAddress = address
+		user.NewUserPaywallAmount = amount
+		user.NewUserPaywallTxNotBefore = txNotBefore
+	}
+	user.NewUserPaywallPollExpiry = time.Now().Add(paywallExpiryDuration).Unix()
+
+	err := b.db.UserUpdate(*user)
 	if err != nil {
 		return err
 	}
 
-	user.NewUserPaywallAddress = address
-	user.NewUserPaywallAmount = amount
-	user.NewUserPaywallTxNotBefore = txNotBefore
-	err = b.db.UserUpdate(*user)
-	if err != nil {
-		return err
-	}
-
-	b.AddUserToPaywallPool(user)
+	b.addUserToPaywallPool(user)
 	return nil
 }
 
@@ -177,7 +224,7 @@ func (b *backend) ProcessVerifyUserPayment(user *database.User, vupt v1.VerifyUs
 		return &reply, nil
 	}
 
-	if paywallHasExpired(user.NewUserPaywallTxNotBefore) {
+	if paywallHasExpired(user.NewUserPaywallPollExpiry) {
 		b.GenerateNewUserPaywall(user)
 
 		reply.PaywallAddress = user.NewUserPaywallAddress
@@ -186,7 +233,7 @@ func (b *backend) ProcessVerifyUserPayment(user *database.User, vupt v1.VerifyUs
 		return &reply, nil
 	}
 
-	txId, err := util.FetchTxWithBlockExplorers(user.NewUserPaywallAddress,
+	tx, err := util.FetchTxWithBlockExplorers(user.NewUserPaywallAddress,
 		user.NewUserPaywallAmount, user.NewUserPaywallTxNotBefore,
 		b.cfg.MinConfirmationsRequired)
 	if err != nil {
@@ -198,11 +245,10 @@ func (b *backend) ProcessVerifyUserPayment(user *database.User, vupt v1.VerifyUs
 		return nil, err
 	}
 
-	if txId != "" {
+	if tx != "" {
 		reply.HasPaid = true
 
-		user.NewUserPaywallTx = txId
-		err = b.db.UserUpdate(*user)
+		err = b.updateUserAsPaid(user, tx)
 		if err != nil {
 			return nil, err
 		}
@@ -221,70 +267,52 @@ func (b *backend) HasUserPaid(user *database.User) bool {
 	}
 
 	// Return true if paywall is disabled
-	if !b.PaywallIsEnabled() {
+	if !b.paywallIsEnabled() {
 		return true
 	}
 
 	return user.NewUserPaywallTx != ""
 }
 
-// AddUserToPaywallPool adds a user and its paywall info to the in-memory pool.
-//
-// This function must be called WITHOUT the mutex held.
-func (b *backend) AddUserToPaywallPool(user *database.User) {
-	if !b.PaywallIsEnabled() {
-		return
-	}
-
+func (b *backend) addUsersToPaywallPool() error {
 	b.Lock()
 	defer b.Unlock()
-
-	b.addUser(user)
-}
-
-func (b *backend) initPaywallUsersPool() error {
-	b.Lock()
-	defer b.Unlock()
-
-	if b.paywallUsers == nil {
-		b.paywallUsers = make(map[uint64]paywallInfo)
-	}
 
 	// Create the in-memory pool of all users who need to pay the paywall.
-	return b.db.AllUsers(func(user *database.User) {
+	err := b.db.AllUsers(func(user *database.User) {
 		if b.HasUserPaid(user) {
 			return
 		}
 		if user.NewUserVerificationToken != nil {
 			return
 		}
-		if paywallHasExpired(user.NewUserPaywallTxNotBefore) {
+		if paywallHasExpired(user.NewUserPaywallPollExpiry) {
 			return
 		}
 
-		b.addUser(user)
+		b.addUserToPaywallPoolWithLock(user)
 	})
+	if err != nil {
+		return err
+	}
+
+	log.Tracef("Adding %v users to paywall pool", len(b.userPaywallPool))
+	return nil
 }
 
-// InitPaywallCheck is intended to be called
-func (b *backend) InitPaywallCheck() error {
+// initPaywallCheck is intended to be called
+func (b *backend) initPaywallChecker() error {
 	if b.cfg.PaywallAmount == 0 {
 		// Paywall not configured.
 		return nil
 	}
 
-	err := b.initPaywallUsersPool()
+	err := b.addUsersToPaywallPool()
 	if err != nil {
 		return err
 	}
 
-	// Initiate the thread that checks for payments.
+	// Start the thread that checks for payments.
 	go b.checkForPayments()
 	return nil
-}
-
-// PaywallIsEnabled returns true if paywall is enabled for the server, false
-// otherwise.
-func (b *backend) PaywallIsEnabled() bool {
-	return b.cfg.PaywallAmount != 0 && b.cfg.PaywallXpub != ""
 }

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -433,7 +433,12 @@ func (p *politeiawww) handleMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reply := p.backend.CreateLoginReply(user)
+	reply, err := p.backend.CreateLoginReply(user)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleMe: CreateLoginReply %v", err)
+		return
+	}
 	util.RespondWithJSON(w, http.StatusOK, *reply)
 }
 
@@ -755,17 +760,17 @@ func (p *politeiawww) handleCommentsGet(w http.ResponseWriter, r *http.Request) 
 	util.RespondWithJSON(w, http.StatusOK, gcr)
 }
 
-// handleVerifyUserPaymentTx checks whether the provided transaction
+// handleVerifyUserPayment checks whether the provided transaction
 // is on the blockchain and meets the requirements to consider the user
 // registration fee as paid.
-func (p *politeiawww) handleVerifyUserPaymentTx(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("handleVerifyUserPaymentTx")
+func (p *politeiawww) handleVerifyUserPayment(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleVerifyUserPayment")
 
 	// Get the verify user payment tx command.
-	var vupt v1.VerifyUserPaymentTx
+	var vupt v1.VerifyUserPayment
 	err := util.ParseGetParams(r, &vupt)
 	if err != nil {
-		RespondWithError(w, r, 0, "handleVerifyUserPaymentTx: ParseGetParams",
+		RespondWithError(w, r, 0, "handleVerifyUserPayment: ParseGetParams",
 			v1.UserError{
 				ErrorCode: v1.ErrorStatusInvalidInput,
 			})
@@ -775,14 +780,14 @@ func (p *politeiawww) handleVerifyUserPaymentTx(w http.ResponseWriter, r *http.R
 	user, err := p.getSessionUser(r)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleVerifyUserPaymentTx: getSessionUser %v", err)
+			"handleVerifyUserPayment: getSessionUser %v", err)
 		return
 	}
 
-	vuptr, err := p.backend.ProcessVerifyUserPaymentTx(user, vupt)
+	vuptr, err := p.backend.ProcessVerifyUserPayment(user, vupt)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleVerifyUserPaymentTx: ProcessVerifyUserPaymentTx %v", err)
+			"handleVerifyUserPayment: ProcessVerifyUserPayment %v", err)
 		return
 	}
 
@@ -1176,8 +1181,8 @@ func _main() error {
 		p.handleNewComment, permissionLogin, true)
 	p.addRoute(http.MethodPost, v1.RouteLikeComment,
 		p.handleLikeComment, permissionLogin, true)
-	p.addRoute(http.MethodGet, v1.RouteVerifyUserPaymentTx,
-		p.handleVerifyUserPaymentTx, permissionLogin, false)
+	p.addRoute(http.MethodGet, v1.RouteVerifyUserPayment,
+		p.handleVerifyUserPayment, permissionLogin, false)
 	p.addRoute(http.MethodGet, v1.RouteUserCommentsVotes,
 		p.handleUserCommentsVotes, permissionLogin, true)
 

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -91,9 +91,9 @@ func makeRequest(url string, timeout time.Duration) ([]byte, error) {
 	return ioutil.ReadAll(response.Body)
 }
 
-// dcrStringToAmount converts a DCR amount as a string into a uint64
+// DcrStringToAmount converts a DCR amount as a string into a uint64
 // representing atoms. Supported input variations: "1", ".1", "0.1"
-func dcrStringToAmount(dcrstr string) (uint64, error) {
+func DcrStringToAmount(dcrstr string) (uint64, error) {
 	match, err := regexp.MatchString("(\\d*\\.)*\\d+", dcrstr)
 	if err != nil {
 		return 0, err
@@ -118,7 +118,7 @@ func dcrStringToAmount(dcrstr string) (uint64, error) {
 	}
 
 	dcrsplit[1] = dcrsplit[1] + "00000000"
-	fraction, err := strconv.ParseUint(dcrsplit[1][0:7], 10, 64)
+	fraction, err := strconv.ParseUint(dcrsplit[1][0:8], 10, 64)
 	if err != nil {
 		return 0, err
 	}
@@ -144,7 +144,7 @@ func fetchTxWithPrimaryBE(url string, address string, minimumAmount uint64, txno
 		}
 
 		for _, vout := range v.Vout {
-			amount, err := dcrStringToAmount(vout.Amount.String())
+			amount, err := DcrStringToAmount(vout.Amount.String())
 			if err != nil {
 				return "", err
 			}
@@ -181,7 +181,7 @@ func fetchTxWithBackupBE(url string, address string, minimumAmount uint64, txnot
 			continue
 		}
 
-		amount, err := dcrStringToAmount(v.Amount.String())
+		amount, err := DcrStringToAmount(v.Amount.String())
 		if err != nil {
 			return "", err
 		}

--- a/util/paywall_test.go
+++ b/util/paywall_test.go
@@ -1,0 +1,65 @@
+package util_test
+
+import (
+	"github.com/decred/politeia/util"
+	"testing"
+)
+
+func TestDcrStringToAmount(t *testing.T) {
+	testCases := []struct {
+		input         string
+		output        uint64
+		expectedError error
+	}{
+		{
+			"0.1",
+			1e7,
+			nil,
+		},
+		{
+			"0.15",
+			1.5e7,
+			nil,
+		},
+		{
+			"000000.10000",
+			1e7,
+			nil,
+		},
+		{
+			".1",
+			1e7,
+			nil,
+		},
+		{
+			"1",
+			1e8,
+			nil,
+		},
+		{
+			"1.0",
+			1e8,
+			nil,
+		},
+		{
+			"500",
+			5e10,
+			nil,
+		},
+	}
+
+	// test
+	for _, testCase := range testCases {
+		result, err := util.DcrStringToAmount(testCase.input)
+		if err != testCase.expectedError {
+			t.Errorf("Expected %v for input %s, got %v.",
+				testCase.expectedError, testCase.input, err)
+		}
+		if err == nil {
+			if result != testCase.output {
+				t.Errorf("Expected %v for input %s, got %v.", testCase.output,
+					testCase.input, result)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR changes the paywall logic to continuously watch the paywall addresses for unpaid users. The full behavior is:

* When a user verifies his registration, his paywall info is automatically added to the verification pool.
* The verification pool iterates the unpaid users, checking dcrdata and/or insight for a transaction that meets the paywall requirements.
* When a user is verified as paid by the pool, it removes his paywall info from the pool and updates the database.
* When the server first starts, it iterates all users in the database and adds unpaid users to the pool.
* The pool will stop watching any users whose paywall info was generated more than 24 hours ago. The user's paywall info will only be re-added to the pool via a call to `/me` or `/login` or `/user/verifypayment` (and the timer resets).
* Calls to `/me`, `/login`, and `/user/verifypayment` will check the database for the user's paywall status.

**Note:** The `/user/verifypaymenttx` route has changed to `/user/verifypayment` and no longer accepts a transaction id, because the server performs its own search for a suitable transaction.

Closes #313.