### PR TITLE
www: Disable abandoned state if voting authorized

### DIFF
--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -1855,8 +1855,9 @@ func (b *backend) ProcessSetProposalStatus(sps www.SetProposalStatus, user *data
 			}
 		}
 
-		// Ensure voting has not been started yet
-		if ir.voting.StartBlockHeight != "" {
+		// Ensure voting has not been started or authorized yet
+		if ir.voting.StartBlockHeight != "" ||
+			voteIsAuthorized(ir) {
 			return nil, www.UserError{
 				ErrorCode: www.ErrorStatusWrongVoteStatus,
 			}


### PR DESCRIPTION
Resolves #629. Also depends on https://github.com/decred/politeiagui/pull/936

This commit disables admin privileges to abandon a proposal if voting has been authorized by the user. 