### PR TITLE
[wwwcli] Make status code arguments human readable.

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/README.md
+++ b/politeiawww/cmd/politeiawwwcli/README.md
@@ -222,8 +222,8 @@ Vote Option:
 ```
 
 ## Proposal Status Codes
-Admins can set the status of a proposal with the `setproposalstatus` command.
-The proposal status codes are listed below.
+A proposal record will include a numeric staus code to represent the status of
+the proposal.  These status codes are listed below.
 
 ```
 PropStatusInvalid      0 // Invalid status
@@ -232,16 +232,4 @@ PropStatusNotReviewed  2 // Proposal has not been reviewed
 PropStatusCensored     3 // Proposal has been censored
 PropStatusPublic       4 // Proposal is publicly visible
 PropStatusLocked       6 // Proposal is locked
-```
-
-## User Edit Action Codes
-Admins can edit certain properties of other users with the `useredit` command.
-The edit action codes are listed below.
-
-```
-UserEditExpireNewUserVerification        1 // Expire new user verification
-UserEditExpireUpdateKeyVerification      2 // Expire update key verification
-UserEditExpireResetPasswordVerification  3 // Expire reset password verification
-UserEditClearUserPaywall                 4 // Clear user paywall
-UserEditUnlock                           5 // Unlock user
 ```

--- a/politeiawww/cmd/politeiawwwcli/commands/edituser.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/edituser.go
@@ -1,24 +1,57 @@
 package commands
 
-import "github.com/decred/politeia/politeiawww/api/v1"
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/decred/politeia/politeiawww/api/v1"
+)
 
 type EditUserCmd struct {
 	Args struct {
-		UserID string `positional-arg-name:"userid"`
-		Action int64  `positional-arg-name:"action"`
-		Reason string `positional-arg-name:"reason"`
+		UserID string `positional-arg-name:"userid" description:"User ID"`
+		Action string `positional-arg-name:"action" description:"Edit user action"`
+		Reason string `positional-arg-name:"reason" description:"Reason for editing the user"`
 	} `positional-args:"true" required:"true"`
 }
 
 func (cmd *EditUserCmd) Execute(args []string) error {
+	EditActions := map[string]v1.UserEditActionT{
+		"expirenewuser":       1,
+		"expireupdatekey":     2,
+		"expireresetpassword": 3,
+		"clearpaywall":        4,
+		"unlock":              5,
+	}
+
+	// Parse edit user action.  This can be either the numeric
+	// action code or the human readable equivalent.
+	var action v1.UserEditActionT
+	a, err := strconv.ParseUint(cmd.Args.Action, 10, 32)
+	if err == nil {
+		// Numeric action code found
+		action = v1.UserEditActionT(a)
+	} else if a, ok := EditActions[cmd.Args.Action]; ok {
+		// Human readable action code found
+		action = a
+	} else {
+		return fmt.Errorf("Invalid useredit action.  Valid actions are:\n  " +
+			"expirenewuser         expires new user verification\n  " +
+			"expireupdatekey       expires update user key verification\n  " +
+			"expireresetpassword   expires reset password verification\n  " +
+			"clearpaywall          clears user registration paywall\n  " +
+			"unlock                unlocks user account from failed logins")
+	}
+
+	// Setup request
 	eu := &v1.EditUser{
 		UserID: cmd.Args.UserID,
-		Action: v1.UserEditActionT(cmd.Args.Action),
+		Action: action,
 		Reason: cmd.Args.Reason,
 	}
 
 	// Print request details
-	err := Print(eu, cfg.Verbose, cfg.RawJSON)
+	err = Print(eu, cfg.Verbose, cfg.RawJSON)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
@@ -11,32 +11,51 @@ import (
 type SetProposalStatusCmd struct {
 	Args struct {
 		Token   string `positional-arg-name:"token" required:"true" description:"Proposal censorship record token"`
-		Status  int    `positional-arg-name:"status" required:"true" description:"Proposal status code"`
+		Status  string `positional-arg-name:"status" required:"true" description:"New proposal status (censored or public)"`
 		Message string `positional-arg-name:"message" description:"Status change message (required if censoring proposal)"`
 	} `positional-args:"true"`
 }
 
 func (cmd *SetProposalStatusCmd) Execute(args []string) error {
-	token := cmd.Args.Token
-	status := cmd.Args.Status
+	PropStatus := map[string]v1.PropStatusT{
+		"censored": 3,
+		"public":   4,
+	}
 
 	// Validate user identity
 	if cfg.Identity == nil {
 		return fmt.Errorf(ErrorNoUserIdentity)
 	}
 
+	// Parse proposal status.  This can be either the numeric
+	// status code or the human readable equivalent.
+	var status v1.PropStatusT
+	s, err := strconv.ParseUint(cmd.Args.Status, 10, 32)
+	if err == nil {
+		// Numeric status code found
+		status = v1.PropStatusT(s)
+	} else if s, ok := PropStatus[cmd.Args.Status]; ok {
+		// Human readable status code found
+		status = s
+	} else {
+		return fmt.Errorf("Invalid proposal status.  Valid statuses are:\n  " +
+			"censored    censor a proposal\n  " +
+			"public      make a proposal public")
+	}
+
 	// Setup request
-	sig := cfg.Identity.SignMessage([]byte(token + strconv.Itoa(status)))
+	sig := cfg.Identity.SignMessage([]byte(cmd.Args.Token +
+		strconv.Itoa(int(status)) + cmd.Args.Message))
 	sps := &v1.SetProposalStatus{
-		Token:               token,
-		ProposalStatus:      v1.PropStatusT(status),
+		Token:               cmd.Args.Token,
+		ProposalStatus:      status,
 		StatusChangeMessage: cmd.Args.Message,
 		Signature:           hex.EncodeToString(sig[:]),
 		PublicKey:           hex.EncodeToString(cfg.Identity.Public.Key[:]),
 	}
 
 	// Print request details
-	err := Print(sps, cfg.Verbose, cfg.RawJSON)
+	err = Print(sps, cfg.Verbose, cfg.RawJSON)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/politeiawwwcli/config/config.go
+++ b/politeiawww/cmd/politeiawwwcli/config/config.go
@@ -252,7 +252,7 @@ func (cfg *Config) loadIdentity() error {
 func cleanAndExpandPath(path string) string {
 	// Expand initial ~ to OS specific home directory
 	if strings.HasPrefix(path, "~") {
-		homeDir := ""
+		var homeDir string
 		usr, err := user.Current()
 		if err == nil {
 			homeDir = usr.HomeDir


### PR DESCRIPTION
Fixes part of #449

This PR converts the status argument in `setproposalstatus` and the action argument in `edituser` from status codes to human readable text. 

**old implementation**
```
$ politeiawwwcli setproposalstatus a75e59a5b651448ea51139f59a97d3dd 3 "censor message"
$ politeiawwwcli edituser 1 4 "some reason"
```

**new implementation**
```
$ politeiawwwcli setproposalstatus a75e59a5b651448ea51139f59a97d3dd censored "censor message"
$ politeiawwwcli edituser 1 clearpaywall "some reason"
```