### PR TITLE
Add CMS field to VersionReply

### DIFF
--- a/politeiawww/api/v1/api.md
+++ b/politeiawww/api/v1/api.md
@@ -240,6 +240,7 @@ to get the CSRF token for the session and to ensure API compatibility.
 | route | string | Route that should be prepended to all calls. For example, "/v1". |
 | pubkey | string | The public key for the corresponding private key that signs various tokens to ensure server authenticity and to prevent replay attacks. |
 | testnet | boolean | Value to inform either its running on testnet or not |
+| cms | boolean | Value to inform either its running the contractor management system or not |
 
 **Example**
 

--- a/politeiawww/api/v1/v1.go
+++ b/politeiawww/api/v1/v1.go
@@ -460,6 +460,7 @@ type VersionReply struct {
 	Route   string `json:"route"`   // prefix to API calls
 	PubKey  string `json:"pubkey"`  // Server public key
 	TestNet bool   `json:"testnet"` // Network indicator
+	CMS     bool   `json:"cms"`     // CMS indicator
 }
 
 // NewUser is used to request that a new user be created within the db.

--- a/politeiawww/config.go
+++ b/politeiawww/config.go
@@ -28,7 +28,7 @@ import (
 	"github.com/decred/politeia/util/version"
 
 	"github.com/dajohi/goemail"
-	"github.com/decred/politeia/politeiad/api/v1"
+	v1 "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiawww/sharedconfig"
 	"github.com/decred/politeia/util"
 	flags "github.com/jessevdk/go-flags"
@@ -147,6 +147,7 @@ type config struct {
 	VoteDurationMin          uint32 `long:"votedurationmin" description:"Minimum duration of a proposal vote in blocks"`
 	VoteDurationMax          uint32 `long:"votedurationmax" description:"Maximum duration of a proposal vote in blocks"`
 	AdminLogFile             string
+	CMS                      bool `long:"cms" description:"Use the Contractor Management System"`
 }
 
 // serviceOptions defines the configuration options for the rpc as a service

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -305,6 +305,7 @@ func (p *politeiawww) handleVersion(w http.ResponseWriter, r *http.Request) {
 		Route:   v1.PoliteiaWWWAPIRoute,
 		PubKey:  hex.EncodeToString(p.cfg.Identity.Key[:]),
 		TestNet: p.cfg.TestNet,
+		CMS:     p.cfg.CMS,
 	})
 	if err != nil {
 		RespondWithError(w, r, 0, "handleVersion: Marshal %v", err)


### PR DESCRIPTION
As briefly discussed on matrix, this will ultimately allow us to toggle between using CMS or not and that setting will be passed via VersionReply to any consumers downstream.