### PR TITLE
[www] Don't add files to inventory cache on new proposal.

### DIFF
--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -1696,7 +1696,6 @@ func (b *backend) ProcessNewProposal(np www.NewProposal, user *database.User) (*
 			Timestamp:        ts,
 			CensorshipRecord: pdReply.CensorshipRecord,
 			Metadata:         n.Metadata,
-			Files:            n.Files,
 			Version:          "1",
 		})
 		b.Unlock()
@@ -1734,7 +1733,6 @@ func (b *backend) ProcessNewProposal(np www.NewProposal, user *database.User) (*
 			Timestamp:        ts,
 			CensorshipRecord: pdReply.CensorshipRecord,
 			Metadata:         n.Metadata,
-			Files:            n.Files,
 			Version:          "1",
 		})
 		b.Unlock()

--- a/politeiawww/backend_proposal_test.go
+++ b/politeiawww/backend_proposal_test.go
@@ -280,8 +280,8 @@ func getProposalDetails(b *backend, token string, t *testing.T) *www.ProposalDet
 }
 
 func verifyProposalDetails(np *www.NewProposal, p www.ProposalRecord, t *testing.T) {
-	if p.Files[0].Payload != np.Files[0].Payload {
-		t.Fatalf("proposal descriptions do not match")
+	if p.Signature != np.Signature {
+		t.Fatalf("proposal signatures do not match")
 	}
 }
 


### PR DESCRIPTION
When the www inventory cache is loaded on startup, www requests the proposal inventory from politeiad without the files included.

When a new proposal is created, it creates a new inventory record with the files included.  This creates inconsistencies in the inventory cache.  Some inventory records include proposal files and some don't. 

This PR updates the new proposal endpoint to not store the proposal's files in the inventory cache.