### PR TITLE
www: Fix UUID validation and proper error returns

### DIFF
--- a/politeiawww/admin.go
+++ b/politeiawww/admin.go
@@ -178,13 +178,9 @@ func (b *backend) ProcessUsers(users *v1.Users) (*v1.UsersReply, error) {
 // to check for any payments that may have been missed by paywall polling.
 func (b *backend) ProcessUserPaymentsRescan(upr v1.UserPaymentsRescan) (*v1.UserPaymentsRescanReply, error) {
 	// Lookup user
-	userID, err := uuid.Parse(upr.UserID)
+	user, err := b.getUserByIDStr(upr.UserID)
 	if err != nil {
-		return nil, fmt.Errorf("parse UUID: %v", err)
-	}
-	user, err := b.db.UserGetById(userID)
-	if err != nil {
-		return nil, fmt.Errorf("UserGetByID: %v", err)
+		return nil, err
 	}
 
 	// Fetch user payments

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -170,6 +170,7 @@ const (
 	ErrorStatusInvalidPropVoteParams       ErrorStatusT = 54
 	ErrorStatusEmailNotVerified            ErrorStatusT = 55
 	ErrorStatusInvalidPropVersion          ErrorStatusT = 56
+	ErrorStatusInvalidUUID                 ErrorStatusT = 57
 
 	// Proposal state codes
 	//
@@ -308,6 +309,7 @@ var (
 		ErrorStatusInvalidPropVoteParams:       "invalid proposal vote parameters",
 		ErrorStatusEmailNotVerified:            "email address is not verified",
 		ErrorStatusInvalidPropVersion:          "invalid proposal version",
+		ErrorStatusInvalidUUID:                 "invalid user UUID",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -53,7 +53,9 @@ func convertWWWIdentityFromDatabaseIdentity(identity database.Identity) v1.UserI
 func (b *backend) getUserByIDStr(userIDStr string) (*database.User, error) {
 	userID, err := uuid.Parse(userIDStr)
 	if err != nil {
-		return nil, err
+		return nil, v1.UserError{
+			ErrorCode: v1.ErrorStatusInvalidUUID,
+		}
 	}
 
 	user, err := b.db.UserGetById(userID)


### PR DESCRIPTION
Now returns proper error in case the passed UUID is invalid or non-existent in our DB. Fixed commands were `manageuser` and `rescanuserpayment`, which receives a UUID as input.

closes #561 