### PR TITLE
politeiad: Fix new comment error bug

### DIFF
--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -1034,7 +1034,9 @@ func (g *gitBackEnd) pluginNewComment(payload string) (string, error) {
 	if _, ok := decredPluginCommentsCache[c.Token]; !ok {
 		decredPluginCommentsCache[c.Token] =
 			make(map[string]decredplugin.Comment)
-	} else {
+	}
+	_, ok = decredPluginCommentsCache[c.Token][c.CommentID]
+	if ok {
 		// Sanity
 		log.Errorf("comment should not have existed.")
 	}


### PR DESCRIPTION
This commit fixes a bug that was causing an error to be incorrectly logged when a comment is submitted to a proposal that already has existing comments.

The error is only supposed to be logged if the politeiad in-memory cache contains an existing comment with the same comment ID as the new comment.  The error is actually being logged anytime there are any existing comments in the cache for the given record.
