### PR TITLE
multi: Improve various error handling

### DIFF
--- a/politeiavoter/politeiavoter.go
+++ b/politeiavoter/politeiavoter.go
@@ -320,7 +320,7 @@ func (c *ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 	if r.StatusCode != http.StatusOK {
 		var ue v1.UserError
 		err = json.Unmarshal(responseBody, &ue)
-		if err == nil {
+		if err == nil && ue.ErrorCode != 0 {
 			return nil, fmt.Errorf("%v, %v %v", r.StatusCode,
 				v1.ErrorStatus[ue.ErrorCode],
 				strings.Join(ue.ErrorContext, ", "))

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -231,7 +231,7 @@ var (
 
 	// ErrorStatus converts error status codes to human readable text.
 	ErrorStatus = map[ErrorStatusT]string{
-		ErrorStatusInvalid:                     "invalid status",
+		ErrorStatusInvalid:                     "invalid error status",
 		ErrorStatusInvalidEmailOrPassword:      "invalid email or password",
 		ErrorStatusMalformedEmail:              "malformed email",
 		ErrorStatusVerificationTokenInvalid:    "invalid verification token",

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2766,11 +2766,6 @@ func (b *backend) ProcessStartVote(sv www.StartVote, user *database.User) (*www.
 func (b *backend) ProcessVoteResults(token string) (*www.VoteResultsReply, error) {
 	log.Tracef("ProcessVoteResults")
 
-	vrr, err := b.getVoteResultsFromPlugin(token)
-	if err != nil {
-		return nil, err
-	}
-
 	// Fetch record from inventory in order to get the voting details
 	// (StartVoteReply)
 	ir, err := b.getInventoryRecord(token)
@@ -2783,6 +2778,11 @@ func (b *backend) ProcessVoteResults(token string) (*www.VoteResultsReply, error
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusWrongStatus,
 		}
+	}
+
+	vrr, err := b.getVoteResultsFromPlugin(token)
+	if err != nil {
+		return nil, err
 	}
 
 	wvrr := convertVoteResultsReplyFromDecredplugin(*vrr, ir)

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -130,7 +130,7 @@ func (c *Client) makeRequest(method, route string, body interface{}) ([]byte, er
 	if r.StatusCode != http.StatusOK {
 		var ue v1.UserError
 		err = json.Unmarshal(responseBody, &ue)
-		if err == nil {
+		if err == nil && ue.ErrorCode != 0 {
 			return nil, fmt.Errorf("%v, %v %v", r.StatusCode,
 				v1.ErrorStatus[ue.ErrorCode], strings.Join(ue.ErrorContext, ", "))
 		}

--- a/politeiawww/cmd/politeiawwwcli/commands/proposalvotes.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/proposalvotes.go
@@ -11,5 +11,14 @@ func (cmd *ProposalVotesCmd) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Remove eligible tickets snapshot from response
+	// so that the output is legible
+	if !cfg.RawJSON {
+		vrr.StartVoteReply.EligibleTickets = []string{
+			"removed by politeiawwwcli for readability",
+		}
+	}
+
 	return Print(vrr, cfg.Verbose, cfg.RawJSON)
 }


### PR DESCRIPTION
Closes #576 

* Update the VoteResults endpoint to verify that the proposal exists
before sending a request to politeiad

* Don't print the user error when politeiavoter or wwwcli receive a 404
from www

* Update the human readable error message for ErrorStatusInvalid to make
it explicit that it is an invalid error status, not an invalid proposal status

* Remove eligible tickets snapshot from wwwcli VoteResults output to
make it readable (only for normal output, not JSON or Verbose)