### PR TITLE
politeiavoter: Retry on failed req due to timeout.

### DIFF
--- a/politeiavoter/politeiavoter.go
+++ b/politeiavoter/politeiavoter.go
@@ -316,6 +316,9 @@ func (c *ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 
 	responseBody := util.ConvertBodyToByteArray(r.Body, false)
 	log.Tracef("Response: %v %v", r.StatusCode, string(responseBody))
+	if r.StatusCode == http.StatusGatewayTimeout {
+		return nil, errRetry
+	}
 	if r.StatusCode != http.StatusOK {
 		var ue v1.UserError
 		err = json.Unmarshal(responseBody, &ue)


### PR DESCRIPTION
This checks the status code returned when making a request to specifically detect a gateway timeout, which can often happen on Tor for various reasons, and convert it to a retry error so that code which deals with retries will properly retry the request.

Fixes #713.