### PR TITLE
[www] Shuffle code around to make locking more obvious.

### DIFF
--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -676,7 +676,6 @@ func (b *backend) validatePubkeyIsUnique(publicKey string, user *database.User) 
 	b.RLock()
 	userIDStr, ok := b.userPubkeys[publicKey]
 	b.RUnlock()
-
 	if !ok {
 		return nil
 	}
@@ -1891,8 +1890,8 @@ func (b *backend) ProcessProposalDetails(propDetails www.ProposalsDetails, user 
 			ErrorCode: www.ErrorStatusProposalNotFound,
 		}
 	}
-	b.RUnlock()
 	cachedProposal := convertPropFromInventoryRecord(p, b.userPubkeys)
+	b.RUnlock()
 
 	var isVettedProposal bool
 	var requestObject interface{}
@@ -1988,11 +1987,14 @@ func (b *backend) ProcessProposalDetails(propDetails www.ProposalsDetails, user 
 		return nil, err
 	}
 
+	b.RLock()
 	reply.Proposal = convertPropFromInventoryRecord(&inventoryRecord{
 		record:   fullRecord,
 		changes:  p.changes,
 		comments: p.comments,
 	}, b.userPubkeys)
+	b.RUnlock()
+
 	reply.Proposal.Username = b.getUsernameById(reply.Proposal.UserId)
 
 	return &reply, nil
@@ -2878,11 +2880,9 @@ func (b *backend) ProcessEditProposal(user *database.User, ep www.EditProposal) 
 			ErrorCode: www.ErrorStatusProposalNotFound,
 		}
 	}
-	b.RUnlock()
 	cachedProposal := convertPropFromInventoryRecord(invRecord, b.userPubkeys)
 
 	// verify if the user is the proposal owner
-	b.RLock()
 	authorIDStr, ok := b.userPubkeys[cachedProposal.PublicKey]
 	b.RUnlock()
 

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -228,6 +228,27 @@ func checkUserIsLocked(failedLoginAttempts uint64) bool {
 	return failedLoginAttempts >= LoginAttemptsToLockUser
 }
 
+// convertPropFromInventoryRecord converts a backend inventoryRecord to a front
+// end inventoryRecord.
+//
+// This function must be called WITH the lock held.
+func (b *backend) convertPropFromInventoryRecord(r inventoryRecord) www.ProposalRecord {
+	proposal := convertPropFromPD(r.record)
+
+	// Set the comments num.
+	proposal.NumComments = uint(len(r.comments))
+
+	// Set the user id.
+	var ok bool
+	proposal.UserId, ok = b.userPubkeys[proposal.PublicKey]
+	if !ok {
+		log.Errorf("user not found for public key %v, for proposal %v",
+			proposal.PublicKey, proposal.CensorshipRecord.Token)
+	}
+
+	return proposal
+}
+
 // hashPassword hashes the given password string with the default bcrypt cost
 // or the minimum cost if the test flag is set to speed up running tests.
 func (b *backend) hashPassword(password string) ([]byte, error) {
@@ -297,9 +318,11 @@ func (b *backend) login(l *www.Login) loginReplyWithError {
 				}
 			}
 
-			// Check if the user is locked again so we can send an email.
+			// Check if the user is locked again so we can send an
+			// email.
 			if checkUserIsLocked(user.FailedLoginAttempts) && !b.test {
-				// This is conditional on the email server being setup.
+				// This is conditional on the email server
+				// being setup.
 				err := b.emailUserLocked(user.Email)
 				if err != nil {
 					return loginReplyWithError{
@@ -457,8 +480,8 @@ func (b *backend) emailResetPasswordVerificationLink(email, token string) error 
 	return b.cfg.SMTP.Send(msg)
 }
 
-// emailUpdateUserKeyVerificationLink emails the link with the verification token
-// used for setting a new key pair if the email server is set up.
+// emailUpdateUserKeyVerificationLink emails the link with the verification
+// token used for setting a new key pair if the email server is set up.
 func (b *backend) emailUpdateUserKeyVerificationLink(email, publicKey, token string) error {
 	if b.cfg.SMTP == nil {
 		return nil
@@ -493,9 +516,9 @@ func (b *backend) emailUpdateUserKeyVerificationLink(email, publicKey, token str
 	return b.cfg.SMTP.Send(msg)
 }
 
-// emailUserLocked notifies the user its account has been locked and
-// emails the link with the reset password verification token
-// if the email server is set up.
+// emailUserLocked notifies the user its account has been locked and emails the
+// link with the reset password verification token if the email server is set
+// up.
 func (b *backend) emailUserLocked(email string) error {
 	if b.cfg.SMTP == nil {
 		return nil
@@ -529,8 +552,8 @@ func (b *backend) emailUserLocked(email string) error {
 	return b.cfg.SMTP.Send(msg)
 }
 
-// makeRequest makes an http request to the method and route provided, serializing
-// the provided object as the request body.
+// makeRequest makes an http request to the method and route provided,
+// serializing the provided object as the request body.
 func (b *backend) makeRequest(method string, route string, v interface{}) ([]byte, error) {
 	var (
 		requestBody []byte
@@ -552,7 +575,8 @@ func (b *backend) makeRequest(method string, route string, v interface{}) ([]byt
 		}
 	}
 
-	req, err := http.NewRequest(method, fullRoute, bytes.NewReader(requestBody))
+	req, err := http.NewRequest(method, fullRoute,
+		bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, err
 	}
@@ -1890,7 +1914,7 @@ func (b *backend) ProcessProposalDetails(propDetails www.ProposalsDetails, user 
 			ErrorCode: www.ErrorStatusProposalNotFound,
 		}
 	}
-	cachedProposal := convertPropFromInventoryRecord(p, b.userPubkeys)
+	cachedProposal := b.convertPropFromInventoryRecord(*p)
 	b.RUnlock()
 
 	var isVettedProposal bool
@@ -1988,11 +2012,11 @@ func (b *backend) ProcessProposalDetails(propDetails www.ProposalsDetails, user 
 	}
 
 	b.RLock()
-	reply.Proposal = convertPropFromInventoryRecord(&inventoryRecord{
+	reply.Proposal = b.convertPropFromInventoryRecord(inventoryRecord{
 		record:   fullRecord,
 		changes:  p.changes,
 		comments: p.comments,
-	}, b.userPubkeys)
+	})
 	b.RUnlock()
 
 	reply.Proposal.Username = b.getUsernameById(reply.Proposal.UserId)
@@ -2729,7 +2753,7 @@ func (b *backend) ProcessGetAllVoteStatus() (*www.GetAllVoteStatusReply, error) 
 			Token:         i.record.CensorshipRecord.Token,
 			Status:        getVoteStatus(i, bestBlock),
 			TotalVotes:    uint64(len(vrr.CastVotes)),
-			OptionsResult: convertVoteResultsFromDecredplugin(vrr),
+			OptionsResult: convertVoteResultsFromDecredplugin(*vrr),
 			EndHeight:     i.voting.EndHeight,
 		}
 
@@ -2769,7 +2793,7 @@ func (b *backend) ProcessVoteStatus(token string) (*www.VoteStatusReply, error) 
 		Token:         token,
 		TotalVotes:    uint64(len(vrr.CastVotes)),
 		Status:        getVoteStatus(&ir, bestBlock),
-		OptionsResult: convertVoteResultsFromDecredplugin(vrr),
+		OptionsResult: convertVoteResultsFromDecredplugin(*vrr),
 		EndHeight:     ir.voting.EndHeight,
 	}, nil
 }
@@ -2880,7 +2904,7 @@ func (b *backend) ProcessEditProposal(user *database.User, ep www.EditProposal) 
 			ErrorCode: www.ErrorStatusProposalNotFound,
 		}
 	}
-	cachedProposal := convertPropFromInventoryRecord(invRecord, b.userPubkeys)
+	cachedProposal := b.convertPropFromInventoryRecord(*invRecord)
 
 	// verify if the user is the proposal owner
 	authorIDStr, ok := b.userPubkeys[cachedProposal.PublicKey]

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -270,23 +270,6 @@ func convertPropCensorFromPD(f pd.CensorshipRecord) www.CensorshipRecord {
 	}
 }
 
-func convertPropFromInventoryRecord(r *inventoryRecord, userPubkeys map[string]string) www.ProposalRecord {
-	proposal := convertPropFromPD(r.record)
-
-	// Set the comments num.
-	proposal.NumComments = uint(len(r.comments))
-
-	// Set the user id.
-	var ok bool
-	proposal.UserId, ok = userPubkeys[proposal.PublicKey]
-	if !ok {
-		log.Errorf("user not found for public key %v, for proposal %v",
-			proposal.PublicKey, proposal.CensorshipRecord.Token)
-	}
-
-	return proposal
-}
-
 func convertPropFromPD(p pd.Record) www.ProposalRecord {
 	md := &BackendProposalMetadata{}
 	var statusChangeMsg string
@@ -347,7 +330,7 @@ func convertErrorStatusFromPD(s int) www.ErrorStatusT {
 	return www.ErrorStatusInvalid
 }
 
-func convertVoteResultsFromDecredplugin(vrr *decredplugin.VoteResultsReply) []www.VoteOptionResult {
+func convertVoteResultsFromDecredplugin(vrr decredplugin.VoteResultsReply) []www.VoteOptionResult {
 	// counter of votes received
 	var vr uint64
 	var ors []www.VoteOptionResult

--- a/politeiawww/inventory.go
+++ b/politeiawww/inventory.go
@@ -361,12 +361,14 @@ func (b *backend) setRecordVoteAuthorization(token string, avr www.AuthorizeVote
 }
 
 // getProposal returns a single proposal by its token
+//
+// This function must be called WITH the mutex held.
 func (b *backend) getProposal(token string) (www.ProposalRecord, error) {
 	ir, err := b._getInventoryRecord(token)
 	if err != nil {
 		return www.ProposalRecord{}, err
 	}
-	pr := convertPropFromInventoryRecord(&ir, b.userPubkeys)
+	pr := b.convertPropFromInventoryRecord(ir)
 	return pr, nil
 }
 
@@ -379,7 +381,7 @@ func (b *backend) getProposals(pr proposalsRequest) []www.ProposalRecord {
 
 	allProposals := make([]www.ProposalRecord, 0, len(b.inventory))
 	for _, vv := range b.inventory {
-		v := convertPropFromInventoryRecord(vv, b.userPubkeys)
+		v := b.convertPropFromInventoryRecord(*vv)
 
 		// Set the number of comments.
 		v.NumComments = uint(len(vv.comments))

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1241,6 +1241,7 @@ func (p *politeiawww) handleEditProposal(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleEditProposal: processEditProposal %v", err)
+		return
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, epr)


### PR DESCRIPTION
This diff adds a missing return to a failure path and locks around the pubkey to userid converter.

Closes #477 