### PR TITLE
[voter] Make sure there is an escape if we don't find an acceptable duration

### DIFF
--- a/politeiavoter/politeiavoter.go
+++ b/politeiavoter/politeiavoter.go
@@ -427,11 +427,11 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 	// the time limit that was provided by the user.
 	buckets := make([]voteInterval, votes)
 	var (
-		done bool
+		done    bool
 		retries int
 	)
 	maxRetries := 1000
-	for retries = 0; !done && retries < maxRetries; retries++{
+	for retries = 0; !done && retries < maxRetries; retries++ {
 		done = true
 		var total time.Duration
 		for i := 0; i < len(buckets); {
@@ -482,8 +482,8 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 			i++
 		}
 	}
-	if retries>=maxRetries {
-		return nil,nil, fmt.Errorf("Could not randomize times "+
+	if retries >= maxRetries {
+		return nil, nil, fmt.Errorf("Could not randomize times " +
 			"accurately. Please increase --voteduration")
 	}
 

--- a/politeiavoter/politeiavoter.go
+++ b/politeiavoter/politeiavoter.go
@@ -426,8 +426,12 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 	// Create array of work to be done. We try really hard to stay within
 	// the time limit that was provided by the user.
 	buckets := make([]voteInterval, votes)
-	var done bool
-	for !done {
+	var (
+		done bool
+		retries int
+	)
+	maxRetries := 1000
+	for retries = 0; !done && retries < maxRetries; retries++{
 		done = true
 		var total time.Duration
 		for i := 0; i < len(buckets); {
@@ -477,6 +481,10 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 			// Next bucket
 			i++
 		}
+	}
+	if retries>=maxRetries {
+		return nil,nil, fmt.Errorf("Could not randomize times "+
+			"accurately. Please increase --voteduration")
 	}
 
 	// Sanity


### PR DESCRIPTION
Because of the bias, the buckets aren't always below the allotted time. Complain to the user if we can't find a solution and recommend increasing the --voteduration.