### PR TITLE
Paywall fixes

### DIFF
--- a/util/paywall.go
+++ b/util/paywall.go
@@ -115,7 +115,7 @@ func makeRequest(url string, timeout time.Duration) ([]byte, error) {
 	if response.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return nil, fmt.Errorf("dcrdata error: %v %v %v"
+			return nil, fmt.Errorf("dcrdata error: %v %v %v",
 				response.StatusCode, url, err)
 		}
 		return nil, fmt.Errorf("dcrdata error: %v %v %s",

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -115,8 +115,8 @@ func makeRequest(url string, timeout time.Duration) ([]byte, error) {
 	if response.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return nil, fmt.Errorf("dcrdata error %v: %v %v %v", err,
-				response.StatusCode, url, body)
+			return nil, fmt.Errorf("dcrdata error: %v %v %v"
+				response.StatusCode, url, err)
 		}
 		return nil, fmt.Errorf("dcrdata error: %v %v %s",
 			response.StatusCode, url, body)

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -31,7 +31,7 @@ const (
 	insightMainnet = "https://mainnet.decred.org/insight/api"
 	insightTestnet = "https://testnet.decred.org/insight/api"
 
-	requestTimeout = 3 // Block explorer request timeout in seconds
+	requestTimeout = 3 * time.Second // Block explorer request timeout
 )
 
 // FaucetResponse represents the expected JSON response from the testnet faucet.


### PR DESCRIPTION
This PR adds a few fixes & updates to the paywall code:
1. Log errored response (status code != 200) from dcrdata or insight.
2. Fix insight requests paths by adding the prefix `/insight`.