### PR TITLE
[www] Add admin ability to deactivate users.

### DIFF
--- a/politeiawww/admin.go
+++ b/politeiawww/admin.go
@@ -105,8 +105,10 @@ func (b *backend) ProcessEditUser(eu *v1.EditUser, adminUser *database.User) (*v
 		user.NewUserPaywallPollExpiry = 0
 	case v1.UserEditUnlock:
 		user.FailedLoginAttempts = 0
-	case v1.UserEditLock:
-		user.FailedLoginAttempts = LoginAttemptsToLockUser
+	case v1.UserEditDeactivate:
+		user.Deactivated = true
+	case v1.UserEditReactivate:
+		user.Deactivated = false
 	default:
 		return nil, fmt.Errorf("unsupported user edit action: %v",
 			v1.UserEditAction[eu.Action])

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -102,6 +102,7 @@ API.  It does not render HTML.
 - [`ErrorStatusVoteNotAuthorized`](#ErrorStatusVoteNotAuthorized)
 - [`ErrorStatusVoteAlreadyAuthorized`](#ErrorStatusVoteAlreadyAuthorized)
 - [`ErrorStatusInvalidAuthVoteAction`](#ErrorStatusInvalidAuthVoteAction)
+- [`ErrorStatusUserDeactivated`](#ErrorStatusUserDeactivated)
 
 **Proposal status codes**
 
@@ -382,6 +383,7 @@ On failure the call shall return `401 Unauthorized` and one of the following
 error codes:
 - [`ErrorStatusInvalidEmailOrPassword`](#ErrorStatusInvalidEmailOrPassword)
 - [`ErrorStatusUserLocked`](#ErrorStatusUserLocked)
+- [`ErrorStatusUserDeactivated`](#ErrorStatusUserDeactivated)
 
 **Example**
 
@@ -2363,7 +2365,8 @@ Reply:
 | <a name="ErrorStatusUserNotAuthor">ErrorStatusUserNotAuthor</a> | 48 | User is not the proposal author. |
 | <a name="ErrorStatusVoteNotAuthorized">ErrorStatusVoteNotAuthorized</a> | 49 | Vote has not been authorized. |
 | <a name="ErrorStatusVoteAlreadyAuthorized">ErrorStatusVoteAlreadyAuthorized</a> | 50 | Vote has already been authorized. |
-| <a name="ErrorStatusInvalidAuthVoteAction">ErrorStatusInvalidAuthVoteAction</a> | 50 | Invalid authorize vote action. |
+| <a name="ErrorStatusInvalidAuthVoteAction">ErrorStatusInvalidAuthVoteAction</a> | 51 | Invalid authorize vote action. |
+| <a name="ErrorStatusUserDeactivated">ErrorStatusUserDeactivated</a> | 52 | Cannot login because user account is deactivated. |
 
 
 ### Proposal status codes
@@ -2387,7 +2390,8 @@ Reply:
 | <a name="UserEditExpireResetPasswordVerification">UserEditExpireResetPasswordVerification</a> | 3 | Expires the reset password verification token. |
 | <a name="UserEditClearUserPaywall">UserEditClearUserPaywall</a> | 4 | Clears the user's paywall. |
 | <a name="UserEditUnlock">UserEditUnlock</a> | 5 | Unlocks a user's account. |
-| <a name="UserEditLock">UserEditLock</a> | 6 | Locks a user's account. |
+| <a name="UserEditDeactivate">UserEditDeactivate</a> | 6 | Deactivates a user's account so that they are unable to login. |
+| <a name="UserEditReactivate">UserEditReactivate</a> | 7 | Reactivates a user's account. |
 
 ### `User`
 
@@ -2411,6 +2415,7 @@ Reply:
 | lastlogintime | int64 | The UNIX timestamp of the last login date; it will be 0 if the user has not logged in before. |
 | failedloginattempts | uint64 | The number of consecutive failed login attempts. |
 | islocked | boolean | Whether the user account is locked due to too many failed login attempts. |
+| isdeactivated | boolean | Whether the user account is deactivated. Deactivated accounts cannot login. |
 | identities | array of [`Identity`](#identity)s | Identities, both activated and deactivated, of the user. |
 | proposals | array of [`Proposal`](#proposal)s | Proposal submitted by the user. |
 | proposalcredits | uint64 | The number of available proposal credits the user has. |

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -162,6 +162,7 @@ const (
 	ErrorStatusVoteNotAuthorized           ErrorStatusT = 49
 	ErrorStatusVoteAlreadyAuthorized       ErrorStatusT = 50
 	ErrorStatusInvalidAuthVoteAction       ErrorStatusT = 51
+	ErrorStatusUserDeactivated             ErrorStatusT = 52
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid           PropStatusT = 0 // Invalid status
@@ -187,7 +188,8 @@ const (
 	UserEditExpireResetPasswordVerification UserEditActionT = 3
 	UserEditClearUserPaywall                UserEditActionT = 4
 	UserEditUnlock                          UserEditActionT = 5
-	UserEditLock                            UserEditActionT = 6
+	UserEditDeactivate                      UserEditActionT = 6
+	UserEditReactivate                      UserEditActionT = 7
 
 	// Authorize vote actions
 	AuthVoteActionAuthorize = "authorize" // Authorize a proposal vote
@@ -297,7 +299,8 @@ var (
 		UserEditExpireResetPasswordVerification: "expire reset password verification",
 		UserEditClearUserPaywall:                "clear user paywall",
 		UserEditUnlock:                          "unlock user",
-		UserEditLock:                            "lock user",
+		UserEditDeactivate:                      "deactivate user",
+		UserEditReactivate:                      "reactivate user",
 	}
 )
 
@@ -1001,6 +1004,7 @@ type User struct {
 	ResetPasswordVerificationExpiry int64            `json:"resetpasswordverificationexpiry"`
 	LastLoginTime                   int64            `json:"lastlogintime"`
 	FailedLoginAttempts             uint64           `json:"failedloginattempts"`
+	Deactivated                     bool             `json:"isdeactivated"`
 	Locked                          bool             `json:"islocked"`
 	Identities                      []UserIdentity   `json:"identities"`
 	Proposals                       []ProposalRecord `json:"proposals"`

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -360,6 +360,18 @@ func (b *backend) login(l *www.Login) loginReplyWithError {
 		}
 	}
 
+	// Check if the user account is deactivated.
+	if user.Deactivated {
+		log.Debugf("Login failure for %v: user deactivated",
+			l.Email)
+		return loginReplyWithError{
+			reply: nil,
+			err: www.UserError{
+				ErrorCode: www.ErrorStatusUserDeactivated,
+			},
+		}
+	}
+
 	// Check if user is locked due to too many login attempts
 	if checkUserIsLocked(user.FailedLoginAttempts) {
 		log.Debugf("Login failure for %v: user locked",

--- a/politeiawww/cmd/politeiawwwcli/commands/edituser.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/edituser.go
@@ -22,7 +22,8 @@ func (cmd *EditUserCmd) Execute(args []string) error {
 		"expireresetpassword": 3,
 		"clearpaywall":        4,
 		"unlock":              5,
-		"lock":                6,
+		"deactivate":          6,
+		"reactivate":          7,
 	}
 
 	// Parse edit user action.  This can be either the numeric
@@ -42,7 +43,8 @@ func (cmd *EditUserCmd) Execute(args []string) error {
 			"expireresetpassword   expires reset password verification\n  " +
 			"clearpaywall          clears user registration paywall\n  " +
 			"unlock                unlocks user account from failed logins\n  " +
-			"lock                  locks user account")
+			"deactivate            deactivates user account\n  " +
+			"reactivate            reactivates user account")
 	}
 
 	// Setup request

--- a/politeiawww/database/database.go
+++ b/politeiawww/database/database.go
@@ -109,6 +109,7 @@ type User struct {
 	ResetPasswordVerificationExpiry int64     // Reset password token expiration
 	LastLoginTime                   int64     // Unix timestamp of when the user last logged in
 	FailedLoginAttempts             uint64    // Number of failed login a user has made in a row
+	Deactivated                     bool      // Whether the account is deactivated or not
 
 	// All identities the user has ever used.  User should only have one
 	// active key at a time.  We allow multiples in order to deal with key

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -44,7 +44,7 @@ func (p *politeiawww) isLoggedInAsAdmin(f http.HandlerFunc) http.HandlerFunc {
 			r.Method, r.URL, r.Proto)
 
 		// Check if user is admin
-		isAdmin, err := p.isAdmin(r)
+		isAdmin, err := p.isAdmin(w, r)
 		if err != nil {
 			log.Errorf("isLoggedInAsAdmin: isAdmin %v", err)
 			util.RespondWithJSON(w, http.StatusUnauthorized, v1.ErrorReply{

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -27,6 +27,7 @@ func convertWWWUserFromDatabaseUser(user *database.User) v1.User {
 		ResetPasswordVerificationExpiry: user.ResetPasswordVerificationExpiry,
 		LastLoginTime:                   user.LastLoginTime,
 		FailedLoginAttempts:             user.FailedLoginAttempts,
+		Deactivated:                     user.Deactivated,
 		Locked:                          checkUserIsLocked(user.FailedLoginAttempts),
 		Identities:                      convertWWWIdentitiesFromDatabaseIdentities(user.Identities),
 		ProposalCredits:                 ProposalCreditBalance(user),


### PR DESCRIPTION
This PR adds the ability for admins to deactivate and re-activate users. Deactivating a user prevents them from logging in, and also kills any existing sessions.

Closes #537.