### PR TITLE
[www] Minor improvements to new user registration.

### DIFF
--- a/politeiawww/admin.go
+++ b/politeiawww/admin.go
@@ -92,6 +92,7 @@ func (b *backend) ProcessEditUser(eu *v1.EditUser, adminUser *database.User) (*v
 	switch eu.Action {
 	case v1.UserEditExpireNewUserVerification:
 		user.NewUserVerificationExpiry = expiredTime
+		user.ResendNewUserVerificationExpiry = expiredTime
 	case v1.UserEditExpireUpdateKeyVerification:
 		user.UpdateKeyVerificationExpiry = expiredTime
 	case v1.UserEditExpireResetPasswordVerification:

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -104,6 +104,7 @@ API.  It does not render HTML.
 - [`ErrorStatusUserDeactivated`](#ErrorStatusUserDeactivated)
 - [`ErrorStatusInvalidPropVoteBits`](#ErrorStatusInvalidPropVoteBits)
 - [`ErrorStatusInvalidPropVoteParams`](#ErrorStatusInvalidPropVoteParams)
+- [`ErrorStatusEmailNotVerified`](#ErrorStatusEmailNotVerified)
 
 **Proposal status codes**
 
@@ -385,6 +386,7 @@ error codes:
 - [`ErrorStatusInvalidEmailOrPassword`](#ErrorStatusInvalidEmailOrPassword)
 - [`ErrorStatusUserLocked`](#ErrorStatusUserLocked)
 - [`ErrorStatusUserDeactivated`](#ErrorStatusUserDeactivated)
+- [`ErrorStatusEmailNotVerified`](#ErrorStatusEmailNotVerified)
 
 **Example**
 
@@ -2350,6 +2352,7 @@ Reply:
 | <a name="ErrorStatusUserDeactivated">ErrorStatusUserDeactivated</a> | 52 | Cannot login because user account is deactivated. |
 | <a name="ErrorStatusInvalidPropVoteBits">ErrorStatusInvalidPropVoteBits</a> | 53 | Invalid proposal vote option bits. |
 | <a name="ErrorStatusInvalidPropVoteParams">ErrorStatusInvalidPropVoteParams</a> | 54 | Invalid proposal vote parameters. |
+| <a name="ErrorStatusEmailNotVerified">ErrorStatusEmailNotVerified</a> | 55 | Cannot login because user's email is not yet verified. |
 
 
 ### Proposal status codes

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -63,7 +63,7 @@ const (
 
 	// VerificationExpiryHours is the number of hours before the
 	// verification token expires
-	VerificationExpiryHours = 48
+	VerificationExpiryHours = 24
 
 	// PolicyMaxImages is the maximum number of images accepted
 	// when creating a new proposal
@@ -165,6 +165,7 @@ const (
 	ErrorStatusUserDeactivated             ErrorStatusT = 52
 	ErrorStatusInvalidPropVoteBits         ErrorStatusT = 53
 	ErrorStatusInvalidPropVoteParams       ErrorStatusT = 54
+	ErrorStatusEmailNotVerified            ErrorStatusT = 55
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid           PropStatusT = 0 // Invalid status
@@ -274,6 +275,7 @@ var (
 		ErrorStatusUserDeactivated:             "user account is deactivated",
 		ErrorStatusInvalidPropVoteBits:         "invalid proposal vote option bits",
 		ErrorStatusInvalidPropVoteParams:       "invalid proposal vote parameters",
+		ErrorStatusEmailNotVerified:            "email address is not verified",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/database/database.go
+++ b/politeiawww/database/database.go
@@ -101,8 +101,9 @@ type User struct {
 	NewUserPaywallTx                string    // Paywall transaction id
 	NewUserPaywallTxNotBefore       int64     // Transactions occurring before this time will not be valid.
 	NewUserPaywallPollExpiry        int64     // After this time, the user's paywall address will not be continuously polled
-	NewUserVerificationToken        []byte    // Verification token during signup
-	NewUserVerificationExpiry       int64     // Verification expiration
+	NewUserVerificationToken        []byte    // New user registration verification token
+	NewUserVerificationExpiry       int64     // New user registration verification expiration
+	ResendNewUserVerificationExpiry int64     // Resend request for new user registration verification expiration
 	UpdateKeyVerificationToken      []byte    // Verification token for updating keypair
 	UpdateKeyVerificationExpiry     int64     // Verification expiration
 	ResetPasswordVerificationToken  []byte    // Reset password token


### PR DESCRIPTION
This commit makes the following changes:

* Add a new user registration expiry field specifically for resend
email requests. This allows a user to request another registration email
before the email-spam-prevention period has ended.

* Reduce the email-spam-prevention period to 1 day.

* Add a new login error that notifies the user he cannot login
specifically because his email is unverified.

This is intended to help address the issues raised in decred/politeiagui#745.