### PR TITLE
[wwwcli] Change setproposalstatus message to optional argument.

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
@@ -9,17 +9,22 @@ import (
 
 type SetproposalstatusCmd struct {
 	Args struct {
-		Token  string `positional-arg-name:"token"`
-		Status int    `positional-arg-name:"status"`
-	} `positional-args:"true" required:"true"`
-	StatusChangeMessage string `long:"message" optional:"true" description:"Status change message"`
+		Token   string `positional-arg-name:"token" required:"true" description:"Proposal censorship record token"`
+		Status  int    `positional-arg-name:"status" required:"true" description:"Proposal status code"`
+		Message string `positional-arg-name:"message" description:"Status change message (required if censoring proposal)"`
+	} `positional-args:"true"`
 }
 
 func (cmd *SetproposalstatusCmd) Execute(args []string) error {
 	if config.UserIdentity == nil {
 		return fmt.Errorf(config.ErrorNoUserIdentity)
 	}
+
 	var ps v1.PropStatusT = v1.PropStatusT(cmd.Args.Status)
-	_, err := Ctx.SetPropStatus(config.UserIdentity, cmd.Args.Token, ps, cmd.StatusChangeMessage)
+	if ps == v1.PropStatusCensored && cmd.Args.Message == "" {
+		return fmt.Errorf("Status change message required when censoring a proposal")
+	}
+
+	_, err := Ctx.SetPropStatus(config.UserIdentity, cmd.Args.Token, ps, cmd.Args.Message)
 	return err
 }


### PR DESCRIPTION
 This PR changes the status change message for the `politeiawwwcli setproposalstatus` command from a command line flag to an optional argument.

```
$ politeiawwwcli setproposalstatus 3d9f611fb8e8ec9a5577079f98be7f4206a35f34371c10b8f68dbba745a238a4 3 "censor message"
```