### PR TITLE
[wwwcli] Hash passwords before sending to server

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -255,7 +255,7 @@ func (c *Ctx) Login(email, password string) (*v1.LoginReply, *identity.FullIdent
 
 	l := v1.Login{
 		Email:    email,
-		Password: password,
+		Password: digest(password),
 	}
 
 	responseBody, err := c.makeRequest("POST", v1.RouteLogin, l)
@@ -304,7 +304,7 @@ func (c *Ctx) NewUser(email, username, password string) (string, *identity.FullI
 	u := v1.NewUser{
 		Email:     email,
 		Username:  username,
-		Password:  password,
+		Password:  digest(password),
 		PublicKey: hex.EncodeToString(id.Public.Key[:]),
 	}
 
@@ -377,7 +377,7 @@ func (c *Ctx) Secret() error {
 func (c *Ctx) ChangeUsername(password, newUsername string) (
 	*v1.ChangeUsernameReply, error) {
 	cu := v1.ChangeUsername{
-		Password:    password,
+		Password:    digest(password),
 		NewUsername: newUsername,
 	}
 	responseBody, err := c.makeRequest("POST", v1.RouteChangeUsername, cu)
@@ -402,8 +402,8 @@ func (c *Ctx) ChangeUsername(password, newUsername string) (
 func (c *Ctx) ChangePassword(currentPassword, newPassword string) (
 	*v1.ChangePasswordReply, error) {
 	cp := v1.ChangePassword{
-		CurrentPassword: currentPassword,
-		NewPassword:     newPassword,
+		CurrentPassword: digest(currentPassword),
+		NewPassword:     digest(newPassword),
 	}
 	responseBody, err := c.makeRequest("POST", v1.RouteChangePassword, cp)
 	if err != nil {
@@ -439,7 +439,7 @@ func (c *Ctx) ResetPassword(email, newPassword string) error {
 		return fmt.Errorf("Could not unmarshal ResetPasswordReply: %v", err)
 	}
 
-	rp.NewPassword = newPassword
+	rp.NewPassword = digest(newPassword)
 	rp.VerificationToken = rpr.VerificationToken
 
 	responseBody, err = c.makeRequest("POST", v1.RouteResetPassword, rp)

--- a/politeiawww/cmd/politeiawwwcli/client/util.go
+++ b/politeiawww/cmd/politeiawwwcli/client/util.go
@@ -15,8 +15,16 @@ import (
 	"github.com/agl/ed25519"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
+	"golang.org/x/crypto/sha3"
 	"golang.org/x/crypto/ssh/terminal"
 )
+
+// digest returns the hex encoded SHA3-256 of a string.
+func digest(s string) string {
+	h := sha3.New256()
+	h.Write([]byte(s))
+	return hex.EncodeToString(h.Sum(nil))
+}
 
 func convertTicketHashes(h []string) ([][]byte, error) {
 	hashes := make([][]byte, 0, len(h))


### PR DESCRIPTION
Closes #421 

This PR updates `politeiawwwcli` to convert passwords to SHA3-256 digests before sending them to the server.