### PR TITLE
[wwwcli] Generate random proposal text when --random is used

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/commands/editproposal.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/editproposal.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -32,7 +34,20 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 	var mdPayload []byte
 	var attachments []client.Attachment
 	if cmd.Random {
-		mdPayload = []byte("This is a name\nThis is a description")
+		// Generate proposal markdown text.
+		var b bytes.Buffer
+		b.WriteString("This is the proposal title\n")
+
+		// The description is 10 lines of random base64 encoded text.
+		for i := 0; i < 10; i++ {
+			r, err := util.Random(32)
+			if err != nil {
+				return err
+			}
+			b.WriteString(base64.StdEncoding.EncodeToString(r) + "\n")
+		}
+
+		mdPayload = b.Bytes()
 	} else {
 		fpath := util.CleanAndExpandPath(cmd.Args.ProposalMarkdown, config.HomeDir)
 		f, err := os.Open(fpath)

--- a/politeiawww/cmd/politeiawwwcli/commands/newproposal.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newproposal.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -31,7 +33,20 @@ func (cmd *NewproposalCmd) Execute(args []string) error {
 	var mdPayload []byte
 	var attachments []client.Attachment
 	if cmd.Random {
-		mdPayload = []byte("This is a name\nThis is a description")
+		// Generate proposal markdown text.
+		var b bytes.Buffer
+		b.WriteString("This is the proposal title\n")
+
+		// The description is 10 lines of random base64 encoded text.
+		for i := 0; i < 10; i++ {
+			r, err := util.Random(32)
+			if err != nil {
+				return err
+			}
+			b.WriteString(base64.StdEncoding.EncodeToString(r) + "\n")
+		}
+
+		mdPayload = b.Bytes()
 	} else {
 		fpath := util.CleanAndExpandPath(cmd.Args.ProposalMarkdown, config.HomeDir)
 		f, err := os.Open(fpath)


### PR DESCRIPTION
politeiawwwcli currently uses hardcoded proposal text when the `--random` flag is used with the `newproposal` and `editproposal` commands.  This PR fixes this by adding 10 lines of randomly generated text to the proposal.   An example proposal is shown below.

```
This is the proposal title
CUJV7uVxJGxuNAY0nfyXoEgv8VF014dqIeVDXOIhDow=
MYfrM2VKOuXeuh+7QMGDQ/1BNH37YnMPkqbIriYQDbI=
FxevhuN3kZzgXSm+o6c5G9rq4YMzlMUphFZyVbuIukk=
ZnZH5dN+QTQxyYrVKBbh62O1aDz5xDcqHCZ6K67y7Oo=
MiYYVGuDRjfwn4lzsBm31eCKSN70mGgc6n97DFYUvC8=
WNqp8JQEBhPJu1PGVKGFPniJwychmE4bVRcCpWiXO08=
cBYVAY9i1xMlLbn9dBbvmdD2Va4salG3CiW3DeDr/2I=
4yRuDqvknXhk+6esB0XZeSg/Y6PTteAJgTzfKciyYqM=
B/0dgDam3D4rhOzM3RY99kNi8rOtJNenlrab2wbUeSU=
ZaKdZTJTVn9yeLjbVgvO48SWV/ewEr+eUuMh2N9xY0c=
```