### PR TITLE
[www] Return user error on invalid filename.

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -64,7 +64,7 @@ API.  It does not render HTML.
 - [`ErrorStatusMaxImageSizeExceededPolicy`](#ErrorStatusMaxImageSizeExceededPolicy)
 - [`ErrorStatusMalformedPassword`](#ErrorStatusMalformedPassword)
 - [`ErrorStatusCommentNotFound`](#ErrorStatusCommentNotFound)
-- [`ErrorStatusInvalidProposalName`](#ErrorStatusInvalidProposalName)
+- [`ErrorStatusInvalidFilename`](#ErrorStatusInvalidFilename)
 - [`ErrorStatusInvalidFileDigest`](#ErrorStatusInvalidFileDigest)
 - [`ErrorStatusInvalidBase64`](#ErrorStatusInvalidBase64)
 - [`ErrorStatusInvalidMIMEType`](#ErrorStatusInvalidMIMEType)
@@ -2226,7 +2226,7 @@ Reply:
 | <a name="ErrorStatusMaxImageSizeExceededPolicy">ErrorStatusMaxImageSizeExceededPolicy</a> | 12 | The submitted proposal has one or more images that are too large. Limits can be obtained by issuing the [Policy](#policy) command. |
 | <a name="ErrorStatusMalformedPassword">ErrorStatusMalformedPassword</a> | 13 | The provided password was malformed. |
 | <a name="ErrorStatusCommentNotFound">ErrorStatusCommentNotFound</a> | 14 | The requested comment does not exist. |
-| <a name="ErrorStatusInvalidProposalName">ErrorStatusInvalidProposalName</a> | 15 | The proposal's name was invalid. |
+| <a name="ErrorStatusInvalidFilename">ErrorStatusInvalidFilename</a> | 15 | The filename was invalid. |
 | <a name="ErrorStatusInvalidFileDigest">ErrorStatusInvalidFileDigest</a> | 16 | The digest (SHA-256 checksum) provided for one of the proposal files was incorrect. This error is provided with additional context: The name of the file with the invalid digest. |
 | <a name="ErrorStatusInvalidBase64">ErrorStatusInvalidBase64</a> | 17 | The name of the file with the invalid encoding.The Base64 encoding provided for one of the proposal files was incorrect. This error is provided with additional context: the name of the file with the invalid encoding. |
 | <a name="ErrorStatusInvalidMIMEType">ErrorStatusInvalidMIMEType</a> | 18 | The MIME type provided for one of the proposal files was not the same as the one derived from the file's content. This error is provided with additional context: The name of the file with the invalid MIME type and the MIME type detected for the file's content. |

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -117,7 +117,7 @@ const (
 	ErrorStatusMaxImageSizeExceededPolicy  ErrorStatusT = 12
 	ErrorStatusMalformedPassword           ErrorStatusT = 13
 	ErrorStatusCommentNotFound             ErrorStatusT = 14
-	ErrorStatusInvalidProposalName         ErrorStatusT = 15
+	ErrorStatusInvalidFilename             ErrorStatusT = 15
 	ErrorStatusInvalidFileDigest           ErrorStatusT = 16
 	ErrorStatusInvalidBase64               ErrorStatusT = 17
 	ErrorStatusInvalidMIMEType             ErrorStatusT = 18
@@ -216,7 +216,7 @@ var (
 		ErrorStatusMaxImageSizeExceededPolicy:  "maximum image file size exceeded",
 		ErrorStatusMalformedPassword:           "malformed password",
 		ErrorStatusCommentNotFound:             "comment not found",
-		ErrorStatusInvalidProposalName:         "invalid proposal name",
+		ErrorStatusInvalidFilename:             "invalid filename",
 		ErrorStatusInvalidFileDigest:           "invalid file digest",
 		ErrorStatusInvalidBase64:               "invalid base64 file content",
 		ErrorStatusInvalidMIMEType:             "invalid MIME type detected for file",

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -336,6 +336,8 @@ func convertErrorStatusFromPD(s int) www.ErrorStatusT {
 		return www.ErrorStatusUnsupportedMIMEType
 	case pd.ErrorStatusInvalidRecordStatusTransition:
 		return www.ErrorStatusInvalidPropStatusTransition
+	case pd.ErrorStatusInvalidFilename:
+		return www.ErrorStatusInvalidFilename
 
 		// These cases are intentionally omitted because
 		// they are indicative of some internal server error,


### PR DESCRIPTION
Closes #478 

This PR does two things:
- Changes the www user error `ErrorStatusInvalidProposalName` to `ErrorStatusInvalidFilename`
- Updates www so that `ErrorStatusInvalidFilename` is returned on an invalid filename instead of a 500 error code

I changed the error name was to make it consistent with the politeiad filename error and so that it can be used for both proposal and attachment filename validation errors.  `ErrorStatusInvalidProposalName` was never actually being used, so it was an easy change.