### PR TITLE
cache: Change version type to uint64

### DIFF
--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -5,6 +5,7 @@
 package cockroachdb
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/decred/politeia/decredplugin"
@@ -18,7 +19,7 @@ func convertMDStreamFromCache(ms cache.MetadataStream) MetadataStream {
 	}
 }
 
-func convertRecordFromCache(r cache.Record) Record {
+func convertRecordFromCache(r cache.Record, version uint64) Record {
 	metadata := make([]MetadataStream, 0, len(r.Metadata))
 	for _, ms := range r.Metadata {
 		metadata = append(metadata, convertMDStreamFromCache(ms))
@@ -38,7 +39,7 @@ func convertRecordFromCache(r cache.Record) Record {
 	return Record{
 		Key:       r.CensorshipRecord.Token + r.Version,
 		Token:     r.CensorshipRecord.Token,
-		Version:   r.Version,
+		Version:   version,
 		Status:    int(r.Status),
 		Timestamp: r.Timestamp,
 		Merkle:    r.CensorshipRecord.Merkle,
@@ -76,7 +77,7 @@ func convertRecordToCache(r Record) cache.Record {
 	}
 
 	return cache.Record{
-		Version:          r.Version,
+		Version:          strconv.FormatUint(r.Version, 10),
 		Status:           cache.RecordStatusT(r.Status),
 		Timestamp:        r.Timestamp,
 		CensorshipRecord: cr,
@@ -151,11 +152,11 @@ func convertLikeCommentToDecred(lc LikeComment) decredplugin.LikeComment {
 	}
 }
 
-func convertAuthorizeVoteFromDecred(av decredplugin.AuthorizeVote, avr decredplugin.AuthorizeVoteReply) AuthorizeVote {
+func convertAuthorizeVoteFromDecred(av decredplugin.AuthorizeVote, avr decredplugin.AuthorizeVoteReply, version uint64) AuthorizeVote {
 	return AuthorizeVote{
 		Key:       av.Token + avr.RecordVersion,
 		Token:     av.Token,
-		Version:   avr.RecordVersion,
+		Version:   version,
 		Action:    av.Action,
 		Signature: av.Signature,
 		PublicKey: av.PublicKey,

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -49,7 +49,7 @@ func (MetadataStream) TableName() string {
 type Record struct {
 	Key       string `gorm:"primary_key"`       // Primary key (token+version)
 	Token     string `gorm:"not null;size:64"`  // Censorship token
-	Version   string `gorm:"not null"`          // Version of files
+	Version   uint64 `gorm:"not null"`          // Version of files
 	Status    int    `gorm:"not null"`          // Current status
 	Timestamp int64  `gorm:"not null"`          // UNIX timestamp of last updated
 	Merkle    string `gorm:"not null;size:64"`  // Merkle root of all files in record
@@ -106,7 +106,7 @@ func (LikeComment) TableName() string {
 type AuthorizeVote struct {
 	Key       string `gorm:"primary_key"`       // Primary key (token+version)
 	Token     string `gorm:"not null;size:64"`  // Censorship token
-	Version   string `gorm:"not null"`          // Version of files
+	Version   uint64 `gorm:"not null"`          // Version of files
 	Action    string `gorm:"not null"`          // Authorize or revoke
 	Signature string `gorm:"not null;size:128"` // Signature of token+version+action
 	PublicKey string `gorm:"not null;size:64"`  // Pubkey used for signature
@@ -137,7 +137,7 @@ func (VoteOption) TableName() string {
 // a proposal vote.
 type StartVote struct {
 	Token            string       `gorm:"primary_key;size:64"` // Censorship token
-	Version          string       `gorm:"not null"`            // Version of files
+	Version          uint64       `gorm:"not null"`            // Version of files
 	Mask             uint64       `gorm:"not null"`            // Valid votebits
 	Duration         uint32       `gorm:"not null"`            // Duration in blocks
 	QuorumPercentage uint32       `gorm:"not null"`            // Percent of eligible votes required for quorum


### PR DESCRIPTION
This commit changes the type of the version fields in the cache models from string to uint64.  This is necessary because some of the queries rely on ordering the results by version.  The bug becomes apparent when the proposal version gets into the double digits.