### PR TITLE
Adds new custom help messages for politeiawwwcli commands

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/commands/censorcomment.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/censorcomment.go
@@ -8,6 +8,28 @@ import (
 	"github.com/decred/politeia/util"
 )
 
+// Help message displayed for the command 'politeiawwwcli help censorcomment'
+var CensorCommentCmdHelpMsg = `censorcomment "token" "commentID" "reason"
+
+Censor comment (admin).
+
+Arguments:
+1. token       (string, required)   Proposal censorship token
+2. commentID   (string, required)   Id of the comment
+3. reason      (string, required)   Reason for censoring the comment
+
+Result:
+{
+  "token":      (string)  Censorship token
+  "commentid":  (string)  Id of comment
+  "reason":     (string)  Reason for censoring the comment
+  "signature":  (string)  Signature of censor comment (Token+CommentID+Reason)
+  "publickey":  (string)  Public key used for signature
+}
+{
+  "receipt":  (string)  Server signature of comment sensor signature
+}`
+
 type CensorCommentCmd struct {
 	Args struct {
 		Token     string `positional-arg-name:"token" description:"Proposal censorship token"`

--- a/politeiawww/cmd/politeiawwwcli/commands/changepassword.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/changepassword.go
@@ -6,6 +6,22 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help changepassword'
+var ChangePasswordCmdHelpMsg = `changepassword "currentPassword" "newPassword" 
+
+Change password for the currently logged in user. 
+
+Arguments:
+1. currentPassword   (string, required)   Current password 
+2. newPassword       (string, required)   New password  
+
+Result:
+{
+  "currentpassword":   (string)  Current password 
+  "newpassword":       (string)  New password 
+}
+{}`
+
 type ChangePasswordCmd struct {
 	Args struct {
 		Password    string `positional-arg-name:"currentPassword"`

--- a/politeiawww/cmd/politeiawwwcli/commands/changeusername.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/changeusername.go
@@ -2,6 +2,22 @@ package commands
 
 import "github.com/decred/politeia/politeiawww/api/v1"
 
+// Help message displayed for the command 'politeiawwwcli help changeusername'
+var ChangeUsernameCmdHelpMsg = `changeusername "password" "newusername" 
+
+Change the username for the currently logged in user.
+
+Arguments:
+1. password      (string, required)   Current password 
+2. newusername   (string, required)   New username  
+
+Result:
+{
+  "password":      (string)  Current password 
+  "newusername":   (string)  New username
+}
+{}`
+
 type ChangeUsernameCmd struct {
 	Args struct {
 		Password    string `positional-arg-name:"password"`

--- a/politeiawww/cmd/politeiawwwcli/commands/editproposal.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/editproposal.go
@@ -13,6 +13,58 @@ import (
 	"github.com/decred/politeia/util"
 )
 
+// Help message displayed for the command 'politeiawwwcli help editproposal'
+var EditProposalCmdHelpMsg = `editproposal "token" "markdownFile" "attachmentFiles" 
+
+Edit a proposal.
+
+Arguments:
+1. token             (string, required)   Proposal censorship token
+2. markdownFile      (string, required)   Edited proposal 
+3. attachmentFiles   (string, optional)   Attachments 
+
+Result:
+{
+  "token":  (string)  Censorship token
+    "files": [
+      {
+        "name":      (string)  Filename 
+        "mime":      (string)  Mime type 
+        "digest":    (string)  File digest 
+        "payload":   (string)  File payload 
+      }
+    ],
+  "publickey": (string)  Public key used to sign proposal
+  "signature": (string)  Signature of the merkle root 
+}
+{
+  "proposal": {
+    "name":          (string)  Suggested short proposal name 
+    "state":         (PropStateT)  Current state of proposal
+    "status":        (PropStatusT)  Current status of proposal
+    "timestamp":     (int64)  Timestamp of last update of proposal
+    "userid":        (string)  ID of user who submitted proposal
+    "username":      (string)  Username of user who submitted proposal
+    "publickey":     (string)  Public key used to sign proposal
+    "signature":     (string)  Signature of merkle root
+    "files": [
+      {
+        "name":      (string)  Filename 
+        "mime":      (string)  Mime type 
+        "digest":    (string)  File digest 
+        "payload":   (string)  File payload 
+      }
+    ],
+    "numcomments":   (uint)    Number of comments on the proposal
+    "version": 		 (string)  Version of proposal
+    "censorshiprecord": {	
+      "token":       (string)  Censorship token
+      "merkle":      (string)  Merkle root of proposal
+      "signature":   (string)  Server side signature of []byte(Merkle+Token)
+    }
+  }
+}`
+
 type EditProposalCmd struct {
 	Args struct {
 		Token       string   `positional-arg-name:"token"`

--- a/politeiawww/cmd/politeiawwwcli/commands/edituser.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/edituser.go
@@ -4,6 +4,20 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help edituser'
+var EditUserCmdHelpMsg = `edituser "userid" "action" "reason"
+
+Edit the details for the given user id (admin).
+
+Arguments:
+1. emailnotifications       (uint64, optional)   Whether to notify via emails
+
+Result:
+{
+  "emailnotifications": null
+}
+{}`
+
 type EditUserCmd struct {
 	EmailNotifications *uint64 `long:"emailnotifications" optional:"true" description:"Whether to notify via emails"`
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/faucet.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/faucet.go
@@ -6,6 +6,19 @@ import (
 	"github.com/decred/politeia/util"
 )
 
+// Help message displayed for the command 'politeiawwwcli help faucet'
+var FaucetCmdHelpMsg = `faucet "address" "amount" 
+
+Use the Decred testnet faucet to send DCR (in atoms) to an address. One atom is
+one hundred millionth of a single DCR (0.00000001 DCR).
+
+Arguments:
+1. address      (string, required)   Receiving address
+2. amount       (uint64, required)   Amount to send (atoms)
+
+Result:
+Paid [amount] DCR to [address] with txID [transaction id]`
+
 type FaucetCmd struct {
 	Args struct {
 		Address       string `positional-arg-name:"address" required:"true" description:"Address to send DCR to"`

--- a/politeiawww/cmd/politeiawwwcli/commands/getcomments.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/getcomments.go
@@ -1,5 +1,34 @@
 package commands
 
+// Help message displayed for the command 'politeiawwwcli help getcomments'
+var GetCommentsCmdHelpMsg = `getcomments "token" 
+
+Get comments for a proposal.
+
+Arguments:
+1. token       (string, required)   Proposal censorship token
+
+Result:
+{
+  "comments": [
+    {
+      "token":        (string)  Censorship token
+      "parentid":     (string)  Id of comment (defaults to '0' (top-level))
+      "comment":      (string)  Comment
+      "signature":    (string)  Signature of token+parentID+comment
+      "publickey":    (string)  Public key of user 
+      "commentid":    (string)  Id of the comment
+      "receipt":      (string)  Server signature of the comment signature
+      "timestamp":    (int64)   Received UNIX timestamp
+      "totalvotes":   (uint64)  Total number of up/down votes
+      "resultvotes":  (int64)   Vote score
+      "censored":     (bool)    If comment has been censored
+      "userid":       (string)  User id
+      "username":     (string)  Username
+    }
+  ]
+}`
+
 type GetCommentsCmd struct {
 	Args struct {
 		Token string `positional-arg-name:"token"`

--- a/politeiawww/cmd/politeiawwwcli/commands/getproposal.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/getproposal.go
@@ -6,6 +6,43 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help getproposal'
+var GetProposalCmdHelpMsg = `getproposal "token" 
+
+Fetch a proposal by censorship token. 
+
+Arguments:
+1. token      (string, required)   Censorship token
+
+Result:
+{
+  "proposal": {
+    "name":          (string)  Suggested short proposal name 
+    "state":         (PropStateT)  Current state of proposal
+    "status":        (PropStatusT)  Current status of proposal
+    "timestamp":     (int64)  Timestamp of last update of proposal
+    "userid":        (string)  ID of user who submitted proposal
+    "username":      (string)  Username of user who submitted proposal
+    "publickey":     (string)  Public key used to sign proposal
+    "signature":     (string)  Signature of merkle root
+    "files": [
+      {
+        "name":      (string)  Filename 
+        "mime":      (string)  Mime type 
+        "digest":    (string)  File digest 
+        "payload":   (string)  File payload 
+      }
+    ],
+    "numcomments":   (uint)  Number of comments on the proposal
+    "version": 		 (string)  Version of proposal
+    "censorshiprecord": {	
+      "token":       (string)  Censorship token
+      "merkle":      (string)  Merkle root of proposal
+      "signature":   (string)  Server side signature of []byte(Merkle+Token)
+    }
+  }
+}`
+
 type GetProposalCmd struct {
 	Args struct {
 		Token   string `positional-arg-name:"token" required:"true"`

--- a/politeiawww/cmd/politeiawwwcli/commands/getunvetted.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/getunvetted.go
@@ -6,6 +6,45 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help getunvetted'
+var GetUnvettedCmdHelpMsg = `getunvetted 
+
+Fetch all unvetted proposals. 
+
+Arguments:
+None
+
+Result:
+{
+  "proposals": [
+    {
+    "name":          (string)  Suggested short proposal name 
+    "state":         (PropStateT)  Current state of proposal
+    "status":        (PropStatusT)  Current status of proposal
+    "timestamp":     (int64)  Timestamp of last update of proposal
+    "userid":        (string)  ID of user who submitted proposal
+    "username":      (string)  Username of user who submitted proposal
+    "publickey":     (string)  Public key used to sign proposal
+    "signature":     (string)  Signature of merkle root
+    "files": [
+      {
+        "name":      (string)  Filename 
+        "mime":      (string)  Mime type 
+        "digest":    (string)  File digest 
+        "payload":   (string)  File payload 
+      }
+    ],
+    "numcomments":   (uint)  Number of comments on the proposal
+    "version": 		 (string)  Version of proposal
+    "censorshiprecord": {	
+      "token":       (string)  Censorship token
+      "merkle":      (string)  Merkle root of proposal
+      "signature":   (string)  Server side signature of []byte(Merkle+Token)
+      }
+    }
+  ]
+}`
+
 type GetUnvettedCmd struct {
 	Before string `long:"before" optional:"true" description:"A proposal censorship token; if provided, the page of proposals returned will end right before the proposal whose token is provided."`
 	After  string `long:"after" optional:"true" description:"A proposal censorship token; if provided, the page of proposals returned will begin right after the proposal whose token is provided."`

--- a/politeiawww/cmd/politeiawwwcli/commands/getvetted.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/getvetted.go
@@ -6,6 +6,45 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help getvetted'
+var GetVettedCmdHelpMsg = `getvetted 
+
+Fetch all vetted proposals. 
+
+Arguments:
+None
+
+Result:
+{
+  "proposals": [
+    {
+    "name":          (string)  Suggested short proposal name 
+    "state":         (PropStateT)  Current state of proposal
+    "status":        (PropStatusT)  Current status of proposal
+    "timestamp":     (int64)  Timestamp of last update of proposal
+    "userid":        (string)  ID of user who submitted proposal
+    "username":      (string)  Username of user who submitted proposal
+    "publickey":     (string)  Public key used to sign proposal
+    "signature":     (string)  Signature of merkle root
+    "files": [
+      {
+        "name":      (string)  Filename 
+        "mime":      (string)  Mime type 
+        "digest":    (string)  File digest 
+        "payload":   (string)  File payload 
+      }
+    ],
+    "numcomments":   (uint)  Number of comments on the proposal
+    "version": 		 (string)  Version of proposal
+    "censorshiprecord": {	
+      "token":       (string)  Censorship token
+      "merkle":      (string)  Merkle root of proposal
+      "signature":   (string)  Server side signature of []byte(Merkle+Token)
+      }
+    }
+  ]
+}`
+
 type GetVettedCmd struct {
 	Before string `long:"before" optional:"true" description:"A proposal censorship token; if provided, the page of proposals returned will end right before the proposal whose token is provided."`
 	After  string `long:"after" optional:"true" description:"A proposal censorship token; if provided, the page of proposals returned will end right after the proposal whose token is provided."`

--- a/politeiawww/cmd/politeiawwwcli/commands/help.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/help.go
@@ -21,6 +21,46 @@ func (cmd *HelpCmd) Execute(args []string) error {
 		fmt.Printf("%s\n", NewUserCmdHelpMsg)
 	case "newproposal":
 		fmt.Printf("%s\n", NewProposalCmdHelpMsg)
+	case "changepassword":
+		fmt.Printf("%s\n", ChangePasswordCmdHelpMsg)
+	case "changeusername":
+		fmt.Printf("%s\n", ChangeUsernameCmdHelpMsg)
+	case "faucet":
+		fmt.Printf("%s\n", FaucetCmdHelpMsg)
+	case "userdetails":
+		fmt.Printf("%s\n", UserDetailsCmdHelpMsg)
+	case "getproposal":
+		fmt.Printf("%s\n", GetProposalCmdHelpMsg)
+	case "userproposals":
+		fmt.Printf("%s\n", UserProposalsCmdHelpMsg)
+	case "getunvetted":
+		fmt.Printf("%s\n", GetUnvettedCmdHelpMsg)
+	case "getvetted":
+		fmt.Printf("%s\n", GetVettedCmdHelpMsg)
+	case "setproposalstatus":
+		fmt.Printf("%s\n", SetProposalStatusCmdHelpMsg)
+	case "newcomment":
+		fmt.Printf("%s\n", NewCommentCmdHelpMsg)
+	case "getcomments":
+		fmt.Printf("%s\n", GetCommentsCmdHelpMsg)
+	case "censorcomment":
+		fmt.Printf("%s\n", CensorCommentCmdHelpMsg)
+	case "votecomment":
+		fmt.Printf("%s\n", VoteCommentCmdHelpMsg)
+	case "editproposal":
+		fmt.Printf("%s\n", EditProposalCmdHelpMsg)
+	case "manageuser":
+		fmt.Printf("%s\n", ManageUserCmdHelpMsg)
+	case "users":
+		fmt.Printf("%s\n", UsersCmdHelpMsg)
+	case "verifyuser":
+		fmt.Printf("%s\n", VerifyUserCmdHelpMsg)
+	case "version":
+		fmt.Printf("%s\n", VersionCmdHelpMsg)
+	case "vote":
+		fmt.Printf("%s\n", VoteCmdHelpMsg)
+	case "edituser":
+		fmt.Printf("%s\n", EditUserCmdHelpMsg)
 	default:
 		fmt.Printf("invalid command\n")
 	}

--- a/politeiawww/cmd/politeiawwwcli/commands/manageuser.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/manageuser.go
@@ -7,6 +7,33 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help manageuser'
+var ManageUserCmdHelpMsg = `manageuser "userid" "action" "reason"
+
+Edit the details for the given user id (admin).
+
+Arguments:
+1. userid       (string, required)   User id
+2. action       (string, required)   Edit user action
+3. reason       (string, required)   Reason for editing the use
+
+Valid actions are:
+1. expirenewuser           Expires new user verification
+2. expireupdatekey         Expires update user key verification
+3. expireresetpassword     Expires reset password verification
+4. clearpaywall            Clears user registration paywall
+5. unlocks                 Unlocks user account from failed logins
+6. deactivates             Deactivates user account
+7. reactivate              Reactivates user account
+
+Result:
+{
+  "userid":  (string)    User id
+  "action":  (string)    Edit user action
+  "reason":  (string)    Reason for action
+}
+{}`
+
 type ManageUserCmd struct {
 	Args struct {
 		UserID string `positional-arg-name:"userid" description:"User ID"`

--- a/politeiawww/cmd/politeiawwwcli/commands/newcomment.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newcomment.go
@@ -7,6 +7,42 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help newcomment'
+var NewCommentCmdHelpMsg = `newcomment "token" "comment"
+
+Comment on proposal as logged in user. 
+
+Arguments:
+1. token       (string, required)   Proposal censorship token
+2. comment     (string, required)   Comment
+3. parentID    (string, required if replying to comment)  Id of commment
+
+Result:
+{
+  "token":       (string)  Censorship token
+  "parentid":    (string)  Id of comment (defaults to '0' (top-level comment))
+  "comment":     (string)  Comment
+  "signature":   (string)  Signature of comment (token+parentID+comment)
+  "publickey":   (string)  Public key of user commenting
+}
+{
+  "comment": {
+    "token":        (string)  Censorship token
+    "parentid":     (string)  Id of comment (defaults to '0' (top-level))
+    "comment":      (string)  Comment
+    "signature":    (string)  Signature of token+parentID+comment
+    "publickey":    (string)  Public key of user 
+    "commentid":    (string)  Id of the comment
+    "receipt":      (string)  Server signature of the comment signature
+    "timestamp":    (int64)   Received UNIX timestamp
+    "totalvotes":   (uint64)  Total number of up/down votes
+    "resultvotes":  (int64)   Vote score
+    "censored":     (bool)    If comment has been censored
+    "userid":       (string)  User id
+    "username":     (string)  Username
+  }
+}`
+
 type NewCommentCmd struct {
 	Args struct {
 		Token    string `positional-arg-name:"token" required:"true"`

--- a/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/setproposalstatus.go
@@ -8,6 +8,51 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help setproposalstatus'
+var SetProposalStatusCmdHelpMsg = `setproposalstatus "token" "status"
+
+Set the status of a proposal (admin).
+
+Arguments:
+1. token      (string, required)   Proposal censorship token
+2. status     (string, required)   New status (censored, public, abandoned)
+3. message    (string, required if censoring proposal)  Status change message
+
+Result:
+{
+  "token":           (string)  Censorship token
+  "proposalstatus":  (PropStatusT)  Proposal status code    
+  "signature":       (string)  Signature of proposal status change
+  "publickey":       (string)  Public key of user changing proposal status
+}
+{
+  "proposal": {
+    "name":          (string)  Suggested short proposal name 
+    "state":         (PropStateT)   Current state of proposal
+    "status":        (PropStatusT)  Current status of proposal
+    "timestamp":     (int64)  Timestamp of last update of proposal
+    "userid":        (string)  ID of user who submitted proposal
+    "username":      (string)  Username of user who submitted proposal
+    "publickey":     (string)  Public key used to sign proposal
+    "signature":     (string)  Signature of merkle root
+    "files": [
+      {
+        "name":      (string)  Filename 
+        "mime":      (string)  Mime type 
+        "digest":    (string)  File digest 
+        "payload":   (string)  File payload 
+      }
+    ],
+    "numcomments":   (uint)  Number of comments on proposal
+    "version": 		 (string)  Version of proposal
+    "censorshiprecord": {	
+      "token":       (string)  Censorship token
+      "merkle":      (string)  Merkle root of proposal
+      "signature":   (string)  Server side signature of []byte(Merkle+Token)
+    }
+  }
+}`
+
 type SetProposalStatusCmd struct {
 	Args struct {
 		Token   string `positional-arg-name:"token" required:"true" description:"Proposal censorship record token"`

--- a/politeiawww/cmd/politeiawwwcli/commands/userdetails.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/userdetails.go
@@ -1,5 +1,46 @@
 package commands
 
+// Help message displayed for the command 'politeiawwwcli help userdetails'
+var UserDetailsCmdHelpMsg = `userdetails "userid" 
+
+Fetch user details by user id. 
+
+Arguments:
+1. userid      (string, required)   User id 
+
+Result:
+{
+  "user": {
+    "id":                                         (uuid.UUID)  Unique user uuid
+    "email":                               (string)  Email address + lookup key
+    "username":                                       (string)  Unique username
+    "isadmin":                                         (bool)  Is user an admin
+    "newuserpaywalladdress":              (string)  Address for paywall payment
+    "newuserpaywallamount":                            (uint64)  Paywall amount
+    "newuserpaywalltx":                        (string)  Paywall transaction id
+    "newuserpaywalltxnotbefore":    (int64)  Txs before this time are not valid
+    "newuserpaywallpollexpiry":   (int64)  Time to stop polling paywall address
+    "newuserverificationtoken":       ([]byte)  Registration verification token
+    "newuserverificationexpiry":  (int64)  Registration verification expiration
+    "updatekeyverificationtoken":   ([]byte)  Keypair update verification token 
+    "updatekeyverificationexpiry":             (int64)  Verification expiration
+    "resetpasswordverificationtoken":            ([]byte)  Reset password token
+    "resetpasswordverificationexpiry": (int64)  Reset password token expiration
+    "lastlogintime":                 (int64)  Unix timestamp of last user login 
+    "failedloginattempts": (uint64)  Number of sequential failed login attempts
+    "isdeactivated":          (bool)  Whether the account is deactivated or not
+    "islocked":                    (bool)  Whether the account is locked or not
+    "identities": [
+      {
+        "pubkey":            (string)  User's public key
+        "isactive":          (bool)    Whether user's identity is active or not 
+      }
+    ],
+    "proposalcredits":       (uint64)  Number of available proposal credits
+    "emailnotifications":    (uint64)  Whether to notify via emails
+  }
+}`
+
 type UserDetailsCmd struct {
 	Args struct {
 		UserID string `positional-arg-name:"userid"`

--- a/politeiawww/cmd/politeiawwwcli/commands/userproposals.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/userproposals.go
@@ -6,6 +6,46 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help userproposals'
+var UserProposalsCmdHelpMsg = `userproposals "userID" 
+
+Fetch all proposals submitted by a specific user.
+
+Arguments:
+1. userID      (string, required)   User id
+
+Result:
+{
+  "proposals": [
+    {
+    "name":          (string)  Suggested short proposal name 
+    "state":         (PropStateT)  Current state of proposal
+    "status":        (PropStatusT)  Current status of proposal
+    "timestamp":     (int64)  Timestamp of last update of proposal
+    "userid":        (string)  ID of user who submitted proposal
+    "username":      (string)  Username of user who submitted proposal
+    "publickey":     (string)  Public key used to sign proposal
+    "signature":     (string)  Signature of merkle root
+    "files": [
+      {
+        "name":      (string)  Filename 
+        "mime":      (string)  Mime type 
+        "digest":    (string)  File digest 
+        "payload":   (string)  File payload 
+      }
+    ],
+    "numcomments":   (uint)  Number of comments on the proposal
+    "version": 		 (string)  Version of proposal
+    "censorshiprecord": {	
+      "token":       (string)  Censorship token
+      "merkle":      (string)  Merkle root of proposal
+      "signature":   (string)  Server side signature of []byte(Merkle+Token)
+      }
+    }
+  ],
+  "numofproposals":  (int)  Number of proposals submitted by user  
+}`
+
 type UserProposalsCmd struct {
 	Args struct {
 		UserID string `positional-arg-name:"userID"`

--- a/politeiawww/cmd/politeiawwwcli/commands/users.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/users.go
@@ -4,6 +4,28 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help users'
+var UsersCmdHelpMsg = `users "email" "username"
+
+Fetch a list of users, optionally filtering by email and/or username.
+
+Arguments:
+1. email       (string, optional)   Email of user
+2. username    (string, optional)   Username of user 
+
+Result:
+{
+  "totalusers":    (uint64)  Total number of all users in the database
+  "totalmatches":  (uint64)  Total number of users that match the filters
+  "users": [
+    {
+      "id":        (string)  User id
+      "email":     (string)  User email address
+      "username":  (string)  Username
+    }
+  ]
+}`
+
 type UsersCmd struct {
 	Email    string `long:"email" optional:"true" description:"Email query"`
 	Username string `long:"username" optional:"true" description:"Username query"`

--- a/politeiawww/cmd/politeiawwwcli/commands/verifyuser.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/verifyuser.go
@@ -7,6 +7,20 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help verifyuser'
+var VerifyUserCmdHelpMsg = `verifyuser "email" "token"
+
+Verify user's email address.
+
+Arguments:
+1. email       (string, optional)   Email of user
+2. token       (string, optional)   Verification token
+
+Result:
+{
+........
+}`
+
 type VerifyUserCmd struct {
 	Args struct {
 		Email string `positional-arg-name:"email" description:"User email address"`

--- a/politeiawww/cmd/politeiawwwcli/commands/version.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/version.go
@@ -1,5 +1,21 @@
 package commands
 
+// Help message displayed for the command 'politeiawwwcli help version'
+var VersionCmdHelpMsg = `version
+
+Fetch server info and CSRF token.
+
+Arguments:
+None
+
+Result:
+{
+  "version":  (string)  Version of backend 
+  "route":    (string)  API route
+  "pubkey":   (string)  Publick key (CSRF token)
+  "testnet":  (bool)    Whether of not testnet is being used
+}`
+
 type VersionCmd struct{}
 
 func (cmd *VersionCmd) Execute(args []string) error {

--- a/politeiawww/cmd/politeiawwwcli/commands/vote.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/vote.go
@@ -12,6 +12,18 @@ import (
 	"github.com/decred/politeia/util"
 )
 
+// Help message displayed for the command 'politeiawwwcli help vote'
+var VoteCmdHelpMsg = `vote "token" "voteid"
+
+Cast ticket votes for a proposal.
+
+Arguments:
+1. token       (string, optional)   Proposal censorship token
+2. voteid      (string, optional)   A single word identifying vote (e.g. yes)
+
+Result:
+ActiveVotes: 500,`
+
 type VoteCmd struct {
 	Args struct {
 		Token  string `positional-arg-name:"token" description:"Proposal censorship token"`

--- a/politeiawww/cmd/politeiawwwcli/commands/votecomment.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/votecomment.go
@@ -7,6 +7,31 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help votecomment'
+var VoteCommentCmdHelpMsg = `votecomment "token" "commentID" "action"
+
+Vote on a comment.
+
+Arguments:
+1. token       (string, required)   Proposal censorship token
+2. commentID   (string, required)   Id of the comment
+3. action      (string, required)   Vote (upvote or downvote)
+
+Result:
+{
+  "token":      (string)  Censorship token
+  "commentid":  (string)  Id of comment
+  "action":     (string)  actionCode (upvote = '1', downvote = '-1')
+  "signature":  (string)  Signature of vote (token + commentID + actionCode)
+  "publickey":  (string)  Public key used for signature
+}
+{
+  "total":    (uint64)  Total number of up and down votes
+  "result":   (int64)  Current tally of likes (can be negative)
+  "receipt":  (string)  Server signature of vote signature
+  "error":    (string)  Error if something went wrong during liking a comment
+}`
+
 type VoteCommentCmd struct {
 	Args struct {
 		Token     string `positional-arg-name:"token"`


### PR DESCRIPTION
This adds new custom help messages for four politeiawwwcli commands. Per Issue #474  , we want custom help messages for all politeiawwwcli commands. This PR adds help for the following commands:

- changeusername
- changepassword
- userdetails
- faucet
