### PR TITLE
 www: Fix NumOfProposals value in UserProposals

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -1216,8 +1216,12 @@ Retrieve a page and the total amount of proposals submitted by the given user; t
 
 | | Type | Description |
 |-|-|-|
-| proposals | array of [`Proposal`](#proposal)s | An Array of proposals submitted by the user. |
-| numOfProposals | int | Number of proposals submitted by the user. |
+| proposals | array of [`Proposal`](#proposal)s | One page of user submitted proposals. |
+| numOfProposals | int | Total number of proposals submitted by the user. If an admin is sending the request or a user is requesting their own proposals then this value includes unvetted, censored, and public proposals. Otherwise, this value only includes public proposals. |
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusUserNotFound`](#ErrorStatusUserNotFound)
 
 **Example**
 

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1029,7 +1029,7 @@ func (p *politeiawww) handleUserProposals(w http.ResponseWriter, r *http.Request
 	user, err := p.getSessionUser(w, r)
 	if err != nil {
 		// since having a logged in user isn't required, simply log the error
-		log.Infof("handleUserDetails: could not get session user %v", err)
+		log.Infof("handleUserProposals: could not get session user %v", err)
 	}
 
 	upr, err := p.backend.ProcessUserProposals(


### PR DESCRIPTION
Closes #578 

This PR fixes how the `NumOfProposals` value is calculated in the `UserProposals` endpoint. 

Before, the `NumOfProposals` value was the total number of proposals that had been submitted by the user regardless of proposals status. 

Now, the `NumOfProposals` value reflects the number of proposals that are available to be returned from the `UserProposals` endpoint. If the request is being sent by an admin or a user is requesting their own proposals then `NumOfProposals` includes unvetted, censored, and public proposals. Otherwise, `NumOfProposals` only includes public proposals.