### PR TITLE
www: Adds mode=piwww to default politeiawww.conf configutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ You can also use the following default configurations:
 
 **politeiawww.conf**:
 
+    mode=piwww
     rpchost=127.0.0.1
     rpcuser=user
     rpcpass=pass


### PR DESCRIPTION
This commit adds `mode=piwww` to the list of default parameters for `politeiawww.conf` in the README. 

Without setting this parameter, the user will get the below error when trying to run politeiawww.
```
"_Could not load configuration file: invalid mode:_".
```

As an alternate solution, we could also tell the user to set this parameter on the command line when loading their identity, as was suggested by @fernandoabolafio in this [chat on #politeia](https://matrix.to/#/!VFRvyndKpzcLrVslQD:decred.org/$1552633121257503xwvMX:matrix.org?via=decred.org&via=matrix.org&via=zettaport.com) (it appears to have worked for the user).
```
politeiawww --mode=piwww  --fetchidentity
``` 