### PR TITLE
[wwwcli] Generate random user identities.

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -1041,3 +1041,48 @@ func (c *Client) CastVotes(b *v1.Ballot) (*v1.BallotReply, error) {
 
 	return &br, nil
 }
+
+func (c *Client) UpdateUserKey(uuk *v1.UpdateUserKey) (*v1.UpdateUserKeyReply, error) {
+	responseBody, err := c.makeRequest("POST", v1.RouteUpdateUserKey, &uuk)
+	if err != nil {
+		return nil, err
+	}
+
+	var uukr v1.UpdateUserKeyReply
+	err = json.Unmarshal(responseBody, &uukr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal UpdateUserKeyReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := PrettyPrintJSON(uukr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &uukr, nil
+}
+
+func (c *Client) VerifyUpdateUserKey(vuuk *v1.VerifyUpdateUserKey) (*v1.VerifyUpdateUserKeyReply, error) {
+	responseBody, err := c.makeRequest("POST", v1.RouteVerifyUpdateUserKey,
+		&vuuk)
+	if err != nil {
+		return nil, err
+	}
+
+	var vuukr v1.VerifyUpdateUserKeyReply
+	err = json.Unmarshal(responseBody, &vuukr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal VerifyUpdateUserKeyReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := PrettyPrintJSON(vuukr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &vuukr, nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -50,6 +50,7 @@ type Cmds struct {
 	SetProposalStatus SetProposalStatusCmd `command:"setproposalstatus" description:"(admin) set the status of a proposal"`
 	StartVote         StartVoteCmd         `command:"startvote" description:"(admin) start the voting period on a proposal"`
 	Tally             TallyCmd             `command:"tally" description:"fetch the vote tally for a proposal"`
+	UpdateUserKey     UpdateUserKeyCmd     `command:"updateuserkey" description:"generate a new identity for the user"`
 	UsernamesByID     UsernamesByIDCmd     `command:"usernamesbyid" description:"fetch usernames by their user ids"`
 	UserDetails       UserDetailsCmd       `command:"userdetails" description:"fetch a user's details by his user id"`
 	UserProposals     UserProposalsCmd     `command:"userproposals" description:"fetch all proposals submitted by a specific user"`

--- a/politeiawww/cmd/politeiawwwcli/commands/login.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/login.go
@@ -38,17 +38,5 @@ func (cmd *LoginCmd) Execute(args []string) error {
 	}
 
 	// Print response details
-	err = Print(lr, cfg.Verbose, cfg.RawJSON)
-	if err != nil {
-		return err
-	}
-
-	// Save identity to disk for subsequent commands
-	// XXX: We are using the email to generate the identity
-	id, err := IdentityFromString(email)
-	if err != nil {
-		return err
-	}
-
-	return cfg.SaveIdentity(id)
+	return Print(lr, cfg.Verbose, cfg.RawJSON)
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/newuser.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newuser.go
@@ -17,6 +17,7 @@ type NewUserCmd struct {
 	Random  bool `long:"random" optional:"true" description:"Generate a random email/password for the user"`
 	Verify  bool `long:"verify" optional:"true" description:"Verify the user's email address"`
 	Paywall bool `long:"paywall" optional:"true" description:"Satisfy paywall fee using testnet faucet"`
+	NoSave  bool `long:"nosave" optional:"true" description:"Do not save the user identity to disk"`
 }
 
 func (cmd *NewUserCmd) Execute(args []string) error {
@@ -59,11 +60,14 @@ func (cmd *NewUserCmd) Execute(args []string) error {
 			pr.MinPasswordLength)
 	}
 
-	// Create user identity
-	// XXX: We are using the email to generate the identity
-	id, err := IdentityFromString(email)
+	// Create user identity and save it to disk
+	id, err := NewIdentity()
 	if err != nil {
 		return err
+	}
+
+	if !cmd.NoSave {
+		cfg.SaveIdentity(id)
 	}
 
 	// Setup new user request

--- a/politeiawww/cmd/politeiawwwcli/commands/updateuserkey.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/updateuserkey.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/decred/politeia/politeiawww/api/v1"
+)
+
+type UpdateUserKeyCmd struct {
+	NoSave bool `long:"nosave" optional:"true" description:"Do not save the user identity to disk"`
+}
+
+func (cmd *UpdateUserKeyCmd) Execute(args []string) error {
+	// Create new identity
+	id, err := NewIdentity()
+	if err != nil {
+		return err
+	}
+
+	// Update user key
+	uuk := &v1.UpdateUserKey{
+		PublicKey: hex.EncodeToString(id.Public.Key[:]),
+	}
+
+	err = Print(uuk, cfg.Verbose, cfg.RawJSON)
+	if err != nil {
+		return err
+	}
+
+	uukr, err := c.UpdateUserKey(uuk)
+	if err != nil {
+		return fmt.Errorf("UpdateUserKey: %v", err)
+	}
+
+	// Verify update user key
+	sig := id.SignMessage([]byte(uukr.VerificationToken))
+	vuuk := &v1.VerifyUpdateUserKey{
+		VerificationToken: uukr.VerificationToken,
+		Signature:         hex.EncodeToString(sig[:]),
+	}
+
+	vuukr, err := c.VerifyUpdateUserKey(vuuk)
+	if err != nil {
+		return fmt.Errorf("VerifyUpdateUserKey: %v", err)
+	}
+
+	err = Print(vuukr, cfg.Verbose, cfg.RawJSON)
+	if err != nil {
+		return err
+	}
+
+	// Save the new identity to disk
+	if !cmd.NoSave {
+		cfg.SaveIdentity(id)
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/util.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/util.go
@@ -69,14 +69,20 @@ func DigestSHA3(s string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func IdentityFromString(s string) (*identity.FullIdentity, error) {
-	buf := [32]byte{}
-	copy(buf[:], []byte(s))
-	r := bytes.NewReader(buf[:])
+// NewIdentity generates a new FullIdentity using randomly generated data to
+// create the public/private key pair.
+func NewIdentity() (*identity.FullIdentity, error) {
+	b, err := util.Random(32)
+	if err != nil {
+		return nil, err
+	}
+
+	r := bytes.NewReader(b[:])
 	pub, priv, err := ed25519.GenerateKey(r)
 	if err != nil {
 		return nil, err
 	}
+
 	id := &identity.FullIdentity{}
 	copy(id.Public.Key[:], pub[:])
 	copy(id.PrivateKey[:], priv[:])


### PR DESCRIPTION
Up until this point,`politeiawwwcli` has been using the email address to generate a new identity in order to make the tool easier to use.  This allowed you to login and logout with different users and have the identity that was saved to disk be automatically updated since `politeiawwwcli` could generate the identity using the user's email address.  This was fine for development, but not that we're getting closer to launching Politeia, this needed to be updated.

This PR does a couple of things:
- Identities are now created using random data instead of the user's email address.
- Updates the `newuser` command to automatically save the identity to disk.  You can use the `--nosave` flag if you don't want the user's identity to be saved.
- Adds the `UpdateUserKey` command.  The new identity is automatically saved to disk when using this command.  The `--nosave` flag can be used if you don't want the new identity to be saved.

Since identities are now randomly generated, if you're logging in and out of different user accounts you'll need to run the `updateuserkey` command to update the identity that is saved to disk before you'll be able to perform user actions that require a signature.
