### PR TITLE
www: Allow user details lookup by pubkey

### DIFF
--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -712,15 +712,15 @@ type VerifyUserPaymentReply struct {
 type Users struct {
 	Username  string `json:"username"`  // String which should match or partially match a username
 	Email     string `json:"email"`     // String which should match or partially match an email
-	PublicKey string `json:"publickey"` // Pubkey used for Signature
+	PublicKey string `json:"publickey"` // Active or inactive user pubkey
 
 }
 
 // UsersReply is a reply to the Users command, replying with a list of users.
 type UsersReply struct {
-	TotalUsers   uint64         `json:"totalusers,omitempty"`   // Total number of all users in the database
-	TotalMatches uint64         `json:"totalmatches,omitempty"` // Total number of users that match the filters
-	Users        []AbridgedUser `json:"users"`                  // List of users that match the filters
+	TotalUsers   uint64         `json:"totalusers,omitempty"` // Total number of all users in the database
+	TotalMatches uint64         `json:"totalmatches"`         // Total number of users that match the filters
+	Users        []AbridgedUser `json:"users"`                // List of users that match the filters
 }
 
 // AbridgedUser is a shortened version of User that's used for the admin list.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -710,21 +710,23 @@ type VerifyUserPaymentReply struct {
 
 // Users is used to request a list of users given a filter.
 type Users struct {
-	Username string `json:"username"` // String which should match or partially match a username
-	Email    string `json:"email"`    // String which should match or partially match an email
+	Username  string `json:"username"`  // String which should match or partially match a username
+	Email     string `json:"email"`     // String which should match or partially match an email
+	PublicKey string `json:"publickey"` // Pubkey used for Signature
+
 }
 
 // UsersReply is a reply to the Users command, replying with a list of users.
 type UsersReply struct {
-	TotalUsers   uint64         `json:"totalusers"`   // Total number of all users in the database
-	TotalMatches uint64         `json:"totalmatches"` // Total number of users that match the filters
-	Users        []AbridgedUser `json:"users"`        // List of users that match the filters
+	TotalUsers   uint64         `json:"totalusers,omitempty"`   // Total number of all users in the database
+	TotalMatches uint64         `json:"totalmatches,omitempty"` // Total number of users that match the filters
+	Users        []AbridgedUser `json:"users"`                  // List of users that match the filters
 }
 
 // AbridgedUser is a shortened version of User that's used for the admin list.
 type AbridgedUser struct {
 	ID       string `json:"id"`
-	Email    string `json:"email"`
+	Email    string `json:"email,omitempty"`
 	Username string `json:"username"`
 }
 

--- a/politeiawww/cmd/politeiawwwcli/commands/users.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/users.go
@@ -34,18 +34,25 @@ func (cmd *UsersCmd) Execute(args []string) error {
 // usersHelpMsg is the output of the help command when 'users' is specified.
 const usersHelpMsg = `users [flags]
 
-Fetch a list of users, optionally filtering by email and/or username.
+Fetch a list of users. If logged in as admin, users returns a list 
+of all users, optionally filtering by username, email or public key. Partial 
+matches are returned. If not logged in (or logged in as non admin) users 
+returns a list of users filtered by username or public key, with only exact
+matches returned. 
 
 Arguments: None
 
 Flags:
   --email       (string, optional)   Email filter
   --username    (string, optional)   Username filter
+  --pubkey      (string, optional)   Public Key
 
-Example:
-users --email=user@example.com --username=user
 
-Result:
+Example (Admin):
+users --email=user@example.com --username=user --pubkey=0b2283a91f6bf95f2c121
+14c7c1259c1396756bea4f64be43fe0f73b383bdf92
+
+Result (Admin):
 {
   "totalusers":    (uint64)  Total number of all users in the database
   "totalmatches":  (uint64)  Total number of users that match the filters
@@ -56,4 +63,18 @@ Result:
       "username":  (string)  Username
     }
   ]
-}`
+}
+
+Example (non Admin):
+--pubkey=0b2283a91f6bf95f2c12114c7c1259c1396756bea4f64be43fe0f73b383bdf92
+
+Result (Non admin):
+{
+  "users": [
+    {
+      "id": 		(string)  User id
+      "username": 	(string)  Username
+    }
+  ]
+}
+`

--- a/politeiawww/cmd/politeiawwwcli/commands/users.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/users.go
@@ -11,15 +11,17 @@ import (
 // UsersCmd retreives a list of users that have been filtered using the
 // specified filtering params.
 type UsersCmd struct {
-	Email    string `long:"email"`    // Email filter
-	Username string `long:"username"` // Username filter
+	Email     string `long:"email"`    // Email filter
+	Username  string `long:"username"` // Username filter
+	PublicKey string `long:"pubkey"`   // Username filter
 }
 
 // Execute executes the users command.
 func (cmd *UsersCmd) Execute(args []string) error {
 	u := v1.Users{
-		Email:    cmd.Email,
-		Username: cmd.Username,
+		Email:     cmd.Email,
+		Username:  cmd.Username,
+		PublicKey: cmd.PublicKey,
 	}
 
 	ur, err := client.Users(&u)

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1611,8 +1611,6 @@ func (p *politeiawww) processUsers(users *www.Users, isAdmin bool) (*www.UsersRe
 		if err != nil {
 			return nil, err
 		}
-
-		// userID = u.ID.String()
 	}
 
 	if isAdmin {

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1583,9 +1583,9 @@ func (p *politeiawww) processManageUser(mu *www.ManageUser, adminUser *user.User
 // processUsers returns a list of users given a set of filters. Admins
 // can search by pubkey, username or admin (partial matches returned).
 // Non admins can search by pubkey or username (only exact matches returned).
-func (p *politeiawww) processUsers(users *v1.Users, isAdmin bool) (*v1.UsersReply, error) {
-	var reply v1.UsersReply
-	reply.Users = make([]v1.AbridgedUser, 0, v1.UserListPageSize)
+func (p *politeiawww) processUsers(users *www.Users, isAdmin bool) (*www.UsersReply, error) {
+	var reply www.UsersReply
+	reply.Users = make([]www.AbridgedUser, 0, www.UserListPageSize)
 	var u *user.User
 	var userID string
 
@@ -1638,9 +1638,9 @@ func (p *politeiawww) processUsers(users *v1.Users, isAdmin bool) (*v1.UsersRepl
 
 			if userMatches {
 				reply.TotalMatches++
-				if reply.TotalMatches < v1.UserListPageSize {
+				if reply.TotalMatches < www.UserListPageSize {
 
-					reply.Users = append(reply.Users, v1.AbridgedUser{
+					reply.Users = append(reply.Users, www.AbridgedUser{
 						ID:       user.ID.String(),
 						Email:    user.Email,
 						Username: user.Username})
@@ -1650,7 +1650,6 @@ func (p *politeiawww) processUsers(users *v1.Users, isAdmin bool) (*v1.UsersRepl
 		if err != nil {
 			return nil, err
 		}
-
 
 	} else {
 		// Get user by username, if provided
@@ -1667,7 +1666,7 @@ func (p *politeiawww) processUsers(users *v1.Users, isAdmin bool) (*v1.UsersRepl
 			}
 		}
 
-		reply.Users = append(reply.Users, v1.AbridgedUser{
+		reply.Users = append(reply.Users, www.AbridgedUser{
 			ID:       u.ID.String(),
 			Username: u.Username})
 	}

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1653,7 +1653,7 @@ func (p *politeiawww) processUsers(users *www.Users, isAdmin bool) (*www.UsersRe
 
 			if pubkeyQuery != "" && userMatches {
 				if user.ID.String() != u.ID.String() {
-				// if user.ID.String() != id {
+					// if user.ID.String() != id {
 					userMatches = false
 				}
 			}

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1581,13 +1581,12 @@ func (p *politeiawww) processManageUser(mu *www.ManageUser, adminUser *user.User
 }
 
 // processUsers returns a list of users given a set of filters. Admins
-// can search by pubkey, username or admin (partial matches returned).
+// can search by pubkey, username or email (partial matches returned).
 // Non admins can search by pubkey or username (only exact matches returned).
 func (p *politeiawww) processUsers(users *www.Users, isAdmin bool) (*www.UsersReply, error) {
 	var reply www.UsersReply
 	reply.Users = make([]www.AbridgedUser, 0, www.UserListPageSize)
 	var u *user.User
-	var userID string
 
 	emailQuery := strings.ToLower(users.Email)
 	usernameQuery := formatUsername(users.Username)
@@ -1602,17 +1601,13 @@ func (p *politeiawww) processUsers(users *www.Users, isAdmin bool) (*www.UsersRe
 		}
 
 		// Get userID by pubkey
-		id, ok := p.userPubkeys[pubkeyQuery]
-		if !ok {
-			return nil, fmt.Errorf("pubkey not found")
-		}
+		id := p.userPubkeys[pubkeyQuery]
 
 		// Get user by userID
 		u, err = p.getUserByIDStr(id)
 		if err != nil {
 			return nil, err
 		}
-		userID = u.ID.String()
 	}
 
 	if isAdmin {
@@ -1637,7 +1632,7 @@ func (p *politeiawww) processUsers(users *www.Users, isAdmin bool) (*www.UsersRe
 			}
 
 			if pubkeyQuery != "" && userMatches {
-				if user.ID.String() != userID {
+				if user.ID.String() != u.ID.String() {
 					userMatches = false
 				}
 			}

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1601,16 +1601,18 @@ func (p *politeiawww) processUsers(users *www.Users, isAdmin bool) (*www.UsersRe
 			return nil, err
 		}
 
-		userID, ok := p.userPubkeys[pubkey]
+		// Get userID by pubkey
+		id, ok := p.userPubkeys[pubkeyQuery]
 		if !ok {
 			return nil, fmt.Errorf("pubkey not found")
 		}
 
 		// Get user by userID
-		u, err := p.db.UserGetById(userID)
+		u, err = p.getUserByIDStr(id)
 		if err != nil {
 			return nil, err
 		}
+		userID = u.ID.String()
 	}
 
 	if isAdmin {

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1601,12 +1601,18 @@ func (p *politeiawww) processUsers(users *www.Users, isAdmin bool) (*www.UsersRe
 			return nil, err
 		}
 
-		// Get user by pubkey
-		u, err = p.db.UserGetByPublicKey(pubkeyQuery)
+		userID, ok := p.userPubkeys[pubkey]
+		if !ok {
+			return nil, fmt.Errorf("pubkey not found")
+		}
+
+		// Get user by userID
+		u, err := p.db.UserGetById(userID)
 		if err != nil {
 			return nil, err
 		}
-		userID = u.ID.String()
+
+		// userID = u.ID.String()
 	}
 
 	if isAdmin {

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -172,50 +172,6 @@ func (l *localdb) UserGetByUsername(username string) (*user.User, error) {
 	return nil, user.ErrUserNotFound
 }
 
-// UserGetByPublicKey returns a user record given its public key,
-// if found in the database.
-//
-// UserGetByPublicKey satisfies the backend interface.
-func (l *localdb) UserGetByPublicKey(pubkey string) (*user.User, error) {
-	l.RLock()
-	defer l.RUnlock()
-
-	if l.shutdown {
-		return nil, user.ErrShutdown
-	}
-
-	log.Debugf("UserGetByPublicKey")
-
-	iter := l.userdb.NewIterator(nil, nil)
-	for iter.Next() {
-		key := iter.Key()
-		value := iter.Value()
-
-		if !isUserRecord(string(key)) {
-			continue
-		}
-
-		u, err := DecodeUser(value)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, identity := range u.Identities {
-
-			if hex.EncodeToString(identity.Key[:]) == pubkey {
-				return u, err
-			}
-		}
-
-	}
-	iter.Release()
-
-	if iter.Error() != nil {
-		return nil, iter.Error()
-	}
-
-	return nil, user.ErrUserNotFound
-}
 
 // UserGetById returns a user record given its id, if found in the database.
 //

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -2,7 +2,6 @@ package localdb
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"path/filepath"
 	"strings"
 	"sync"

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -143,7 +143,7 @@ func (l *localdb) UserGetByUsername(username string) (*user.User, error) {
 		return nil, user.ErrShutdown
 	}
 
-	log.Debugf("UserGetByUsername\n")
+	log.Debugf("UserGetByUsername")
 
 	iter := l.userdb.NewIterator(nil, nil)
 	for iter.Next() {
@@ -228,7 +228,7 @@ func (l *localdb) UserGetById(id uuid.UUID) (*user.User, error) {
 		return nil, user.ErrShutdown
 	}
 
-	log.Debugf("UserGetById\n")
+	log.Debugf("UserGetById")
 
 	iter := l.userdb.NewIterator(nil, nil)
 	for iter.Next() {
@@ -297,7 +297,7 @@ func (l *localdb) AllUsers(callbackFn func(u *user.User)) error {
 		return user.ErrShutdown
 	}
 
-	log.Debugf("AllUsers\n")
+	log.Debugf("AllUsers")
 
 	iter := l.userdb.NewIterator(nil, nil)
 	for iter.Next() {

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -172,7 +172,6 @@ func (l *localdb) UserGetByUsername(username string) (*user.User, error) {
 	return nil, user.ErrUserNotFound
 }
 
-
 // UserGetById returns a user record given its id, if found in the database.
 //
 // UserGetById satisfies the backend interface.

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -2,6 +2,7 @@ package localdb
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -161,6 +162,51 @@ func (l *localdb) UserGetByUsername(username string) (*user.User, error) {
 		if strings.ToLower(u.Username) == strings.ToLower(username) {
 			return u, err
 		}
+	}
+	iter.Release()
+
+	if iter.Error() != nil {
+		return nil, iter.Error()
+	}
+
+	return nil, user.ErrUserNotFound
+}
+
+// UserGetByPublicKey returns a user record given its public key,
+// if found in the database.
+//
+// UserGetByPublicKey satisfies the backend interface.
+func (l *localdb) UserGetByPublicKey(pubkey string) (*user.User, error) {
+	l.RLock()
+	defer l.RUnlock()
+
+	if l.shutdown {
+		return nil, user.ErrShutdown
+	}
+
+	log.Debugf("UserGetByPublicKey")
+
+	iter := l.userdb.NewIterator(nil, nil)
+	for iter.Next() {
+		key := iter.Key()
+		value := iter.Value()
+
+		if !isUserRecord(string(key)) {
+			continue
+		}
+
+		u, err := DecodeUser(value)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, identity := range u.Identities {
+
+			if hex.EncodeToString(identity.Key[:]) == pubkey {
+				return u, err
+			}
+		}
+
 	}
 	iter.Release()
 

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -155,12 +155,13 @@ func (u *User) PublicKey() string {
 // Database interface that is required by the web server.
 type Database interface {
 	// User functions
-	UserGet(string) (*User, error)           // Return user record, key is email
-	UserGetByUsername(string) (*User, error) // Return user record given the username
-	UserGetById(uuid.UUID) (*User, error)    // Return user record given its id
-	UserNew(User) error                      // Add new user
-	UserUpdate(User) error                   // Update existing user
-	AllUsers(callbackFn func(u *User)) error // Iterate all users
+	UserGet(string) (*User, error)            // Return user record, key is email
+	UserGetByUsername(string) (*User, error)  // Return user record given the username
+	UserGetById(uuid.UUID) (*User, error)     // Return user record given its id
+	UserGetByPublicKey(string) (*User, error) // Return user record given its pubkey
+	UserNew(User) error                       // Add new user
+	UserUpdate(User) error                    // Update existing user
+	AllUsers(callbackFn func(u *User)) error  // Iterate all users
 
 	// Close performs cleanup of the backend.
 	Close() error

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -155,12 +155,12 @@ func (u *User) PublicKey() string {
 // Database interface that is required by the web server.
 type Database interface {
 	// User functions
-	UserGet(string) (*User, error)            // Return user record, key is email
-	UserGetByUsername(string) (*User, error)  // Return user record given the username
-	UserGetById(uuid.UUID) (*User, error)     // Return user record given its id
-	UserNew(User) error                       // Add new user
-	UserUpdate(User) error                    // Update existing user
-	AllUsers(callbackFn func(u *User)) error  // Iterate all users
+	UserGet(string) (*User, error)           // Return user record, key is email
+	UserGetByUsername(string) (*User, error) // Return user record given the username
+	UserGetById(uuid.UUID) (*User, error)    // Return user record given its id
+	UserNew(User) error                      // Add new user
+	UserUpdate(User) error                   // Update existing user
+	AllUsers(callbackFn func(u *User)) error // Iterate all users
 
 	// Close performs cleanup of the backend.
 	Close() error

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -158,7 +158,6 @@ type Database interface {
 	UserGet(string) (*User, error)            // Return user record, key is email
 	UserGetByUsername(string) (*User, error)  // Return user record given the username
 	UserGetById(uuid.UUID) (*User, error)     // Return user record given its id
-	UserGetByPublicKey(string) (*User, error) // Return user record given its pubkey
 	UserNew(User) error                       // Add new user
 	UserUpdate(User) error                    // Update existing user
 	AllUsers(callbackFn func(u *User)) error  // Iterate all users


### PR DESCRIPTION
In order for an external tool to be able to verify things like a
comment score, there needs to be a way to lookup public user details
 by pubkey. This commit accomplishes this via the following changes:

- Makes the /users endpoint public
- Adds UserGetByPublicKey method to the user database interface
- Allows non-admins to filter users by username or pubkey (endpoint
returns only user ID and username for matches)
- Allows admins to search by username, email, or pubkey (endpoint
returns user ID, email, and username for matches)