### PR TITLE
util: Remove MIME validation from LoadFile

### DIFF
--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -25,6 +25,7 @@ import (
 	"github.com/decred/dcrtime/merkle"
 	"github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
+	"github.com/decred/politeia/politeiad/api/v1/mime"
 	"github.com/decred/politeia/util"
 )
 
@@ -435,6 +436,10 @@ func getFile(filename string) (*v1.File, *[sha256.Size]byte, error) {
 	file.MIME, file.Digest, file.Payload, err = util.LoadFile(filename)
 	if err != nil {
 		return nil, nil, err
+	}
+	if !mime.MimeValid(file.MIME) {
+		return nil, nil, fmt.Errorf("unsupported mime type '%v' "+
+			"for file '%v'", file.MIME, filename)
 	}
 
 	// Get digest

--- a/util/file.go
+++ b/util/file.go
@@ -84,10 +84,6 @@ func LoadFile(filename string) (mimeType string, digest string, payload string, 
 
 	// MIME
 	mimeType = mime.DetectMimeType(b)
-	if !mime.MimeValid(mimeType) {
-		err = mime.ErrUnsupportedMimeType
-		return
-	}
 
 	// Digest
 	h := sha256.New()


### PR DESCRIPTION
This removes MIME type validation from `util.LoadFile`.  It was causing politeiad inventory calls to error out when an old version of a record contained a now unsupported MIME type.  

MIME types are validated when records are submitted, but are no longer validated when records are retrieved.