### PR TITLE
www: Remove proposals from user details

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -534,7 +534,6 @@ Reply:
       "pubkey": "5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
       "isactive": true
     }],
-    "proposals": [],
     "comments": []
   }
 }
@@ -2423,7 +2422,6 @@ Reply:
 | islocked | boolean | Whether the user account is locked due to too many failed login attempts. |
 | isdeactivated | boolean | Whether the user account is deactivated. Deactivated accounts cannot login. |
 | identities | array of [`Identity`](#identity)s | Identities, both activated and deactivated, of the user. |
-| proposals | array of [`Proposal`](#proposal)s | Proposal submitted by the user. |
 | proposalcredits | uint64 | The number of available proposal credits the user has. |
 
 ### `Abridged User`

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -1003,29 +1003,27 @@ type EditUserReply struct{}
 
 // User represents an individual user.
 type User struct {
-	ID                              string           `json:"id"`
-	Email                           string           `json:"email"`
-	Username                        string           `json:"username"`
-	Admin                           bool             `json:"isadmin"`
-	NewUserPaywallAddress           string           `json:"newuserpaywalladdress"`
-	NewUserPaywallAmount            uint64           `json:"newuserpaywallamount"`
-	NewUserPaywallTx                string           `json:"newuserpaywalltx"`
-	NewUserPaywallTxNotBefore       int64            `json:"newuserpaywalltxnotbefore"`
-	NewUserPaywallPollExpiry        int64            `json:"newuserpaywallpollexpiry"`
-	NewUserVerificationToken        []byte           `json:"newuserverificationtoken"`
-	NewUserVerificationExpiry       int64            `json:"newuserverificationexpiry"`
-	UpdateKeyVerificationToken      []byte           `json:"updatekeyverificationtoken"`
-	UpdateKeyVerificationExpiry     int64            `json:"updatekeyverificationexpiry"`
-	ResetPasswordVerificationToken  []byte           `json:"resetpasswordverificationtoken"`
-	ResetPasswordVerificationExpiry int64            `json:"resetpasswordverificationexpiry"`
-	LastLoginTime                   int64            `json:"lastlogintime"`
-	FailedLoginAttempts             uint64           `json:"failedloginattempts"`
-	Deactivated                     bool             `json:"isdeactivated"`
-	Locked                          bool             `json:"islocked"`
-	Identities                      []UserIdentity   `json:"identities"`
-	Proposals                       []ProposalRecord `json:"proposals"`
-	NumOfProposals                  int              `json:"numofproposals"` // number of proposals submitted by the user
-	ProposalCredits                 uint64           `json:"proposalcredits"`
+	ID                              string         `json:"id"`
+	Email                           string         `json:"email"`
+	Username                        string         `json:"username"`
+	Admin                           bool           `json:"isadmin"`
+	NewUserPaywallAddress           string         `json:"newuserpaywalladdress"`
+	NewUserPaywallAmount            uint64         `json:"newuserpaywallamount"`
+	NewUserPaywallTx                string         `json:"newuserpaywalltx"`
+	NewUserPaywallTxNotBefore       int64          `json:"newuserpaywalltxnotbefore"`
+	NewUserPaywallPollExpiry        int64          `json:"newuserpaywallpollexpiry"`
+	NewUserVerificationToken        []byte         `json:"newuserverificationtoken"`
+	NewUserVerificationExpiry       int64          `json:"newuserverificationexpiry"`
+	UpdateKeyVerificationToken      []byte         `json:"updatekeyverificationtoken"`
+	UpdateKeyVerificationExpiry     int64          `json:"updatekeyverificationexpiry"`
+	ResetPasswordVerificationToken  []byte         `json:"resetpasswordverificationtoken"`
+	ResetPasswordVerificationExpiry int64          `json:"resetpasswordverificationexpiry"`
+	LastLoginTime                   int64          `json:"lastlogintime"`
+	FailedLoginAttempts             uint64         `json:"failedloginattempts"`
+	Deactivated                     bool           `json:"isdeactivated"`
+	Locked                          bool           `json:"islocked"`
+	Identities                      []UserIdentity `json:"identities"`
+	ProposalCredits                 uint64         `json:"proposalcredits"`
 }
 
 // UserIdentity represents a user's unique identity.

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -73,15 +73,12 @@ func filterUserPublicFields(user v1.User) v1.User {
 		ID:         user.ID,
 		Username:   user.Username,
 		Identities: user.Identities,
-		Proposals:  user.Proposals,
 	}
 }
 
-// ProcessUserDetails return the requested user's details
-// Some fields can be omitted or blank depending on the
-// requester's access level
+// ProcessUserDetails return the requested user's details. Some fields can be
+// omitted or blank depending on the requester's access level.
 func (b *backend) ProcessUserDetails(ud *v1.UserDetails, isCurrentUser bool, isAdmin bool) (*v1.UserDetailsReply, error) {
-
 	// Fetch the database user.
 	user, err := b.getUserByIDStr(ud.UserID)
 	if err != nil {
@@ -92,24 +89,12 @@ func (b *backend) ProcessUserDetails(ud *v1.UserDetails, isCurrentUser bool, isA
 	var udr v1.UserDetailsReply
 	wwwUser := convertWWWUserFromDatabaseUser(user)
 
-	// Fetch the first page of the user's proposals.
-	up := v1.UserProposals{
-		UserId: ud.UserID,
-	}
-	upr, err := b.ProcessUserProposals(&up, isCurrentUser, isAdmin)
-	if err != nil {
-		return nil, err
-	}
-	wwwUser.Proposals = upr.Proposals
-
 	// Filter returned fields in case the user isn't the admin or the current user
 	if !isAdmin && !isCurrentUser {
 		udr.User = filterUserPublicFields(wwwUser)
 	} else {
 		udr.User = wwwUser
 	}
-
-	udr.User.NumOfProposals = b.getCountOfProposalsByUserID(up.UserId)
 
 	return &udr, nil
 }

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1173,7 +1173,7 @@ func (p *politeiawww) handleUserDetails(w http.ResponseWriter, r *http.Request) 
 
 	userID, err := uuid.Parse(ud.UserID)
 	if err != nil {
-		RespondWithError(w, r, 0, "handleUserProposals: ParseUint",
+		RespondWithError(w, r, 0, "handleUserDetails: ParseUint",
 			v1.UserError{
 				ErrorCode: v1.ErrorStatusInvalidInput,
 			})


### PR DESCRIPTION
Closes #498 

This PR removes proposal data from the user struct that is returned by the `UserDetails` route. Proposal data should be accessed through the `UserProposals` route.