### PR TITLE
www: Fix fireEvent bugs

### DIFF
--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1037,7 +1037,7 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 	}
 
 	// Fire off proposal status change event
-	p.eventManager._fireEvent(EventTypeProposalStatusChange,
+	p.fireEvent(EventTypeProposalStatusChange,
 		EventDataProposalStatusChange{
 			Proposal:          updatedProp,
 			AdminUser:         u,
@@ -1198,7 +1198,7 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 	}
 
 	// Fire off edit proposal event
-	p.eventManager._fireEvent(EventTypeProposalEdited,
+	p.fireEvent(EventTypeProposalEdited,
 		EventDataProposalEdited{
 			Proposal: updatedProp,
 		},
@@ -1913,14 +1913,12 @@ func (p *politeiawww) processStartVote(sv www.StartVote, u *user.User) (*www.Sta
 		return nil, err
 	}
 
-	if !p.test {
-		p.eventManager._fireEvent(EventTypeProposalVoteStarted,
-			EventDataProposalVoteStarted{
-				AdminUser: u,
-				StartVote: &sv,
-			},
-		)
-	}
+	p.fireEvent(EventTypeProposalVoteStarted,
+		EventDataProposalVoteStarted{
+			AdminUser: u,
+			StartVote: &sv,
+		},
+	)
 
 	// return a copy
 	rv := convertStartVoteReplyFromDecred(*vr)

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -304,9 +304,6 @@ func PayWithTestnetFaucet(faucetURL string, address string, amount uint64, overr
 
 	dcramount := strconv.FormatFloat(dcrutil.Amount(amount).ToCoin(),
 		'f', -1, 32)
-	if err != nil {
-		return "", fmt.Errorf("unable to process amount: %v", err)
-	}
 
 	// build request
 	form := url.Values{}


### PR DESCRIPTION
The `_fireEvent` function was being called without the lock being held in a few different places.  This commit updates those calls to use the `fireEvent` function instead, which does not require the caller to have the lock held.

It also fixes an error in `util/paywall.go` that travis was complaining about.