### PR TITLE
politeiavoter: Retry on failed req due to URL err.

### DIFF
--- a/politeiavoter/politeiavoter.go
+++ b/politeiavoter/politeiavoter.go
@@ -308,6 +308,9 @@ func (c *ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 	}
 	req.Header.Add(v1.CsrfToken, c.csrf)
 	r, err := c.client.Do(req)
+	if _, ok := err.(*url.Error); ok {
+		return nil, errRetry
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This checks the error returned when making a request to specifically detect a `*url.Error`, which can often happen on Tor for various reasons, and convert it to a retry error so that code which deals with retries will properly retry the request.