### PR TITLE
d: Remove svg from accepted MIME types

### DIFF
--- a/politeiad/api/v1/api.md
+++ b/politeiad/api/v1/api.md
@@ -767,7 +767,7 @@ Reply:
 | | Type | Description |
 |-|-|-|
 | name | string | Name is the suggested filename. There should be no filenames that are overlapping and the name shall be validated before being used. |
-| mime | string | MIME type of the payload. Currently the system only supports md and png/svg files. The server shall reject invalid MIME types. |
+| mime | string | MIME type of the payload. Currently the system only supports md and png files. The server shall reject invalid MIME types. |
 | digest | string | Digest is a SHA256 digest of the payload. The digest shall be verified by politeiad. |
 | payload | string | Payload is the actual file content. It shall be base64 encoded. |
 

--- a/politeiad/api/v1/mime/bmime.go
+++ b/politeiad/api/v1/mime/bmime.go
@@ -12,7 +12,6 @@ var (
 	// can be communicated between client and server.
 	validMimeTypesList = []string{
 		"image/png",
-		"image/svg+xml",
 		"text/plain",
 		"text/plain; charset=utf-8",
 	}

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -1307,7 +1307,6 @@ Reply:
   "maxmdsize": 524288,
   "validmimetypes": [
     "image/png",
-    "image/svg+xml",
     "text/plain",
     "text/plain; charset=utf-8"
   ],
@@ -2495,7 +2494,7 @@ This is a shortened representation of a user, used for lists.
 | | Type | Description |
 |-|-|-|
 | name | string | Name is the suggested filename. There should be no filenames that are overlapping and the name shall be validated before being used. |
-| mime | string | MIME type of the payload. Currently the system only supports md and png/svg files. The server shall reject invalid MIME types. |
+| mime | string | MIME type of the payload. Currently the system only supports md and png files. The server shall reject invalid MIME types. |
 | digest | string | Digest is a SHA256 digest of the payload. The digest shall be verified by politeiad. |
 | payload | string | Payload is the actual file content. It shall be base64 encoded. Files have size limits that can be obtained via the [`Policy`](#policy) call. The server shall strictly enforce policy limits. |
 


### PR DESCRIPTION
Closes #607

We have decided to remove SVG image support until adequate Golang tooling exists for sanitizing SVG.