### PR TITLE
[www] Add admin route for users list.

### DIFF
--- a/politeiawww/admin.go
+++ b/politeiawww/admin.go
@@ -127,6 +127,8 @@ func (b *backend) ProcessUsers(users *v1.Users) (*v1.UsersReply, error) {
 		reply.TotalUsers++
 		userMatches := true
 
+		// If both emailQuery and usernameQuery are non-empty, the user must
+		// match both.
 		if emailQuery != "" {
 			if !strings.Contains(strings.ToLower(user.Email), emailQuery) {
 				userMatches = false

--- a/politeiawww/admin.go
+++ b/politeiawww/admin.go
@@ -128,7 +128,7 @@ func (b *backend) ProcessUsers(users *v1.Users) (*v1.UsersReply, error) {
 		userMatches := true
 
 		// If both emailQuery and usernameQuery are non-empty, the user must
-		// match both.
+		// match both to be included in the results.
 		if emailQuery != "" {
 			if !strings.Contains(strings.ToLower(user.Email), emailQuery) {
 				userMatches = false

--- a/politeiawww/admin.go
+++ b/politeiawww/admin.go
@@ -115,6 +115,7 @@ func (b *backend) ProcessEditUser(eu *v1.EditUser, adminUser *database.User) (*v
 	return &v1.EditUserReply{}, err
 }
 
+// ProcessUsers returns a list of users given a set of filters.
 func (b *backend) ProcessUsers(users *v1.Users) (*v1.UsersReply, error) {
 	var reply v1.UsersReply
 	reply.Users = make([]v1.AbridgedUser, 0)

--- a/politeiawww/admin.go
+++ b/politeiawww/admin.go
@@ -121,7 +121,7 @@ func (b *backend) ProcessUsers(users *v1.Users) (*v1.UsersReply, error) {
 	reply.Users = make([]v1.AbridgedUser, 0)
 
 	emailQuery := strings.ToLower(users.Email)
-	usernameQuery := strings.ToLower(users.Username)
+	usernameQuery := formatUsername(users.Username)
 
 	var totalMatches uint
 	err := b.db.AllUsers(func(user *database.User) {

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -591,7 +591,8 @@ Returns a list of users given optional filters. This call requires admin privile
 
 | Parameter | Type | Description |
 |-|-|-|
-| total | uint64 | The total number of all users (not just the users that matched the query). |
+| totalusers | uint64 | The total number of all users in the database. |
+| totalmatches | uint64 | The total number of users that matched the query. |
 | users | array of [Abridged User](#abridged-user) | The list of users that match the query. This list will be capped at the `userlistpagesize`, which is specified in the [`Policy`](#policy) call. |
 
 On failure the call shall return `400 Bad Request` and one of the following

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -18,6 +18,7 @@ API.  It does not render HTML.
 - [`Verify user payment`](#verify-user-payment)
 - [`User details`](#user-details)
 - [`Edit user`](#edit-user)
+- [`Users`](#users)
 - [`Update user key`](#update-user-key)
 - [`Verify update user key`](#verify-update-user-key)
 - [`Change username`](#change-username)
@@ -571,6 +572,50 @@ Reply:
 
 ```json
 {}
+```
+
+### `Users`
+
+Returns a list of users given optional filters. This call requires admin privileges.
+
+**Route:** `GET /v1/users`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+| email | string | A query string to match against user email addresses. | |
+| username | string | A query string to match against usernames. | |
+
+**Results:**
+
+| Parameter | Type | Description |
+|-|-|-|
+| total | uint64 | The total number of all users (not just the users that matched the query). |
+| users | array of [Abridged User](#abridged-user) | The list of users that match the query. This list will be capped at the `userlistpagesize`, which is specified in the [`Policy`](#policy) call. |
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusInvalidInput`](#ErrorStatusInvalidInput)
+
+**Example**
+
+Request:
+
+```json
+{
+  "email": "@aol.com",
+  "username": "JakeFromStateFarm"
+}
+```
+
+Reply:
+
+```json
+{
+  "total": 132,
+  "users": []
+}
 ```
 
 ### `Update user key`
@@ -1214,6 +1259,7 @@ SHALL observe.
 | maxusernamelength | integer | maximum number of characters accepted for username |
 | usernamesupportedchars | array of strings | the regular expression of a valid username |
 | proposallistpagesize | integer | maximum number of proposals returned for the routes that return lists of proposals |
+| userlistpagesize | integer | maximum number of users returned for the routes that return lists of users |
 | maximages | integer | maximum number of images accepted when creating a new proposal |
 | maximagesize | integer | maximum image file size (in bytes) accepted when creating a new proposal |
 | maxmds | integer | maximum number of markdown files accepted when creating a new proposal |
@@ -2365,6 +2411,16 @@ Reply:
 | identities | array of [`Identity`](#identity)s | Identities, both activated and deactivated, of the user. |
 | proposals | array of [`Proposal`](#proposal)s | Proposal submitted by the user. |
 | proposalcredits | uint64 | The number of available proposal credits the user has. |
+
+### `Abridged User`
+
+This is a shortened representation of a user, used for lists.
+
+| | Type | Description |
+|-|-|-|
+| id | string | The unique id of the user. |
+| email | string | Email address. |
+| username | string | Unique username. |
 
 ### `Proposal`
 

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -614,7 +614,8 @@ Reply:
 
 ```json
 {
-  "total": 132,
+  "totalusers": 132,
+  "totalmatches": 0,
   "users": []
 }
 ```

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -547,14 +547,14 @@ type VerifyUserPaymentReply struct {
 
 // Users is used to request a list of users given a filter.
 type Users struct {
-	Username string `json:"username"`
-	Email    string `json:"email"`
+	Username string `json:"username"` // String which should match or partially match a username
+	Email    string `json:"email"`    // String which should match or partially match an email
 }
 
 // UsersReply is a reply to the Users command, replying with a list of users.
 type UsersReply struct {
-	Total uint64         `json:"total"`
-	Users []AbridgedUser `json:"users"`
+	Total uint64         `json:"total"` // Total number of all users in the database
+	Users []AbridgedUser `json:"users"` // List of users that match the filters
 }
 
 // AbridgedUser is a shortened version of User that's used for the admin list.

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -29,6 +29,7 @@ const (
 	RouteVerifyUserPayment      = "/user/verifypayment"
 	RouteUserDetails            = "/user/{userid:[0-9a-zA-Z-]{36}}"
 	RouteEditUser               = "/user/edit"
+	RouteUsers                  = "/users"
 	RouteLogin                  = "/login"
 	RouteLogout                 = "/logout"
 	RouteSecret                 = "/secret"
@@ -103,6 +104,10 @@ const (
 	// ProposalListPageSize is the maximum number of proposals returned
 	// for the routes that return lists of proposals
 	ProposalListPageSize = 20
+
+	// UserListPageSize is the maximum number of users returned
+	// for the routes that return lists of users
+	UserListPageSize = 20
 
 	// Error status codes
 	ErrorStatusInvalid                     ErrorStatusT = 0
@@ -540,6 +545,25 @@ type VerifyUserPaymentReply struct {
 	PaywallTxNotBefore int64  `json:"paywalltxnotbefore"` // Minimum timestamp for paywall tx
 }
 
+// Users is used to request a list of users given a filter.
+type Users struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}
+
+// UsersReply is a reply to the Users command, replying with a list of users.
+type UsersReply struct {
+	Total uint64         `json:"total"`
+	Users []AbridgedUser `json:"users"`
+}
+
+// AbridgedUser is a shortened version of User that's used for the admin list.
+type AbridgedUser struct {
+	ID       string `json:"id"`
+	Email    string `json:"email"`
+	Username string `json:"username"`
+}
+
 // Login attempts to login the user.  Note that by necessity the password
 // travels in the clear.
 type Login struct {
@@ -681,6 +705,7 @@ type PolicyReply struct {
 	MaxUsernameLength          uint     `json:"maxusernamelength"`
 	UsernameSupportedChars     []string `json:"usernamesupportedchars"`
 	ProposalListPageSize       uint     `json:"proposallistpagesize"`
+	UserListPageSize           uint     `json:"userlistpagesize"`
 	MaxImages                  uint     `json:"maximages"`
 	MaxImageSize               uint     `json:"maximagesize"`
 	MaxMDs                     uint     `json:"maxmds"`

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -553,8 +553,9 @@ type Users struct {
 
 // UsersReply is a reply to the Users command, replying with a list of users.
 type UsersReply struct {
-	Total uint64         `json:"total"` // Total number of all users in the database
-	Users []AbridgedUser `json:"users"` // List of users that match the filters
+	TotalUsers   uint64         `json:"totalusers"`   // Total number of all users in the database
+	TotalMatches uint64         `json:"totalmatches"` // Total number of users that match the filters
+	Users        []AbridgedUser `json:"users"`        // List of users that match the filters
 }
 
 // AbridgedUser is a shortened version of User that's used for the admin list.

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -3120,6 +3120,7 @@ func (b *backend) ProcessPolicy(p www.Policy) *www.PolicyReply {
 		MaxUsernameLength:          www.PolicyMaxUsernameLength,
 		UsernameSupportedChars:     www.PolicyUsernameSupportedChars,
 		ProposalListPageSize:       www.ProposalListPageSize,
+		UserListPageSize:           www.UserListPageSize,
 		MaxImages:                  www.PolicyMaxImages,
 		MaxImageSize:               www.PolicyMaxImageSize,
 		MaxMDs:                     www.PolicyMaxMDs,

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -931,12 +931,8 @@ func (c *Client) UserDetails(userID string) (*v1.UserDetailsReply, error) {
 	return &udr, nil
 }
 
-func (c *Client) Users(email, username string) (*v1.UsersReply, error) {
-	u := v1.Users{
-		Email:    email,
-		Username: username,
-	}
-	responseBody, err := c.makeRequest("GET", "/users", &u)
+func (c *Client) Users(u *v1.Users) (*v1.UsersReply, error) {
+	responseBody, err := c.makeRequest("GET", v1.RouteUsers, u)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -931,6 +931,32 @@ func (c *Client) UserDetails(userID string) (*v1.UserDetailsReply, error) {
 	return &udr, nil
 }
 
+func (c *Client) Users(email, username string) (*v1.UsersReply, error) {
+	u := v1.Users{
+		Email:    email,
+		Username: username,
+	}
+	responseBody, err := c.makeRequest("GET", "/users", &u)
+	if err != nil {
+		return nil, err
+	}
+
+	var ur v1.UsersReply
+	err = json.Unmarshal(responseBody, &ur)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal UsersReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := PrettyPrintJSON(ur)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ur, nil
+}
+
 func (c *Client) EditUser(eu *v1.EditUser) (*v1.EditUserReply, error) {
 	responseBody, err := c.makeRequest("POST", v1.RouteEditUser, eu)
 	if err != nil {

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -55,6 +55,7 @@ type Cmds struct {
 	UsernamesByID     UsernamesByIDCmd     `command:"usernamesbyid" description:"fetch usernames by their user ids"`
 	UserDetails       UserDetailsCmd       `command:"userdetails" description:"fetch a user's details by his user id"`
 	UserProposals     UserProposalsCmd     `command:"userproposals" description:"fetch all proposals submitted by a specific user"`
+	Users             UsersCmd             `command:"users" description:"fetch a list of users, optionally filtering them by email and/or username"`
 	VerifyUser        VerifyUserCmd        `command:"verifyuser" description:"verify user's email address"`
 	VerifyUserPayment VerifyUserPaymentCmd `command:"verifyuserpayment" description:"check if the user has paid their user registration fee"`
 	Version           VersionCmd           `command:"version" description:"fetch server info and CSRF token"`

--- a/politeiawww/cmd/politeiawwwcli/commands/users.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/users.go
@@ -1,0 +1,14 @@
+package commands
+
+type UsersCmd struct {
+	Email    string `long:"email" optional:"true" description:"Email query"`
+	Username string `long:"username" optional:"true" description:"Username query"`
+}
+
+func (cmd *UsersCmd) Execute(args []string) error {
+	ur, err := c.Users(cmd.Email, cmd.Username)
+	if err != nil {
+		return err
+	}
+	return Print(ur, cfg.Verbose, cfg.RawJSON)
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/users.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/users.go
@@ -1,12 +1,21 @@
 package commands
 
+import (
+	"github.com/decred/politeia/politeiawww/api/v1"
+)
+
 type UsersCmd struct {
 	Email    string `long:"email" optional:"true" description:"Email query"`
 	Username string `long:"username" optional:"true" description:"Username query"`
 }
 
 func (cmd *UsersCmd) Execute(args []string) error {
-	ur, err := c.Users(cmd.Email, cmd.Username)
+	u := v1.Users{
+		Email:    cmd.Email,
+		Username: cmd.Username,
+	}
+
+	ur, err := c.Users(&u)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1171,6 +1171,30 @@ func (p *politeiawww) handleUserDetails(w http.ResponseWriter, r *http.Request) 
 	util.RespondWithJSON(w, http.StatusOK, udr)
 }
 
+// handleUsers handles fetching a list of users.
+func (p *politeiawww) handleUsers(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleUsers")
+
+	var u v1.Users
+	err := util.ParseGetParams(r, &u)
+	if err != nil {
+		RespondWithError(w, r, 0, "handleUsers: ParseGetParams",
+			v1.UserError{
+				ErrorCode: v1.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	ur, err := p.backend.ProcessUsers(&u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleUsers: ProcessUsers %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, ur)
+}
+
 // handleEditUser handles editing a user's details.
 func (p *politeiawww) handleEditUser(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleEditUser")
@@ -1536,6 +1560,8 @@ func _main() error {
 		p.handleEditUser, permissionAdmin, true)
 	p.addRoute(http.MethodPost, v1.RouteCensorComment,
 		p.handleCensorComment, permissionAdmin, true)
+	p.addRoute(http.MethodGet, v1.RouteUsers,
+		p.handleUsers, permissionAdmin, false)
 
 	// Persist session cookies.
 	var cookieKey []byte


### PR DESCRIPTION
This commit adds a new admin-only route for fetching a list of users.
It supports filtering by email and/or username, and only returns the
first 20 results. It also returns the total number of all users in the
database.

Closes #505.