### PR TITLE
readme: remove 'dep' listing as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ https://github.com/decred/politeiagui
 
 ## Development
 
-#### 1. Install [Go](https://golang.org/doc/install), [dep](https://github.com/golang/dep), and [Git](https://git-scm.com/downloads).
+#### 1. Install [Go](https://golang.org/doc/install) version 1.11 or higher, and [Git](https://git-scm.com/downloads).
 
 Make sure each of these are in the PATH.
 


### PR DESCRIPTION
dep is no longer required so should not be listed as a requirement in step 1 of setup.

Added a message that notes that Go version 1.11 is higher, since this is required for using Go modules.