### PR TITLE
www: Fix VotesStatus not init

### DIFF
--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -2949,6 +2949,7 @@ func (b *backend) ProcessGetAllVoteStatus() (*www.GetAllVoteStatusReply, error) 
 
 	// iterate over all props and see what is public
 	var gavsr www.GetAllVoteStatusReply
+	gavsr.VotesStatus = make([]www.VoteStatusReply, 0)
 	for _, i := range b.inventory {
 
 		ps := convertPropStatusFromPD(i.record.Status)


### PR DESCRIPTION
GET api/v1/proposals/votestatus
it should be init ,and return 
```
{
votesstatus: [ ]
}
```
insteadof
```
{
 votesstaus: null
} 
```
when len of inventory is 0.