### PR TITLE
[www] Format usernames and enforce no white space or uppercase letters.

### DIFF
--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -182,8 +182,7 @@ var (
 	// PolicyUsernameSupportedChars is the regular expression of a valid
 	// username
 	PolicyUsernameSupportedChars = []string{
-		"A-z", "0-9", ".", ",", ":", ";", "-", " ", "@", "+",
-		"(", ")"}
+		"a-z", "0-9", ".", ",", ":", ";", "-", "@", "+", "(", ")"}
 
 	// PoliteiaWWWAPIRoute is the prefix to the API route
 	PoliteiaWWWAPIRoute = fmt.Sprintf("/v%v", PoliteiaWWWAPIVersion)


### PR DESCRIPTION
Closes #324.

This PR ensures that usernames are properly formatted.  When a new user is created or a username is updated, the white space is trimmed and the username is converted to lowercase.  The validateUsername regex check was also updated to enforce the no white space and no upper case letters rules.