### PR TITLE
[www] Set default path for CSRF cookies

### DIFF
--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1345,7 +1345,9 @@ func _main() error {
 
 	var csrfHandle func(http.Handler) http.Handler
 	if !p.cfg.Proxy {
-		csrfHandle = csrf.Protect(csrfKey)
+		// make sure the cookie path is the parent of all routes
+		// it fixes multiple CSRF tokens being stored in the cookie
+		csrfHandle = csrf.Protect(csrfKey, csrf.Path("/api"))
 	}
 
 	p.router = mux.NewRouter()

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1347,7 +1347,7 @@ func _main() error {
 	if !p.cfg.Proxy {
 		// make sure the cookie path is the parent of all routes
 		// it fixes multiple CSRF tokens being stored in the cookie
-		csrfHandle = csrf.Protect(csrfKey, csrf.Path("/api"))
+		csrfHandle = csrf.Protect(csrfKey, csrf.Path("/"))
 	}
 
 	p.router = mux.NewRouter()


### PR DESCRIPTION
Set default path for CSRF cookies to `/` in order to avoid multiple tokens stored in the cookie
closes https://github.com/decred/politeiagui/issues/540
