### PR TITLE
add proposalpaywall cmd to wwwcli and update wwwtest

### DIFF
--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -470,8 +470,8 @@ type UserProposalCredits struct{}
 
 // UserProposalCredits is used to reply to the UserProposalCredits command.
 type UserProposalCreditsReply struct {
-	UnspentCredits []ProposalCredit `json:"unspentcredits"` // credits that the user has purchased, but have not yet been used to submit proposals
-	SpentCredits   []ProposalCredit `json:"spentcredits"`   // credits that the user has purchased and that have already been used to submit proposals
+	UnspentCredits []ProposalCredit `json:"unspentcredits"` // credits that the user has purchased, but have not yet been used to submit proposals (credit price in atoms)
+	SpentCredits   []ProposalCredit `json:"spentcredits"`   // credits that the user has purchased and that have already been used to submit proposals (credit price in atoms)
 }
 
 // UserProposals is used to request a list of proposals that the

--- a/politeiawww/cmd/politeiawwwcli/README.md
+++ b/politeiawww/cmd/politeiawwwcli/README.md
@@ -77,13 +77,24 @@ Once logged in, you can submit proposals, comment on proposals, cast votes, or p
 If you receive a 403 from the Politeia server, it's most likely an issue with the CSRF tokens.  You can fix this by running either the `version` command or by loggin in with a user.
 
 ## Proposal Status Codes
-If your user has admin privileges, they can set the status of a proposal with the `setproposalstatus` command.  The proposal status codes are listed below.  
+Admins can set the status of a proposal with the `setproposalstatus` command.  The proposal status codes are listed below.
 
 ```
-PropStatusInvalid     PropStatusT = 0 // Invalid status
-PropStatusNotFound    PropStatusT = 1 // Proposal not found
-PropStatusNotReviewed PropStatusT = 2 // Proposal has not been reviewed
-PropStatusCensored    PropStatusT = 3 // Proposal has been censored
-PropStatusPublic      PropStatusT = 4 // Proposal is publicly visible
-PropStatusLocked      PropStatusT = 6 // Proposal is locked
+PropStatusInvalid      0 // Invalid status
+PropStatusNotFound     1 // Proposal not found
+PropStatusNotReviewed  2 // Proposal has not been reviewed
+PropStatusCensored     3 // Proposal has been censored
+PropStatusPublic       4 // Proposal is publicly visible
+PropStatusLocked       6 // Proposal is locked
+```
+
+## User Edit Action Codes
+Admin users can edit certain properties of other users with the `useredit` command.  The edit action codes are listed below.
+
+```
+UserEditExpireNewUserVerification        1 // Expire new user verification
+UserEditExpireUpdateKeyVerification      2 // Expire update key verification
+UserEditExpireResetPasswordVerification  3 // Expire reset password verification
+UserEditClearUserPaywall                 4 // Clear user paywall
+UserEditUnlock                           5 // Unlock user
 ```

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -465,6 +465,26 @@ func (c *Ctx) Logout() error {
 	return err
 }
 
+func (c *Ctx) ProposalPaywall() (*v1.ProposalPaywallDetailsReply, error) {
+	ppd := v1.ProposalPaywallDetails{}
+	responseBody, err := c.makeRequest("GET", v1.RouteProposalPaywallDetails, ppd)
+	if err != nil {
+		return nil, err
+	}
+
+	var ppdr v1.ProposalPaywallDetailsReply
+	err = json.Unmarshal(responseBody, &ppdr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal ProposalPaywalDetailsReply: %v", err)
+	}
+
+	if config.Verbose {
+		prettyPrintJSON(ppdr)
+	}
+
+	return &ppdr, nil
+}
+
 func (c *Ctx) NewProposal(id *identity.FullIdentity, attachments []Attachment, mdPayload []byte) (*v1.NewProposalReply, error) {
 	np := v1.NewProposal{
 		Files:     make([]v1.File, 0),

--- a/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
@@ -30,6 +30,7 @@ type Options struct {
 	NewUser           NewuserCmd           `command:"newuser" description:"create a new Politeia user"`
 	Faucet            FaucetCmd            `command:"faucet" description:"use the Decred testnet faucet to send DCR to an address"`
 	Policy            PolicyCmd            `command:"policy" description:"fetch server policy"`
+	ProposalPaywall   ProposalpaywallCmd   `command:"proposalpaywall" description:"fetch proposal paywall details"`
 	ProposalVotes     ProposalvotesCmd     `command:"proposalvotes" description:"fetch vote results for a specific proposal"`
 	ResetPassword     ResetpasswordCmd     `command:"resetpassword" description:"change the password for a user that is not currently logged in"`
 	Secret            SecretCmd            `command:"secret"`

--- a/politeiawww/cmd/politeiawwwcli/commands/proposalpaywall.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/proposalpaywall.go
@@ -1,0 +1,8 @@
+package commands
+
+type ProposalpaywallCmd struct{}
+
+func (cmd *ProposalpaywallCmd) Execute(args []string) error {
+	_, err := Ctx.ProposalPaywall()
+	return err
+}

--- a/politeiawww/database/database.go
+++ b/politeiawww/database/database.go
@@ -119,12 +119,14 @@ type User struct {
 	// All proposal credits that have been purchased by the user, but have not
 	// yet been used to submit a proposal.  Once a credit is used to submit a
 	// proposal, it is updated with the proposal's censorship token and moved to
-	// the user's spent proposal credits list.
+	// the user's spent proposal credits list.  The price that the proposal
+	// credit was purchased at is in atoms.
 	UnspentProposalCredits []ProposalCredit
 
 	// All credits that have been purchased by the user and have already been
 	// used to submit proposals.  Spent credits have a proposal censorship token
-	// associated with them to signify that they have been spent.
+	// associated with them to signify that they have been spent. The price that
+	// the proposal credit was purchased at is in atoms.
 	SpentProposalCredits []ProposalCredit
 }
 


### PR DESCRIPTION
Closes #405 

- [x] Add a proposalpaywall command to politeaiwwwcli to fetch proposal paywall details
- [x] Update politeiawwwtest to work with proposal paywalls

politeiawwwtest hadn't been updated in a little while.  In addition to the two items listed above, this PR cleans up politeiawwwtest and gets it working again.