### PR TITLE
[wwwcli] Add inventory, vote, and tally commands.

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/README.md
+++ b/politeiawww/cmd/politeiawwwcli/README.md
@@ -160,10 +160,66 @@ proposal.
 $ politeiawwwcli startvote [censorhipRecordToken]
 ```
 
-### Voting on a proposal
-Voting on a proposal can be done using the `politeiavoter` tool. 
+### Voting on a proposal - politeiavoter
+Voting on a proposal can be done using the 
+[politeiavoter](https://github.com/decred/politeia/tree/master/politeiavoter/)
+tool.
 
-* [politeiavoter](https://github.com/decred/politeia/tree/master/politeiavoter/)
+### Voting on a proposal - politeiawwwcli
+You can also vote on proposals using `politeiawwwcli`, but for right now, it 
+only works on testnet and you have to be running your dcrwallet locally using
+the default port.  If you are doing these things, then you can use the 
+`inventory`, `vote`, and `tally` commands.
+
+`inventory` will fetch all of the active proposal votes and print the details
+for the proposal votes in which you have eligible tickets.
+
+```
+$ politeiawwwcli inventory
+Token: ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899
+  Proposal        : This is the proposal title
+  Eligible tickets: 3
+  Start block     : 30938
+  End block       : 32954
+  Mask            : 3
+  Vote Option:
+    ID                   : no
+    Description          : Don't approve proposal
+    Bits                 : 1
+  Vote Option:
+    ID                   : yes
+    Description          : Approve proposal
+    Bits                 : 2
+    To choose this option: politeiawwwcli vote ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899 yes
+```
+
+`vote` will cast votes using your eligible tickets.  You'll be asked to enter
+your wallet password.
+
+```
+$ politeiawwwcli vote ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899 yes
+Enter the private passphrase of your wallet:
+Votes succeeded: 3
+Votes failed   : 0
+```
+
+`tally` will return the current voting resuts the for passed in proposal.
+
+```
+$ politeiawwwcli tally ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899
+Vote Option:
+  ID                   : no
+  Description          : Don't approve proposal
+  Bits                 : 1
+  Votes received       : 0
+  Percentage           : 0%
+Vote Option:
+  ID                   : yes
+  Description          : Approve proposal
+  Bits                 : 2
+  Votes received       : 3
+  Percentage           : 100%
+```
 
 ## Proposal Status Codes
 Admins can set the status of a proposal with the `setproposalstatus` command.

--- a/politeiawww/cmd/politeiawwwcli/client/util.go
+++ b/politeiawww/cmd/politeiawwwcli/client/util.go
@@ -1,12 +1,9 @@
 package client
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
-
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 func PrettyPrintJSON(v interface{}) error {
@@ -16,25 +13,4 @@ func PrettyPrintJSON(v interface{}) error {
 	}
 	fmt.Fprintf(os.Stdout, "%s\n", b)
 	return nil
-}
-
-// PromptPassphrase is used to prompt the user for the private passphrase to
-// their wallet.
-func PromptPassphrase() ([]byte, error) {
-	prompt := "Enter the private passphrase of your wallet: "
-	for {
-		fmt.Printf("%v", prompt)
-		pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
-		if err != nil {
-			return nil, err
-		}
-		fmt.Printf("\n")
-
-		pass = bytes.TrimSpace(pass)
-		if len(pass) == 0 {
-			continue
-		}
-
-		return pass, nil
-	}
 }

--- a/politeiawww/cmd/politeiawwwcli/client/wallet.go
+++ b/politeiawww/cmd/politeiawwwcli/client/wallet.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/decred/dcrwallet/rpc/walletrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+func (c *Client) LoadWalletClient() error {
+	creds, err := credentials.NewClientTLSFromFile(c.cfg.WalletCert, "")
+	if err != nil {
+		return err
+	}
+
+	conn, err := grpc.Dial(c.cfg.WalletHost,
+		grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return err
+	}
+
+	c.ctx = context.Background()
+	c.creds = creds
+	c.conn = conn
+	c.wallet = walletrpc.NewWalletServiceClient(conn)
+	return nil
+}
+
+func (c *Client) WalletAccounts() (*walletrpc.AccountsResponse, error) {
+	if c.wallet == nil {
+		return nil, fmt.Errorf("walletrpc client not loaded")
+	}
+
+	if c.cfg.Verbose {
+		fmt.Printf("walletrpc %v Accounts\n", c.cfg.WalletHost)
+	}
+
+	ar, err := c.wallet.Accounts(c.ctx, &walletrpc.AccountsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	if c.cfg.Verbose {
+		err := PrettyPrintJSON(ar)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ar, nil
+}
+
+func (c *Client) CommittedTickets(ct *walletrpc.CommittedTicketsRequest) (*walletrpc.CommittedTicketsResponse, error) {
+	if c.wallet == nil {
+		return nil, fmt.Errorf("walletrpc client not loaded")
+	}
+
+	if c.cfg.Verbose {
+		fmt.Printf("walletrpc %v CommittedTickets\n", c.cfg.WalletHost)
+	}
+
+	ctr, err := c.wallet.CommittedTickets(c.ctx, ct)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.cfg.Verbose {
+		err := PrettyPrintJSON(ctr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ctr, nil
+}
+
+func (c *Client) SignMessages(sm *walletrpc.SignMessagesRequest) (*walletrpc.SignMessagesResponse, error) {
+	if c.wallet == nil {
+		return nil, fmt.Errorf("walletrpc client not loaded")
+	}
+
+	if c.cfg.Verbose {
+		fmt.Printf("walletrpc %v SignMessages\n", c.cfg.WalletHost)
+	}
+
+	smr, err := c.wallet.SignMessages(c.ctx, sm)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.cfg.Verbose {
+		err := PrettyPrintJSON(smr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return smr, nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -35,6 +35,7 @@ type Cmds struct {
 	GetProposal       GetProposalCmd       `command:"getproposal" description:"fetch a proposal"`
 	GetUnvetted       GetUnvettedCmd       `command:"getunvetted" description:"fetch unvetted proposals"`
 	GetVetted         GetVettedCmd         `command:"getvetted" description:"fetch vetted proposals"`
+	Inventory         InventoryCmd         `command:"inventory" description:"fetch the proposals that are being voted on"`
 	Login             LoginCmd             `command:"login" description:"login to Politeia"`
 	Logout            LogoutCmd            `command:"logout" description:"logout of Politeia"`
 	Me                MeCmd                `command:"me" description:"return the user information of the currently logged in user"`
@@ -48,12 +49,14 @@ type Cmds struct {
 	Secret            SecretCmd            `command:"secret" description:"ping politeiawww"`
 	SetProposalStatus SetProposalStatusCmd `command:"setproposalstatus" description:"(admin) set the status of a proposal"`
 	StartVote         StartVoteCmd         `command:"startvote" description:"(admin) start the voting period on a proposal"`
+	Tally             TallyCmd             `command:"tally" description:"fetch the vote tally for a proposal"`
 	UsernamesByID     UsernamesByIDCmd     `command:"usernamesbyid" description:"fetch usernames by their user ids"`
 	UserDetails       UserDetailsCmd       `command:"userdetails" description:"fetch a user's details by his user id"`
 	UserProposals     UserProposalsCmd     `command:"userproposals" description:"fetch all proposals submitted by a specific user"`
 	VerifyUser        VerifyUserCmd        `command:"verifyuser" description:"verify user's email address"`
 	VerifyUserPayment VerifyUserPaymentCmd `command:"verifyuserpayment" description:"check if the user has paid their user registration fee"`
 	Version           VersionCmd           `command:"version" description:"fetch server info and CSRF token"`
+	Vote              VoteCmd              `command:"vote" description:"cast ticket votes for a proposal"`
 	VoteComment       VoteCommentCmd       `command:"votecomment" description:"vote on a comment"`
 	VoteStatus        VoteStatusCmd        `command:"votestatus" description:"fetch the vote status of a proposal"`
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/inventory.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/inventory.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/decred/dcrwallet/rpc/walletrpc"
+)
+
+type InventoryCmd struct{}
+
+func (cmd *InventoryCmd) Execute(args []string) error {
+	// Connect to user's wallet
+	err := c.LoadWalletClient()
+	if err != nil {
+		return fmt.Errorf("LoadWalletClient: %v", err)
+	}
+
+	// Get all active proposal votes
+	avr, err := c.ActiveVotes()
+	if err != nil {
+		return fmt.Errorf("ActiveVotes: %v", err)
+	}
+
+	// Get current block height
+	ar, err := c.WalletAccounts()
+	if err != nil {
+		return fmt.Errorf("WalletAccounts: %v", err)
+	}
+
+	// Validate active votes and print the details of the
+	// votes that the user is eligible to vote in
+	for _, v := range avr.Votes {
+		// Ensure a CensorshipRecord exists
+		if v.Proposal.CensorshipRecord.Token == "" {
+			// This should not happen
+			fmt.Printf("skipping empty CensorshipRecord\n")
+			continue
+		}
+
+		// Ensure vote bits are valid
+		if v.StartVote.Vote.Token == "" || v.StartVote.Vote.Mask == 0 ||
+			v.StartVote.Vote.Options == nil {
+			// This should not happen
+			fmt.Printf("invalid vote bits: %v", v.Proposal.CensorshipRecord.Token)
+			continue
+		}
+
+		// Ensure vote has not expired
+		endHeight, err := strconv.ParseInt(v.StartVoteReply.EndHeight, 10, 32)
+		if err != nil {
+			return err
+		}
+
+		if int64(ar.CurrentBlockHeight) > endHeight {
+			// This should not happen
+			fmt.Printf("Vote expired: current %v > end %v %v\n",
+				endHeight, ar.CurrentBlockHeight, v.StartVote.Vote.Token)
+			continue
+		}
+
+		// Ensure user has eligible tickets for this proposal vote
+		ticketPool, err := ConvertTicketHashes(v.StartVoteReply.EligibleTickets)
+		if err != nil {
+			return err
+		}
+
+		ctr, err := c.CommittedTickets(&walletrpc.CommittedTicketsRequest{
+			Tickets: ticketPool,
+		})
+		if err != nil {
+			return fmt.Errorf("CommittedTickets: %v", err)
+		}
+
+		if len(ctr.TicketAddresses) == 0 {
+			// User doesn't have any eligible tickets
+			fmt.Printf("Token: %v\n", v.StartVote.Vote.Token)
+			fmt.Printf("  Proposal        : %v\n", v.Proposal.Name)
+			fmt.Printf("  Eligible tickets: %v\n", len(ctr.TicketAddresses))
+			continue
+		}
+
+		// Print details for the active proposal votes where
+		// the user has eligible tickets
+		fmt.Printf("Token: %v\n", v.StartVote.Vote.Token)
+		fmt.Printf("  Proposal        : %v\n", v.Proposal.Name)
+		fmt.Printf("  Eligible tickets: %v\n", len(ctr.TicketAddresses))
+		fmt.Printf("  Start block     : %v\n", v.StartVoteReply.StartBlockHeight)
+		fmt.Printf("  End block       : %v\n", v.StartVoteReply.EndHeight)
+		fmt.Printf("  Mask            : %v\n", v.StartVote.Vote.Mask)
+		for _, vo := range v.StartVote.Vote.Options {
+			fmt.Printf("  Vote Option:\n")
+			fmt.Printf("    ID                   : %v\n", vo.Id)
+			fmt.Printf("    Description          : %v\n",
+				vo.Description)
+			fmt.Printf("    Bits                 : %v\n", vo.Bits)
+			fmt.Printf("    To choose this option: politeiawwwcli vote %v %v\n",
+				v.StartVote.Vote.Token, vo.Id)
+		}
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/tally.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/tally.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type TallyCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token" description:"Proposal censorship token"`
+	} `positional-args:"true" required:"true"`
+}
+
+func (cmd *TallyCmd) Execute(args []string) error {
+	// Get vote results for proposal
+	vrr, err := c.ProposalVotes(cmd.Args.Token)
+	if err != nil {
+		return fmt.Errorf("ProposalVotes: %v", err)
+	}
+
+	// Tally votes
+	var total uint
+	tally := make(map[uint64]uint)
+	for _, v := range vrr.CastVotes {
+		bits, err := strconv.ParseUint(v.VoteBit, 10, 64)
+		if err != nil {
+			return err
+		}
+		tally[bits]++
+		total++
+	}
+
+	if total == 0 {
+		return fmt.Errorf("no votes recorded")
+	}
+
+	// Print results
+	for _, vo := range vrr.StartVote.Vote.Options {
+		votes := tally[vo.Bits]
+		fmt.Printf("Vote Option:\n")
+		fmt.Printf("  ID                   : %v\n", vo.Id)
+		fmt.Printf("  Description          : %v\n", vo.Description)
+		fmt.Printf("  Bits                 : %v\n", vo.Bits)
+		fmt.Printf("  Votes received       : %v\n", votes)
+		fmt.Printf("  Percentage           : %v%%\n",
+			float64(votes)/float64(total)*100)
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/vote.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/vote.go
@@ -1,0 +1,201 @@
+package commands
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrwallet/rpc/walletrpc"
+	"github.com/decred/politeia/politeiad/api/v1/identity"
+	"github.com/decred/politeia/politeiawww/api/v1"
+	"github.com/decred/politeia/util"
+)
+
+type VoteCmd struct {
+	Args struct {
+		Token  string `positional-arg-name:"token" description:"Proposal censorship token"`
+		VoteID string `positional-arg-name:"voteid" description:"A single unique word identifying the vote (e.g. yes)"`
+	} `positional-args:"true" required:"true"`
+}
+
+func (cmd *VoteCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	voteID := cmd.Args.VoteID
+
+	// Connet to user's wallet
+	err := c.LoadWalletClient()
+	if err != nil {
+		return fmt.Errorf("LoadWalletClient: %v", err)
+	}
+
+	// Get server public key
+	vr, err := c.Version()
+	if err != nil {
+		return fmt.Errorf("Version: %v", err)
+	}
+
+	serverID, err := util.IdentityFromString(vr.PubKey)
+	if err != nil {
+		return err
+	}
+
+	// Get all active proposal votes
+	avr, err := c.ActiveVotes()
+	if err != nil {
+		return fmt.Errorf("ActiveVotes: %v", err)
+	}
+
+	// Find the proposal that the user wants to vote on
+	var pvt *v1.ProposalVoteTuple
+	for _, v := range avr.Votes {
+		if token == v.Proposal.CensorshipRecord.Token {
+			pvt = &v
+			break
+		}
+	}
+
+	if pvt == nil {
+		return fmt.Errorf("proposal not found: %v", token)
+	}
+
+	// Ensure that the passed in voteID is one of the
+	// proposal's voting options and save the vote bits
+	var voteBits string
+	for _, option := range pvt.StartVote.Vote.Options {
+		if voteID == option.Id {
+			voteBits = strconv.FormatUint(option.Bits, 16)
+			break
+		}
+	}
+
+	if voteBits == "" {
+		return fmt.Errorf("vote id not found: %v", voteID)
+	}
+
+	// Find user's tickets that are eligible to vote on this
+	// proposal
+	ticketPool, err := ConvertTicketHashes(pvt.StartVoteReply.EligibleTickets)
+	if err != nil {
+		return err
+	}
+
+	ctr, err := c.CommittedTickets(&walletrpc.CommittedTicketsRequest{
+		Tickets: ticketPool,
+	})
+	if err != nil {
+		return fmt.Errorf("CommittedTickets: %v", err)
+	}
+
+	if len(ctr.TicketAddresses) == 0 {
+		return fmt.Errorf("user has no eligible tickets: %v",
+			pvt.StartVote.Vote.Token)
+	}
+
+	// Create slice of hexidecimal ticket hashes to represent
+	// the user's eligible tickets
+	eligibleTickets := make([]string, 0, len(ctr.TicketAddresses))
+	for i, v := range ctr.TicketAddresses {
+		h, err := chainhash.NewHash(v.Ticket)
+		if err != nil {
+			return fmt.Errorf("NewHash failed on index %v: %v", i, err)
+		}
+		eligibleTickets = append(eligibleTickets, h.String())
+	}
+
+	// Prompt user for wallet password
+	passphrase, err := PromptPassphrase()
+	if err != nil {
+		return fmt.Errorf("PromptPassphrase: %v", err)
+	}
+
+	// Sign eligible tickets with vote preference
+	messages := make([]*walletrpc.SignMessagesRequest_Message, 0,
+		len(eligibleTickets))
+	for i, v := range ctr.TicketAddresses {
+		// ctr.TicketAddresses and eligibleTickets use the same index
+		msg := token + eligibleTickets[i] + voteBits
+		messages = append(messages, &walletrpc.SignMessagesRequest_Message{
+			Address: v.Address,
+			Message: msg,
+		})
+	}
+
+	sigs, err := c.SignMessages(&walletrpc.SignMessagesRequest{
+		Passphrase: passphrase,
+		Messages:   messages,
+	})
+	if err != nil {
+		return fmt.Errorf("SignMessages: %v", err)
+	}
+
+	// Validate signatures
+	for i, r := range sigs.Replies {
+		if r.Error != "" {
+			return fmt.Errorf("signature failed index %v: %v", i, r.Error)
+		}
+	}
+
+	// Setup cast votes request
+	votes := make([]v1.CastVote, 0, len(eligibleTickets))
+	for i, ticket := range eligibleTickets {
+		// eligibleTickets and sigs use the same index
+		votes = append(votes, v1.CastVote{
+			Token:     token,
+			Ticket:    ticket,
+			VoteBit:   voteBits,
+			Signature: hex.EncodeToString(sigs.Replies[i].Signature),
+		})
+	}
+
+	// Cast proposal votes
+	br, err := c.CastVotes(&v1.Ballot{
+		Votes: votes,
+	})
+	if err != nil {
+		return fmt.Errorf("CastVotes: %v", err)
+	}
+
+	// Check for any failed votes. Vote receipts don't include
+	// the ticket hash so in order to associate a failed
+	// receipt with a specific ticket, we need  to lookup the
+	// ticket hash and store it seperately.
+	failedReceipts := make([]v1.CastVoteReply, 0, len(br.Receipts))
+	failedTickets := make([]string, 0, len(eligibleTickets))
+	for i, v := range br.Receipts {
+		// Lookup ticket hash
+		// br.Receipts and eligibleTickets use the same index
+		h := eligibleTickets[i]
+
+		// Check for voting error
+		if v.Error != "" {
+			failedReceipts = append(failedReceipts, v)
+			failedTickets = append(failedTickets, h)
+			continue
+		}
+
+		// Validate server signature
+		sig, err := identity.SignatureFromString(v.Signature)
+		if err != nil {
+			v.Error = err.Error()
+			failedReceipts = append(failedReceipts, v)
+			failedTickets = append(failedTickets, h)
+			continue
+		}
+
+		if !serverID.VerifyMessage([]byte(v.ClientSignature), *sig) {
+			v.Error = "Could not verify receipt " + v.ClientSignature
+			failedReceipts = append(failedReceipts, v)
+			failedTickets = append(failedTickets, h)
+		}
+	}
+
+	// Print results
+	fmt.Printf("Votes succeeded: %v\n", len(br.Receipts)-len(failedReceipts))
+	fmt.Printf("Votes failed   : %v\n", len(failedReceipts))
+	for i, v := range failedReceipts {
+		fmt.Printf("Failed vote    : %v %v\n", failedTickets[i], v.Error)
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/config/config.go
+++ b/politeiawww/cmd/politeiawwwcli/config/config.go
@@ -22,7 +22,7 @@ const (
 	defaultConfigFilename    = "politeiawwwcli.conf"
 	defaultHost              = "https://proposals.decred.org/api"
 	defaultFaucetHost        = "https://faucet.decred.org/requestfaucet"
-	defaultWalletHost        = "https://127.0.0.1"
+	defaultWalletHost        = "127.0.0.1"
 	defaultWalletMainnetPort = "19110" // we don't allow mainnet for right now
 	defaultWalletTestnetPort = "19111"
 


### PR DESCRIPTION
This adds the politeiavoter inventory, vote, and tally commands to politeiawwwcli.  For right now, they only work on testnet and you have to be running dcrwallet locally using the default port.  Additional cli options will be added in the future that allow you to use these commands anywhere.

```
$ politeiawwwcli inventory
Token: ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899
  Proposal        : This is the proposal title
  Eligible tickets: 3
  Start block     : 30938
  End block       : 32954
  Mask            : 3
  Vote Option:
    ID                   : no
    Description          : Don't approve proposal
    Bits                 : 1
    To choose this option: politeiawwwcli vote ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899 no
  Vote Option:
    ID                   : yes
    Description          : Approve proposal
    Bits                 : 2
    To choose this option: politeiawwwcli vote ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899 yes
```
```
$ politeiawwwcli vote ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899 yes
Enter the private passphrase of your wallet:
Votes succeeded: 3
Votes failed   : 0
```

```
$ politeiawwwcli tally ee42e2e231c02b3d202de9f5df7b2d361a5ab078f675a8823e3db73afb799899
Vote Option:
  ID                   : no
  Description          : Don't approve proposal
  Bits                 : 1
  Votes received       : 0
  Percentage           : 0%
Vote Option:
  ID                   : yes
  Description          : Approve proposal
  Bits                 : 2
  Votes received       : 3
  Percentage           : 100%
```