### PR TITLE
[wwwcli] Add activevotes, castvotes, and proposalvotes commands

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/README.md
+++ b/politeiawww/cmd/politeiawwwcli/README.md
@@ -4,8 +4,11 @@
 
 ## Available Commands
 ```
+activevotes        Retrieve all proposals being actively voted on
+castvotes          Cast ticket votes for a specific proposal
 changepassword     change the password for the currently logged in user
 changeusername     change the username for the currently logged in user
+faucet             use the Decred testnet faucet to send DCR to an address
 getcomments        fetch a proposal's comments
 getproposal        fetch a proposal
 getunvetted        fetch unvetted proposals
@@ -16,21 +19,26 @@ me                 return the user information of the currently logged in user
 newcomment         comment on a proposal
 newproposal        submit a new proposal to Politeia
 newuser            create a new Politeia user
+policy             fetch server policy
+proposalvotes      fetch vote results for a specific proposal
 resetpassword      change the password for a user that is not currently logged in
 secret
 setproposalstatus  (admin only) set the status of a proposal
 startvote          (admin only) start the voting period on a proposal
 updateuserkey      update the user identity saved to appDataDir
+usernamesbyid      fetch usernames by their user ids
 userproposals      fetch all proposals submitted by a specific user
 verifyuser         verify user's email address
 verifyuserpayment  check if the user has paid their user registration fee
-version            fetch version info and CSRF token 
+version            fetch server info and CSRF token
 ```
 
 ## Application Options
 ```
-     --host=     politeiawww host (default: https://127.0.0.1:4443)
- -j, --json      Print JSON
+    --host=    politeiawww host (default: https://proposals.decred.org)
+-j, --json     Print JSON
+-v, --verbose  Print request and response details
+
 ```
 
 ## Help Options

--- a/politeiawww/cmd/politeiawwwcli/commands/activevotes.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/activevotes.go
@@ -1,0 +1,8 @@
+package commands
+
+type ActivevotesCmd struct{}
+
+func (cmd *ActivevotesCmd) Execute(args []string) error {
+	_, err := Ctx.ActiveVotes()
+	return err
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/castvotes.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/castvotes.go
@@ -1,0 +1,15 @@
+package commands
+
+type CastvotesArgs struct {
+	Token  string `positional-arg-name:"token" description:"Proposal censorship token"`
+	VoteId string `positional-arg-name:"voteid" description:"A single unique word identifying the vote (e.g. yes). The voteid is applied to all the tickets in your wallet."`
+}
+
+type CastvotesCmd struct {
+	Args CastvotesArgs `positional-args:"true" required:"true"`
+}
+
+func (cmd *CastvotesCmd) Execute(args []string) error {
+	_, err := Ctx.CastVotes(cmd.Args.Token, cmd.Args.VoteId)
+	return err
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
@@ -12,6 +12,8 @@ type Options struct {
 	Verbose func()             `short:"v" long:"verbose" description:"Print request and response details"`
 
 	// cli commands
+	ActiveVotes       ActivevotesCmd       `command:"activevotes" description:"Retrieve all proposals being actively voted on"`
+	CastVotes         CastvotesCmd         `command:"castvotes" description:"Cast ticket votes for a specific proposal"`
 	ChangePassword    ChangepasswordCmd    `command:"changepassword" description:"change the password for the currently logged in user"`
 	ChangeUsername    ChangeusernameCmd    `command:"changeusername" description:"change the username for the currently logged in user"`
 	GetComments       GetcommentsCmd       `command:"getcomments" description:"fetch a proposal's comments"`
@@ -26,6 +28,7 @@ type Options struct {
 	NewUser           NewuserCmd           `command:"newuser" description:"create a new Politeia user"`
 	Faucet            FaucetCmd            `command:"faucet" description:"use the Decred testnet faucet to send DCR to an address"`
 	Policy            PolicyCmd            `command:"policy" description:"fetch server policy"`
+	ProposalVotes     ProposalvotesCmd     `command:"proposalvotes" description:"fetch vote results for a specific proposal"`
 	ResetPassword     ResetpasswordCmd     `command:"resetpassword" description:"change the password for a user that is not currently logged in"`
 	Secret            SecretCmd            `command:"secret"`
 	SetProposalStatus SetproposalstatusCmd `command:"setproposalstatus" description:"(admin only) set the status of a proposal"`
@@ -41,12 +44,12 @@ type Options struct {
 // registers callbacks for cli flags
 func RegisterCallbacks() {
 	Opts.Host = func(host string) error {
-		err := config.UpdateHost(host)
+		err := config.SetHost(host)
 		if err != nil {
 			return err
 		}
-
 		Ctx.SetCookies(host, config.Cookies)
+		Ctx.SetCsrf(config.CsrfToken)
 		return nil
 	}
 

--- a/politeiawww/cmd/politeiawwwcli/commands/proposalvotes.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/proposalvotes.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/decred/politeia/politeiawww/cmd/politeiawwwcli/config"
+)
+
+type ProposalvotesArgs struct {
+	Token string `positional-arg-name:"token" description:"Proposal censorship token"`
+}
+
+type ProposalvotesCmd struct {
+	Args ProposalvotesArgs `positional-args:"true" required:"true"`
+}
+
+func (cmd *ProposalvotesCmd) Execute(args []string) error {
+	vrr, err := Ctx.ProposalVotes(cmd.Args.Token)
+	if err != nil {
+		return err
+	}
+
+	// tally votes
+	tally := make(map[string]uint)
+	for _, v := range vrr.CastVotes {
+		tally[v.VoteBit]++
+	}
+
+	// print vote tally as JSON
+	if config.Verbose {
+		tallyJSON, err := json.Marshal(tally)
+		if err != nil {
+			return fmt.Errorf("Could not marshal vote tally: %v", err)
+		}
+		fmt.Printf("%s\n", tallyJSON)
+	}
+
+	return err
+}


### PR DESCRIPTION
Closes #315 
Closes #291 

This PR adds the activevotes, castvotes, and proposalvotes comands to politeiawwwcli.  It defaults to using a testnet wallet on localhost to sign votes for right now.  I'll add in the ability to change this using a config file and cli flags in a future PR.

This PR also fixes a bug with the --host flag.  You can now interact with multiple politeiawww hosts without any issues.