### PR TITLE
www: Fix bugs with email notifications for comments

### DIFF
--- a/politeiawww/email.go
+++ b/politeiawww/email.go
@@ -437,20 +437,25 @@ func (b *backend) emailAdminsForProposalVoteAuthorized(
 func (b *backend) emailAuthorForCommentOnProposal(
 	proposal *v1.ProposalRecord,
 	authorUser *database.User,
-	username string,
+	commentID, username string,
 ) error {
 	if b.cfg.SMTP == nil {
 		return nil
 	}
 
-	l, err := url.Parse(fmt.Sprintf("%v/proposals/%v", b.cfg.WebServerAddress,
-		proposal.CensorshipRecord.Token))
+	l, err := url.Parse(fmt.Sprintf("%v/proposals/%v/comments/%v",
+		b.cfg.WebServerAddress, proposal.CensorshipRecord.Token, commentID))
 	if err != nil {
 		return err
 	}
 
 	if authorUser.EmailNotifications&
 		uint64(v1.NotificationEmailCommentOnMyProposal) == 0 {
+		return nil
+	}
+
+	// Don't send email when author comments on own proposal
+	if username == authorUser.Username {
 		return nil
 	}
 
@@ -488,6 +493,11 @@ func (b *backend) emailAuthorForCommentOnComment(
 
 	if authorUser.EmailNotifications&
 		uint64(v1.NotificationEmailCommentOnMyComment) == 0 {
+		return nil
+	}
+
+	// Don't send email when author replies to his own comment
+	if username == authorUser.Username {
 		return nil
 	}
 

--- a/politeiawww/events.go
+++ b/politeiawww/events.go
@@ -370,7 +370,7 @@ func (b *backend) _setupCommentReplyEmailNotifications() {
 			if c.Comment.ParentID == "0" {
 				// Top-level comment
 				err := b.emailAuthorForCommentOnProposal(proposal, author,
-					c.Comment.Username)
+					c.Comment.CommentID, c.Comment.Username)
 				if err != nil {
 					log.Errorf("email author of proposal %v for new comment %v: %v",
 						c.Comment.Token, c.Comment.CommentID, err)


### PR DESCRIPTION
This commit resolves two bugs with email notifications for comments.

-Change link in email notification for new comments to the permalink of the comment, instead of the proposal link.

-Disable email notifications for comments and replies posted by the proposal's author.