### PR TITLE
multi: Fix CleanAndExpandPath implementation

### DIFF
--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -95,20 +95,6 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "\n")
 }
 
-// cleanAndExpandPath expands environment variables and leading ~ in the
-// passed path, cleans the result, and returns it.
-func cleanAndExpandPath(path string) string {
-	// Expand initial ~ to OS specific home directory.
-	if strings.HasPrefix(path, "~") {
-		homeDir := filepath.Dir(defaultHomeDir)
-		path = strings.Replace(path, "~", homeDir, 1)
-	}
-
-	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
-	// but the variables can still be expanded via POSIX-style $VARIABLE.
-	return filepath.Clean(os.ExpandEnv(path))
-}
-
 // getErrorFromResponse extracts a user-readable string from the response from
 // politeiad, which will contain a JSON error.
 func getErrorFromResponse(r *http.Response) (string, error) {
@@ -161,7 +147,7 @@ func getIdentity() error {
 	} else {
 		fmt.Printf("Saving identity to %v\n", rf)
 	}
-	rf = cleanAndExpandPath(rf)
+	rf = util.CleanAndExpandPath(rf)
 
 	// Save identity
 	err = os.MkdirAll(filepath.Dir(rf), 0700)

--- a/politeiad/config.go
+++ b/politeiad/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -90,15 +91,55 @@ type serviceOptions struct {
 // cleanAndExpandPath expands environment variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 func cleanAndExpandPath(path string) string {
-	// Expand initial ~ to OS specific home directory.
-	if strings.HasPrefix(path, "~") {
-		homeDir := filepath.Dir(defaultHomeDir)
-		path = strings.Replace(path, "~", homeDir, 1)
+	// Nothing to do when no path is given.
+	if path == "" {
+		return path
 	}
 
-	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
-	// but the variables can still be expanded via POSIX-style $VARIABLE.
-	return filepath.Clean(os.ExpandEnv(path))
+	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
+	// %VARIABLE%, but the variables can still be expanded via POSIX-style
+	// $VARIABLE.
+	path = os.ExpandEnv(path)
+
+	if !strings.HasPrefix(path, "~") {
+		return filepath.Clean(path)
+	}
+
+	// Expand initial ~ to the current user's home directory, or ~otheruser
+	// to otheruser's home directory.  On Windows, both forward and backward
+	// slashes can be used.
+	path = path[1:]
+
+	var pathSeparators string
+	if runtime.GOOS == "windows" {
+		pathSeparators = string(os.PathSeparator) + "/"
+	} else {
+		pathSeparators = string(os.PathSeparator)
+	}
+
+	userName := ""
+	if i := strings.IndexAny(path, pathSeparators); i != -1 {
+		userName = path[:i]
+		path = path[i:]
+	}
+
+	homeDir := ""
+	var u *user.User
+	var err error
+	if userName == "" {
+		u, err = user.Current()
+	} else {
+		u, err = user.Lookup(userName)
+	}
+	if err == nil {
+		homeDir = u.HomeDir
+	}
+	// Fallback to CWD if user lookup fails or user has no home directory.
+	if homeDir == "" {
+		homeDir = "."
+	}
+
+	return filepath.Join(homeDir, path)
 }
 
 // validLogLevel returns whether or not logLevel is a valid debug log level.

--- a/politeiawww/cmd/politeiawwwcli/commands/editproposal.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/editproposal.go
@@ -114,7 +114,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		md = b.Bytes()
 	} else {
 		// Read markdown file into memory and convert to type File
-		fpath := util.CleanAndExpandPath(mdFile, cfg.HomeDir)
+		fpath := util.CleanAndExpandPath(mdFile)
 
 		var err error
 		md, err = ioutil.ReadFile(fpath)
@@ -134,7 +134,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 
 	// Read attachment files into memory and convert to type File
 	for _, file := range attachmentFiles {
-		path := util.CleanAndExpandPath(file, cfg.HomeDir)
+		path := util.CleanAndExpandPath(file)
 		attachment, err := ioutil.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("ReadFile %v: %v", path, err)

--- a/politeiawww/cmd/politeiawwwcli/commands/newproposal.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newproposal.go
@@ -82,7 +82,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		md = b.Bytes()
 	} else {
 		// Read  markdown file into memory and convert to type File
-		fpath := util.CleanAndExpandPath(mdFile, cfg.HomeDir)
+		fpath := util.CleanAndExpandPath(mdFile)
 
 		var err error
 		md, err = ioutil.ReadFile(fpath)
@@ -102,7 +102,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 
 	// Read attachment files into memory and convert to type File
 	for _, file := range attachmentFiles {
-		path := util.CleanAndExpandPath(file, cfg.HomeDir)
+		path := util.CleanAndExpandPath(file)
 		attachment, err := ioutil.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("ReadFile %v: %v", path, err)

--- a/politeiawww/config.go
+++ b/politeiawww/config.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -153,15 +154,55 @@ type serviceOptions struct {
 // cleanAndExpandPath expands environment variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 func cleanAndExpandPath(path string) string {
-	// Expand initial ~ to OS specific home directory.
-	if strings.HasPrefix(path, "~") {
-		homeDir := filepath.Dir(sharedconfig.DefaultHomeDir)
-		path = strings.Replace(path, "~", homeDir, 1)
+	// Nothing to do when no path is given.
+	if path == "" {
+		return path
 	}
 
-	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
-	// but they variables can still be expanded via POSIX-style $VARIABLE.
-	return filepath.Clean(os.ExpandEnv(path))
+	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
+	// %VARIABLE%, but the variables can still be expanded via POSIX-style
+	// $VARIABLE.
+	path = os.ExpandEnv(path)
+
+	if !strings.HasPrefix(path, "~") {
+		return filepath.Clean(path)
+	}
+
+	// Expand initial ~ to the current user's home directory, or ~otheruser
+	// to otheruser's home directory.  On Windows, both forward and backward
+	// slashes can be used.
+	path = path[1:]
+
+	var pathSeparators string
+	if runtime.GOOS == "windows" {
+		pathSeparators = string(os.PathSeparator) + "/"
+	} else {
+		pathSeparators = string(os.PathSeparator)
+	}
+
+	userName := ""
+	if i := strings.IndexAny(path, pathSeparators); i != -1 {
+		userName = path[:i]
+		path = path[i:]
+	}
+
+	homeDir := ""
+	var u *user.User
+	var err error
+	if userName == "" {
+		u, err = user.Current()
+	} else {
+		u, err = user.Lookup(userName)
+	}
+	if err == nil {
+		homeDir = u.HomeDir
+	}
+	// Fallback to CWD if user lookup fails or user has no home directory.
+	if homeDir == "" {
+		homeDir = "."
+	}
+
+	return filepath.Join(homeDir, path)
 }
 
 // validLogLevel returns whether or not logLevel is a valid debug log level.

--- a/util/file.go
+++ b/util/file.go
@@ -11,7 +11,9 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/decred/politeia/politeiad/api/v1/mime"
@@ -110,13 +112,54 @@ func FileExists(name string) bool {
 
 // CleanAndExpandPath expands environment variables and leading ~ in the
 // passed path, cleans the result, and returns it.
-func CleanAndExpandPath(path, homeDir string) string {
-	// Expand initial ~ to OS specific home directory.
-	if strings.HasPrefix(path, "~") {
-		path = strings.Replace(path, "~", homeDir, 1)
+func CleanAndExpandPath(path string) string {
+	// Nothing to do when no path is given.
+	if path == "" {
+		return path
 	}
 
-	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
-	// but they variables can still be expanded via POSIX-style $VARIABLE.
-	return filepath.Clean(os.ExpandEnv(path))
+	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
+	// %VARIABLE%, but the variables can still be expanded via POSIX-style
+	// $VARIABLE.
+	path = os.ExpandEnv(path)
+
+	if !strings.HasPrefix(path, "~") {
+		return filepath.Clean(path)
+	}
+
+	// Expand initial ~ to the current user's home directory, or ~otheruser
+	// to otheruser's home directory.  On Windows, both forward and backward
+	// slashes can be used.
+	path = path[1:]
+
+	var pathSeparators string
+	if runtime.GOOS == "windows" {
+		pathSeparators = string(os.PathSeparator) + "/"
+	} else {
+		pathSeparators = string(os.PathSeparator)
+	}
+
+	userName := ""
+	if i := strings.IndexAny(path, pathSeparators); i != -1 {
+		userName = path[:i]
+		path = path[i:]
+	}
+
+	homeDir := ""
+	var u *user.User
+	var err error
+	if userName == "" {
+		u, err = user.Current()
+	} else {
+		u, err = user.Lookup(userName)
+	}
+	if err == nil {
+		homeDir = u.HomeDir
+	}
+	// Fallback to CWD if user lookup fails or user has no home directory.
+	if homeDir == "" {
+		homeDir = "."
+	}
+
+	return filepath.Join(homeDir, path)
 }


### PR DESCRIPTION
Closes #692.

This commit fixes the implementation of the `cleanAndExpandPath` function that is used in politeiad and politeiawww.  The old implementation was replacing the `~` character with the OS specific data directory.  The new implementation was taken from dcrd and replaces the `~` character with the OS specific home directory.