### PR TITLE
voter: Retry send vote on network error

### DIFF
--- a/politeiavoter/politeiavoter.go
+++ b/politeiavoter/politeiavoter.go
@@ -451,7 +451,8 @@ func (c *ctx) sendVote(ballot *v1.Ballot) (*v1.CastVoteReply, error) {
 
 	responseBody, err := c.makeRequest("POST", v1.RouteCastVotes, ballot)
 	if err != nil {
-		return nil, err
+		log.Errorf("%v", err)
+		return nil, errRetry
 	}
 
 	var vr v1.BallotReply


### PR DESCRIPTION
Closes #567 

This updates the way `politeiavoter` handles network errors that may occur during vote trickling.  Instead of exiting, `politeiavoter` will log the error, wait a set duration (44 seconds), and then retry sending the vote.  