### PR TITLE
www: Verifies that comment exists before like action

### DIFF
--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2198,6 +2198,14 @@ func (b *backend) ProcessLikeComment(lc www.LikeComment, user *database.User) (*
 		}
 	}
 
+	// Verify comment exists
+	_, ok := ir.comments[lc.CommentID]
+	if !ok {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCommentNotFound,
+		}
+	}
+
 	// Ensure proposal is public
 	pr := convertPropFromPD(ir.record)
 	if pr.Status != www.PropStatusPublic {


### PR DESCRIPTION
Now `ProcessLikeComment` verifies at the start of the execution if the comment exists, before proceeding with plugin and daemon interactions.

closes #580 