### PR TITLE
Add admin censor message

### DIFF
--- a/politeiad/api/v1/v1.go
+++ b/politeiad/api/v1/v1.go
@@ -262,6 +262,7 @@ type SetUnvettedStatus struct {
 	Challenge   string           `json:"challenge"`   // Random challenge
 	Token       string           `json:"token"`       // Censorship token
 	Status      RecordStatusT    `json:"status"`      // New status of record
+	Signature   string           `json:"singature"`   // Admin's signature of token + status + message
 	MDAppend    []MetadataStream `json:"mdappend"`    // Metadata streams to append
 	MDOverwrite []MetadataStream `json:"mdoverwrite"` // Metadata streams to overwrite
 }

--- a/politeiad/api/v1/v1.go
+++ b/politeiad/api/v1/v1.go
@@ -262,7 +262,6 @@ type SetUnvettedStatus struct {
 	Challenge   string           `json:"challenge"`   // Random challenge
 	Token       string           `json:"token"`       // Censorship token
 	Status      RecordStatusT    `json:"status"`      // New status of record
-	Signature   string           `json:"singature"`   // Admin's signature of token + status + message
 	MDAppend    []MetadataStream `json:"mdappend"`    // Metadata streams to append
 	MDOverwrite []MetadataStream `json:"mdoverwrite"` // Metadata streams to overwrite
 }

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -1829,6 +1829,8 @@ func (g *gitBackEnd) setUnvettedStatus(token []byte, status backend.MDStatusT, m
 			To:   status,
 		}
 	}
+	// set new metadata to record
+	record.Metadata = mdAppend
 
 	return record, nil
 }

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -588,6 +588,7 @@ func (p *politeia) setUnvettedStatus(w http.ResponseWriter, r *http.Request) {
 		p.respondWithServerError(w, errorCode)
 		return
 	}
+
 	reply := v1.SetUnvettedStatusReply{
 		Response: hex.EncodeToString(response[:]),
 		Record:   p.convertBackendRecord(*record),

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -93,9 +93,6 @@ const (
 	// for the routes that return lists of proposals
 	ProposalListPageSize = 20
 
-	// PolicyMinCensorMessageLength is the min length of a censor message
-	PolicyMinCensorMessageLength = 8
-
 	// Error status codes
 	ErrorStatusInvalid                     ErrorStatusT = 0
 	ErrorStatusInvalidEmailOrPassword      ErrorStatusT = 1
@@ -135,7 +132,6 @@ const (
 	ErrorStatusCannotVerifyPayment         ErrorStatusT = 35
 	ErrorStatusDuplicatePublicKey          ErrorStatusT = 36
 	ErrorStatusInvalidPropVoteStatus       ErrorStatusT = 37
-	ErrorMalformedCensorMessage            ErrorStatusT = 38
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid     PropStatusT = 0 // Invalid status
@@ -213,7 +209,6 @@ var (
 		ErrorStatusCannotVerifyPayment:         "cannot verify payment at this time",
 		ErrorStatusDuplicatePublicKey:          "public key already taken by another user",
 		ErrorStatusInvalidPropVoteStatus:       "invalid proposal vote status",
-		ErrorMalformedCensorMessage:            "invalid censor message",
 	}
 
 	// PropVoteStatus converts votes status codes to human readable text
@@ -510,7 +505,7 @@ type SetProposalStatus struct {
 	ProposalStatus PropStatusT `json:"proposalstatus"`
 	Signature      string      `json:"signature"` // Signature of Token+string(ProposalStatus)+message
 	PublicKey      string      `json:"publickey"`
-	Message        string      `json:"message"` // Admin's message
+	Message        string      `json:"message,omitempty"` // Admin's message
 }
 
 // SetProposalStatusReply is used to reply to a SetProposalStatus command.
@@ -574,7 +569,6 @@ type PolicyReply struct {
 	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
 	MaxCommentLength           uint     `json:"maxcommentlength"`
 	BackendPublicKey           string   `json:"backendpublickey"`
-	MinCensorMessageLength     uint     `json:"mincensormessagelength"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -93,6 +93,9 @@ const (
 	// for the routes that return lists of proposals
 	ProposalListPageSize = 20
 
+	// PolicyMinCensorMessageLength is the min length of a censor message
+	PolicyMinCensorMessageLength = 8
+
 	// Error status codes
 	ErrorStatusInvalid                     ErrorStatusT = 0
 	ErrorStatusInvalidEmailOrPassword      ErrorStatusT = 1
@@ -132,6 +135,7 @@ const (
 	ErrorStatusCannotVerifyPayment         ErrorStatusT = 35
 	ErrorStatusDuplicatePublicKey          ErrorStatusT = 36
 	ErrorStatusInvalidPropVoteStatus       ErrorStatusT = 37
+	ErrorMalformedCensorMessage            ErrorStatusT = 38
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid     PropStatusT = 0 // Invalid status
@@ -209,6 +213,7 @@ var (
 		ErrorStatusCannotVerifyPayment:         "cannot verify payment at this time",
 		ErrorStatusDuplicatePublicKey:          "public key already taken by another user",
 		ErrorStatusInvalidPropVoteStatus:       "invalid proposal vote status",
+		ErrorMalformedCensorMessage:            "invalid censor message",
 	}
 
 	// PropVoteStatus converts votes status codes to human readable text
@@ -249,15 +254,16 @@ type CensorshipRecord struct {
 
 // ProposalRecord is an entire proposal and it's content.
 type ProposalRecord struct {
-	Name        string      `json:"name"`        // Suggested short proposal name
-	Status      PropStatusT `json:"status"`      // Current status of proposal
-	Timestamp   int64       `json:"timestamp"`   // Last update of proposal
-	UserId      string      `json:"userid"`      // ID of user who submitted proposal
-	Username    string      `json:"username"`    // Username of user who submitted proposal
-	PublicKey   string      `json:"publickey"`   // Key used for signature.
-	Signature   string      `json:"signature"`   // Signature of merkle root
-	Files       []File      `json:"files"`       // Files that make up the proposal
-	NumComments uint        `json:"numcomments"` // Number of comments on the proposal
+	Name        string      `json:"name"`              // Suggested short proposal name
+	Status      PropStatusT `json:"status"`            // Current status of proposal
+	Timestamp   int64       `json:"timestamp"`         // Last update of proposal
+	UserId      string      `json:"userid"`            // ID of user who submitted proposal
+	Username    string      `json:"username"`          // Username of user who submitted proposal
+	PublicKey   string      `json:"publickey"`         // Key used for signature.
+	Signature   string      `json:"signature"`         // Signature of merkle root
+	Files       []File      `json:"files"`             // Files that make up the proposal
+	NumComments uint        `json:"numcomments"`       // Number of comments on the proposal
+	Message     string      `json:"message,omitempty"` // Admin's message associated to the last status change
 
 	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
 }
@@ -502,8 +508,9 @@ type ProposalDetailsReply struct {
 type SetProposalStatus struct {
 	Token          string      `json:"token"`
 	ProposalStatus PropStatusT `json:"proposalstatus"`
-	Signature      string      `json:"signature"` // Signature of Token+string(ProposalStatus)
+	Signature      string      `json:"signature"` // Signature of Token+string(ProposalStatus)+message
 	PublicKey      string      `json:"publickey"`
+	Message        string      `json:"message"` // Admin's message
 }
 
 // SetProposalStatusReply is used to reply to a SetProposalStatus command.
@@ -567,6 +574,7 @@ type PolicyReply struct {
 	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
 	MaxCommentLength           uint     `json:"maxcommentlength"`
 	BackendPublicKey           string   `json:"backendpublickey"`
+	MinCensorMessageLength     uint     `json:"mincensormessagelength"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -1591,14 +1591,6 @@ func (b *backend) ProcessSetProposalStatus(sps www.SetProposalStatus, user *data
 		return nil, err
 	}
 
-	// Validate censor message when the proposal is being censored
-	if sps.ProposalStatus == v1.PropStatusCensored &&
-		len(sps.Message) < v1.PolicyMinCensorMessageLength {
-		return nil, v1.UserError{
-			ErrorCode: v1.ErrorMalformedCensorMessage,
-		}
-	}
-
 	// Create change record
 	newStatus := convertPropStatusFromWWW(sps.ProposalStatus)
 	r := MDStreamChanges{
@@ -2418,7 +2410,6 @@ func (b *backend) ProcessPolicy(p www.Policy) *www.PolicyReply {
 		MaxProposalNameLength:      www.PolicyMaxProposalNameLength,
 		ProposalNameSupportedChars: www.PolicyProposalNameSupportedChars,
 		MaxCommentLength:           www.PolicyMaxCommentLength,
-		MinCensorMessageLength:     www.PolicyMinCensorMessageLength,
 	}
 }
 

--- a/politeiawww/backend_proposal_test.go
+++ b/politeiawww/backend_proposal_test.go
@@ -245,13 +245,14 @@ func publishProposal(b *backend, token string, t *testing.T, user *database.User
 	}
 }
 
-func censorProposal(b *backend, token string, t *testing.T, user *database.User, id *identity.FullIdentity) {
+func censorProposal(b *backend, token string, message string, t *testing.T, user *database.User, id *identity.FullIdentity) {
 	sps := www.SetProposalStatus{
 		Token:          token,
 		ProposalStatus: www.PropStatusCensored,
+		Message:        message,
 	}
 
-	msg := sps.Token + strconv.FormatUint(uint64(sps.ProposalStatus), 10)
+	msg := sps.Token + strconv.FormatUint(uint64(sps.ProposalStatus), 10) + message
 	signature, err := getSignature([]byte(msg), id)
 	if err != nil {
 		t.Fatal(err)
@@ -459,7 +460,8 @@ func TestCensoredProposal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	censorProposal(b, npr.CensorshipRecord.Token, t, user, id)
+	csrMessage := "unappropriated content"
+	censorProposal(b, npr.CensorshipRecord.Token, csrMessage, t, user, id)
 	pdr := getProposalDetails(b, npr.CensorshipRecord.Token, t)
 	verifyProposalDetails(np, pdr.Proposal, t)
 

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -560,13 +560,14 @@ func (c *Ctx) ProposalsForUser(userId string) (*v1.UserProposalsReply, error) {
 }
 
 func (c *Ctx) SetPropStatus(id *identity.FullIdentity, token string,
-	status v1.PropStatusT) (*v1.SetProposalStatusReply, error) {
+	status v1.PropStatusT, message string) (*v1.SetProposalStatusReply, error) {
 	ps := v1.SetProposalStatus{
 		Token:          token,
 		ProposalStatus: status,
+		Message:        message,
 	}
 	// Sign token+string(status)
-	msg := []byte(ps.Token + strconv.FormatUint(uint64(ps.ProposalStatus), 10))
+	msg := []byte(ps.Token + strconv.FormatUint(uint64(ps.ProposalStatus), 10) + ps.Message)
 	var err error
 	sig := id.SignMessage(msg)
 	ps.Signature = hex.EncodeToString(sig[:])

--- a/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
@@ -9,8 +9,9 @@ import (
 
 type SetproposalstatusCmd struct {
 	Args struct {
-		Token  string `positional-arg-name:"token"`
-		Status int    `positional-arg-name:"status"`
+		Token   string `positional-arg-name:"token"`
+		Status  int    `positional-arg-name:"status"`
+		Message string `positional-arg-name:"message"`
 	} `positional-args:"true" required:"true"`
 }
 
@@ -19,6 +20,6 @@ func (cmd *SetproposalstatusCmd) Execute(args []string) error {
 		return fmt.Errorf(config.ErrorNoUserIdentity)
 	}
 	var ps v1.PropStatusT = v1.PropStatusT(cmd.Args.Status)
-	_, err := Ctx.SetPropStatus(config.UserIdentity, cmd.Args.Token, ps)
+	_, err := Ctx.SetPropStatus(config.UserIdentity, cmd.Args.Token, ps, cmd.Args.Message)
 	return err
 }

--- a/politeiawww/cmd/politeiawwwtest/main.go
+++ b/politeiawww/cmd/politeiawwwtest/main.go
@@ -75,7 +75,7 @@ func vote(opts *Options, c *client.Ctx) {
 
 	// Move prop to vetted
 	psr1, err := c.SetPropStatus(id, prop1.CensorshipRecord.Token,
-		v1.PropStatusPublic)
+		v1.PropStatusPublic, "")
 	handleError(err)
 
 	if psr1.Proposal.Status != v1.PropStatusPublic {
@@ -417,7 +417,7 @@ func main() {
 
 		// Set proposal status - move prop1 to public
 		psr1, err := c.SetPropStatus(id, prop1.CensorshipRecord.Token,
-			v1.PropStatusPublic)
+			v1.PropStatusPublic, "")
 		handleError(err)
 
 		if psr1.Proposal.Status != v1.PropStatusPublic {
@@ -428,7 +428,7 @@ func main() {
 
 		// Set proposal status - move prop2 to censored
 		psr2, err := c.SetPropStatus(id, prop2.CensorshipRecord.Token,
-			v1.PropStatusCensored)
+			v1.PropStatusCensored, "unappropriated content")
 		handleError(err)
 
 		if psr2.Proposal.Status != v1.PropStatusCensored {


### PR DESCRIPTION
closes #97 
This PR intends to accomplish:
- ~~Provide a receipt on ProposalSetStatus (server signature of the admin's signature)~~
- [x] Store an Admin's message on every proposal status change (required only when transiting from unvetted to censored)
- [x] Policy validation of admin's message 
- [x] Retrieve the last status change message within the proposal data
