### PR TITLE
[www] Add user payments rescan endpoint.

### DIFF
--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -27,6 +27,7 @@ const (
 	RouteUserProposals          = "/user/proposals"
 	RouteUserProposalCredits    = "/user/proposals/credits"
 	RouteVerifyUserPayment      = "/user/verifypayment"
+	RouteUserPaymentsRescan     = "/user/payments/rescan"
 	RouteUserDetails            = "/user/{userid:[0-9a-zA-Z-]{36}}"
 	RouteEditUser               = "/user/edit"
 	RouteUsers                  = "/users"
@@ -512,6 +513,20 @@ type UserProposalCredits struct{}
 type UserProposalCreditsReply struct {
 	UnspentCredits []ProposalCredit `json:"unspentcredits"` // credits that the user has purchased, but have not yet been used to submit proposals (credit price in atoms)
 	SpentCredits   []ProposalCredit `json:"spentcredits"`   // credits that the user has purchased and that have already been used to submit proposals (credit price in atoms)
+}
+
+// UserPaymentsRescan allows an admin to rescan a user's paywall address to
+// check for any payments that may have been missed by paywall polling. Any
+// proposal credits that are created as a result of the rescan are returned in
+// the UserPaymentsRescanReply. This call isn't RESTful, but a PUT request is
+// used since it's idempotent.
+type UserPaymentsRescan struct {
+	UserID string `json:"userid"` // ID of user to rescan
+}
+
+// UserPaymentsRescanReply is used to reply to the UserPaymentsRescan command.
+type UserPaymentsRescanReply struct {
+	NewCredits []ProposalCredit `json:"newcredits"` // Credits that were created by the rescan
 }
 
 // UserProposals is used to request a list of proposals that the

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -79,7 +79,7 @@ func (c *Client) makeRequest(method, route string, body interface{}) ([]byte, er
 				return nil, err
 			}
 			queryParams = "?" + form.Encode()
-		case method == http.MethodPost:
+		case method == http.MethodPost || method == http.MethodPut:
 			var err error
 			requestBody, err = json.Marshal(body)
 			if err != nil {
@@ -96,6 +96,12 @@ func (c *Client) makeRequest(method, route string, body interface{}) ([]byte, er
 		fmt.Printf("Request: GET %v\n", fullRoute)
 	case c.cfg.Verbose && method == http.MethodPost:
 		fmt.Printf("Request: POST %v\n", fullRoute)
+		err := PrettyPrintJSON(body)
+		if err != nil {
+			return nil, err
+		}
+	case c.cfg.Verbose && method == http.MethodPut:
+		fmt.Printf("Request: PUT %v\n", fullRoute)
 		err := PrettyPrintJSON(body)
 		if err != nil {
 			return nil, err
@@ -1130,4 +1136,26 @@ func (c *Client) ProposalPaywallPayment() (*v1.ProposalPaywallPaymentReply, erro
 	}
 
 	return &pppr, nil
+}
+
+func (c *Client) UserPaymentsRescan(upr *v1.UserPaymentsRescan) (*v1.UserPaymentsRescanReply, error) {
+	responseBody, err := c.makeRequest("PUT", v1.RouteUserPaymentsRescan, upr)
+	if err != nil {
+		return nil, err
+	}
+
+	var uprr v1.UserPaymentsRescanReply
+	err = json.Unmarshal(responseBody, &uprr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal UserPaymentsRescanReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := PrettyPrintJSON(uprr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &uprr, nil
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -23,43 +23,44 @@ func SetClient(client *client.Client) {
 }
 
 type Cmds struct {
-	AuthorizeVote     AuthorizeVoteCmd     `command:"authorizevote" description:"authorize a proposal vote (must be proposal author)"`
-	CensorComment     CensorCommentCmd     `command:"censorcomment" description:"(admin) censor a proposal comment"`
-	ChangePassword    ChangePasswordCmd    `command:"changepassword" description:"change the password for the currently logged in user"`
-	CommentsVotes     CommentsVotesCmd     `command:"commentsvotes" description:"fetch all the comments voted by the user on a proposal"`
-	ChangeUsername    ChangeUsernameCmd    `command:"changeusername" description:"change the username for the currently logged in user"`
-	EditProposal      EditProposalCmd      `command:"editproposal" description:"edit a proposal"`
-	EditUser          EditUserCmd          `command:"edituser" description:"(admin) edit the details for the given user id"`
-	Faucet            FaucetCmd            `command:"faucet" description:"use the Decred testnet faucet to send DCR to an address"`
-	GetComments       GetCommentsCmd       `command:"getcomments" description:"fetch a proposal's comments"`
-	GetProposal       GetProposalCmd       `command:"getproposal" description:"fetch a proposal"`
-	GetUnvetted       GetUnvettedCmd       `command:"getunvetted" description:"fetch unvetted proposals"`
-	GetVetted         GetVettedCmd         `command:"getvetted" description:"fetch vetted proposals"`
-	GetPaywallPayment GetPaywallPaymentCmd `command:"getpaywallpayment" description:"fetch payment details for a proposal paywall payment"`
-	Inventory         InventoryCmd         `command:"inventory" description:"fetch the proposals that are being voted on"`
-	Login             LoginCmd             `command:"login" description:"login to Politeia"`
-	Logout            LogoutCmd            `command:"logout" description:"logout of Politeia"`
-	Me                MeCmd                `command:"me" description:"return the user information of the currently logged in user"`
-	NewProposal       NewProposalCmd       `command:"newproposal" description:"submit a new proposal to Politeia"`
-	NewComment        NewCommentCmd        `command:"newcomment" description:"comment on a proposal"`
-	NewUser           NewUserCmd           `command:"newuser" description:"create a new Politeia user"`
-	Policy            PolicyCmd            `command:"policy" description:"fetch server policy"`
-	ProposalPaywall   ProposalPaywallCmd   `command:"proposalpaywall" description:"fetch proposal paywall details"`
-	ProposalVotes     ProposalVotesCmd     `command:"proposalvotes" description:"fetch vote results for a specific proposal"`
-	ResetPassword     ResetPasswordCmd     `command:"resetpassword" description:"change the password for a user that is not currently logged in"`
-	Secret            SecretCmd            `command:"secret" description:"ping politeiawww"`
-	SetProposalStatus SetProposalStatusCmd `command:"setproposalstatus" description:"(admin) set the status of a proposal"`
-	StartVote         StartVoteCmd         `command:"startvote" description:"(admin) start the voting period on a proposal"`
-	Tally             TallyCmd             `command:"tally" description:"fetch the vote tally for a proposal"`
-	UpdateUserKey     UpdateUserKeyCmd     `command:"updateuserkey" description:"generate a new identity for the user"`
-	UsernamesByID     UsernamesByIDCmd     `command:"usernamesbyid" description:"fetch usernames by their user ids"`
-	UserDetails       UserDetailsCmd       `command:"userdetails" description:"fetch a user's details by his user id"`
-	UserProposals     UserProposalsCmd     `command:"userproposals" description:"fetch all proposals submitted by a specific user"`
-	Users             UsersCmd             `command:"users" description:"fetch a list of users, optionally filtering them by email and/or username"`
-	VerifyUser        VerifyUserCmd        `command:"verifyuser" description:"verify user's email address"`
-	VerifyUserPayment VerifyUserPaymentCmd `command:"verifyuserpayment" description:"check if the user has paid their user registration fee"`
-	Version           VersionCmd           `command:"version" description:"fetch server info and CSRF token"`
-	Vote              VoteCmd              `command:"vote" description:"cast ticket votes for a proposal"`
-	VoteComment       VoteCommentCmd       `command:"votecomment" description:"vote on a comment"`
-	VoteStatus        VoteStatusCmd        `command:"votestatus" description:"fetch the vote status of a proposal"`
+	AuthorizeVote      AuthorizeVoteCmd      `command:"authorizevote" description:"authorize a proposal vote (must be proposal author)"`
+	CensorComment      CensorCommentCmd      `command:"censorcomment" description:"(admin) censor a proposal comment"`
+	ChangePassword     ChangePasswordCmd     `command:"changepassword" description:"change the password for the currently logged in user"`
+	CommentsVotes      CommentsVotesCmd      `command:"commentsvotes" description:"fetch all the comments voted by the user on a proposal"`
+	ChangeUsername     ChangeUsernameCmd     `command:"changeusername" description:"change the username for the currently logged in user"`
+	EditProposal       EditProposalCmd       `command:"editproposal" description:"edit a proposal"`
+	EditUser           EditUserCmd           `command:"edituser" description:"(admin) edit the details for the given user id"`
+	Faucet             FaucetCmd             `command:"faucet" description:"use the Decred testnet faucet to send DCR to an address"`
+	GetComments        GetCommentsCmd        `command:"getcomments" description:"fetch a proposal's comments"`
+	GetProposal        GetProposalCmd        `command:"getproposal" description:"fetch a proposal"`
+	GetUnvetted        GetUnvettedCmd        `command:"getunvetted" description:"fetch unvetted proposals"`
+	GetVetted          GetVettedCmd          `command:"getvetted" description:"fetch vetted proposals"`
+	GetPaywallPayment  GetPaywallPaymentCmd  `command:"getpaywallpayment" description:"fetch payment details for a proposal paywall payment"`
+	Inventory          InventoryCmd          `command:"inventory" description:"fetch the proposals that are being voted on"`
+	Login              LoginCmd              `command:"login" description:"login to Politeia"`
+	Logout             LogoutCmd             `command:"logout" description:"logout of Politeia"`
+	Me                 MeCmd                 `command:"me" description:"return the user information of the currently logged in user"`
+	NewProposal        NewProposalCmd        `command:"newproposal" description:"submit a new proposal to Politeia"`
+	NewComment         NewCommentCmd         `command:"newcomment" description:"comment on a proposal"`
+	NewUser            NewUserCmd            `command:"newuser" description:"create a new Politeia user"`
+	Policy             PolicyCmd             `command:"policy" description:"fetch server policy"`
+	ProposalPaywall    ProposalPaywallCmd    `command:"proposalpaywall" description:"fetch proposal paywall details"`
+	ProposalVotes      ProposalVotesCmd      `command:"proposalvotes" description:"fetch vote results for a specific proposal"`
+	RescanUserPayments RescanUserPaymentsCmd `command:"rescanuserpayments" description:"rescan user payments to check for missed payments"`
+	ResetPassword      ResetPasswordCmd      `command:"resetpassword" description:"change the password for a user that is not currently logged in"`
+	Secret             SecretCmd             `command:"secret" description:"ping politeiawww"`
+	SetProposalStatus  SetProposalStatusCmd  `command:"setproposalstatus" description:"(admin) set the status of a proposal"`
+	StartVote          StartVoteCmd          `command:"startvote" description:"(admin) start the voting period on a proposal"`
+	Tally              TallyCmd              `command:"tally" description:"fetch the vote tally for a proposal"`
+	UpdateUserKey      UpdateUserKeyCmd      `command:"updateuserkey" description:"generate a new identity for the user"`
+	UsernamesByID      UsernamesByIDCmd      `command:"usernamesbyid" description:"fetch usernames by their user ids"`
+	UserDetails        UserDetailsCmd        `command:"userdetails" description:"fetch a user's details by his user id"`
+	UserProposals      UserProposalsCmd      `command:"userproposals" description:"fetch all proposals submitted by a specific user"`
+	Users              UsersCmd              `command:"users" description:"fetch a list of users, optionally filtering them by email and/or username"`
+	VerifyUser         VerifyUserCmd         `command:"verifyuser" description:"verify user's email address"`
+	VerifyUserPayment  VerifyUserPaymentCmd  `command:"verifyuserpayment" description:"check if the user has paid their user registration fee"`
+	Version            VersionCmd            `command:"version" description:"fetch server info and CSRF token"`
+	Vote               VoteCmd               `command:"vote" description:"cast ticket votes for a proposal"`
+	VoteComment        VoteCommentCmd        `command:"votecomment" description:"vote on a comment"`
+	VoteStatus         VoteStatusCmd         `command:"votestatus" description:"fetch the vote status of a proposal"`
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/rescanuserpayments.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/rescanuserpayments.go
@@ -1,0 +1,27 @@
+package commands
+
+import "github.com/decred/politeia/politeiawww/api/v1"
+
+type RescanUserPaymentsCmd struct {
+	Args struct {
+		UserID string `positional-arg-name:"userid" description:"User ID"`
+	} `positional-args:"true" required:"true"`
+}
+
+func (cmd *RescanUserPaymentsCmd) Execute(args []string) error {
+	upr := &v1.UserPaymentsRescan{
+		UserID: cmd.Args.UserID,
+	}
+
+	err := Print(upr, cfg.Verbose, cfg.RawJSON)
+	if err != nil {
+		return err
+	}
+
+	uprr, err := c.UserPaymentsRescan(upr)
+	if err != nil {
+		return err
+	}
+
+	return Print(uprr, cfg.Verbose, cfg.RawJSON)
+}

--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -227,7 +227,7 @@ func (b *backend) checkForProposalPayments(pool map[uuid.UUID]paywallPoolMember)
 		} else if tx != nil {
 			// Update pool member if payment tx was found but
 			// does not have enough confimrations.
-			poolMember.txID = tx.ID
+			poolMember.txID = tx.TxID
 			poolMember.txAmount = tx.Amount
 			poolMember.txConfirmations = tx.Confirmations
 
@@ -564,7 +564,7 @@ func (b *backend) verifyProposalPayment(user *database.User) (*util.TxDetails, e
 		default:
 			// Payment tx found that meets all criteria. Create
 			// proposal credits and update user db record.
-			paywall.TxID = tx.ID
+			paywall.TxID = tx.TxID
 			paywall.TxAmount = tx.Amount
 			paywall.NumCredits = tx.Amount / paywall.CreditPrice
 


### PR DESCRIPTION
Closes #500 

This diff adds the endpoint `/user/payments/rescan` which allows an admin to rescan a user's paywall address to check for any payments that may have been missed by paywall polling.  If a payment is found that doesn't correspond to existing proposal credits, then new credits are created and added to the user's account.