### PR TITLE
[www/util]: add proposal summary validation

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -1374,8 +1374,9 @@ SHALL observe.
 | validmimetypes | array of strings | list of all acceptable MIME types that can be communicated between client and server. |
 | maxproposalnamelength | integer | max length of a proposal name |
 | minproposalnamelength | integer | min length of a proposal name |
-| maxproposalsummarylength | integer | max length of a proposal summary |
 | proposalnamesupportedchars | array of strings | the regular expression of a valid proposal name |
+| maxproposalsummarylength | integer | max length of a proposal summary |
+| minproposalsummarylength | integer | min length of a proposal summary |
 | maxcommentlength | integer | maximum number of characters accepted for comments |
 | backendpublickey | string |  |
 
@@ -1415,6 +1416,7 @@ Reply:
   "backendpublickey": "",
   "minproposalnamelength": 8,
   "maxproposalnamelength": 80,
+  "minproposalsummarylength": 10,
   "maxproposalsummarylength": 255
 }
 ```

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -1372,6 +1372,7 @@ SHALL observe.
 | validmimetypes | array of strings | list of all acceptable MIME types that can be communicated between client and server. |
 | maxproposalnamelength | integer | max length of a proposal name |
 | minproposalnamelength | integer | min length of a proposal name |
+| maxproposalsummarylength | integer | max length of a proposal summary |
 | proposalnamesupportedchars | array of strings | the regular expression of a valid proposal name |
 | maxcommentlength | integer | maximum number of characters accepted for comments |
 | backendpublickey | string |  |
@@ -1411,7 +1412,8 @@ Reply:
   "maxcommentlength": 8000,
   "backendpublickey": "",
   "minproposalnamelength": 8,
-  "maxproposalnamelength": 80
+  "maxproposalnamelength": 80,
+  "maxproposalsummarylength": 255
 }
 ```
 

--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -109,6 +109,7 @@ notifications.  It does not render HTML.
 - [`ErrorStatusInvalidUUID`](#ErrorStatusInvalidUUID)
 - [`ErrorStatusInvalidLikeCommentAction`](#ErrorStatusInvalidLikeCommentAction)
 - [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
+- [`ErrorStatusProposalInvalidSummary`](#ErrorStatusProposalInvalidSummary)
 
 **Proposal status codes**
 
@@ -1079,6 +1080,7 @@ error codes:
 - [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
 - [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
 - [`ErrorStatusUserNotPaid`](#ErrorStatusUserNotPaid)
+- [`ErrorStatusProposalInvalidSummary`](#ErrorStatusProposalInvalidSummary)
 
 **Example**
 
@@ -2489,6 +2491,7 @@ Reply:
 | <a name="ErrorStatusInvalidUUID">ErrorStatusInvalidUUID</a> | 56 | Invalid user UUID. |
 | <a name="ErrorStatusInvalidLikeCommentAction">ErrorStatusInvalidLikeCommentAction</a> | 57 | Invalid like comment action. |
 | <a name="ErrorStatusInvalidCensorshipToken">ErrorStatusInvalidCensorshipToken</a> | 58 | Invalid proposal censorship token. |
+| <a name="ErrorStatusProposalInvalidSummary">ErrorStatusProposalInvalidSummary</a> | 8 | The provided proposal summary is invalid. This error is provided with additional context: the regular expression accepted. |
 
 
 

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -106,6 +106,9 @@ const (
 	// accepted for comments
 	PolicyMaxCommentLength = 8000
 
+	// PolicyMaxProposalSummaryLength is the min length of a proposal summary
+	PolicyMinProposalSummaryLength = 10
+
 	// PolicyMaxProposalSummaryLength is the max length of a proposal summary
 	PolicyMaxProposalSummaryLength = 255
 
@@ -794,6 +797,7 @@ type PolicyReply struct {
 	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
 	MaxCommentLength           uint     `json:"maxcommentlength"`
 	BackendPublicKey           string   `json:"backendpublickey"`
+	MinProposalSummaryLength   uint     `json:"minproposalsummarylength"`
 	MaxProposalSummaryLength   uint     `json:"maxproposalsummarylength"`
 }
 

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -106,6 +106,9 @@ const (
 	// accepted for comments
 	PolicyMaxCommentLength = 8000
 
+	// PolicyMaxProposalSummaryLength is the max length of a proposal summary
+	PolicyMaxProposalSummaryLength = 255
+
 	// ProposalListPageSize is the maximum number of proposals returned
 	// for the routes that return lists of proposals
 	ProposalListPageSize = 20
@@ -789,6 +792,7 @@ type PolicyReply struct {
 	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
 	MaxCommentLength           uint     `json:"maxcommentlength"`
 	BackendPublicKey           string   `json:"backendpublickey"`
+	MaxProposalSummaryLength   uint     `json:"maxproposalsummarylength"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -177,6 +177,7 @@ const (
 	ErrorStatusInvalidUUID                 ErrorStatusT = 56
 	ErrorStatusInvalidLikeCommentAction    ErrorStatusT = 57
 	ErrorStatusInvalidCensorshipToken      ErrorStatusT = 58
+	ErrorStatusProposalInvalidSummary      ErrorStatusT = 59
 
 	// Proposal state codes
 	//
@@ -318,6 +319,7 @@ var (
 		ErrorStatusInvalidUUID:                 "invalid user UUID",
 		ErrorStatusInvalidLikeCommentAction:    "invalid like comment action",
 		ErrorStatusInvalidCensorshipToken:      "invalid proposal censorship token",
+		ErrorStatusProposalInvalidSummary:      "invalid proposal summary",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -752,6 +752,18 @@ func (b *backend) validateProposal(np www.NewProposal, user *database.User) erro
 		}
 	}
 
+	// proposal summary validation
+	summary, err := getProposalSummary(np.Files)
+	if err != nil {
+		return err
+	}
+	if !util.IsValidProposalSummary(summary) {
+		return www.UserError{
+			ErrorCode:    www.ErrorStatusProposalInvalidSummary,
+			ErrorContext: []string{util.CreateProposalSummaryRegex()},
+		}
+	}
+
 	// Note that we need validate the string representation of the merkle
 	mr := merkle.Root(hashes)
 	if !pk.VerifyMessage([]byte(hex.EncodeToString(mr[:])), sig) {
@@ -2130,6 +2142,16 @@ func getProposalName(files []www.File) (string, error) {
 	for _, file := range files {
 		if file.Name == indexFile {
 			return util.GetProposalName(file.Payload)
+		}
+	}
+	return "", nil
+}
+
+// getProposalSummary returns the proposal summary based on the index markdown file
+func getProposalSummary(files []www.File) (string, error) {
+	for _, file := range files {
+		if file.Name == indexFile {
+			return util.GetProposalSummary(file.Payload)
 		}
 	}
 	return "", nil

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -1934,9 +1934,10 @@ func (b *backend) ProcessPolicy(p www.Policy) *www.PolicyReply {
 		ValidMIMETypes:             mime.ValidMimeTypes(),
 		MinProposalNameLength:      www.PolicyMinProposalNameLength,
 		MaxProposalNameLength:      www.PolicyMaxProposalNameLength,
-		MaxProposalSummaryLength:   www.PolicyMaxProposalSummaryLength,
 		ProposalNameSupportedChars: www.PolicyProposalNameSupportedChars,
 		MaxCommentLength:           www.PolicyMaxCommentLength,
+		MinProposalSummaryLength:   www.PolicyMinProposalSummaryLength,
+		MaxProposalSummaryLength:   www.PolicyMaxProposalSummaryLength,
 	}
 }
 

--- a/politeiawww/backend.go
+++ b/politeiawww/backend.go
@@ -1922,6 +1922,7 @@ func (b *backend) ProcessPolicy(p www.Policy) *www.PolicyReply {
 		ValidMIMETypes:             mime.ValidMimeTypes(),
 		MinProposalNameLength:      www.PolicyMinProposalNameLength,
 		MaxProposalNameLength:      www.PolicyMaxProposalNameLength,
+		MaxProposalSummaryLength:   www.PolicyMaxProposalSummaryLength,
 		ProposalNameSupportedChars: www.PolicyProposalNameSupportedChars,
 		MaxCommentLength:           www.PolicyMaxCommentLength,
 	}

--- a/politeiawww/cmd/politeiawwwcli/commands/policy.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/policy.go
@@ -39,6 +39,7 @@ Response:
 	"validmimetypes"             ([]string) List of acceptable MIME types
 	"minproposalnamelength"      (uint)     Minimum length of a proposal name
 	"maxproposalnamelength"      (uint)     Maximum length of a proposal name
+	"minproposalsummarylength"   (uint)   	Minimum length of a proposal summary
 	"maxproposalsummarylength"   (uint)   	Maximum length of a proposal summary
 	"proposalnamesupportedchars" ([]string) Regex of a valid proposal name
 	"maxcommentlength"           (uint)     Maximum characters in comments

--- a/politeiawww/cmd/politeiawwwcli/commands/policy.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/policy.go
@@ -39,6 +39,7 @@ Response:
 	"validmimetypes"             ([]string) List of acceptable MIME types
 	"minproposalnamelength"      (uint)     Minimum length of a proposal name
 	"maxproposalnamelength"      (uint)     Maximum length of a proposal name
+	"maxproposalsummarylength"   (uint)   	Maximum length of a proposal summary
 	"proposalnamesupportedchars" ([]string) Regex of a valid proposal name
 	"maxcommentlength"           (uint)     Maximum characters in comments
 	"backendpublickey"           (string)   Backend public key

--- a/util/proposal.go
+++ b/util/proposal.go
@@ -16,7 +16,8 @@ import (
 )
 
 var (
-	validProposalName = regexp.MustCompile(CreateProposalNameRegex())
+	validProposalName    = regexp.MustCompile(CreateProposalNameRegex())
+	validProposalSummary = regexp.MustCompile(CreateProposalSummaryRegex())
 )
 
 // ProposalName returns a proposal name
@@ -76,16 +77,15 @@ func GetProposalSummary(payload string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// carriage return is insterted after proposal summary.
+	// \r is insterted after proposal summary.
 	// ReadString stops reading payload after \r
-	// header == title && summary
+	// header == title && summary (both come before \r)
 	// TrimLeft removes the proposal name
 	header, err := reader.ReadString('\r')
-	proposalSummary := strings.TrimLeft(header, string(name))
+	proposalSummary := strings.TrimPrefix(header, string(name))
 	if err != nil {
 		return "", err
 	}
-	fmt.Println(proposalSummary)
 	return proposalSummary, nil
 }
 
@@ -95,5 +95,8 @@ func IsValidProposalSummary(str string) bool {
 
 func CreateProposalSummaryRegex() string {
 	var validProposalSummaryBuffer bytes.Buffer
+	validProposalSummaryBuffer.WriteString(`[\s\S]{`)
+	validProposalSummaryBuffer.WriteString(strconv.Itoa(www.PolicyMinProposalSummaryLength) + ",")
+	validProposalSummaryBuffer.WriteString(strconv.Itoa(www.PolicyMaxProposalSummaryLength) + "}$")
 	return validProposalSummaryBuffer.String()
 }

--- a/util/proposal.go
+++ b/util/proposal.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"regexp"
 	"strconv"
 
@@ -15,7 +16,8 @@ import (
 )
 
 var (
-	validProposalName = regexp.MustCompile(CreateProposalNameRegex())
+	validProposalName    = regexp.MustCompile(CreateProposalNameRegex())
+	validProposalSummary = regexp.MustCompile(CreateProposalSummaryRegex())
 )
 
 // ProposalName returns a proposal name
@@ -33,7 +35,6 @@ func GetProposalName(payload string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	return string(proposalName), nil
 }
 
@@ -59,4 +60,31 @@ func CreateProposalNameRegex() string {
 	validProposalNameBuffer.WriteString(strconv.Itoa(www.PolicyMaxProposalNameLength) + "}$")
 
 	return validProposalNameBuffer.String()
+}
+
+// ProposalSummary returns a proposal summary
+func GetProposalSummary(payload string) (string, error) {
+	// decode payload (base64)
+	rawPayload, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return "", err
+	}
+
+	reader := bufio.NewReader(bytes.NewReader(rawPayload))
+	proposalSummary, _, err := reader.ReadLine()
+	if err != nil {
+		return "", err
+	}
+	fmt.Println(proposalSummary)
+	return string(proposalSummary), nil
+}
+
+func IsValidProposalSummary(str string) bool {
+	return validProposalSummary.MatchString(str)
+}
+
+func CreateProposalSummaryRegex() string {
+	var validProposalSummaryBuffer bytes.Buffer
+
+	return validProposalSummaryBuffer.String()
 }


### PR DESCRIPTION
Resolves #685 and #569 

GUI changes depend on https://github.com/decred/politeiagui/pull/1010

this commit adds a new policy field for the min/max length of a proposal summary (10 / 255 chars). Necessary validation was added to enforce this policy on the backend. The docs along with wwwcli were also updated to reflect this addition.