### PR TITLE
Don't allow a comment to be censored multiple times.

### DIFF
--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -1242,11 +1242,17 @@ func (g *gitBackEnd) pluginCensorComment(payload string) (string, error) {
 		return "", fmt.Errorf("proposal not found %v", censor.Token)
 	}
 
-	// Ensure comment exists in comments cache
+	// Ensure comment exists in comments cache and has not
+	// already been censored
 	c, ok := decredPluginCommentsCache[censor.Token][censor.CommentID]
 	if !ok {
 		g.Unlock()
 		return "", fmt.Errorf("comment not found %v:%v",
+			censor.Token, censor.CommentID)
+	}
+	if c.Censored {
+		g.Unlock()
+		return "", fmt.Errorf("comment already censored %v: %v",
 			censor.Token, censor.CommentID)
 	}
 

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2249,9 +2249,16 @@ func (b *backend) ProcessCensorComment(cc www.CensorComment, user *database.User
 		return nil, fmt.Errorf("inventory proposal not found: %v", cc.Token)
 	}
 
-	// Ensure comment exists.
-	if _, ok := b.inventory[cc.Token].comments[cc.CommentID]; !ok {
-		return nil, fmt.Errorf("comment not found %v: %v", cc.Token, cc.CommentID)
+	// Ensure comment exists and has not already been censored.
+	c, ok := b.inventory[cc.Token].comments[cc.CommentID]
+	if !ok {
+		return nil, fmt.Errorf("comment not found %v: %v",
+			cc.Token, cc.CommentID)
+	}
+	if c.Censored {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCannotCensorComment,
+		}
 	}
 
 	// Ensure proposal voting has not ended.


### PR DESCRIPTION
This adds in logic so that a comment cannot be censored multiple times.  

The original implementation of censor comment would delete the comment from the cache so these checks were not necessary.  When we updated the implementation to keep the comment in the cache, I failed to add these additional checks in.

With this pr, if an admin tries to censor a comment that has already been censored, they will no get a 400 response with the user error "cannot censor comment".

