### PR TITLE
www - Return the timestamp by status of a proposal

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -1079,6 +1079,9 @@ Reply:
       "name":"Edited proposal",
       "status":4,
       "timestamp":1535468714,
+      "publishedat": 1508296860900,
+      "censoredat": 0,
+      "abandonedat": 0,
       "userid":"",
       "username":"",
       "publickey":"1bc17b4aaa7d08030d0cb984d3b67ce7b681508b46ce307b22dfd630141788a0",
@@ -1142,6 +1145,9 @@ Reply:
       "name": "My Proposal",
       "status": 2,
       "timestamp": 1508296860781,
+      "publishedat": 0,
+      "censoredat": 0,
+      "abandonedat": 0,
       "censorshiprecord": {
         "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
         "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
@@ -1189,6 +1195,9 @@ Reply:
     "name": "My Proposal",
     "status": 4,
     "timestamp": 1508296860781,
+    "publishedat": 1508296860900,
+    "censoredat": 0,
+    "abandonedat": 0,
     "censorshiprecord": {
       "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
       "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
@@ -2480,7 +2489,11 @@ This is a shortened representation of a user, used for lists.
 | censorshiprecord | [`censorshiprecord`](#censorship-record) | The censorship record that was created when the proposal was submitted. |
 | files | array of [`File`](#file)s | This property will only be populated for the [`Proposal details`](#proposal-details) call. |
 | numcomments | number | The number of comments on the proposal. This should be ignored for proposals which are not public. |
-
+| statatuschangemessage | Message associated to the status change. |
+| pubishedat | The timestamp of when the proposal has been published. If the proposals has not been pubished, this field will not be present. |
+| censoredat | The timestamp of when the proposal has been censored. If the proposals has not been censored, this field will not be present. |
+| abandonedat | The timestamp of when the proposal has been abandoned. If the proposals has not been abandoned, this field will not be present. |
+ 
 ### `Identity`
 
 | | Type | Description |

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -381,6 +381,9 @@ type ProposalRecord struct {
 	NumComments         uint        `json:"numcomments"`                   // Number of comments on the proposal
 	Version             string      `json:"version"`                       // Record version
 	StatusChangeMessage string      `json:"statuschangemessage,omitempty"` // Message associated to the status change
+	PublishedAt         int64       `json:"publishedat,omitempty"`         // The timestamp of when the proposal has been published
+	CensoredAt          int64       `json:"censoredat,omitempty"`          // The timestamp of when the proposal has been censored
+	AbandonedAt         int64       `json:"abandonedat,omitempty"`         // The timestamp of when the proposal has been abandoned
 
 	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
 }

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -244,6 +244,11 @@ func (b *backend) _convertPropFromInventoryRecord(r inventoryRecord) www.Proposa
 	// Set the comments num.
 	proposal.NumComments = uint(len(r.comments))
 
+	// Set the proposals status timestamps
+	proposal.PublishedAt,
+		proposal.CensoredAt,
+		proposal.AbandonedAt = getProposalStatusTimestamps(r)
+
 	// Set the user id.
 	var ok bool
 	proposal.UserId, ok = b.userPubkeys[proposal.PublicKey]
@@ -253,6 +258,21 @@ func (b *backend) _convertPropFromInventoryRecord(r inventoryRecord) www.Proposa
 	}
 
 	return proposal
+}
+
+func getProposalStatusTimestamps(ir inventoryRecord) (int64, int64, int64) {
+	var publishedAt, censoredAt, abandonedAt int64
+	for _, c := range ir.changes {
+		switch convertPropStatusFromPD(c.NewStatus) {
+		case www.PropStatusPublic:
+			publishedAt = c.Timestamp
+		case www.PropStatusCensored:
+			censoredAt = c.Timestamp
+		case www.PropStatusAbandoned:
+			abandonedAt = c.Timestamp
+		}
+	}
+	return publishedAt, censoredAt, abandonedAt
 }
 
 // hashPassword hashes the given password string with the default bcrypt cost

--- a/politeiawww/inventory.go
+++ b/politeiawww/inventory.go
@@ -163,7 +163,7 @@ func (b *backend) _updateInventoryRecord(record pd.Record) error {
 	return nil
 }
 
-// updateInventoryCount updates the count of proposals by each statys
+// updateInventoryCount updates the count of proposals by each status
 //
 // this function must be called WITH the mutex held
 func (b *backend) _updateInventoryCountOfPropStatus(status pd.RecordStatusT, oldStatus *pd.RecordStatusT) {
@@ -485,7 +485,7 @@ func (b *backend) getInventoryRecord(token string) (inventoryRecord, error) {
 // getInventoryRecordComment returns a comment from the inventory given its
 // record token and the comment id.
 //
-// This functions must be called WITH the mutex held.
+// This function must be called WITH the mutex held.
 func (b *backend) _getInventoryRecordComment(token string, commentID string) (*www.Comment, error) {
 	comment, ok := b.inventory[token].comments[commentID]
 	if !ok {


### PR DESCRIPTION
This Pull Request adds 3 new fields into the proposal struct:
```Go

        PublishedAt         int64       `json:"publishedat"`                   // The timestamp of when the proposal has been published
	CensoredAt          int64       `json:"censoredat"`                    // The timestamp of when the proposal has been censored
	AbandonedAt         int64       `json:"abandonedat"`                   // The timestamp of when the proposal has been abandoned
```

closes #618 