### PR TITLE
wwwcli: Add new help messages

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/commands/getpaywallpayment.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/getpaywallpayment.go
@@ -1,5 +1,20 @@
 package commands
 
+// Help message displayed for the command 'politeiawwwcli help getpaywallpayment'
+var GetPaywallPaymentCmdHelpMsg = `getpaywallpayment
+
+Fetch proposal paywall payment details for currently logged in user. 
+
+Arguments:
+None
+
+Response:
+{
+  "txid"           (string)  Transaction id
+  "amount"         (uint64)  Amount sent to paywall address in atoms
+  "confirmations"  (uint64)  Number of confirmations of payment tx
+}`
+
 type GetPaywallPaymentCmd struct{}
 
 func (cmd *GetPaywallPaymentCmd) Execute(args []string) error {

--- a/politeiawww/cmd/politeiawwwcli/commands/help.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/help.go
@@ -61,6 +61,24 @@ func (cmd *HelpCmd) Execute(args []string) error {
 		fmt.Printf("%s\n", EditUserCmdHelpMsg)
 	case "subscribe":
 		fmt.Printf("%s\n", SubscribeCmdHelpMsg)
+	case "me":
+		fmt.Printf("%s\n", MeCmdHelpMsg)
+	case "policy":
+		fmt.Printf("%s\n", PolicyCmdHelpMsg)
+	case "resetpassword":
+		fmt.Printf("%s\n", ResetPasswordCmdHelpMsg)
+	case "updateuserkey":
+		fmt.Printf("%s\n", UpdateUserKeyCmdHelpMsg)
+	case "getpaywallpayment":
+		fmt.Printf("%s\n", GetPaywallPaymentCmdHelpMsg)
+	case "proposalpaywall":
+		fmt.Printf("%s\n", ProposalPaywallCmdHelpMsg)
+	case "rescanuserpayments":
+		fmt.Printf("%s\n", RescanUserPaymentsCmdHelpMsg)
+	case "verifyuserpayment":
+		fmt.Printf("%s\n", VerifyUserPaymentCmdHelpMsg)
+	case "startvote":
+		fmt.Printf("%s\n", StartVoteCmdHelpMsg)
 	default:
 		fmt.Printf("invalid command\n")
 	}

--- a/politeiawww/cmd/politeiawwwcli/commands/me.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/me.go
@@ -1,5 +1,29 @@
 package commands
 
+// Help message displayed for the command 'politeiawwwcli help me'
+var MeCmdHelpMsg = `me
+
+Fetch details for the currently logged in user. 
+
+Arguments:
+None
+
+Response:
+{
+  "isadmin":                 (bool)        Is user an admin
+  "userid":                  (uuid.UUID)   Unique user uuid
+  "email":                   (string)      Email address + lookup key
+  "username":                (string)      Unique username
+  "publickey":               (string)      User's public key
+  "paywalladdress":          (string)      Registration paywall address
+  "paywallamount":           (uint64)      Registration paywall amount in atoms
+  "paywalltxnotbefore":      (int64)       Minimum timestamp for paywall tx
+  "paywalltxid":             (string)      Paywall payment tx ID
+  "proposalcredits":         (uint64)      Proposal credits available to spend
+  "lastlogintime":           (int64)       Unix timestamp of last login date
+  "sessionmaxage":           (int64)       Unix timestamp of session max age
+}`
+
 type MeCmd struct{}
 
 func (cmd *MeCmd) Execute(args []string) error {

--- a/politeiawww/cmd/politeiawwwcli/commands/policy.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/policy.go
@@ -1,5 +1,33 @@
 package commands
 
+// Help message displayed for the command 'politeiawwwcli help policy'
+var PolicyCmdHelpMsg = `policy
+
+Fetch server policy.
+
+Arguments:
+None
+
+Response:
+{
+	"minpasswordlength"          (uint)     Minimum password length
+	"minusernamelength"          (uint)     Minimum username length
+	"maxusernamelength"          (uint)     Maximum username length 
+	"usernamesupportedchars"     ([]string) List of unsupported characters 
+	"proposallistpagesize"       (uint)     Maximum proposals per page
+	"userlistpagesize"           (uint)     Maximum users per page
+	"maximages"                  (uint)     Maximum number of proposal images
+	"maximagesize"               (uint)     Maximum image file size (in bytes)
+	"maxmds"                     (uint)     Maximum number of markdown files
+	"maxmdsize"                  (uint)     Maximum markdown file size (bytes)
+	"validmimetypes"             ([]string) List of acceptable MIME types
+	"minproposalnamelength"      (uint)     Minimum length of a proposal name
+	"maxproposalnamelength"      (uint)     Maximum length of a proposal name
+	"proposalnamesupportedchars" ([]string) Regex of a valid proposal name
+	"maxcommentlength"           (uint)     Maximum characters in comments
+	"backendpublickey"           (string)   Backend public key
+}`
+
 type PolicyCmd struct{}
 
 func (cmd *PolicyCmd) Execute(args []string) error {

--- a/politeiawww/cmd/politeiawwwcli/commands/proposalpaywall.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/proposalpaywall.go
@@ -2,6 +2,21 @@ package commands
 
 import "github.com/decred/politeia/politeiawww/api/v1"
 
+// Help message displayed for the command 'politeiawwwcli help proposalpaywall'
+var ProposalPaywallCmdHelpMsg = `proposalpaywall
+
+Fetch proposal paywall details.
+
+Arguments:
+None
+
+Response:
+{
+  "creditprice"          (uint64)  Price per proposal credit in atoms
+  "paywalladdress"       (string)  Proposal paywall address
+  "paywalltxnotbefore"   (string)  Minimum timestamp for paywall tx
+}`
+
 type ProposalPaywallCmd struct{}
 
 func (cmd *ProposalPaywallCmd) Execute(args []string) error {

--- a/politeiawww/cmd/politeiawwwcli/commands/rescanuserpayments.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/rescanuserpayments.go
@@ -2,6 +2,19 @@ package commands
 
 import "github.com/decred/politeia/politeiawww/api/v1"
 
+// Help message displayed for the command 'politeiawwwcli help rescanuserpayments'
+var RescanUserPaymentsCmdHelpMsg = `rescanuserpayments 
+
+Rescan user payments to check for missed payments.
+
+Arguments:
+1. userid        (string, required)   User id 
+
+Result:
+{
+  "newcredits"   ([]uint64)  Credits that were created by the rescan
+}`
+
 type RescanUserPaymentsCmd struct {
 	Args struct {
 		UserID string `positional-arg-name:"userid" description:"User ID"`

--- a/politeiawww/cmd/politeiawwwcli/commands/resetpassword.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/resetpassword.go
@@ -6,6 +6,20 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help resetpassword'
+var ResetPasswordCmdHelpMsg = `resetpassword "email" "password"
+
+Reset password for currently logged in user. 
+
+Arguments:
+1. email      (string, required)   Email address of user
+2. password   (string, required)   New password
+
+Result:
+{
+  "verificationtoken"    (string)  Verification token
+}`
+
 type ResetPasswordCmd struct {
 	Args struct {
 		Email       string `positional-arg-name:"email"`

--- a/politeiawww/cmd/politeiawwwcli/commands/startvote.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/startvote.go
@@ -8,6 +8,26 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help startvote'
+var StartVoteCmdHelpMsg = `startvote "token" "duration" "quorumpercentage" "passpercentage"
+
+Start voting period for a proposal. Requires admin privileges.
+
+Arguments:
+1. token              (string, required)  Proposal censorship token
+1. duration           (uint32, optional)  Duration of vote in blocks
+2. quorumpercentage   (uint32, optional)  Percent of votes required for quorum
+3. passpercentage     (uint32, optional)  Percent of votes required to pass
+
+Result:
+
+{
+  "startblockheight"     (string)    Block height at start of vote
+  "startblockhash"       (string)    Hash of first block of vote interval
+  "endheight"            (string)    Height of vote end
+  "eligibletickets"      ([]string)  Valid voting tickets   
+}`
+
 type StartVoteCmd struct {
 	Args struct {
 		Token string `positional-arg-name:"token" description:"Proposal censorship token"`

--- a/politeiawww/cmd/politeiawwwcli/commands/updateuserkey.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/updateuserkey.go
@@ -7,6 +7,20 @@ import (
 	"github.com/decred/politeia/politeiawww/api/v1"
 )
 
+// Help message displayed for the command 'politeiawwwcli help updateuserkey'
+var UpdateUserKeyCmdHelpMsg = `updateuserkey
+
+Generate a new public key for the currently logged in user. 
+
+Arguments:
+None
+
+Result:
+{
+  "publickey"   (string)  User's public key
+}
+{}`
+
 type UpdateUserKeyCmd struct {
 	NoSave bool `long:"nosave" description:"Do not save the user identity to disk"`
 }

--- a/politeiawww/cmd/politeiawwwcli/commands/verifyuserpayment.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/verifyuserpayment.go
@@ -2,6 +2,22 @@ package commands
 
 import "fmt"
 
+// Help message displayed for the command 'politeiawwwcli help verifyuserpayment'
+var VerifyUserPaymentCmdHelpMsg = `verifyuserpayment 
+
+Check if the currently logged in user has paid their user registration fee.
+
+Arguments:
+None
+
+Result:
+{
+  "haspaid"                (bool)    Has paid or not
+  "paywalladdress"         (string)  Registration paywall address
+  "paywallamount"          (uint64)  Registration paywall amount in atoms
+  "paywalltxnotbefore"     (int64)   Minimum timestamp for paywall tx
+}`
+
 type VerifyUserPaymentCmd struct{}
 
 func (cmd *VerifyUserPaymentCmd) Execute(args []string) error {


### PR DESCRIPTION
This commit adds new help messages for the commands:
- getpaywallpayment
- me
- policy
- proposalpaywall
- rescanuserpayments
- resetpassword
- startvote
- updateuserkey
- verifyuserpayment