### PR TITLE
[d/util]: add validation for http.StatusOk

### DIFF
--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -393,6 +393,16 @@ func bestBlock() (*dcrdataapi.BlockDataBasic, error) {
 	}
 	defer r.Body.Close()
 
+	if r.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("dcrdata error: %v %v %v",
+				r.StatusCode, url, err)
+		}
+		return nil, fmt.Errorf("dcrdata error: %v %v %s",
+			r.StatusCode, url, body)
+	}
+
 	var bdb dcrdataapi.BlockDataBasic
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&bdb); err != nil {
@@ -412,6 +422,16 @@ func block(block uint32) (*dcrdataapi.BlockDataBasic, error) {
 	}
 	defer r.Body.Close()
 
+	if r.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("dcrdata error: %v %v %v",
+				r.StatusCode, url, err)
+		}
+		return nil, fmt.Errorf("dcrdata error: %v %v %s",
+			r.StatusCode, url, body)
+	}
+
 	var bdb dcrdataapi.BlockDataBasic
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&bdb); err != nil {
@@ -430,6 +450,16 @@ func snapshot(hash string) ([]string, error) {
 		return nil, err
 	}
 	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("dcrdata error: %v %v %v",
+				r.StatusCode, url, err)
+		}
+		return nil, fmt.Errorf("dcrdata error: %v %v %s",
+			r.StatusCode, url, body)
+	}
 
 	var tickets []string
 	decoder := json.NewDecoder(r.Body)
@@ -460,7 +490,13 @@ func batchTransactions(hashes []string) ([]dcrdataapi.TrimmedTx, error) {
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("POST request failed: %d", r.StatusCode)
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("dcrdata error: %v %v %v",
+				r.StatusCode, url, err)
+		}
+		return nil, fmt.Errorf("dcrdata error: %v %v %s",
+			r.StatusCode, url, body)
 	}
 
 	// Unmarshal the resonse

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -302,11 +302,7 @@ func PayWithTestnetFaucet(faucetURL string, address string, amount uint64, overr
 		return "", fmt.Errorf("faucet only supports testnet")
 	}
 
-	dcramount := strconv.FormatFloat(dcrutil.Amount(amount).ToCoin(),
-		'f', -1, 32)
-	if err != nil {
-		return "", fmt.Errorf("unable to process amount: %v", err)
-	}
+	dcramount := strconv.FormatFloat(dcrutil.Amount(amount).ToCoin(), 'f', -1, 32)
 
 	// build request
 	form := url.Values{}
@@ -332,6 +328,16 @@ func PayWithTestnetFaucet(faucetURL string, address string, amount uint64, overr
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("testnet faucet error: %v %v %v",
+				resp.StatusCode, faucetURL, err)
+		}
+		return "", fmt.Errorf("testnet faucet error: %v %v %s",
+			resp.StatusCode, faucetURL, body)
 	}
 
 	if resp == nil {


### PR DESCRIPTION
Resolves #698 

This commit adds validation to ensure HTTP status codes are `http.StatusOK` before decoding a JSON response