### PR TITLE
multi: Add --skipverify flag

### DIFF
--- a/politeiavoter/config.go
+++ b/politeiavoter/config.go
@@ -74,6 +74,7 @@ type config struct {
 	ProxyUser        string `long:"proxyuser" description:"Username for proxy server"`
 	ProxyPass        string `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
 	VoteDuration     string `long:"voteduration" description:"Duration to cast all votes e.g. 1d2h10m (default 0s)"`
+	SkipVerify       bool   `long:"skipverify" description:"Skip verifying the server's certifcate chain and host name."`
 
 	dial         func(string, string) (net.Conn, error)
 	voteDuration time.Duration // Parsed VoteDuration

--- a/politeiavoter/politeiavoter.go
+++ b/politeiavoter/politeiavoter.go
@@ -40,10 +40,6 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-var (
-	verify bool // Validate server TLS certificate
-)
-
 func generateSeed() (int64, error) {
 	var seedBytes [8]byte
 	_, err := crand.Read(seedBytes[:])
@@ -155,9 +151,9 @@ type ctx struct {
 	wallet pb.WalletServiceClient
 }
 
-func newClient(skipVerify bool, cfg *config) (*ctx, error) {
+func newClient(cfg *config) (*ctx, error) {
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: skipVerify,
+		InsecureSkipVerify: cfg.SkipVerify,
 	}
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
@@ -239,7 +235,7 @@ func (c *ctx) getCSRF() (*v1.VersionReply, error) {
 
 func firstContact(cfg *config) (*ctx, error) {
 	// Always hit / first for csrf token and obtain api version
-	c, err := newClient(true, cfg)
+	c, err := newClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -37,7 +37,7 @@ type Client struct {
 func New(cfg *config.Config) (*Client, error) {
 	// Create http client
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: cfg.SkipVerify,
 	}
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,

--- a/politeiawww/cmd/politeiawwwcli/config/config.go
+++ b/politeiawww/cmd/politeiawwwcli/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	Host        string `long:"host" description:"politeiawww host"`
 	RawJSON     bool   `short:"j" long:"json" description:"Print raw JSON output"`
 	ShowVersion bool   `short:"V" long:"version" description:"Display version information and exit"`
+	SkipVerify  bool   `long:"skipverify" description:"Skip verifying the server's certifcate chain and host name."`
 	Verbose     bool   `short:"v" long:"verbose" description:"Print verbose output"`
 
 	Version string // cli version


### PR DESCRIPTION
This commit adds the flag `--skipverify` to `politeiavoter` and `politeiawwwcli`.  When enabled, the server's certificate chain and host name will not be verified.  This flag is being added so that these cli tools can be used when running politeia locally with self signed certs.