### PR TITLE
www: Fix session lookup bug

### DIFF
--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -114,6 +114,12 @@ func (p *politeiawww) getSessionUser(w http.ResponseWriter, r *http.Request) (*d
 	if err != nil {
 		return nil, err
 	}
+
+	if id == "" {
+		// User is not logged in
+		return nil, err
+	}
+
 	log.Tracef("getSessionUser: %v", id)
 	pid, err := uuid.Parse(id)
 	if err != nil {


### PR DESCRIPTION
This commit fixes a bug that was causing the proposal details route to return a 500 when accessed by a user that was not logged in.