### PR TITLE
[d+www] Add vote parameters to start vote.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -19,6 +19,9 @@ const (
 	MDStreamAuthorizeVote    = 13 // Vote authorization by proposal author
 	MDStreamVoteBits         = 14 // Vote bits and mask
 	MDStreamVoteSnapshot     = 15 // Vote tickets and start/end parameters
+
+	VoteDurationMin = 2016 // Minimum vote duration (in blocks)
+	VoteDurationMax = 4032 // Maximum vote duration (in blocks)
 )
 
 // CastVote is a signed vote.
@@ -106,10 +109,12 @@ type VoteOption struct {
 
 // Vote represents the vote options for vote that is identified by its token.
 type Vote struct {
-	Token    string       `json:"token"`    // Token that identifies vote
-	Mask     uint64       `json:"mask"`     // Valid votebits
-	Duration uint32       `json:"duration"` // Duration in blocks
-	Options  []VoteOption `json:"options"`  // Vote option
+	Token            string       `json:"token"`            // Token that identifies vote
+	Mask             uint64       `json:"mask"`             // Valid votebits
+	Duration         uint32       `json:"duration"`         // Duration in blocks
+	QuorumPercentage uint32       `json:"quorumpercentage"` // Percent of eligible votes required for quorum
+	PassPercentage   uint32       `json:"passpercentage"`   // Percent of total votes required to pass
+	Options          []VoteOption `json:"options"`          // Vote option
 }
 
 // EncodeVote encodes Vote into a JSON byte slice.

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -1712,12 +1712,14 @@ func (g *gitBackEnd) pluginStartVote(payload string) (string, error) {
 		return "", fmt.Errorf("no eligble voters for %v", token)
 	}
 
-	// Make sure vote duration isn't too large. Assume < 2 weeks
+	// Make sure vote duration is within min/max range
 	// XXX calculate this value for testnet instead of using hard coded values.
-	if vote.Vote.Duration < 2016 || vote.Vote.Duration > 2016*2 {
+	if vote.Vote.Duration < decredplugin.VoteDurationMin ||
+		vote.Vote.Duration > decredplugin.VoteDurationMax {
 		// XXX return a user error instead of an internal error
 		return "", fmt.Errorf("invalid duration: %v (%v - %v)",
-			vote.Vote.Duration, 2016, 2016*2)
+			vote.Vote.Duration, decredplugin.VoteDurationMin,
+			decredplugin.VoteDurationMax)
 	}
 
 	svr := decredplugin.StartVoteReply{

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -103,6 +103,8 @@ API.  It does not render HTML.
 - [`ErrorStatusVoteAlreadyAuthorized`](#ErrorStatusVoteAlreadyAuthorized)
 - [`ErrorStatusInvalidAuthVoteAction`](#ErrorStatusInvalidAuthVoteAction)
 - [`ErrorStatusUserDeactivated`](#ErrorStatusUserDeactivated)
+- [`ErrorStatusInvalidPropVoteBits`](#ErrorStatusInvalidPropVoteBits)
+- [`ErrorStatusInvalidPropVoteParams`](#ErrorStatusInvalidPropVoteParams)
 
 **Proposal status codes**
 
@@ -1789,6 +1791,18 @@ forwarded as-is to the politeia daemon.
 | Description | string | Human readable description of this option |
 | Bits | uint64 | Bits that make up this choice, e.g. 0x01 |
 
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusNoPublicKey`](#ErrorStatusNoPublicKey)
+- [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
+- [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
+- [`ErrorStatusInvalidPropVoteBits`](#ErrorStatusInvalidPropVoteBits)
+- [`ErrorStatusInvalidPropVoteParams`](#ErrorStatusInvalidPropVoteParams)
+- [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
+- [`ErrorStatusWrongStatus`](#ErrorStatusWrongStatus)
+- [`ErrorStatusVoteNotAuthorized`](#ErrorStatusVoteNotAuthorized)
+- [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
+
 **Example**
 
 Request:
@@ -2367,6 +2381,8 @@ Reply:
 | <a name="ErrorStatusVoteAlreadyAuthorized">ErrorStatusVoteAlreadyAuthorized</a> | 50 | Vote has already been authorized. |
 | <a name="ErrorStatusInvalidAuthVoteAction">ErrorStatusInvalidAuthVoteAction</a> | 51 | Invalid authorize vote action. |
 | <a name="ErrorStatusUserDeactivated">ErrorStatusUserDeactivated</a> | 52 | Cannot login because user account is deactivated. |
+| <a name="ErrorStatusInvalidPropVoteBits">ErrorStatusInvalidPropVoteBits</a> | 53 | Invalid proposal vote option bits. |
+| <a name="ErrorStatusInvalidPropVoteParams">ErrorStatusInvalidPropVoteParams</a> | 54 | Invalid proposal vote parameters. |
 
 
 ### Proposal status codes

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -164,6 +164,8 @@ const (
 	ErrorStatusVoteAlreadyAuthorized       ErrorStatusT = 50
 	ErrorStatusInvalidAuthVoteAction       ErrorStatusT = 51
 	ErrorStatusUserDeactivated             ErrorStatusT = 52
+	ErrorStatusInvalidPropVoteBits         ErrorStatusT = 53
+	ErrorStatusInvalidPropVoteParams       ErrorStatusT = 54
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid           PropStatusT = 0 // Invalid status
@@ -270,6 +272,9 @@ var (
 		ErrorStatusVoteNotAuthorized:           "vote has not been authorized",
 		ErrorStatusVoteAlreadyAuthorized:       "vote has already been authorized",
 		ErrorStatusInvalidAuthVoteAction:       "invalid authorize vote action",
+		ErrorStatusUserDeactivated:             "user account is deactivated",
+		ErrorStatusInvalidPropVoteBits:         "invalid proposal vote option bits",
+		ErrorStatusInvalidPropVoteParams:       "invalid proposal vote parameters",
 	}
 
 	// PropStatus converts propsal status codes to human readable text
@@ -749,10 +754,12 @@ type VoteOption struct {
 
 // Vote represents the vote options for vote that is identified by its token.
 type Vote struct {
-	Token    string       `json:"token"`    // Token that identifies vote
-	Mask     uint64       `json:"mask"`     // Valid votebits
-	Duration uint32       `json:"duration"` // Duration in blocks
-	Options  []VoteOption `json:"options"`  //Vote options
+	Token            string       `json:"token"`            // Token that identifies vote
+	Mask             uint64       `json:"mask"`             // Valid votebits
+	Duration         uint32       `json:"duration"`         // Duration in blocks
+	QuorumPercentage uint32       `json:"quorumpercentage"` // Percent of eligible votes required for quorum
+	PassPercentage   uint32       `json:"passpercentage"`   // Percent of total votes required to pass
+	Options          []VoteOption `json:"options"`          // Vote options
 }
 
 // ActiveVote obtains all proposals that have active votes.

--- a/politeiawww/cmd/politeiawwwcli/commands/startvote.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/startvote.go
@@ -3,33 +3,62 @@ package commands
 import (
 	"encoding/hex"
 	"fmt"
+	"strconv"
 
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
 type StartVoteCmd struct {
 	Args struct {
-		Token string `positional-arg-name:"token"`
+		Token string `positional-arg-name:"token" description:"Proposal censorship token"`
 	} `positional-args:"true" required:"true"`
+	Duration         string `long:"duration" description:"Vote duration in blocks"`
+	QuorumPercentage string `long:"quorumpercentage" description:"Percentage of eligible tickets required for quorum (0-100)"`
+	PassPercentage   string `long:"passpercentage" description:"Percentage of votes required for vote to pass (0-100)"`
 }
 
 func (cmd *StartVoteCmd) Execute(args []string) error {
-	token := cmd.Args.Token
-
 	// Check for user identity
 	if cfg.Identity == nil {
 		return fmt.Errorf(ErrorNoUserIdentity)
 	}
 
+	// Set vote parameter defaults
+	if cmd.Duration == "" {
+		cmd.Duration = "2016"
+	}
+	if cmd.QuorumPercentage == "" {
+		cmd.QuorumPercentage = "10"
+	}
+	if cmd.PassPercentage == "" {
+		cmd.PassPercentage = "75"
+	}
+
+	// Convert vote parameters
+	duration, err := strconv.ParseUint(cmd.Duration, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parsing Duration: %v", err)
+	}
+	quorum, err := strconv.ParseUint(cmd.QuorumPercentage, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parsing QuorumPercentage: %v", err)
+	}
+	pass, err := strconv.ParseUint(cmd.PassPercentage, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parsing PassPercentage: %v", err)
+	}
+
 	// Setup start vote request
-	sig := cfg.Identity.SignMessage([]byte(token))
+	sig := cfg.Identity.SignMessage([]byte(cmd.Args.Token))
 	sv := &v1.StartVote{
 		Signature: hex.EncodeToString(sig[:]),
 		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
 		Vote: v1.Vote{
-			Token:    token,
-			Mask:     0x03, // bit 0 no, bit 1 yes
-			Duration: 2016,
+			Token:            cmd.Args.Token,
+			Mask:             0x03, // bit 0 no, bit 1 yes
+			Duration:         uint32(duration),
+			QuorumPercentage: uint32(quorum),
+			PassPercentage:   uint32(pass),
 			Options: []v1.VoteOption{
 				{
 					Id:          "no",
@@ -46,7 +75,7 @@ func (cmd *StartVoteCmd) Execute(args []string) error {
 	}
 
 	// Print request details
-	err := Print(sv, cfg.Verbose, cfg.RawJSON)
+	err = Print(sv, cfg.Verbose, cfg.RawJSON)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/config.go
+++ b/politeiawww/config.go
@@ -44,6 +44,9 @@ const (
 	defaultPaywallMinConfirmations = uint64(2)
 	defaultPaywallAmount           = uint64(0)
 
+	defaultVoteDurationMin = uint32(2016)
+	defaultVoteDurationMax = uint32(4032)
+
 	// dust value can be found increasing the amount value until we get false
 	// from IsDustAmount function. Amounts can not be lower than dust
 	// func IsDustAmount(amount int64, relayFeePerKb int64) bool {
@@ -112,6 +115,8 @@ type config struct {
 	PaywallAmount            uint64 `long:"paywallamount" description:"Amount of DCR (in atoms) required for a user to register or submit a proposal."`
 	PaywallXpub              string `long:"paywallxpub" description:"Extended public key for deriving paywall addresses."`
 	MinConfirmationsRequired uint64 `long:"minconfirmations" description:"Minimum blocks confirmation for accepting paywall as paid. Only works in TestNet."`
+	VoteDurationMin          uint32 `long:"votedurationmin" description:"Minimum duration of a proposal vote in blocks"`
+	VoteDurationMax          uint32 `long:"votedurationmax" description:"Maximum duration of a proposal vote in blocks"`
 	AdminLogFile             string
 }
 
@@ -346,6 +351,8 @@ func loadConfig() (*config, []string, error) {
 		PaywallAmount:            defaultPaywallAmount,
 		MinConfirmationsRequired: defaultPaywallMinConfirmations,
 		Version:                  version.String(),
+		VoteDurationMin:          defaultVoteDurationMin,
+		VoteDurationMax:          defaultVoteDurationMax,
 	}
 
 	// Service options which are only added on Windows.

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -65,10 +65,12 @@ func convertVoteOptionsFromWWW(vo []www.VoteOption) []decredplugin.VoteOption {
 
 func convertVoteFromWWW(v www.Vote) decredplugin.Vote {
 	return decredplugin.Vote{
-		Token:    v.Token,
-		Mask:     v.Mask,
-		Duration: v.Duration,
-		Options:  convertVoteOptionsFromWWW(v.Options),
+		Token:            v.Token,
+		Mask:             v.Mask,
+		Duration:         v.Duration,
+		QuorumPercentage: v.QuorumPercentage,
+		PassPercentage:   v.PassPercentage,
+		Options:          convertVoteOptionsFromWWW(v.Options),
 	}
 }
 
@@ -131,10 +133,12 @@ func convertVoteOptionsFromDecredplugin(vo []decredplugin.VoteOption) []www.Vote
 
 func convertVoteFromDecredplugin(v decredplugin.Vote) www.Vote {
 	return www.Vote{
-		Token:    v.Token,
-		Mask:     v.Mask,
-		Duration: v.Duration,
-		Options:  convertVoteOptionsFromDecredplugin(v.Options),
+		Token:            v.Token,
+		Mask:             v.Mask,
+		Duration:         v.Duration,
+		QuorumPercentage: v.QuorumPercentage,
+		PassPercentage:   v.PassPercentage,
+		Options:          convertVoteOptionsFromDecredplugin(v.Options),
 	}
 }
 

--- a/politeiawww/sample-politeiawww.conf
+++ b/politeiawww/sample-politeiawww.conf
@@ -39,6 +39,10 @@
 ; Whether or not to bypass CSRF
 ; proxy=true
 
+; Proposal vote configuration
+; votedurationmin=2016
+; votedurationmax=4032
+
 ; ------------------------------------------------------------------------------
 ; Debug
 ; ------------------------------------------------------------------------------


### PR DESCRIPTION
Close #538 

This diff adds the parameters `QuorumPercentage` and `PassPercentage` the to start vote command. 
 `QuorumPercentage` is used to indicate the percentage of eligible tickets that must vote in order fo a quorum to have been met.  `PassPercentage` is used to indicate the percentage of total votes that are required for the vote to pass.  Vote duration is turned into a configurable www parameter.