### PR TITLE
www + d: Move comments likes tally from d to www

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -15,7 +15,7 @@ const (
 	CmdCensorComment         = "censorcomment"
 	CmdGetComments           = "getcomments"
 	CmdProposalVotes         = "proposalvotes"
-	CmdProposalCommentsVotes = "proposalcommentsvotes"
+	CmdProposalCommentsLikes = "proposalcommentslikes"
 	MDStreamAuthorizeVote    = 13 // Vote authorization by proposal author
 	MDStreamVoteBits         = 14 // Vote bits and mask
 	MDStreamVoteSnapshot     = 15 // Vote tickets and start/end parameters
@@ -530,57 +530,48 @@ func DecodeGetCommentsReply(payload []byte) (*GetCommentsReply, error) {
 	return &gcr, nil
 }
 
-// UserCommentVote describes the voting action an user with a given pubkey has given
-// to a comment (e.g: up or down vote)
-type UserCommentVote struct {
-	Pubkey    string `json:"pubkey"`    // Public key
-	CommentID string `json:"commentid"` // Comment ID
-	Action    string `json:"action"`    // Up or downvote (1, -1)
-	Token     string `json:"token"`     // Censorhship token
-}
-
-// GetProposalCommentsVotes is a command to fetch all vote actions
-// on the comments of a given proposa
-type GetProposalCommentsVotes struct {
+// GetProposalCommentsLikes is a command to fetch all vote actions
+// on the comments of a given proposal
+type GetProposalCommentsLikes struct {
 	Token string `json:"token"` // Censorship token
 }
 
-// EncodeGetProposalCommentsVotes encodes GetCommentsVotes into a JSON byte slice.
-func EncodeGetProposalCommentsVotes(gpcv GetProposalCommentsVotes) ([]byte, error) {
+// EncodeGetProposalCommentsLikes encodes GetProposalCommentsLikes into a JSON byte slice.
+func EncodeGetProposalCommentsLikes(gpcv GetProposalCommentsLikes) ([]byte, error) {
 	return json.Marshal(gpcv)
 }
 
-// DecodeGetProposalCommentsVotes decodes a JSON byte slice into a GetProposalCommentsVotes.
-func DecodeGetProposalCommentsVotes(payload []byte) (*GetProposalCommentsVotes, error) {
-	var gpcv GetProposalCommentsVotes
+// DecodeGetProposalCommentsLikes decodes a JSON byte slice into a GetProposalCommentsLikes.
+func DecodeGetProposalCommentsLikes(payload []byte) (*GetProposalCommentsLikes, error) {
+	var gpcl GetProposalCommentsLikes
 
-	err := json.Unmarshal(payload, &gpcv)
+	err := json.Unmarshal(payload, &gpcl)
 	if err != nil {
 		return nil, err
 	}
 
-	return &gpcv, nil
+	return &gpcl, nil
 }
 
-// GetProposalCommentsVotesReply is a reply with all vote actions
+// GetProposalCommentsLikesReply is a reply with all vote actions
 // for the comments of a given proposal
-type GetProposalCommentsVotesReply struct {
-	UserCommentsVotes []UserCommentVote `json:"usercommentsvotes"`
+type GetProposalCommentsLikesReply struct {
+	CommentsLikes []LikeComment `json:"commentslikes"`
 }
 
-// EncodeGetProposalCommentsVotesReply encodes EncodeGetProposalCommentsVotesReply into a JSON byte slice.
-func EncodeGetProposalCommentsVotesReply(gpcvr GetProposalCommentsVotesReply) ([]byte, error) {
-	return json.Marshal(gpcvr)
+// EncodeGetProposalCommentsLikesReply encodes EncodeGetProposalCommentsLikesReply into a JSON byte slice.
+func EncodeGetProposalCommentsLikesReply(gpclr GetProposalCommentsLikesReply) ([]byte, error) {
+	return json.Marshal(gpclr)
 }
 
-// DecodeGetProposalCommentsVotesReply decodes a JSON byte slice into a GetProposalCommentsVotesReply.
-func DecodeGetProposalCommentsVotesReply(payload []byte) (*GetProposalCommentsVotesReply, error) {
-	var gpcvr GetProposalCommentsVotesReply
+// DecodeGetProposalCommentsLikesReply decodes a JSON byte slice into a GetProposalCommentsLikesReply.
+func DecodeGetProposalCommentsLikesReply(payload []byte) (*GetProposalCommentsLikesReply, error) {
+	var gpclr GetProposalCommentsLikesReply
 
-	err := json.Unmarshal(payload, &gpcvr)
+	err := json.Unmarshal(payload, &gpclr)
 	if err != nil {
 		return nil, err
 	}
 
-	return &gpcvr, nil
+	return &gpclr, nil
 }

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2218,9 +2218,9 @@ func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
 	case decredplugin.CmdGetComments:
 		payload, err := g.pluginGetComments(payload)
 		return decredplugin.CmdGetComments, payload, err
-	case decredplugin.CmdProposalCommentsVotes:
-		payload, err := g.pluginGetProposalCommentVotes(payload)
-		return decredplugin.CmdProposalCommentsVotes, payload, err
+	case decredplugin.CmdProposalCommentsLikes:
+		payload, err := g.pluginGetProposalCommentsLikes(payload)
+		return decredplugin.CmdProposalCommentsLikes, payload, err
 	}
 	return "", "", fmt.Errorf("invalid payload command") // XXX this needs to become a type error
 }

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -2238,11 +2238,11 @@ Reply:
 }
 ```
 
-### `User Comments Votes`
+### `User Comments Likes`
 
 Retrieve the comment votes for the current logged in user given a proposal token
 
-**Route:** `GET v1/user/proposals/{token}/commentsvotes`
+**Route:** `GET v1/user/proposals/{token}/commentslikes`
 
 **Params:** none
 
@@ -2250,9 +2250,9 @@ Retrieve the comment votes for the current logged in user given a proposal token
 
 | | Type | Description |
 | - | - | - |
-| commentsvotes | array of CommentVote | Votes issued by the current user |
+| commentslikes | array of CommentLike | Likes issued by the current user |
 
-**CommentVote:**
+**CommentLike:**
 
 | | Type | Description |
 | - | - | - |
@@ -2263,12 +2263,12 @@ Retrieve the comment votes for the current logged in user given a proposal token
 **Example:**
 
 Request:
-Path: `v1/user/proposals/8a11057fb910564a7d2506430505c3991f59e35f8a7757b8000a032505b254d8/commentsvotes`
+Path: `v1/user/proposals/8a11057fb910564a7d2506430505c3991f59e35f8a7757b8000a032505b254d8/commentslikes`
 
 Reply:
 ```json
   {
-    "commentsvotes":
+    "commentslikes":
     [
       {
         "action":"-1",

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -54,7 +54,7 @@ const (
 	RouteStartVote              = "/proposals/startvote"
 	RouteActiveVote             = "/proposals/activevote" // XXX rename to ActiveVotes
 	RouteCastVotes              = "/proposals/castvotes"
-	RouteUserCommentsVotes      = "/user/proposals/{token:[A-z0-9]{64}}/commentsvotes"
+	RouteUserCommentsLikes      = "/user/proposals/{token:[A-z0-9]{64}}/commentslikes"
 	RouteVoteResults            = "/proposals/{token:[A-z0-9]{64}}/votes"
 	RouteAllVoteStatus          = "/proposals/votestatus"
 	RouteVoteStatus             = "/proposals/{token:[A-z0-9]{64}}/votestatus"
@@ -943,22 +943,22 @@ type CensorCommentReply struct {
 	Receipt string `json:"receipt"` // Server signature of client signature
 }
 
-// CommentVote describes the voting action an user has given
+// CommentLike describes the voting action an user has given
 // to a comment (e.g: up or down vote)
-type CommentVote struct {
+type CommentLike struct {
 	Action    string `json:"action"`    // Up or downvote (1, -1)
 	CommentID string `json:"commentid"` // Comment ID
 	Token     string `json:"token"`     // Censorship token
 }
 
-// UserCommentsVotes is a command to fetch all user vote actions
+// UserCommentsLikes is a command to fetch all user vote actions
 // on the comments of a given proposal
-type UserCommentsVotes struct{}
+type UserCommentsLikes struct{}
 
-// UserCommentsVotesReply is a reply with all user vote actions
+// UserCommentsLikesReply is a reply with all user vote actions
 // for the comments of a given proposal
-type UserCommentsVotesReply struct {
-	CommentsVotes []CommentVote `json:"commentsvotes"`
+type UserCommentsLikesReply struct {
+	CommentsLikes []CommentLike `json:"commentslikes"`
 }
 
 // VoteOptionResult is a structure that describes a VotingOption along with the

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -90,6 +90,9 @@ type backend struct {
 
 	// Count of user proposals
 	numOfPropsByUserID map[string]int
+
+	// User vote action on each comment
+	userLikeActionByCommentID map[string]map[string]map[string]int64 // [token][userid][commentid]action
 }
 
 type BackendProposalMetadata struct {
@@ -936,7 +939,6 @@ func (b *backend) LoadInventory() error {
 
 	err = b.initializeInventory(inv)
 	if err != nil {
-		b.Unlock()
 		return fmt.Errorf("initializeInventory: %v", err)
 	}
 
@@ -2187,27 +2189,17 @@ func (b *backend) ProcessLikeComment(lc www.LikeComment, user *database.User) (*
 	if err != nil {
 		return nil, err
 	}
-	lcrWWW := convertDecredLikeCommentReplyToWWWLikeCommentReply(*lcr)
 
-	// Add action to comment to cache
-	if lcr.Error == "" {
-		b.Lock()
-		defer b.Unlock()
+	comment, err := b.updateResultsForCommentLike(lc)
+	if err != nil {
+		return nil, err
+	}
 
-		c, err := b._getInventoryRecordComment(lc.Token, lc.CommentID)
-		if err != nil {
-			return nil, fmt.Errorf("Could not find comment %v:%v",
-				lc.Token, lc.CommentID)
-		}
-
-		// Update vote counts
-		c.TotalVotes = lcr.Total
-		c.ResultVotes = lcr.Result
-		err = b._setRecordComment(*c)
-		if err != nil {
-			return nil, fmt.Errorf("setRecordComment %v", err)
-		}
-
+	lcrWWW := www.LikeCommentReply{
+		Total:   comment.TotalVotes,
+		Result:  comment.ResultVotes,
+		Receipt: lcr.Receipt,
+		Error:   lcr.Error,
 	}
 
 	return &lcrWWW, nil
@@ -2873,72 +2865,26 @@ func (b *backend) ProcessVoteStatus(token string) (*www.VoteStatusReply, error) 
 	}, nil
 }
 
-// ProcessUserCommentsVotes returns the votes an user has for the comments of a given proposal
-func (b *backend) ProcessUserCommentsVotes(user *database.User, token string) (*www.UserCommentsVotesReply, error) {
-	log.Tracef("ProcessUserCommentsVotes")
+// ProcessUserCommentsLikes returns the votes an user has for the comments of a given proposal
+func (b *backend) ProcessUserCommentsLikes(user *database.User, token string) (*www.UserCommentsLikesReply, error) {
+	log.Tracef("ProcessUserCommentsLikes")
 
-	payload, err := decredplugin.EncodeGetProposalCommentsVotes(decredplugin.GetProposalCommentsVotes{
-		Token: token,
-	})
-	if err != nil {
-		return nil, err
+	userID := user.ID.String()
+	uclr := www.UserCommentsLikesReply{}
+	b.RLock()
+	defer b.RUnlock()
+
+	userLikeActions := b.userLikeActionByCommentID[token][userID]
+
+	for commentID, action := range userLikeActions {
+		uclr.CommentsLikes = append(uclr.CommentsLikes, www.CommentLike{
+			Action:    strconv.FormatInt(action, 10),
+			CommentID: commentID,
+			Token:     token,
+		})
 	}
 
-	// Obtain proposal comments votes from plugin
-	challenge, err := util.Random(pd.ChallengeSize)
-	if err != nil {
-		return nil, err
-	}
-
-	pc := pd.PluginCommand{
-		Challenge: hex.EncodeToString(challenge),
-		ID:        decredplugin.ID,
-		Command:   decredplugin.CmdProposalCommentsVotes,
-		CommandID: decredplugin.CmdProposalCommentsVotes,
-		Payload:   string(payload),
-	}
-
-	responseBody, err := b.makeRequest(http.MethodPost,
-		pd.PluginCommandRoute, pc)
-	if err != nil {
-		return nil, err
-	}
-
-	var reply pd.PluginCommandReply
-	err = json.Unmarshal(responseBody, &reply)
-	if err != nil {
-		return nil, fmt.Errorf("Could not unmarshal "+
-			"PluginCommandReply: %v", err)
-	}
-
-	// Verify the challenge.
-	err = util.VerifyChallenge(b.cfg.Identity, challenge, reply.Response)
-	if err != nil {
-		return nil, err
-	}
-
-	gpcvr, err := decredplugin.DecodeGetProposalCommentsVotesReply([]byte(reply.Payload))
-	if err != nil {
-		return nil, err
-	}
-
-	var ucvr www.UserCommentsVotesReply
-	for _, ucv := range gpcvr.UserCommentsVotes {
-		// check if the pubkey refers to the current user
-		// if it does, add the comment-action to CommentsVotes
-		b.RLock()
-		id, ok := b.userPubkeys[ucv.Pubkey]
-		b.RUnlock()
-		if ok && id == user.ID.String() {
-			ucvr.CommentsVotes = append(ucvr.CommentsVotes, www.CommentVote{
-				Action:    ucv.Action,
-				CommentID: ucv.CommentID,
-				Token:     token,
-			})
-		}
-	}
-
-	return &ucvr, nil
+	return &uclr, nil
 }
 
 // ProcessEditProposal attempts to edit a proposal on politeiad
@@ -3259,11 +3205,12 @@ func NewBackend(cfg *config) (*backend, error) {
 
 	// Context
 	b := &backend{
-		db:                 db,
-		cfg:                cfg,
-		userPubkeys:        make(map[string]string),
-		userPaywallPool:    make(map[uuid.UUID]paywallPoolMember),
-		numOfPropsByUserID: make(map[string]int),
+		db:                        db,
+		cfg:                       cfg,
+		userPubkeys:               make(map[string]string),
+		userPaywallPool:           make(map[uuid.UUID]paywallPoolMember),
+		numOfPropsByUserID:        make(map[string]int),
+		userLikeActionByCommentID: make(map[string]map[string]map[string]int64),
 	}
 
 	// Setup pubkey-userid map

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -760,27 +760,27 @@ func (c *Client) GetComments(token string) (*v1.GetCommentsReply, error) {
 	return &gcr, nil
 }
 
-func (c *Client) UserCommentsVotes(token string) (*v1.UserCommentsVotesReply, error) {
-	route := "/user/proposals/" + token + "/commentsvotes"
+func (c *Client) UserCommentsLikes(token string) (*v1.UserCommentsLikesReply, error) {
+	route := "/user/proposals/" + token + "/commentslikes"
 	responseBody, err := c.makeRequest("GET", route, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var ucvr v1.UserCommentsVotesReply
-	err = json.Unmarshal(responseBody, &ucvr)
+	var uclr v1.UserCommentsLikesReply
+	err = json.Unmarshal(responseBody, &uclr)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal UserCommentsVotesReply: %v", err)
+		return nil, fmt.Errorf("unmarshal UserCommentsLikesReply: %v", err)
 	}
 
 	if c.cfg.Verbose {
-		err := PrettyPrintJSON(ucvr)
+		err := PrettyPrintJSON(uclr)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return &ucvr, nil
+	return &uclr, nil
 }
 
 func (c *Client) LikeComment(lc *v1.LikeComment) (*v1.LikeCommentReply, error) {

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -26,7 +26,7 @@ type Cmds struct {
 	AuthorizeVote      AuthorizeVoteCmd      `command:"authorizevote" description:"authorize a proposal vote (must be proposal author)"`
 	CensorComment      CensorCommentCmd      `command:"censorcomment" description:"(admin) censor a proposal comment"`
 	ChangePassword     ChangePasswordCmd     `command:"changepassword" description:"change the password for the currently logged in user"`
-	CommentsVotes      CommentsVotesCmd      `command:"commentsvotes" description:"fetch all the comments voted by the user on a proposal"`
+	CommentsLikes      CommentsLikesCmd      `command:"commentslikes" description:"fetch all the comments voted by the user on a proposal"`
 	ChangeUsername     ChangeUsernameCmd     `command:"changeusername" description:"change the username for the currently logged in user"`
 	EditProposal       EditProposalCmd       `command:"editproposal" description:"edit a proposal"`
 	ManageUser         ManageUserCmd         `command:"manageuser" description:"(admin) edit the details for the given user id"`

--- a/politeiawww/cmd/politeiawwwcli/commands/commentsvotes.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commentsvotes.go
@@ -1,13 +1,13 @@
 package commands
 
-type CommentsVotesCmd struct {
+type CommentsLikesCmd struct {
 	Args struct {
 		Token string `positional-arg-name:"token"`
 	} `positional-args:"true" required:"true"`
 }
 
-func (cmd *CommentsVotesCmd) Execute(args []string) error {
-	cvr, err := c.UserCommentsVotes(cmd.Args.Token)
+func (cmd *CommentsLikesCmd) Execute(args []string) error {
+	cvr, err := c.UserCommentsLikes(cmd.Args.Token)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1284,9 +1284,9 @@ func (p *politeiawww) handleVoteStatus(w http.ResponseWriter, r *http.Request) {
 	util.RespondWithJSON(w, http.StatusOK, vsr)
 }
 
-// handleUserCommentsVotes returns the user votes on comments of a given proposal.
-func (p *politeiawww) handleUserCommentsVotes(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("handleUserCommentsVotes")
+// handleUserCommentsLikes returns the user votes on comments of a given proposal.
+func (p *politeiawww) handleUserCommentsLikes(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleUserCommentsLikes")
 
 	pathParams := mux.Vars(r)
 	token := pathParams["token"]
@@ -1294,18 +1294,18 @@ func (p *politeiawww) handleUserCommentsVotes(w http.ResponseWriter, r *http.Req
 	user, err := p.getSessionUser(w, r)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleUserCommentsVotes: getSessionUser %v", err)
+			"handleUserCommentsLikes: getSessionUser %v", err)
 		return
 	}
 
-	ucvr, err := p.backend.ProcessUserCommentsVotes(user, token)
+	uclr, err := p.backend.ProcessUserCommentsLikes(user, token)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleUserCommentsVotes: processUserCommentsVotes %v", err)
+			"handleUserCommentsLikes: processUserCommentsLikes %v", err)
 		return
 	}
 
-	util.RespondWithJSON(w, http.StatusOK, ucvr)
+	util.RespondWithJSON(w, http.StatusOK, uclr)
 }
 
 // handleEditProposal attempts to edit a proposal
@@ -1573,8 +1573,8 @@ func _main() error {
 		p.handleLikeComment, permissionLogin, true)
 	p.addRoute(http.MethodGet, v1.RouteVerifyUserPayment,
 		p.handleVerifyUserPayment, permissionLogin, false)
-	p.addRoute(http.MethodGet, v1.RouteUserCommentsVotes,
-		p.handleUserCommentsVotes, permissionLogin, true)
+	p.addRoute(http.MethodGet, v1.RouteUserCommentsLikes,
+		p.handleUserCommentsLikes, permissionLogin, true)
 	p.addRoute(http.MethodGet, v1.RouteUserProposalCredits,
 		p.handleUserProposalCredits, permissionLogin, false)
 	p.addRoute(http.MethodPost, v1.RouteEditProposal,


### PR DESCRIPTION
This PR removes the comment likes tally from d and add into www. It also standardizes the terminology as comment likes instead of mixing comment votes and comment likes across structs and functions.

The comment likes are all fetched from d when the www inventory is initialized and it is updated as new "comment likes" come in.
closes #603