### PR TITLE
[WWW] Update “comment” and “like comment” enforcement rules

### DIFF
--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -143,6 +143,8 @@ const (
 	ErrorStatusInvalidUserEditAction       ErrorStatusT = 40
 	ErrorStatusUserActionNotAllowed        ErrorStatusT = 41
 	ErrorStatusCannotEditPropOnVoting      ErrorStatusT = 42
+	ErrorStatusCannotCommentOnProp         ErrorStatusT = 43
+	ErrorStatusCannotVoteOnPropComment     ErrorStatusT = 44
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid           PropStatusT = 0 // Invalid status
@@ -234,6 +236,8 @@ var (
 		ErrorStatusInvalidUserEditAction:       "invalid user edit action",
 		ErrorStatusUserActionNotAllowed:        "user action is not allowed",
 		ErrorStatusCannotEditPropOnVoting:      "cannot edit proposals on voting",
+		ErrorStatusCannotCommentOnProp:         "cannot comment on proposal",
+		ErrorStatusCannotVoteOnPropComment:     "cannot vote on proposal comment",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2119,13 +2119,6 @@ func (b *backend) ProcessLikeComment(lc www.LikeComment, user *database.User) (*
 		return nil, fmt.Errorf("ProcessLikeComment: inventory proposal not found: %v", lc.Token)
 	}
 
-	// make sure the proposal is public
-	if convertPropStatusFromPD(ir.record.Status) != www.PropStatusPublic {
-		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusCannotVoteOnPropComment,
-		}
-	}
-
 	// make sure the proposal voting has not ended
 	bb, err := b.getBestBlock()
 	if err != nil {

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2133,7 +2133,6 @@ func (b *backend) ProcessLikeComment(lc www.LikeComment, user *database.User) (*
 	}
 
 	if getVoteStatus(ir, bb) == www.PropVoteStatusFinished {
-		// vote is either active or finished
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusCannotVoteOnPropComment,
 		}

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2005,6 +2005,34 @@ func (b *backend) ProcessComment(c www.NewComment, user *database.User) (*www.Ne
 		return nil, err
 	}
 
+	// get proposal record from inventory
+	b.RLock()
+	ir, ok := b.inventory[c.Token]
+	b.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("ProcessComment: inventory proposal not found: %v", c.Token)
+	}
+
+	// make sure the proposal is public
+	if convertPropStatusFromPD(ir.record.Status) != www.PropStatusPublic {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCannotCommentOnProp,
+		}
+	}
+
+	// make sure the proposal voting has not ended
+	bb, err := b.getBestBlock()
+	if err != nil {
+		return nil, fmt.Errorf("ProcessComment: getBestBlock: %v", err)
+	}
+
+	if getVoteStatus(ir, bb) == www.PropVoteStatusFinished {
+		// vote is either active or finished
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCannotCommentOnProp,
+		}
+	}
+
 	// Validate comment
 	if err := validateComment(c); err != nil {
 		return nil, err
@@ -2083,18 +2111,31 @@ func (b *backend) ProcessLikeComment(lc www.LikeComment, user *database.User) (*
 		return nil, err
 	}
 
-	// Validate prop vote status
+	// get the proposal record from inventory
 	b.RLock()
 	ir, ok := b.inventory[lc.Token]
 	b.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("Could not find proposal")
+		return nil, fmt.Errorf("ProcessLikeComment: inventory proposal not found: %v", lc.Token)
 	}
 
-	if ir.voting.EndHeight != "" {
+	// make sure the proposal is public
+	if convertPropStatusFromPD(ir.record.Status) != www.PropStatusPublic {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCannotVoteOnPropComment,
+		}
+	}
+
+	// make sure the proposal voting has not ended
+	bb, err := b.getBestBlock()
+	if err != nil {
+		return nil, fmt.Errorf("ProcessLikeComment: getBestBlock: %v", err)
+	}
+
+	if getVoteStatus(ir, bb) == www.PropVoteStatusFinished {
 		// vote is either active or finished
 		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusInvalidPropVoteStatus,
+			ErrorCode: www.ErrorStatusCannotVoteOnPropComment,
 		}
 	}
 


### PR DESCRIPTION
This PR improves the enforcement rules for creating comments and liking comments. The enforcement update is:
- Only public proposals can be commented or receive "like" for its comments
- Proposals which voting has already ended cannot receive comments or "like" for its comments