### PR TITLE
d+www: Add the proposal status abandoned

### DIFF
--- a/politeiad/api/v1/api.md
+++ b/politeiad/api/v1/api.md
@@ -15,6 +15,7 @@ censorship mechanism.
 - [`Get unvetted record`](#get-unvetted-record)
 - [`Get vetted record`](#get-vetted-record)
 - [`Set unvetted status`](#set-unvetted-status)
+- [`Set vetted status`](#set-vetted-status)
 - [`Update unvetted record`](#update-unvetted-record)
 - [`Update vetted record`](#update-vetted-record)
 - [`Update vetted metadata`](#update-vetted-metadata)
@@ -364,6 +365,73 @@ Reply:
 {
   "response":"a5cd683beec39c34ec7b01ad7c2c0c57757dbe7353f5b759ac6121755a5465b5edd157b0d198c8fdfa7d9960876dc4dfbd10dfb63acba93b8ba05d342668320d",
   "status":3
+}
+```
+
+### `Set vetted status`
+
+Set vetted status of a record.  The only state transition that is allowed is 
+setting a record that is public to archived.  Changes must be vetted by
+issuing a [`Set vetted status`](#set-vetted-status) call.
+
+One can, optionally, send in metadata streams for update as well.  This can,
+for example, be used to mark who made an update.
+
+Marking a proposal as abanonded is a permanent action and once a record is
+archived it can not be modified.
+
+This command requires administrator privileges.
+
+**Route**: `POST /v1/setvettedstatus`
+
+**Params**:
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| challenge | string | 32 byte hex encoded array. | Yes |
+| token | string | Record identifier. | Yes |
+| status | number | New record status. | Yes |
+| mdappend | array of [`MetadataStream`](#metadatastream) | Append payload to metadata stream(s). | No |
+| mdoverwrite | array of [`MetadataStream`](#metadatastream) | Overwrite payload to metadata stream(s). | No |
+
+**Results**:
+
+| | Type | Description |
+|-|-|-|
+| response | string | hex encoded signature of challenge byte array. |
+| status | number | New record status. |
+
+**Example**
+
+Request:
+
+```json
+{
+  "challenge":"db30532986113a7f973a589700e4296c93b3d9662a07c778bcf1ef4011dceb90",
+  "token":"1993f120323c4a4f89bf75cbd72e8eb728246e1e48292052abe8221e49588423",
+  "status":6,
+  "mdappend":
+  [
+    {
+      "id":2,
+      "payload":"{\"11foo\":\"11bar\"}"
+    }
+  ],
+  "mdoverwrite":
+  [
+    {
+      "id":12,"payload":"\"zap\""
+    }
+  ]
+}
+```
+
+Reply:
+
+```json
+{
+  "response":"a5cd683beec39c34ec7b01ad7c2c0c57757dbe7353f5b759ac6121755a5465b5edd157b0d198c8fdfa7d9960876dc4dfbd10dfb63acba93b8ba05d342668320d",
+  "status":6
 }
 ```
 

--- a/politeiad/api/v1/v1.go
+++ b/politeiad/api/v1/v1.go
@@ -32,6 +32,7 @@ const (
 	// Auth required
 	InventoryRoute         = "/v1/inventory/"                  // Inventory records
 	SetUnvettedStatusRoute = "/v1/setunvettedstatus/"          // Set unvetted status
+	SetVettedStatusRoute   = "/v1/setvettedstatus/"            // Set vetted status
 	PluginCommandRoute     = "/v1/plugin/"                     // Send a command to a plugin
 	PluginInventoryRoute   = PluginCommandRoute + "inventory/" // Inventory all plugins
 
@@ -65,7 +66,7 @@ const (
 	RecordStatusCensored          RecordStatusT = 3 // Record has been censored
 	RecordStatusPublic            RecordStatusT = 4 // Record is publicly visible
 	RecordStatusUnreviewedChanges RecordStatusT = 5 // Unvetted record that has been changed
-	RecordStatusLocked            RecordStatusT = 6 // Record is locked, note that this has not been implemented yet.
+	RecordStatusArchived          RecordStatusT = 6 // Vetted record that has been archived
 
 	// Default network bits
 	DefaultMainnetHost = "politeia.decred.org"
@@ -106,7 +107,7 @@ var (
 		RecordStatusCensored:          "censored",
 		RecordStatusPublic:            "public",
 		RecordStatusUnreviewedChanges: "unreviewed changes",
-		RecordStatusLocked:            "locked",
+		RecordStatusArchived:          "archived",
 	}
 
 	// Input validation
@@ -274,6 +275,23 @@ type SetUnvettedStatus struct {
 // SetUnvettedStatus is a response to a SetUnvettedStatus.  It returns the
 // potentially modified record without the Files.
 type SetUnvettedStatusReply struct {
+	Response string `json:"response"` // Challenge response
+	Record   Record `json:"record"`
+}
+
+// SetVettedStatus updates the status of a vetted record. This is used to
+// archive a vetted proposal. Additionally, metadata updates may travel along.
+type SetVettedStatus struct {
+	Challenge   string           `json:"challenge"`   // Random challenge
+	Token       string           `json:"token"`       // Censorship token
+	Status      RecordStatusT    `json:"status"`      // New status of record
+	MDAppend    []MetadataStream `json:"mdappend"`    // Metadata streams to append
+	MDOverwrite []MetadataStream `json:"mdoverwrite"` // Metadata streams to overwrite
+}
+
+// SetVettedStatusReply is a response to SetVettedStatus. It returns the
+// potentially modified record without the Files.
+type SetVettedStatusReply struct {
 	Response string `json:"response"` // Challenge response
 	Record   Record `json:"record"`
 }

--- a/politeiad/backend/backend.go
+++ b/politeiad/backend/backend.go
@@ -34,9 +34,9 @@ var (
 	// expected.
 	ErrChangesRecord = errors.New("changes record")
 
-	// ErrRecordLocked is returned when an updated was attempted on a
-	// locked record.
-	ErrRecordLocked = errors.New("record is locked")
+	// ErrRecordArchived is returned when an update was attempted on a
+	// archived record.
+	ErrRecordArchived = errors.New("record is archived")
 
 	// ErrJournalsNotReplayed is returned when the journals have not been replayed
 	// and the subsequent code expect it to be replayed
@@ -73,7 +73,7 @@ const (
 	MDStatusVetted            MDStatusT = 2 // Vetted record
 	MDStatusCensored          MDStatusT = 3 // Censored record
 	MDStatusIterationUnvetted MDStatusT = 4 // Unvetted record that has been changed
-	MDStatusLocked            MDStatusT = 5 // Record is locked, only vetted->locked allowed
+	MDStatusArchived          MDStatusT = 5 // Vetted record that has been archived
 )
 
 var (
@@ -84,7 +84,7 @@ var (
 		MDStatusVetted:            "vetted",
 		MDStatusCensored:          "censored",
 		MDStatusIterationUnvetted: "iteration unvetted",
-		MDStatusLocked:            "locked",
+		MDStatusArchived:          "archived",
 	}
 )
 
@@ -151,6 +151,7 @@ type Backend interface {
 	// Update vetted record (token, mdAppend, mdOverwrite, fAdd, fDelete)
 	UpdateVettedRecord([]byte, []MetadataStream, []MetadataStream, []File,
 		[]string) (*Record, error)
+
 	// Update vetted metadata (token, mdAppend, mdOverwrite)
 	UpdateVettedMetadata([]byte, []MetadataStream,
 		[]MetadataStream) error
@@ -163,6 +164,10 @@ type Backend interface {
 
 	// Set unvetted record status
 	SetUnvettedStatus([]byte, MDStatusT, []MetadataStream,
+		[]MetadataStream) (*Record, error)
+
+	// Set vetted record status
+	SetVettedStatus([]byte, MDStatusT, []MetadataStream,
 		[]MetadataStream) (*Record, error)
 
 	// Inventory retrieves various record records.

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -113,7 +113,7 @@ API.  It does not render HTML.
 - [`PropStatusNotReviewed`](#PropStatusNotReviewed)
 - [`PropStatusCensored`](#PropStatusCensored)
 - [`PropStatusPublic`](#PropStatusPublic)
-- [`PropStatusLocked`](#PropStatusLocked)
+- [`PropStatusAbandoned`](#PropStatusAbandoned)
 
 ## HTTP status codes and errors
 
@@ -1323,8 +1323,8 @@ Reply:
 
 ### `Set proposal status`
 
-Set status of proposal to `PropStatusPublic` or `PropStatusCensored`.  This
-call requires admin privileges.
+Set status of proposal to `PropStatusPublic`, `PropStatusCensored` or
+`PropStatusAbandoned`.  This call requires admin privileges.
 
 **Route:** `POST /v1/proposals/{token}/status`
 
@@ -1333,7 +1333,7 @@ call requires admin privileges.
 | Parameter | Type | Description | Required |
 |-|-|-|-|
 | token | string | Token is the unique censorship token that identifies a specific proposal. | Yes |
-| proposalstatus | number | Status indicates the new status for the proposal. Valid statuses are: [PropStatusCensored](#PropStatusCensored), [PropStatusPublic](#PropStatusPublic). Status can only be changed if the current proposal status is [PropStatusNotReviewed](#PropStatusNotReviewed) | Yes |
+| proposalstatus | number | Status indicates the new status for the proposal. Valid statuses are: [PropStatusCensored](#PropStatusCensored), [PropStatusPublic](#PropStatusPublic), [PropStatusAbandoned](#PropStatusAbandoned). | Yes |
 | signature | string | Signature of token+string(status). | Yes |
 | publickey | string | Public key from the client side, sent to politeiawww for verification | Yes |
 
@@ -1345,7 +1345,14 @@ call requires admin privileges.
 
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
+- [`ErrorStatusNoPublicKey`](#ErrorStatusNoPublicKey)
+- [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
+- [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
+- [`ErrorStatusChangeMessageCannotBeBlank`](#ErrorStatusChangeMessageCannotBeBlank)
 - [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
+- [`ErrorStatusReviewerAdminEqualsAuthor`](#ErrorStatusReviewerAdminEqualsAuthor)
+- [`ErrorStatusInvalidPropStatusTransition`](#ErrorStatusInvalidPropStatusTransition)
+- [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
 
 **Example**
 
@@ -1366,6 +1373,7 @@ Reply:
 {
 	"proposal": {
 		"name": "My Proposal",
+		"state": "2",
 		"status": 4,
 		"timestamp": 1539212044,
 		"userid": "",
@@ -2387,7 +2395,8 @@ Reply:
 | <a name="PropStatusNotReviewed">PropStatusNotReviewed</a> | 2 | The proposal has not been reviewed by an admin. |
 | <a name="PropStatusCensored">PropStatusCensored</a> | 3 | The proposal has been censored by an admin. |
 | <a name="PropStatusPublic">PropStatusPublic</a> | 4 | The proposal has been published by an admin. |
-| <a name="PropStatusLocked">PropStatusLocked</a> | 6 | The proposal has been locked by an admin. |
+| <a name="PropStatusUnreviewedChanges">PropStatusUnreviewedChanges</a> | 5 | The proposal has not been rewieved by an admin yet and has been edited by the author. |
+| <a name="PropStatusAbandoned">PropStatusAbandoned</a> | 6 | The proposal is public and has been deemed abandoned by an admin. |
 
 ### User edit actions
 
@@ -2461,6 +2470,7 @@ This is a shortened representation of a user, used for lists.
 | | Type | Description |
 |-|-|-|
 | name | string | The name of the proposal. |
+| state | number | Current state of the proposal. |
 | status | number | Current status of the proposal. |
 | timestamp | number | The unix time of the last update of the proposal. |
 | userid | string | The ID of the user who created the proposal. |

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -179,7 +179,9 @@ const (
 	// PropStateVetted includes proposals with a status of:
 	//   * PropStatusPublic
 	//   * PropStatusAbandoned
-	//   * PropStatusLocked
+	//
+	// Proposal states correspond to the unvetted and vetted politeiad
+	// repositories.
 	PropStateInvalid  PropStateT = 0 // Invalid state
 	PropStateUnvetted PropStateT = 1 // Unvetted proposal
 	PropStateVetted   PropStateT = 2 // Vetted proposal
@@ -191,7 +193,7 @@ const (
 	PropStatusCensored          PropStatusT = 3 // Proposal has been censored
 	PropStatusPublic            PropStatusT = 4 // Proposal is publicly visible
 	PropStatusUnreviewedChanges PropStatusT = 5 // Proposal is not public and has unreviewed changes
-	PropStatusLocked            PropStatusT = 6 // Proposal is locked, NOT IMPLEMENTED
+	PropStatusAbandoned         PropStatusT = 6 // Proposal has been declared abandoned by an admin
 
 	// Proposal vote status codes
 	PropVoteStatusInvalid       PropVoteStatusT = 0 // Invalid vote status
@@ -311,7 +313,7 @@ var (
 		PropStatusNotReviewed: "unreviewed",
 		PropStatusCensored:    "censored",
 		PropStatusPublic:      "public",
-		PropStatusLocked:      "locked",
+		PropStatusAbandoned:   "abandoned",
 	}
 
 	// PropVoteStatus converts votes status codes to human readable text
@@ -1090,4 +1092,5 @@ type ProposalsStatsReply struct {
 	NumOfUnvetted        int `json:"numofunvetted"`        // Counting number of unvetted proposals
 	NumOfUnvettedChanges int `json:"numofunvettedchanges"` // Counting number of proposals with unvetted changes
 	NumOfPublic          int `json:"numofpublic"`          // Counting number of public proposals
+	NumOfAbandoned       int `json:"numofabandoned"`       // Counting number of abandoned proposals
 }

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -5,6 +5,7 @@ import (
 )
 
 type ErrorStatusT int
+type PropStateT int
 type PropStatusT int
 type PropVoteStatusT int
 type UserManageActionT int
@@ -168,6 +169,20 @@ const (
 	ErrorStatusInvalidPropVoteBits         ErrorStatusT = 53
 	ErrorStatusInvalidPropVoteParams       ErrorStatusT = 54
 	ErrorStatusEmailNotVerified            ErrorStatusT = 55
+
+	// Proposal state codes
+	//
+	// PropStateUnvetted includes proposals with a status of:
+	//   * PropStatusNotReviewed
+	//   * PropStatusUnreviewedChanges
+	//   * PropStatusCensored
+	// PropStateVetted includes proposals with a status of:
+	//   * PropStatusPublic
+	//   * PropStatusAbandoned
+	//   * PropStatusLocked
+	PropStateInvalid  PropStateT = 0 // Invalid state
+	PropStateUnvetted PropStateT = 1 // Unvetted proposal
+	PropStateVetted   PropStateT = 2 // Vetted proposal
 
 	// Proposal status codes (set and get)
 	PropStatusInvalid           PropStatusT = 0 // Invalid status
@@ -351,6 +366,7 @@ type CensorshipRecord struct {
 // ProposalRecord is an entire proposal and it's content.
 type ProposalRecord struct {
 	Name                string      `json:"name"`                          // Suggested short proposal name
+	State               PropStateT  `json:"state"`                         // Current state of proposal
 	Status              PropStatusT `json:"status"`                        // Current status of proposal
 	Timestamp           int64       `json:"timestamp"`                     // Last update of proposal
 	UserId              string      `json:"userid"`                        // ID of user who submitted proposal

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -1556,8 +1556,8 @@ func (b *backend) ProcessAllVetted(v www.GetAllVetted) *www.GetAllVettedReply {
 		Proposals: b.getProposals(proposalsRequest{
 			After:  v.After,
 			Before: v.Before,
-			StatusMap: map[www.PropStatusT]bool{
-				www.PropStatusPublic: true,
+			StateMap: map[www.PropStateT]bool{
+				www.PropStateVetted: true,
 			},
 		}),
 	}
@@ -1570,10 +1570,8 @@ func (b *backend) ProcessAllUnvetted(u www.GetAllUnvetted) *www.GetAllUnvettedRe
 		Proposals: b.getProposals(proposalsRequest{
 			After:  u.After,
 			Before: u.Before,
-			StatusMap: map[www.PropStatusT]bool{
-				www.PropStatusNotReviewed:       true,
-				www.PropStatusCensored:          true,
-				www.PropStatusUnreviewedChanges: true,
+			StateMap: map[www.PropStateT]bool{
+				www.PropStateUnvetted: true,
 			},
 		}),
 	}
@@ -2383,11 +2381,9 @@ func (b *backend) ProcessUserProposals(up *www.UserProposals, isCurrentUser, isA
 			After:  up.After,
 			Before: up.Before,
 			UserId: up.UserId,
-			StatusMap: map[www.PropStatusT]bool{
-				www.PropStatusNotReviewed:       isCurrentUser || isAdminUser,
-				www.PropStatusCensored:          isCurrentUser || isAdminUser,
-				www.PropStatusUnreviewedChanges: isCurrentUser || isAdminUser,
-				www.PropStatusPublic:            true,
+			StateMap: map[www.PropStateT]bool{
+				www.PropStateUnvetted: isCurrentUser || isAdminUser,
+				www.PropStateVetted:   true,
 			},
 		}),
 		NumOfProposals: numProposals,

--- a/politeiawww/cmd/politeiawwwcli/README.md
+++ b/politeiawww/cmd/politeiawwwcli/README.md
@@ -226,10 +226,11 @@ A proposal record will include a numeric staus code to represent the status of
 the proposal.  These status codes are listed below.
 
 ```
-PropStatusInvalid      0 // Invalid status
-PropStatusNotFound     1 // Proposal not found
-PropStatusNotReviewed  2 // Proposal has not been reviewed
-PropStatusCensored     3 // Proposal has been censored
-PropStatusPublic       4 // Proposal is publicly visible
-PropStatusLocked       6 // Proposal is locked
+PropStatusInvalid           = 0 // Invalid status
+PropStatusNotFound          = 1 // Proposal not found
+PropStatusNotReviewed       = 2 // Proposal has not been reviewed
+PropStatusCensored          = 3 // Proposal has been censored
+PropStatusPublic            = 4 // Proposal is publicly visible
+PropStatusUnreviewedChanges = 5 // Proposal is not public and has unreviewed changes
+PropStatusAbandoned         = 6 // Proposal has been declared abandoned by an admin
 ```

--- a/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
@@ -18,8 +18,9 @@ type SetProposalStatusCmd struct {
 
 func (cmd *SetProposalStatusCmd) Execute(args []string) error {
 	PropStatus := map[string]v1.PropStatusT{
-		"censored": 3,
-		"public":   4,
+		"censored":  v1.PropStatusCensored,
+		"public":    v1.PropStatusPublic,
+		"abandoned": v1.PropStatusAbandoned,
 	}
 
 	// Validate user identity
@@ -38,9 +39,10 @@ func (cmd *SetProposalStatusCmd) Execute(args []string) error {
 		// Human readable status code found
 		status = s
 	} else {
-		return fmt.Errorf("Invalid proposal status.  Valid statuses are:\n  " +
-			"censored    censor a proposal\n  " +
-			"public      make a proposal public")
+		return fmt.Errorf("Invalid proposal status.  Valid statuses are:\n" +
+			"  censored    censor a proposal\n" +
+			"  public      make a proposal public\n" +
+			"  abandoned   declare a public proposal abandoned")
 	}
 
 	// Setup request

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -177,8 +177,8 @@ func convertPropStatusFromWWW(s www.PropStatusT) pd.RecordStatusT {
 		return pd.RecordStatusCensored
 	case www.PropStatusPublic:
 		return pd.RecordStatusPublic
-	case www.PropStatusLocked:
-		return pd.RecordStatusLocked
+	case www.PropStatusAbandoned:
+		return pd.RecordStatusArchived
 	}
 	return pd.RecordStatusInvalid
 }
@@ -245,8 +245,8 @@ func convertPropStatusFromPD(s pd.RecordStatusT) www.PropStatusT {
 		return www.PropStatusPublic
 	case pd.RecordStatusUnreviewedChanges:
 		return www.PropStatusUnreviewedChanges
-	case pd.RecordStatusLocked:
-		return www.PropStatusLocked
+	case pd.RecordStatusArchived:
+		return www.PropStatusAbandoned
 	}
 	return www.PropStatusInvalid
 }
@@ -306,7 +306,7 @@ func convertPropFromPD(p pd.Record) www.ProposalRecord {
 	case www.PropStatusNotReviewed, www.PropStatusUnreviewedChanges,
 		www.PropStatusCensored:
 		state = www.PropStateUnvetted
-	case www.PropStatusPublic, www.PropStatusLocked:
+	case www.PropStatusPublic, www.PropStatusAbandoned:
 		state = www.PropStateVetted
 	default:
 		state = www.PropStateInvalid

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -300,9 +300,22 @@ func convertPropFromPD(p pd.Record) www.ProposalRecord {
 		}
 	}
 
+	var state www.PropStateT
+	status := convertPropStatusFromPD(p.Status)
+	switch status {
+	case www.PropStatusNotReviewed, www.PropStatusUnreviewedChanges,
+		www.PropStatusCensored:
+		state = www.PropStateUnvetted
+	case www.PropStatusPublic, www.PropStatusLocked:
+		state = www.PropStateVetted
+	default:
+		state = www.PropStateInvalid
+	}
+
 	return www.ProposalRecord{
 		Name:                md.Name,
-		Status:              convertPropStatusFromPD(p.Status),
+		State:               state,
+		Status:              status,
 		Timestamp:           md.Timestamp,
 		PublicKey:           md.PublicKey,
 		Signature:           md.Signature,

--- a/politeiawww/inventory.go
+++ b/politeiawww/inventory.go
@@ -44,6 +44,7 @@ type proposalsStats struct {
 	NumOfUnvetted        int
 	NumOfUnvettedChanges int
 	NumOfPublic          int
+	NumOfAbandoned       int
 }
 
 // _inventoryProposalStats returns the number of proposals that are in the
@@ -57,6 +58,7 @@ func (b *backend) _inventoryProposalStats() proposalsStats {
 		NumOfUnvetted:        b.numOfUnvetted,
 		NumOfUnvettedChanges: b.numOfUnvettedChanges,
 		NumOfPublic:          b.numOfPublic,
+		NumOfAbandoned:       b.numOfAbandoned,
 	}
 }
 
@@ -96,6 +98,8 @@ func (b *backend) userProposalStats(userID string) proposalsStats {
 			ps.NumOfCensored += 1
 		case www.PropStatusPublic:
 			ps.NumOfPublic += 1
+		case www.PropStatusAbandoned:
+			ps.NumOfAbandoned += 1
 		}
 	}
 
@@ -173,6 +177,8 @@ func (b *backend) _updateInventoryCountOfPropStatus(status pd.RecordStatusT, old
 			b.numOfCensored += v
 		case www.PropStatusPublic:
 			b.numOfPublic += v
+		case www.PropStatusAbandoned:
+			b.numOfAbandoned += v
 		default:
 			b.numOfInvalid += v
 		}
@@ -638,7 +644,7 @@ func (b *backend) getProposals(pr proposalsRequest) []www.ProposalRecord {
 			continue
 		}
 
-		// Filter by the status.
+		// Filter by the state.
 		if val, ok := pr.StateMap[proposal.State]; !ok || !val {
 			continue
 		}
@@ -672,7 +678,7 @@ func (b *backend) getProposals(pr proposalsRequest) []www.ProposalRecord {
 				continue
 			}
 
-			// Filter by the status.
+			// Filter by the state.
 			if val, ok := pr.StateMap[proposal.State]; !ok || !val {
 				continue
 			}

--- a/politeiawww/inventory.go
+++ b/politeiawww/inventory.go
@@ -30,10 +30,10 @@ type inventoryRecord struct {
 // proposalsRequest is used for passing parameters into the
 // getProposals() function.
 type proposalsRequest struct {
-	After     string
-	Before    string
-	UserId    string
-	StatusMap map[www.PropStatusT]bool
+	After    string
+	Before   string
+	UserId   string
+	StateMap map[www.PropStateT]bool
 }
 
 // proposalsStats is used to summarize proposal statistics
@@ -639,7 +639,7 @@ func (b *backend) getProposals(pr proposalsRequest) []www.ProposalRecord {
 		}
 
 		// Filter by the status.
-		if val, ok := pr.StatusMap[proposal.Status]; !ok || !val {
+		if val, ok := pr.StateMap[proposal.State]; !ok || !val {
 			continue
 		}
 
@@ -673,7 +673,7 @@ func (b *backend) getProposals(pr proposalsRequest) []www.ProposalRecord {
 			}
 
 			// Filter by the status.
-			if val, ok := pr.StatusMap[proposal.Status]; !ok || !val {
+			if val, ok := pr.StateMap[proposal.State]; !ok || !val {
 				continue
 			}
 

--- a/politeiawww/inventory_test.go
+++ b/politeiawww/inventory_test.go
@@ -157,8 +157,8 @@ func TestInventoryPagination(t *testing.T) {
 
 	pr := proposalsRequest{
 		UserId: user.ID.String(),
-		StatusMap: map[www.PropStatusT]bool{
-			www.PropStatusNotReviewed: true,
+		StateMap: map[www.PropStateT]bool{
+			www.PropStateUnvetted: true,
 		},
 	}
 


### PR DESCRIPTION
Closes #479 

This commit adds the 'archived' record status to politeiad and the 'abandoned' proposal status to politeiawww. An abanonded proposal in politeiawww corresponds to a archvied proposal in politiad. Admins can declare a proposal abandoned at any time as long as the proposal is public and voting has not yet started. The admin must include a change message when changing a proposal status to abandoned and the admin's action is logged. Abandoned proposals are publicly viewable but cannot be edited, have the voting period authorized for them, have any new comments made or have any new comment votes cast.  Abandoned proposals are vetted proposals and are returned from the politeiad and politeiawww endpoints for fetching vetted proposals.