### PR TITLE
Add capability to "edit" proposals

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -233,6 +233,12 @@
   revision = "a93b200c26cbae3bb09dd0dc2c7c7fe1468a034a"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/otiai10/copy"
+  packages = ["."]
+  revision = "7e9a647135a142c2669943d4a4d29be015ce9392"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -287,6 +293,7 @@
     "ripemd160",
     "salsa20/salsa",
     "scrypt",
+    "sha3",
     "ssh/terminal"
   ]
   revision = "f70185d77e8278766928032ee1355e3da47e7181"
@@ -375,6 +382,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "54113b96317f784242f017126094a42f5a23393b241710e77163060edc0b4881"
+  inputs-digest = "08ef3c6bce16282ea574641a648d238d9ff4b4a60c823877a0b06f91ccb4fbd3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/politeiad/api/v1/api.md
+++ b/politeiad/api/v1/api.md
@@ -16,6 +16,7 @@ censorship mechanism.
 - [`Get vetted record`](#get-vetted-record)
 - [`Set unvetted status`](#set-unvetted-status)
 - [`Update unvetted record`](#update-unvetted-record)
+- [`Update vetted record`](#update-vetted-record)
 - [`Update vetted metadata`](#update-vetted-metadata)
 - [`Inventory`](#inventory)
 
@@ -368,14 +369,14 @@ Reply:
 
 ### `Update unvetted record`
 
-Update a record.  This call enables a user to update a record by
+Update a unvetted record. This call enables a user to update a record by
 adding/overwriting files, deleting files and append/overwrite metadata
 records.  All changes will be recorded as changesets in the backend.
 
-The returned censorship record will contain the newly calculated merkle root of
-the entire record.  It is the responsibility of the caller to keep track of
-files that have been added or removed if they wish to independently verify the
-record.
+The returned censorship record will contain the newly calculated merkle root
+of the entire record. It is the responsibility of the caller to keep track of
+files that have been added or removed if they wish to independently verify 
+the record.
 
 Note that metadata streams are NOT part of the official record.  They exist for
 the caller to be able to associate pertinent data to the record.  For example,
@@ -399,7 +400,7 @@ they can be used to store JSON encoded comments in a proposal system.
 | | Type | Description |
 |-|-|-|
 | response | string | hex encoded signature of challenge byte array. |
-| censorshiprecord | [CensorshipRecord](#censorship-record) | A censorship record that provides the submitter with a method to extract the record and prove that he/she submitted it. |
+| record | [Record](#record) | Record, including metadata. |
 
 **Example**
 
@@ -437,12 +438,138 @@ Reply:
 
 ```json
 {
-  "response":"ee90b6bc26a899916d80dacef0bef1ba8238b94d9a00edbc04c69372c21faa96abbe3f6f91ece0879ca4616e713951380cdb7762e23c477708f4aba35c366b0c",
-  "censorshiprecord":
+  "response":"f782a969a49cd5e779a748b8c3aa1be758d19f4af0631519e0a74d8cd26787a8d74ad359e738623985e16f64d2c1d5871273c85627519295afc4058703bd6508",
+  "record":
   {
-    "token":"793766f3be00e093318b8f13e6e0e200be209d56b53263ce61c5f9fbb2309321",
-    "merkle":"12a31b5e662dfa0a572e9fc523eb703f9708de5e2d53aba74f8ebcebbdb706f7",
-    "signature":"1d00f3aba3e73d635a4c1f25525681840c46a63addfa2a9dd6a8372143b4fe270e03bda3c1583a4f41f29176c4eb963f98457f35f4d392581a4c4fc635cf7802"
+    "status":5,
+    "timestamp":1513013590,
+    "version": 1,
+    "censorshiprecord":
+    {
+      "token":"793766f3be00e093318b8f13e6e0e200be209d56b53263ce61c5f9fbb2309321",
+      "merkle":"77ba3195336398cd9faa7bc8cefe2bbfbb2b4979fef92a400ce6e91e29ef22d2",
+      "signature":"c94cd71ba065381ad1832d59b5b3d525213012e3a8ed29e8f15646ecaad1ce0109f88cdb343dde516d80c6b32ae69794d897ce6964a719347d61443483b35103"
+    },
+    "metadata":
+    [
+      {
+        "id":2,
+        "payload":"{\"foo\":\"bar\"}"},
+        {"id":12,"payload":"{\"moo\":\"lala\"}"
+      }
+    ],
+    "files":
+    [
+      {
+        "name":"b",
+        "mime":"text/plain; charset=utf-8",
+        "digest":"12a31b5e662dfa0a572e9fc523eb703f9708de5e2d53aba74f8ebcebbdb706f7",
+        "payload":"aWJsZWgK"
+      }
+    ]
+  }
+}
+```
+
+### `Update vetted record`
+
+Update a vetted record. This call enables a user to update a record by
+adding/overwriting files, deleting files and append/overwrite metadata
+records. All changes will be recorded as changesets in the backend.
+
+A new version of the record will be generated and returned. The returned 
+censorship record will contain the newly calculated merkle root of the 
+entire record.
+
+Note that metadata streams are NOT part of the official record.  They exist for
+the caller to be able to associate pertinent data to the record.  For example,
+they can be used to store JSON encoded comments in a proposal system.
+
+**Route**: `POST /v1/updatevetted`
+
+**Params**:
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| challenge | string | 32 byte hex encoded array. | Yes |
+| token | string | 32 byte record identifier. |
+| mdappend | array of [`MetadataStream`](#metadatastream) | Append payload to metadata stream(s). | No |
+| mdoverwrite | array of [`MetadataStream`](#metadatastream) | Overwrite payload to metadata stream(s). | No |
+| filesdel | array of string | Filesnames to remove from record. | No |
+| filesadd | array of [`File`](#file) | Files to add/overwrite in record. | No |
+
+**Results**:
+
+| | Type | Description |
+|-|-|-|
+| response | string | hex encoded signature of challenge byte array. |
+| record | [Record](#record) | Record, including metadata. |
+
+**Example**
+
+Request:
+
+```json
+{
+  "challenge":"3d41f60ffd17176e7b456e67a2fb712d3ff7a719edb45db11c87b124b9d9afc1",
+  "token":"793766f3be00e093318b8f13e6e0e200be209d56b53263ce61c5f9fbb2309321",
+  "mdappend":
+  [
+    {
+      "id":12,
+      "payload":"{\"foo\":\"bar\"}"
+    }
+  ],
+  "mdoverwrite":null,
+  "filesdel":
+  [
+    "a"
+  ],
+  "filesadd":
+  [
+    {
+    "name":"b",
+    "mime":"text/plain; charset=utf-8",
+    "digest":"12a31b5e662dfa0a572e9fc523eb703f9708de5e2d53aba74f8ebcebbdb706f7",
+    "payload":"aWJsZWgK"
+    }
+  ]
+}
+```
+
+Reply:
+
+```json
+{
+  "response":"f782a969a49cd5e779a748b8c3aa1be758d19f4af0631519e0a74d8cd26787a8d74ad359e738623985e16f64d2c1d5871273c85627519295afc4058703bd6508",
+  "record":
+  {
+    "status":4,
+    "timestamp":1513013590,
+    "version": 2,
+    "censorshiprecord":
+    {
+      "token":"793766f3be00e093318b8f13e6e0e200be209d56b53263ce61c5f9fbb2309321",
+      "merkle":"77ba3195336398cd9faa7bc8cefe2bbfbb2b4979fef92a400ce6e91e29ef22d2",
+      "signature":"c94cd71ba065381ad1832d59b5b3d525213012e3a8ed29e8f15646ecaad1ce0109f88cdb343dde516d80c6b32ae69794d897ce6964a719347d61443483b35103"
+    },
+    "metadata":
+    [
+      {
+        "id":2,
+        "payload":"{\"foo\":\"bar\"}"},
+        {"id":12,"payload":"{\"moo\":\"lala\"}"
+      }
+    ],
+    "files":
+    [
+      {
+        "name":"b",
+        "mime":"text/plain; charset=utf-8",
+        "digest":"12a31b5e662dfa0a572e9fc523eb703f9708de5e2d53aba74f8ebcebbdb706f7",
+        "payload":"aWJsZWgK"
+      }
+    ]
   }
 }
 ```
@@ -597,5 +724,6 @@ Reply:
 | status | [`Record status`](#record-status) | Current status. |
 | timestamp | int64 | Last update. |
 | censorshiprecord | [`Censorship record`](#censorship-record) | Censorship record. |
+| version | string | Version of this record |
 | metadata | [`Metadata stream`](#metadata-stream) | Metadata streams. |
 | files | [`Files`](#files) | Files. |

--- a/politeiad/api/v1/v1.go
+++ b/politeiad/api/v1/v1.go
@@ -25,6 +25,7 @@ const (
 	IdentityRoute             = "/v1/identity/"       // Retrieve identity
 	NewRecordRoute            = "/v1/newrecord/"      // New record
 	UpdateUnvettedRoute       = "/v1/updateunvetted/" // Update unvetted record
+	UpdateVettedRoute         = "/v1/updatevetted/"   // Update vetted record
 	UpdateVettedMetadataRoute = "/v1/updatevettedmd/" // Update vetted metadata
 	GetUnvettedRoute          = "/v1/getunvetted/"    // Retrieve unvetted record
 	GetVettedRoute            = "/v1/getvetted/"      // Retrieve vetted record
@@ -55,6 +56,7 @@ const (
 	ErrorStatusDuplicateFilename             ErrorStatusT = 12
 	ErrorStatusFileNotFound                  ErrorStatusT = 13
 	ErrorStatusNoChanges                     ErrorStatusT = 14
+	ErrorStatusRecordFound                   ErrorStatusT = 15
 
 	// Record status codes (set and get)
 	RecordStatusInvalid           RecordStatusT = 0 // Invalid status
@@ -92,6 +94,7 @@ var (
 		ErrorStatusDuplicateFilename:             "duplicate filename",
 		ErrorStatusFileNotFound:                  "file not found",
 		ErrorStatusNoChanges:                     "no changes in record",
+		ErrorStatusRecordFound:                   "record found",
 	}
 
 	// RecordStatus converts record status codes to human readable text.
@@ -209,6 +212,7 @@ type Record struct {
 	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
 
 	// User data
+	Version  string           `json:"version"`  // Version of this record
 	Metadata []MetadataStream `json:"metadata"` // Metadata streams
 	Files    []File           `json:"files"`    // Files that make up the record
 }
@@ -273,8 +277,8 @@ type SetUnvettedStatusReply struct {
 	Record   Record `json:"record"`
 }
 
-// UpdateUnvetted update an unvetted record.
-type UpdateUnvetted struct {
+// UpdateRecord update an unvetted record.
+type UpdateRecord struct {
 	Challenge   string           `json:"challenge"`   // Random challenge
 	Token       string           `json:"token"`       // Censorship token
 	MDAppend    []MetadataStream `json:"mdappend"`    // Metadata streams to append
@@ -283,12 +287,12 @@ type UpdateUnvetted struct {
 	FilesAdd    []File           `json:"filesadd"`    // Files that are modified or added
 }
 
-// UpdateUnvetted returns a CensorshipRecord which may or may not have changed.
-// Metadata updates do not create a new CensorshipRecord.
-type UpdateUnvettedReply struct {
+// UpdateRecordReply returns a CensorshipRecord which may or may not have
+// changed.  Metadata only updates do not create a new CensorshipRecord.
+type UpdateRecordReply struct {
 	Response string `json:"response"` // Challenge response
 
-	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
+	Record Record `json:"record"`
 }
 
 // UpdateVettedMetadata update a vetted metadata.  This is allowed for

--- a/politeiad/backend/backend.go
+++ b/politeiad/backend/backend.go
@@ -16,6 +16,10 @@ var (
 	// ErrRecordNotFound is emitted when a record could not be found
 	ErrRecordNotFound = errors.New("record not found")
 
+	// ErrRecordFound is emitted when a record is found while none was
+	// expected.
+	ErrRecordFound = errors.New("record found")
+
 	// ErrFileNotFound is emitted when a file inside a record could not be
 	// found
 	ErrFileNotFound = errors.New("file not found")
@@ -23,8 +27,12 @@ var (
 	// ErrShutdown is emitted when the backend is shutting down.
 	ErrShutdown = errors.New("backend is shutting down")
 
-	// ErrShutdown is emitted when the backend is shutting down.
+	// ErrNoChanges there are no changes to the record.
 	ErrNoChanges = errors.New("no changes to record")
+
+	// ErrChangesRecord is returned when a record would change when not
+	// expected.
+	ErrChangesRecord = errors.New("changes record")
 
 	// ErrRecordLocked is returned when an updated was attempted on a
 	// locked record.
@@ -110,10 +118,11 @@ type MetadataStream struct {
 	Payload string // String encoded metadata
 }
 
-// Record is a permanent that includes the submitted files, metadata and
+// Record is a permanent Record that includes the submitted files, metadata and
 // internal metadata.
 type Record struct {
 	RecordMetadata RecordMetadata   // Internal metadata
+	Version        string           // Version of Files
 	Metadata       []MetadataStream // User provided metadata
 	Files          []File           // User provided files
 }
@@ -137,8 +146,11 @@ type Backend interface {
 
 	// Update unvetted record (token, mdAppend, mdOverwrite, fAdd, fDelete)
 	UpdateUnvettedRecord([]byte, []MetadataStream, []MetadataStream, []File,
-		[]string) (*RecordMetadata, error)
+		[]string) (*Record, error)
 
+	// Update vetted record (token, mdAppend, mdOverwrite, fAdd, fDelete)
+	UpdateVettedRecord([]byte, []MetadataStream, []MetadataStream, []File,
+		[]string) (*Record, error)
 	// Update vetted metadata (token, mdAppend, mdOverwrite)
 	UpdateVettedMetadata([]byte, []MetadataStream,
 		[]MetadataStream) error

--- a/politeiad/backend/gitbe/gitbe_test.go
+++ b/politeiad/backend/gitbe/gitbe_test.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -392,5 +393,67 @@ func TestAnchorWithCommits(t *testing.T) {
 	}
 }
 
-func TestDcrtimeFsck(t *testing.T) {
+func TestFilePathVersion(t *testing.T) {
+	dir, err := ioutil.TempDir("", "pathversion")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	t.Logf("dir: %v", dir)
+	d, err := _joinLatest(dir)
+	if err != backend.ErrRecordNotFound {
+		t.Fatal(err)
+	}
+	if d != "" {
+		t.Fatalf("expected \"\", got %v", d)
+	}
+
+	// Create version 0 and check again
+	newDir := pijoin(dir, "0")
+	err = os.MkdirAll(newDir, 0766)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDir := joinLatest(dir)
+	// Abuse filepath.Split by pretending 0 is a file
+	splitDir, splitFile := filepath.Split(testDir)
+	if splitDir != dir+"/" {
+		t.Fatalf("invalid dir, expected %v, got %v", dir+"/", splitDir)
+	}
+	if splitFile != "0" {
+		t.Fatalf("invalid dir, expected 0, got %v", splitFile)
+	}
+
+	// Create version 1 and check again
+	newDir = pijoin(dir, "1")
+	err = os.MkdirAll(newDir, 0766)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDir = joinLatest(dir)
+	// Abuse filepath.Split by pretending 1 is a file
+	splitDir, splitFile = filepath.Split(testDir)
+	if splitDir != dir+"/" {
+		t.Fatalf("invalid dir, expected %v, got %v", dir+"/", splitDir)
+	}
+	if splitFile != "1" {
+		t.Fatalf("invalid dir, expected 1, got %v", splitFile)
+	}
+
+	// Create version 33 and check again
+	newDir = pijoin(dir, "33")
+	err = os.MkdirAll(newDir, 0766)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDir = joinLatest(dir)
+	// Abuse filepath.Split by pretending 33 is a file
+	splitDir, splitFile = filepath.Split(testDir)
+	if splitDir != dir+"/" {
+		t.Fatalf("invalid dir, expected %v, got %v", dir+"/", splitDir)
+	}
+	if splitFile != "33" {
+		t.Fatalf("invalid dir, expected 33, got %v", splitFile)
+	}
 }

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -29,6 +29,7 @@ API.  It does not render HTML.
 - [`Proposal paywall details`](#proposal-paywall-details)
 - [`User proposal credits`](#user-proposal-credits)
 - [`New proposal`](#new-proposal)
+- [`Edit Proposal`](#edit-proposal)
 - [`Proposal details`](#proposal-details)
 - [`Set proposal status`](#set-proposal-status)
 - [`Policy`](#policy)
@@ -959,6 +960,86 @@ Reply:
   }
 }
 ```
+
+### `Edit proposal`
+
+Edit an existent proposal into the politeiawww server.
+The proposal name is derived from the first line of the markdown file - index.md.
+
+Note that updating public proposals will generate a new record version. While 
+updating an unvetted record will change the record but it will not generate
+a new version.
+
+The example shown below is for a public proposal where the proposal version is increased
+by one after the update.
+
+**Route:** `POST /v1/proposals/edit`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+| files | array of [`File`](#file)s | Files are the body of the proposal. It should consist of one markdown file - named "index.md" - and up to five pictures. **Note:** all parameters within each [`File`](#file) are required. | Yes |
+| signature | string | Signature of the string representation of the Merkle root of the files payload. Note that the merkle digests are calculated on the decoded payload.. | Yes |
+| publickey | string | Public key from the client side, sent to politeiawww for verification | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| proposal | [`Proposal`](#proposal) | The updated proposal. |
+
+**Example:**
+
+Request:
+
+```json
+{
+   "files":[
+      {
+         "name":"index.md",
+         "mime":"text/plain; charset=utf-8",
+         "payload":"RWRpdGVkIHByb3Bvc2FsCmVkaXRlZCBkZXNjcmlwdGlvbg==",
+         "digest":"a3c46ac82db1c9e5d780d9ddd046d73a0fdfcb1a2c55ab730f71a4213725e605"
+      }
+   ],
+   "publickey":"1bc17b4aaa7d08030d0cb984d3b67ce7b681508b46ce307b22dfd630141788a0",
+   "signature":"e8159f104bb4caa9a7952868ead44af8f1015cac72abd81b1fc83a434e26e0ce75c6a3a8a5c8d8f68405e82eea35c60e2d46fb0ff652eaf53690d57a7d4c8000",
+   "token":"6ef01f0ffae69fd267f98756231b8349a14f254c28d2312239cb80579e850337"
+}
+```
+
+Reply:
+
+```json
+{
+   "proposal":{
+      "name":"Edited proposal",
+      "status":4,
+      "timestamp":1535468714,
+      "userid":"",
+      "username":"",
+      "publickey":"1bc17b4aaa7d08030d0cb984d3b67ce7b681508b46ce307b22dfd630141788a0",
+      "signature":"e8159f104bb4caa9a7952868ead44af8f1015cac72abd81b1fc83a434e26e0ce75c6a3a8a5c8d8f68405e82eea35c60e2d46fb0ff652eaf53690d57a7d4c8000",
+      "files":[
+         {
+            "name":"index.md",
+            "mime":"text/plain; charset=utf-8",
+            "digest":"a3c46ac82db1c9e5d780d9ddd046d73a0fdfcb1a2c55ab730f71a4213725e605",
+            "payload":"RWRpdGVkIHByb3Bvc2FsCmVkaXRlZCBkZXNjcmlwdGlvbg=="
+         }
+      ],
+      "numcomments":0,
+      "version":"2",
+      "censorshiprecord":{
+         "token":"6ef01f0ffae69fd267f98756231b8349a14f254c28d2312239cb80579e850337",
+         "merkle":"a3c46ac82db1c9e5d780d9ddd046d73a0fdfcb1a2c55ab730f71a4213725e605",
+         "signature":"aead575825a8cf3195079e263fe8eeb342f0fe51757e79de7bb8e733c672c0762cd3a0eb58de5057813028244910324d71ffd96d4a809a4c4634883b62a08007"
+      }
+   }
+}
+```
+
 
 ### `Unvetted`
 
@@ -2128,6 +2209,7 @@ Reply:
 | userid | string | The ID of the user who created the proposal. |
 | publickey | string | The public key of the user who created the proposal. |
 | signature | string | The signature of the merkle root, signed by the user who created the proposal. |
+| version | string | The proposal version. |
 | censorshiprecord | [`censorshiprecord`](#censorship-record) | The censorship record that was created when the proposal was submitted. |
 | files | array of [`File`](#file)s | This property will only be populated for the [`Proposal details`](#proposal-details) call. |
 | numcomments | number | The number of comments on the proposal. This should be ignored for proposals which are not public. |

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -36,6 +36,7 @@ const (
 	RouteAllVetted              = "/proposals/vetted"
 	RouteAllUnvetted            = "/proposals/unvetted"
 	RouteNewProposal            = "/proposals/new"
+	RouteEditProposal           = "/proposals/edit"
 	RouteProposalDetails        = "/proposals/{token:[A-z0-9]{64}}"
 	RouteSetProposalStatus      = "/proposals/{token:[A-z0-9]{64}}/status"
 	RoutePolicy                 = "/policy"
@@ -140,14 +141,17 @@ const (
 	ErrorStatusUserLocked                  ErrorStatusT = 38
 	ErrorStatusNoProposalCredits           ErrorStatusT = 39
 	ErrorStatusInvalidUserEditAction       ErrorStatusT = 40
+	ErrorStatusUserActionNotAllowed        ErrorStatusT = 41
+	ErrorStatusCannotEditPropOnVoting      ErrorStatusT = 42
 
 	// Proposal status codes (set and get)
-	PropStatusInvalid     PropStatusT = 0 // Invalid status
-	PropStatusNotFound    PropStatusT = 1 // Proposal not found
-	PropStatusNotReviewed PropStatusT = 2 // Proposal has not been reviewed
-	PropStatusCensored    PropStatusT = 3 // Proposal has been censored
-	PropStatusPublic      PropStatusT = 4 // Proposal is publicly visible
-	PropStatusLocked      PropStatusT = 6 // Proposal is locked, NOT IMPLEMENTED
+	PropStatusInvalid           PropStatusT = 0 // Invalid status
+	PropStatusNotFound          PropStatusT = 1 // Proposal not found
+	PropStatusNotReviewed       PropStatusT = 2 // Proposal has not been reviewed
+	PropStatusCensored          PropStatusT = 3 // Proposal has been censored
+	PropStatusPublic            PropStatusT = 4 // Proposal is publicly visible
+	PropStatusUnreviewedChanges PropStatusT = 5 // Proposal that has changes that are not reviewed
+	PropStatusLocked            PropStatusT = 6 // Proposal is locked, NOT IMPLEMENTED
 
 	// Proposal vote status codes
 	PropVoteStatusInvalid     PropVoteStatusT = 0 // Invalid vote status
@@ -228,6 +232,8 @@ var (
 		ErrorStatusUserLocked:                  "user locked due to too many login attempts",
 		ErrorStatusNoProposalCredits:           "no proposal credits",
 		ErrorStatusInvalidUserEditAction:       "invalid user edit action",
+		ErrorStatusUserActionNotAllowed:        "user action is not allowed",
+		ErrorStatusCannotEditPropOnVoting:      "cannot edit proposals on voting",
 	}
 
 	// PropStatus converts propsal status codes to human readable text
@@ -297,6 +303,7 @@ type ProposalRecord struct {
 	Signature   string      `json:"signature"`   // Signature of merkle root
 	Files       []File      `json:"files"`       // Files that make up the proposal
 	NumComments uint        `json:"numcomments"` // Number of comments on the proposal
+	Version     string      `json:"version"`     // Record version
 
 	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
 }
@@ -557,7 +564,7 @@ type NewProposal struct {
 	Signature string `json:"signature"` // Signature of merkle root
 }
 
-// NewProposalReply is used to reply to the NewProposal command.
+// NewProposalReply is used to reply to the NewProposal command
 type NewProposalReply struct {
 	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
 }
@@ -897,4 +904,17 @@ type User struct {
 type UserIdentity struct {
 	Pubkey string `json:"pubkey"`
 	Active bool   `json:"isactive"`
+}
+
+// EditProposal attemps to edit a proposal
+type EditProposal struct {
+	Token     string `json:"token"`
+	Files     []File `json:"files"`
+	PublicKey string `json:"publickey"`
+	Signature string `json:"signature"`
+}
+
+// EditProposalReply is used to reply to the EditProposal command
+type EditProposalReply struct {
+	Proposal ProposalRecord `json:"proposal"`
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/editproposal.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/editproposal.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/decred/politeia/politeiawww/cmd/politeiawwwcli/client"
+	"github.com/decred/politeia/politeiawww/cmd/politeiawwwcli/config"
+	"github.com/decred/politeia/util"
+)
+
+type EditProposalCmd struct {
+	Args struct {
+		Token            string   `positional-arg-name:"token"`
+		ProposalMarkdown string   `positional-arg-name:"proposalFilename"`
+		Attachments      []string `positional-arg-name:"attachmentsFilenames"`
+	} `positional-args:"true" optional:"true"`
+	Random bool `long:"random" optional:"true" description:"Generate a random proposal"`
+}
+
+func (cmd *EditProposalCmd) Execute(args []string) error {
+	if config.UserIdentity == nil {
+		return fmt.Errorf(config.ErrorNoUserIdentity)
+	}
+	if !cmd.Random && cmd.Args.ProposalMarkdown == "" {
+		return fmt.Errorf("You must either provide a markdown file " +
+			"or use the --random flag")
+	}
+	var mdPayload []byte
+	var attachments []client.Attachment
+	if cmd.Random {
+		mdPayload = []byte("This is a name\nThis is a description")
+	} else {
+		fpath := util.CleanAndExpandPath(cmd.Args.ProposalMarkdown, config.HomeDir)
+		f, err := os.Open(fpath)
+		if err != nil {
+			return fmt.Errorf("Error: %v", err)
+		}
+		defer f.Close()
+		r := bufio.NewReader(f)
+		var description string
+		var name string
+		for i := 0; ; i++ {
+			line, err := r.ReadString('\n')
+			if i == 0 {
+				name = line
+			} else {
+				description += line
+			}
+			if err == io.EOF {
+				break
+			}
+		}
+
+		mdPayload = []byte(name + "\n" + description)
+
+		if len(cmd.Args.Attachments) > 0 {
+			for _, file := range cmd.Args.Attachments {
+				fpath := util.CleanAndExpandPath(file, config.HomeDir)
+				f, err := os.Open(fpath)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+
+				fileInfo, _ := f.Stat()
+				var size = fileInfo.Size()
+				bytes := make([]byte, size)
+
+				// read file into bytes
+				buffer := bufio.NewReader(f)
+				_, err = buffer.Read(bytes)
+				if err != nil {
+					return err
+				}
+
+				attachments = append(attachments, client.Attachment{
+					Filename: filepath.Base(file),
+					Payload:  bytes,
+				})
+
+			}
+		}
+
+	}
+
+	_, err := Ctx.EditProposal(config.UserIdentity, mdPayload, attachments, cmd.Args.Token)
+	return err
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/politeiawwwcli.go
@@ -17,6 +17,7 @@ type Options struct {
 	ChangePassword    ChangepasswordCmd    `command:"changepassword" description:"change the password for the currently logged in user"`
 	CommentsVotes     CommentsvotesCmd     `command:"commentsvotes" description:"fetch all the comments voted by the user on a proposal"`
 	ChangeUsername    ChangeusernameCmd    `command:"changeusername" description:"change the username for the currently logged in user"`
+	EditProposal      EditProposalCmd      `command:"editproposal" description:"edit a proposal"`
 	EditUser          EdituserCmd          `command:"edituser" description:"edit the details for the given user id"`
 	GetComments       GetcommentsCmd       `command:"getcomments" description:"fetch a proposal's comments"`
 	GetProposal       GetproposalCmd       `command:"getproposal" description:"fetch a proposal"`

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -222,6 +222,8 @@ func convertPropStatusFromPD(s pd.RecordStatusT) www.PropStatusT {
 		return www.PropStatusCensored
 	case pd.RecordStatusPublic:
 		return www.PropStatusPublic
+	case pd.RecordStatusUnreviewedChanges:
+		return www.PropStatusUnreviewedChanges
 	case pd.RecordStatusLocked:
 		return www.PropStatusLocked
 	}
@@ -255,11 +257,6 @@ func convertPropCensorFromPD(f pd.CensorshipRecord) www.CensorshipRecord {
 
 func convertPropFromInventoryRecord(r *inventoryRecord, userPubkeys map[string]string) www.ProposalRecord {
 	proposal := convertPropFromPD(r.record)
-
-	// Set the most up-to-date status.
-	for _, v := range r.changes {
-		proposal.Status = convertPropStatusFromPD(v.NewStatus)
-	}
 
 	// Set the comments num.
 	proposal.NumComments = uint(len(r.comments))
@@ -298,6 +295,7 @@ func convertPropFromPD(p pd.Record) www.ProposalRecord {
 		Signature:        md.Signature,
 		Files:            convertPropFilesFromPD(p.Files),
 		CensorshipRecord: convertPropCensorFromPD(p.CensorshipRecord),
+		Version:          p.Version,
 	}
 }
 

--- a/politeiawww/inventory.go
+++ b/politeiawww/inventory.go
@@ -61,13 +61,15 @@ func (b *backend) newInventoryRecord(record pd.Record) error {
 // updateInventoryRecord updates an existing record.
 //
 // This function must be called WITH the mutex held.
-func (b *backend) updateInventoryRecord(record pd.Record) {
-	b.inventory[record.CensorshipRecord.Token] = &inventoryRecord{
-		record:   record,
-		comments: make(map[string]www.Comment),
+func (b *backend) updateInventoryRecord(record pd.Record) error {
+	ir, ok := b.inventory[record.CensorshipRecord.Token]
+	if !ok {
+		return fmt.Errorf("inventory record not found: %v", record.CensorshipRecord.Token)
 	}
-
+	ir.record = record
+	b.inventory[record.CensorshipRecord.Token] = ir
 	b.loadRecordMetadata(record)
+	return nil
 }
 
 // loadRecord load an record metadata and comments into inventory.
@@ -222,7 +224,7 @@ func (b *backend) loadComments(t string) error {
 	return nil
 }
 
-// loadReocrd load an entire record metadata into inventory.
+// loadRecordMetadata load an entire record metadata into inventory.
 //
 // This function must be called WITH the mutex held.
 func (b *backend) loadRecordMetadata(v pd.Record) {

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -100,7 +100,7 @@ func (p *politeiawww) loadInventory(f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := p.backend.LoadInventory(); err != nil {
 			RespondWithError(w, r, 0,
-				"failed to get Load Inventory", err)
+				"failed to load inventory: %v", err)
 			return
 		}
 		f(w, r)

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -10,10 +10,10 @@ import (
 
 func convertWWWUserFromDatabaseUser(user *database.User) v1.User {
 	return v1.User{
-		ID:       strconv.FormatUint(user.ID, 10),
-		Email:    user.Email,
-		Username: user.Username,
-		Admin:    user.Admin,
+		ID:                              strconv.FormatUint(user.ID, 10),
+		Admin:                           user.Admin,
+		Email:                           user.Email,
+		Username:                        user.Username,
 		NewUserPaywallAddress:           user.NewUserPaywallAddress,
 		NewUserPaywallAmount:            user.NewUserPaywallAmount,
 		NewUserPaywallTx:                user.NewUserPaywallTx,

--- a/util/dcrtime_test.go
+++ b/util/dcrtime_test.go
@@ -60,8 +60,7 @@ func TestVerify(t *testing.T) {
 	}
 
 	// Use pre anchored digest
-	digest := "4458a9d635eabdc3c7d75e8e747cdbb94b2b166245eb7a197982ff2e100d960b"
-	//digest2 := "18ba0bde80cc33cdec19206646940896436399d1f15223398242e042113a7e39"
+	digest := "44425372a555e6ac6dad89d5a5b05cd33385c0c9114c5e90e7861da31ae2f289"
 
 	vr, err := Verify(defaultTestnetHost(), []string{digest})
 	if err != nil {
@@ -76,14 +75,14 @@ func TestVerify(t *testing.T) {
 	if digest != d.Digest {
 		t.Fatalf("invalid digest expected %v got %v", digest, d.Digest)
 	}
-	expectedTX := "cdec2565ac832d6ed1bcea1822cc4ddf06d8f9457a96dcddeec2b3eccbe94980"
+	expectedTX := "2aeb59d362752e73757e4b88812da784fe2f4118d2e28121f286b9fa0ef50c1d"
 	if expectedTX != d.ChainInformation.Transaction {
 		t.Fatalf("invalid tx expected %v got %v", expectedTX,
 			d.ChainInformation.Transaction)
 	}
-	expectedMerkle := "83c0c40f949cc4c02a2c51ed32246acdc7d00eb8a6ae07c67031b11d0db9752a"
+	expectedMerkle := "74bdabc1613ab132490e59fe0551bca62a29c90eca88edeba650d021ac5eaecb"
 	if expectedMerkle != d.ChainInformation.MerkleRoot {
-		t.Fatalf("invalid tx expected %v got %v", expectedMerkle,
+		t.Fatalf("invalid merkle expected %v got %v", expectedMerkle,
 			d.ChainInformation.MerkleRoot)
 	}
 


### PR DESCRIPTION
In reality what this means is that we are creating a version directory for the latest proposal. When a proposal is updated it creates a new version directory with all content in it. This seems to be the least painful way to implement versioning without having to keep track of all kinds of additional files etc. Also from a code perspective this is the least LOC change possible since most of the code remains intact, only file paths change from a git perspective.