### PR TITLE
politeiad: fix initial run

### DIFF
--- a/politeiad/backend/gitbe/git.go
+++ b/politeiad/backend/gitbe/git.go
@@ -305,11 +305,8 @@ func (g *gitBackEnd) gitClone(from, to string, repoConfig map[string]string) err
 
 	// Clone the repo (with config, if applicable).
 	args := []string{"clone", from, to}
-	if repoConfig != nil {
-		args = append(args, "-c")
-		for k, v := range repoConfig {
-			args = append(args, k+"="+v)
-		}
+	for k, v := range repoConfig {
+		args = append(args, "-c", k+"="+v)
 	}
 	_, err = g.git("", args...)
 	return err

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -92,6 +92,8 @@ var (
 		// This prevents git from converting CRLF when committing and checking
 		// out files, which helps when running on Windows.
 		"core.autocrlf": "false",
+		"user.name":     "Politeia",
+		"user.email":    "noreply@decred.org",
 	}
 
 	errNothingToDo = errors.New("nothing to do")


### PR DESCRIPTION
Git requires user.name and user.email to be set.
git config requires a -c before each key/value pair.