### PR TITLE
Add EditInvoice and SetInvoiceStatus routes

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -13,8 +13,18 @@ server side notifications.  It does not render HTML.
 - [`New invoice`](#new-invoice)
 - [`User invoices`](#user-invoices)
 - [`Admin invoices`](#admin-invoices)
+- [`Set invoice status`](#set-invoice-status)
 
+**Invoice status codes**
 
+- [`InvoiceStatusInvalid`](#InvoiceStatusInvalid)
+- [`InvoiceStatusNotFound`](#InvoiceStatusNotFound)
+- [`InvoiceStatusNew`](#InvoiceStatusNew)
+- [`InvoiceStatusUpdated`](#InvoiceStatusUpdated)
+- [`InvoiceStatusDisputed`](#InvoiceStatusDisputed)
+- [`InvoiceStatusRejected`](#InvoiceStatusRejected)
+- [`InvoiceStatusApproved`](#InvoiceStatusApproved)
+- [`InvoiceStatusPaid`](#InvoiceStatusPaid)
 
 ### `Invite new user`
 
@@ -224,6 +234,70 @@ Reply:
 }
 ```
 
+### `Set invoice status`
+
+Sets the invoice status to either `InvoiceStatusApproved` or `InvoiceStatusRejected`.
+
+Note: This call requires admin privileges.
+
+**Route:** `POST /v1/invoice/status`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| token | string | Token is the unique censorship token that identifies a specific invoice. | Yes |
+| status | number | The new [status](#invoice-status-codes) for the invoice. | Yes |
+| reason | string | The reason for the new status. This is only required if the status is `InvoiceStatusRejected`. | |
+| signature | string | Signature of token+string(status). | Yes |
+| publickey | string | The user's public key, sent for signature verification. | Yes |
+
+**Results:**
+
+| Parameter | Type | Description |
+|-|-|-|-|
+| invoice | [`Invoice`](#invoice) | The updated invoice. |
+
+This call can return one of the following error codes:
+
+- [`ErrorStatusInvoiceNotFound`](#ErrorStatusInvoiceNotFound)
+
+**Example**
+
+Request:
+
+```json
+{
+  "invoicestatus": 4,
+  "publickey": "f5519b6fdee08be45d47d5dd794e81303688a8798012d8983ba3f15af70a747c",
+  "signature": "041a12e5df95ec132be27f0c716fd8f7fc23889d05f66a26ef64326bd5d4e8c2bfed660235856da219237d185fb38c6be99125d834c57030428c6b96a2576900",
+  "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527"
+}
+```
+
+Reply:
+
+```json
+{
+  "invoice": {
+    "status": 4,
+    "month": 12,
+    "year": 2018,
+    "timestamp": 1508296860781,
+    "userid": "0",
+    "username": "foobar",
+    "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+    "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e",
+    "version": "1",
+    "censorshiprecord": {
+      "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+      "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+      "signature": "fcc92e26b8f38b90c2887259d88ce614654f32ecd76ade1438a0def40d360e461d995c796f16a17108fad226793fd4f52ff013428eda3b39cd504ed5f1811d0d"
+    }
+  }
+}
+```
+
 ### `Admin invoices`
 
 Retrieve a page of invoices given the month and year and status.
@@ -279,3 +353,16 @@ Reply:
   }]
 }
 ```
+
+### Invoice status codes
+
+| Status | Value | Description |
+|-|-|-|
+| <a name="InvoiceStatusInvalid">InvoiceStatusInvalid</a>| 0 | An invalid status. This shall be considered a bug. |
+| <a name="InvoiceStatusNotFound">InvoiceStatusNotFound</a> | 1 | The invoice was not found. |
+| <a name="InvoiceStatusNew">InvoiceStatusNew</a> | 2 | The invoice has not been reviewed by an admin. |
+| <a name="InvoiceStatusUpdated">InvoiceStatusUpdated</a> | 3 | The invoice has been changed and the changes have not been reviewed by an admin. |
+| <a name="InvoiceStatusDisputed">InvoiceStatusDisputed</a> | 4 | A portion of the invoice has been disputed and requires contractor resolution. |
+| <a name="InvoiceStatusRejected">InvoiceStatusRejected</a> | 5 | The invoice has been rejected by an admin. |
+| <a name="InvoiceStatusApproved">InvoiceStatusApproved</a> | 6 | The invoice has been approved by an admin. |
+| <a name="InvoiceStatusPaid">InvoiceStatusPaid</a> | 7 | The invoice has been paid. |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -13,6 +13,7 @@ server side notifications.  It does not render HTML.
 - [`New invoice`](#new-invoice)
 - [`User invoices`](#user-invoices)
 - [`Admin invoices`](#admin-invoices)
+- [`Edit invoice`](#edit-invoice)
 - [`Set invoice status`](#set-invoice-status)
 
 **Invoice status codes**
@@ -236,11 +237,11 @@ Reply:
 
 ### `Set invoice status`
 
-Sets the invoice status to either `InvoiceStatusApproved` or `InvoiceStatusRejected`.
+Sets the invoice status to either `InvoiceStatusApproved`, `InvoiceStatusRejected` or `InvoiceStatusDisputed`.
 
 Note: This call requires admin privileges.
 
-**Route:** `POST /v1/invoice/status`
+**Route:** `POST /v1/invoice/{token}/status`
 
 **Params:**
 
@@ -351,6 +352,78 @@ Reply:
       "signature": "fcc92e26b8f38b90c2887259d88ce614654f32ecd76ade1438a0def40d360e461d995c796f16a17108fad226793fd4f52ff013428eda3b39cd504ed5f1811d0d"
     }
   }]
+}
+```
+
+### `Edit invoice`
+
+Edits an exisiting invoice and will update the status to `InvoiceStatusUpdated`.
+
+Note: This call requires the user to be the same as the invoice creator.
+
+**Route:** `POST /v1/invoices/edit`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| token | string | Token is the unique censorship token that identifies a specific invoice. | Yes |
+| files | [`[]File`](#file) | The invoice CSV file and any other attachments for line items. The first line should be a comment with the month and year, with the format: `# 2006-01` | Yes |
+| publickey | string | The user's public key. | Yes |
+| signature | string | The signature of the string representation of the file payload. | Yes |
+
+**Results:**
+
+| Parameter | Type | Description |
+|-|-|-|
+| invoice | [`Invoice`](#invoice) | The updated invoice. |
+
+This call can return one of the following error codes:
+
+- [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
+- [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
+- [`ErrorStatusNoPublicKey`](#ErrorStatusNoPublicKey)
+- [`ErrorStatusInvalidInput`](#ErrorStatusInvalidInput)
+- [`ErrorStatusMalformedInvoiceFile`](#ErrorStatusMalformedInvoiceFile)
+- [`ErrorStatusDuplicateInvoice`](#ErrorStatusDuplicateInvoice)
+
+**Example**
+
+Request:
+
+```json
+{
+  "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+  "files": [{
+      "name":"invoice.json",
+      "mime": "text/plain; charset=utf-8",
+      "digest": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+      "payload": "VGhpcyBpcyBhIGRlc2NyaXB0aW9u"
+    }
+  ]
+}
+```
+
+Reply:
+
+```json
+{
+  "invoice": {
+    "status": 4,
+    "month": 12,
+    "year": 2018,
+    "timestamp": 1508296860781,
+    "userid": "0",
+    "username": "foobar",
+    "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+    "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e",
+    "version": "1",
+    "censorshiprecord": {
+      "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+      "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+      "signature": "fcc92e26b8f38b90c2887259d88ce614654f32ecd76ade1438a0def40d360e461d995c796f16a17108fad226793fd4f52ff013428eda3b39cd504ed5f1811d0d"
+    }
+  }
 }
 ```
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -9,13 +9,14 @@ type InvoiceStatusT int
 const (
 
 	// Contractor Management Routes
-
-	RouteInviteNewUser  = "/invite"
-	RouteRegisterUser   = "/register"
-	RouteNewInvoice     = "/invoices/new"
-	RouteInvoiceDetails = "/invoices/{token:[A-z0-9]{64}}"
-	RouteUserInvoices   = "/user/invoices"
-	RouteAdminInvoices  = "/admin/invoices"
+	RouteInviteNewUser    = "/invite"
+	RouteRegisterUser     = "/register"
+	RouteNewInvoice       = "/invoices/new"
+	RouteEditInvoice      = "/invoices/edit"
+	RouteInvoiceDetails   = "/invoices/{token:[A-z0-9]{64}}"
+	RouteSetInvoiceStatus = "/invoices/{token:[A-z0-9]{64}}/status"
+	RouteUserInvoices     = "/user/invoices"
+	RouteAdminInvoices    = "/admin/invoices"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status
@@ -70,6 +71,19 @@ type NewInvoice struct {
 // NewInvoiceReply is used to reply to the NewInvoiceReply command.
 type NewInvoiceReply struct {
 	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
+}
+
+// EditInvoice attempts to edit a proposal
+type EditInvoice struct {
+	Token     string     `json:"token"`
+	Files     []www.File `json:"files"`
+	PublicKey string     `json:"publickey"`
+	Signature string     `json:"signature"`
+}
+
+// EditInvoiceReply is used to reply to the EditInvoice command
+type EditInvoiceReply struct {
+	Invoice InvoiceRecord `json:"invoice"`
 }
 
 // InvoiceRecord is an entire invoice and its content.
@@ -138,4 +152,18 @@ type AdminInvoices struct {
 // AdminInvoiceReply is used to reply to an admin invoices command.
 type AdminInvoicesReply struct {
 	Invoices []InvoiceRecord `json:"invoices"`
+}
+
+// SetInvoiceStatus is used to approve or reject an unreviewed invoice.
+type SetInvoiceStatus struct {
+	Token     string         `json:"token"`
+	Status    InvoiceStatusT `json:"status"`
+	Reason    string         `json:"reason"`
+	Signature string         `json:"signature"` // Signature of Token+string(InvoiceStatus)
+	PublicKey string         `json:"publickey"` // Public key of admin
+}
+
+// SetInvoiceStatusReply is used to reply to a SetInvoiceStatus command.
+type SetInvoiceStatusReply struct {
+	Invoice InvoiceRecord `json:"invoice"`
 }

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -208,6 +208,7 @@ const (
 	ErrorStatusMalformedInvoiceFile           ErrorStatusT = 64
 	ErrorStatusInvalidInvoiceStatusTransition ErrorStatusT = 65
 	ErrorStatusReasonNotProvided              ErrorStatusT = 66
+	ErrorStatusInvoiceDuplicate               ErrorStatusT = 67
 
 	// Proposal state codes
 	//
@@ -363,6 +364,7 @@ var (
 		ErrorStatusInvalidInvoiceStatusTransition: "invalid invoice status transition",
 		ErrorStatusReasonNotProvided:              "reason for action not provided",
 		ErrorStatusMalformedInvoiceFile:           "submitted invoice file is malformed",
+		ErrorStatusInvoiceDuplicate:               "submitted invoice is a duplicate of an existing invoice",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -139,71 +139,73 @@ const (
 	UserListPageSize = 20
 
 	// Error status codes
-	ErrorStatusInvalid                     ErrorStatusT = 0
-	ErrorStatusInvalidEmailOrPassword      ErrorStatusT = 1
-	ErrorStatusMalformedEmail              ErrorStatusT = 2
-	ErrorStatusVerificationTokenInvalid    ErrorStatusT = 3
-	ErrorStatusVerificationTokenExpired    ErrorStatusT = 4
-	ErrorStatusProposalMissingFiles        ErrorStatusT = 5
-	ErrorStatusProposalNotFound            ErrorStatusT = 6
-	ErrorStatusProposalDuplicateFilenames  ErrorStatusT = 7
-	ErrorStatusProposalInvalidTitle        ErrorStatusT = 8
-	ErrorStatusMaxMDsExceededPolicy        ErrorStatusT = 9
-	ErrorStatusMaxImagesExceededPolicy     ErrorStatusT = 10
-	ErrorStatusMaxMDSizeExceededPolicy     ErrorStatusT = 11
-	ErrorStatusMaxImageSizeExceededPolicy  ErrorStatusT = 12
-	ErrorStatusMalformedPassword           ErrorStatusT = 13
-	ErrorStatusCommentNotFound             ErrorStatusT = 14
-	ErrorStatusInvalidFilename             ErrorStatusT = 15
-	ErrorStatusInvalidFileDigest           ErrorStatusT = 16
-	ErrorStatusInvalidBase64               ErrorStatusT = 17
-	ErrorStatusInvalidMIMEType             ErrorStatusT = 18
-	ErrorStatusUnsupportedMIMEType         ErrorStatusT = 19
-	ErrorStatusInvalidPropStatusTransition ErrorStatusT = 20
-	ErrorStatusInvalidPublicKey            ErrorStatusT = 21
-	ErrorStatusNoPublicKey                 ErrorStatusT = 22
-	ErrorStatusInvalidSignature            ErrorStatusT = 23
-	ErrorStatusInvalidInput                ErrorStatusT = 24
-	ErrorStatusInvalidSigningKey           ErrorStatusT = 25
-	ErrorStatusCommentLengthExceededPolicy ErrorStatusT = 26
-	ErrorStatusUserNotFound                ErrorStatusT = 27
-	ErrorStatusWrongStatus                 ErrorStatusT = 28
-	ErrorStatusNotLoggedIn                 ErrorStatusT = 29
-	ErrorStatusUserNotPaid                 ErrorStatusT = 30
-	ErrorStatusReviewerAdminEqualsAuthor   ErrorStatusT = 31
-	ErrorStatusMalformedUsername           ErrorStatusT = 32
-	ErrorStatusDuplicateUsername           ErrorStatusT = 33
-	ErrorStatusVerificationTokenUnexpired  ErrorStatusT = 34
-	ErrorStatusCannotVerifyPayment         ErrorStatusT = 35
-	ErrorStatusDuplicatePublicKey          ErrorStatusT = 36
-	ErrorStatusInvalidPropVoteStatus       ErrorStatusT = 37
-	ErrorStatusUserLocked                  ErrorStatusT = 38
-	ErrorStatusNoProposalCredits           ErrorStatusT = 39
-	ErrorStatusInvalidUserManageAction     ErrorStatusT = 40
-	ErrorStatusUserActionNotAllowed        ErrorStatusT = 41
-	ErrorStatusWrongVoteStatus             ErrorStatusT = 42
-	ErrorStatusCannotCommentOnProp         ErrorStatusT = 43
-	ErrorStatusCannotVoteOnPropComment     ErrorStatusT = 44
-	ErrorStatusChangeMessageCannotBeBlank  ErrorStatusT = 45
-	ErrorStatusCensorReasonCannotBeBlank   ErrorStatusT = 46
-	ErrorStatusCannotCensorComment         ErrorStatusT = 47
-	ErrorStatusUserNotAuthor               ErrorStatusT = 48
-	ErrorStatusVoteNotAuthorized           ErrorStatusT = 49
-	ErrorStatusVoteAlreadyAuthorized       ErrorStatusT = 50
-	ErrorStatusInvalidAuthVoteAction       ErrorStatusT = 51
-	ErrorStatusUserDeactivated             ErrorStatusT = 52
-	ErrorStatusInvalidPropVoteBits         ErrorStatusT = 53
-	ErrorStatusInvalidPropVoteParams       ErrorStatusT = 54
-	ErrorStatusEmailNotVerified            ErrorStatusT = 55
-	ErrorStatusInvalidUUID                 ErrorStatusT = 56
-	ErrorStatusInvalidLikeCommentAction    ErrorStatusT = 57
-	ErrorStatusInvalidCensorshipToken      ErrorStatusT = 58
-	ErrorStatusEmailAlreadyVerified        ErrorStatusT = 59
-	ErrorStatusMalformedName               ErrorStatusT = 60
-	ErrorStatusMalformedLocation           ErrorStatusT = 61
-	ErrorStatusInvoiceNotFound             ErrorStatusT = 62
-	ErrorStatusInvalidMonthYearRequest     ErrorStatusT = 63
-	ErrorStatusMalformedInvoiceFile        ErrorStatusT = 64
+	ErrorStatusInvalid                        ErrorStatusT = 0
+	ErrorStatusInvalidEmailOrPassword         ErrorStatusT = 1
+	ErrorStatusMalformedEmail                 ErrorStatusT = 2
+	ErrorStatusVerificationTokenInvalid       ErrorStatusT = 3
+	ErrorStatusVerificationTokenExpired       ErrorStatusT = 4
+	ErrorStatusProposalMissingFiles           ErrorStatusT = 5
+	ErrorStatusProposalNotFound               ErrorStatusT = 6
+	ErrorStatusProposalDuplicateFilenames     ErrorStatusT = 7
+	ErrorStatusProposalInvalidTitle           ErrorStatusT = 8
+	ErrorStatusMaxMDsExceededPolicy           ErrorStatusT = 9
+	ErrorStatusMaxImagesExceededPolicy        ErrorStatusT = 10
+	ErrorStatusMaxMDSizeExceededPolicy        ErrorStatusT = 11
+	ErrorStatusMaxImageSizeExceededPolicy     ErrorStatusT = 12
+	ErrorStatusMalformedPassword              ErrorStatusT = 13
+	ErrorStatusCommentNotFound                ErrorStatusT = 14
+	ErrorStatusInvalidFilename                ErrorStatusT = 15
+	ErrorStatusInvalidFileDigest              ErrorStatusT = 16
+	ErrorStatusInvalidBase64                  ErrorStatusT = 17
+	ErrorStatusInvalidMIMEType                ErrorStatusT = 18
+	ErrorStatusUnsupportedMIMEType            ErrorStatusT = 19
+	ErrorStatusInvalidPropStatusTransition    ErrorStatusT = 20
+	ErrorStatusInvalidPublicKey               ErrorStatusT = 21
+	ErrorStatusNoPublicKey                    ErrorStatusT = 22
+	ErrorStatusInvalidSignature               ErrorStatusT = 23
+	ErrorStatusInvalidInput                   ErrorStatusT = 24
+	ErrorStatusInvalidSigningKey              ErrorStatusT = 25
+	ErrorStatusCommentLengthExceededPolicy    ErrorStatusT = 26
+	ErrorStatusUserNotFound                   ErrorStatusT = 27
+	ErrorStatusWrongStatus                    ErrorStatusT = 28
+	ErrorStatusNotLoggedIn                    ErrorStatusT = 29
+	ErrorStatusUserNotPaid                    ErrorStatusT = 30
+	ErrorStatusReviewerAdminEqualsAuthor      ErrorStatusT = 31
+	ErrorStatusMalformedUsername              ErrorStatusT = 32
+	ErrorStatusDuplicateUsername              ErrorStatusT = 33
+	ErrorStatusVerificationTokenUnexpired     ErrorStatusT = 34
+	ErrorStatusCannotVerifyPayment            ErrorStatusT = 35
+	ErrorStatusDuplicatePublicKey             ErrorStatusT = 36
+	ErrorStatusInvalidPropVoteStatus          ErrorStatusT = 37
+	ErrorStatusUserLocked                     ErrorStatusT = 38
+	ErrorStatusNoProposalCredits              ErrorStatusT = 39
+	ErrorStatusInvalidUserManageAction        ErrorStatusT = 40
+	ErrorStatusUserActionNotAllowed           ErrorStatusT = 41
+	ErrorStatusWrongVoteStatus                ErrorStatusT = 42
+	ErrorStatusCannotCommentOnProp            ErrorStatusT = 43
+	ErrorStatusCannotVoteOnPropComment        ErrorStatusT = 44
+	ErrorStatusChangeMessageCannotBeBlank     ErrorStatusT = 45
+	ErrorStatusCensorReasonCannotBeBlank      ErrorStatusT = 46
+	ErrorStatusCannotCensorComment            ErrorStatusT = 47
+	ErrorStatusUserNotAuthor                  ErrorStatusT = 48
+	ErrorStatusVoteNotAuthorized              ErrorStatusT = 49
+	ErrorStatusVoteAlreadyAuthorized          ErrorStatusT = 50
+	ErrorStatusInvalidAuthVoteAction          ErrorStatusT = 51
+	ErrorStatusUserDeactivated                ErrorStatusT = 52
+	ErrorStatusInvalidPropVoteBits            ErrorStatusT = 53
+	ErrorStatusInvalidPropVoteParams          ErrorStatusT = 54
+	ErrorStatusEmailNotVerified               ErrorStatusT = 55
+	ErrorStatusInvalidUUID                    ErrorStatusT = 56
+	ErrorStatusInvalidLikeCommentAction       ErrorStatusT = 57
+	ErrorStatusInvalidCensorshipToken         ErrorStatusT = 58
+	ErrorStatusEmailAlreadyVerified           ErrorStatusT = 59
+	ErrorStatusMalformedName                  ErrorStatusT = 60
+	ErrorStatusMalformedLocation              ErrorStatusT = 61
+	ErrorStatusInvoiceNotFound                ErrorStatusT = 62
+	ErrorStatusInvalidMonthYearRequest        ErrorStatusT = 63
+	ErrorStatusMalformedInvoiceFile           ErrorStatusT = 64
+	ErrorStatusInvalidInvoiceStatusTransition ErrorStatusT = 65
+	ErrorStatusReasonNotProvided              ErrorStatusT = 66
 
 	// Proposal state codes
 	//
@@ -292,70 +294,72 @@ var (
 
 	// ErrorStatus converts error status codes to human readable text.
 	ErrorStatus = map[ErrorStatusT]string{
-		ErrorStatusInvalid:                     "invalid error status",
-		ErrorStatusInvalidEmailOrPassword:      "invalid email or password",
-		ErrorStatusMalformedEmail:              "malformed email",
-		ErrorStatusVerificationTokenInvalid:    "invalid verification token",
-		ErrorStatusVerificationTokenExpired:    "expired verification token",
-		ErrorStatusProposalMissingFiles:        "missing proposal files",
-		ErrorStatusProposalNotFound:            "proposal not found",
-		ErrorStatusProposalDuplicateFilenames:  "duplicate proposal files",
-		ErrorStatusProposalInvalidTitle:        "invalid proposal title",
-		ErrorStatusMaxMDsExceededPolicy:        "maximum markdown files exceeded",
-		ErrorStatusMaxImagesExceededPolicy:     "maximum image files exceeded",
-		ErrorStatusMaxMDSizeExceededPolicy:     "maximum markdown file size exceeded",
-		ErrorStatusMaxImageSizeExceededPolicy:  "maximum image file size exceeded",
-		ErrorStatusMalformedPassword:           "malformed password",
-		ErrorStatusCommentNotFound:             "comment not found",
-		ErrorStatusInvalidFilename:             "invalid filename",
-		ErrorStatusInvalidFileDigest:           "invalid file digest",
-		ErrorStatusInvalidBase64:               "invalid base64 file content",
-		ErrorStatusInvalidMIMEType:             "invalid MIME type detected for file",
-		ErrorStatusUnsupportedMIMEType:         "unsupported MIME type for file",
-		ErrorStatusInvalidPropStatusTransition: "invalid proposal status",
-		ErrorStatusInvalidPublicKey:            "invalid public key",
-		ErrorStatusNoPublicKey:                 "no active public key",
-		ErrorStatusInvalidSignature:            "invalid signature",
-		ErrorStatusInvalidInput:                "invalid input",
-		ErrorStatusInvalidSigningKey:           "invalid signing key",
-		ErrorStatusCommentLengthExceededPolicy: "maximum comment length exceeded",
-		ErrorStatusUserNotFound:                "user not found",
-		ErrorStatusWrongStatus:                 "wrong status",
-		ErrorStatusNotLoggedIn:                 "user not logged in",
-		ErrorStatusUserNotPaid:                 "user hasn't paid paywall",
-		ErrorStatusReviewerAdminEqualsAuthor:   "user cannot change the status of his own proposal",
-		ErrorStatusMalformedUsername:           "malformed username",
-		ErrorStatusDuplicateUsername:           "duplicate username",
-		ErrorStatusVerificationTokenUnexpired:  "verification token not yet expired",
-		ErrorStatusCannotVerifyPayment:         "cannot verify payment at this time",
-		ErrorStatusDuplicatePublicKey:          "public key already taken by another user",
-		ErrorStatusInvalidPropVoteStatus:       "invalid proposal vote status",
-		ErrorStatusUserLocked:                  "user locked due to too many login attempts",
-		ErrorStatusNoProposalCredits:           "no proposal credits",
-		ErrorStatusInvalidUserManageAction:     "invalid user edit action",
-		ErrorStatusUserActionNotAllowed:        "user action is not allowed",
-		ErrorStatusWrongVoteStatus:             "wrong proposal vote status",
-		ErrorStatusCannotCommentOnProp:         "cannot comment on proposal",
-		ErrorStatusCannotVoteOnPropComment:     "cannot vote on proposal comment",
-		ErrorStatusChangeMessageCannotBeBlank:  "status change message cannot be blank",
-		ErrorStatusCensorReasonCannotBeBlank:   "censor comment reason cannot be blank",
-		ErrorStatusCannotCensorComment:         "cannot censor comment",
-		ErrorStatusUserNotAuthor:               "user is not the proposal author",
-		ErrorStatusVoteNotAuthorized:           "vote has not been authorized",
-		ErrorStatusVoteAlreadyAuthorized:       "vote has already been authorized",
-		ErrorStatusInvalidAuthVoteAction:       "invalid authorize vote action",
-		ErrorStatusUserDeactivated:             "user account is deactivated",
-		ErrorStatusInvalidPropVoteBits:         "invalid proposal vote option bits",
-		ErrorStatusInvalidPropVoteParams:       "invalid proposal vote parameters",
-		ErrorStatusEmailNotVerified:            "email address is not verified",
-		ErrorStatusInvalidUUID:                 "invalid user UUID",
-		ErrorStatusInvalidLikeCommentAction:    "invalid like comment action",
-		ErrorStatusInvalidCensorshipToken:      "invalid proposal censorship token",
-		ErrorStatusEmailAlreadyVerified:        "email address is already verified",
-		ErrorStatusMalformedName:               "malformed name",
-		ErrorStatusMalformedLocation:           "malformed location",
-		ErrorStatusInvoiceNotFound:             "invoice cannot be found",
-		ErrorStatusInvalidMonthYearRequest:     "month or year was set, while the other was not",
+		ErrorStatusInvalid:                        "invalid error status",
+		ErrorStatusInvalidEmailOrPassword:         "invalid email or password",
+		ErrorStatusMalformedEmail:                 "malformed email",
+		ErrorStatusVerificationTokenInvalid:       "invalid verification token",
+		ErrorStatusVerificationTokenExpired:       "expired verification token",
+		ErrorStatusProposalMissingFiles:           "missing proposal files",
+		ErrorStatusProposalNotFound:               "proposal not found",
+		ErrorStatusProposalDuplicateFilenames:     "duplicate proposal files",
+		ErrorStatusProposalInvalidTitle:           "invalid proposal title",
+		ErrorStatusMaxMDsExceededPolicy:           "maximum markdown files exceeded",
+		ErrorStatusMaxImagesExceededPolicy:        "maximum image files exceeded",
+		ErrorStatusMaxMDSizeExceededPolicy:        "maximum markdown file size exceeded",
+		ErrorStatusMaxImageSizeExceededPolicy:     "maximum image file size exceeded",
+		ErrorStatusMalformedPassword:              "malformed password",
+		ErrorStatusCommentNotFound:                "comment not found",
+		ErrorStatusInvalidFilename:                "invalid filename",
+		ErrorStatusInvalidFileDigest:              "invalid file digest",
+		ErrorStatusInvalidBase64:                  "invalid base64 file content",
+		ErrorStatusInvalidMIMEType:                "invalid MIME type detected for file",
+		ErrorStatusUnsupportedMIMEType:            "unsupported MIME type for file",
+		ErrorStatusInvalidPropStatusTransition:    "invalid proposal status",
+		ErrorStatusInvalidPublicKey:               "invalid public key",
+		ErrorStatusNoPublicKey:                    "no active public key",
+		ErrorStatusInvalidSignature:               "invalid signature",
+		ErrorStatusInvalidInput:                   "invalid input",
+		ErrorStatusInvalidSigningKey:              "invalid signing key",
+		ErrorStatusCommentLengthExceededPolicy:    "maximum comment length exceeded",
+		ErrorStatusUserNotFound:                   "user not found",
+		ErrorStatusWrongStatus:                    "wrong status",
+		ErrorStatusNotLoggedIn:                    "user not logged in",
+		ErrorStatusUserNotPaid:                    "user hasn't paid paywall",
+		ErrorStatusReviewerAdminEqualsAuthor:      "user cannot change the status of his own proposal",
+		ErrorStatusMalformedUsername:              "malformed username",
+		ErrorStatusDuplicateUsername:              "duplicate username",
+		ErrorStatusVerificationTokenUnexpired:     "verification token not yet expired",
+		ErrorStatusCannotVerifyPayment:            "cannot verify payment at this time",
+		ErrorStatusDuplicatePublicKey:             "public key already taken by another user",
+		ErrorStatusInvalidPropVoteStatus:          "invalid proposal vote status",
+		ErrorStatusUserLocked:                     "user locked due to too many login attempts",
+		ErrorStatusNoProposalCredits:              "no proposal credits",
+		ErrorStatusInvalidUserManageAction:        "invalid user edit action",
+		ErrorStatusUserActionNotAllowed:           "user action is not allowed",
+		ErrorStatusWrongVoteStatus:                "wrong proposal vote status",
+		ErrorStatusCannotCommentOnProp:            "cannot comment on proposal",
+		ErrorStatusCannotVoteOnPropComment:        "cannot vote on proposal comment",
+		ErrorStatusChangeMessageCannotBeBlank:     "status change message cannot be blank",
+		ErrorStatusCensorReasonCannotBeBlank:      "censor comment reason cannot be blank",
+		ErrorStatusCannotCensorComment:            "cannot censor comment",
+		ErrorStatusUserNotAuthor:                  "user is not the proposal author",
+		ErrorStatusVoteNotAuthorized:              "vote has not been authorized",
+		ErrorStatusVoteAlreadyAuthorized:          "vote has already been authorized",
+		ErrorStatusInvalidAuthVoteAction:          "invalid authorize vote action",
+		ErrorStatusUserDeactivated:                "user account is deactivated",
+		ErrorStatusInvalidPropVoteBits:            "invalid proposal vote option bits",
+		ErrorStatusInvalidPropVoteParams:          "invalid proposal vote parameters",
+		ErrorStatusEmailNotVerified:               "email address is not verified",
+		ErrorStatusInvalidUUID:                    "invalid user UUID",
+		ErrorStatusInvalidLikeCommentAction:       "invalid like comment action",
+		ErrorStatusInvalidCensorshipToken:         "invalid proposal censorship token",
+		ErrorStatusEmailAlreadyVerified:           "email address is already verified",
+		ErrorStatusMalformedName:                  "malformed name",
+		ErrorStatusMalformedLocation:              "malformed location",
+		ErrorStatusInvoiceNotFound:                "invoice cannot be found",
+		ErrorStatusInvalidMonthYearRequest:        "month or year was set, while the other was not",
+		ErrorStatusInvalidInvoiceStatusTransition: "invalid invoice status",
+		ErrorStatusReasonNotProvided:              "reason for action not provided",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -139,66 +139,68 @@ const (
 	UserListPageSize = 20
 
 	// Error status codes
-	ErrorStatusInvalid                        ErrorStatusT = 0
-	ErrorStatusInvalidEmailOrPassword         ErrorStatusT = 1
-	ErrorStatusMalformedEmail                 ErrorStatusT = 2
-	ErrorStatusVerificationTokenInvalid       ErrorStatusT = 3
-	ErrorStatusVerificationTokenExpired       ErrorStatusT = 4
-	ErrorStatusProposalMissingFiles           ErrorStatusT = 5
-	ErrorStatusProposalNotFound               ErrorStatusT = 6
-	ErrorStatusProposalDuplicateFilenames     ErrorStatusT = 7
-	ErrorStatusProposalInvalidTitle           ErrorStatusT = 8
-	ErrorStatusMaxMDsExceededPolicy           ErrorStatusT = 9
-	ErrorStatusMaxImagesExceededPolicy        ErrorStatusT = 10
-	ErrorStatusMaxMDSizeExceededPolicy        ErrorStatusT = 11
-	ErrorStatusMaxImageSizeExceededPolicy     ErrorStatusT = 12
-	ErrorStatusMalformedPassword              ErrorStatusT = 13
-	ErrorStatusCommentNotFound                ErrorStatusT = 14
-	ErrorStatusInvalidFilename                ErrorStatusT = 15
-	ErrorStatusInvalidFileDigest              ErrorStatusT = 16
-	ErrorStatusInvalidBase64                  ErrorStatusT = 17
-	ErrorStatusInvalidMIMEType                ErrorStatusT = 18
-	ErrorStatusUnsupportedMIMEType            ErrorStatusT = 19
-	ErrorStatusInvalidPropStatusTransition    ErrorStatusT = 20
-	ErrorStatusInvalidPublicKey               ErrorStatusT = 21
-	ErrorStatusNoPublicKey                    ErrorStatusT = 22
-	ErrorStatusInvalidSignature               ErrorStatusT = 23
-	ErrorStatusInvalidInput                   ErrorStatusT = 24
-	ErrorStatusInvalidSigningKey              ErrorStatusT = 25
-	ErrorStatusCommentLengthExceededPolicy    ErrorStatusT = 26
-	ErrorStatusUserNotFound                   ErrorStatusT = 27
-	ErrorStatusWrongStatus                    ErrorStatusT = 28
-	ErrorStatusNotLoggedIn                    ErrorStatusT = 29
-	ErrorStatusUserNotPaid                    ErrorStatusT = 30
-	ErrorStatusReviewerAdminEqualsAuthor      ErrorStatusT = 31
-	ErrorStatusMalformedUsername              ErrorStatusT = 32
-	ErrorStatusDuplicateUsername              ErrorStatusT = 33
-	ErrorStatusVerificationTokenUnexpired     ErrorStatusT = 34
-	ErrorStatusCannotVerifyPayment            ErrorStatusT = 35
-	ErrorStatusDuplicatePublicKey             ErrorStatusT = 36
-	ErrorStatusInvalidPropVoteStatus          ErrorStatusT = 37
-	ErrorStatusUserLocked                     ErrorStatusT = 38
-	ErrorStatusNoProposalCredits              ErrorStatusT = 39
-	ErrorStatusInvalidUserManageAction        ErrorStatusT = 40
-	ErrorStatusUserActionNotAllowed           ErrorStatusT = 41
-	ErrorStatusWrongVoteStatus                ErrorStatusT = 42
-	ErrorStatusCannotCommentOnProp            ErrorStatusT = 43
-	ErrorStatusCannotVoteOnPropComment        ErrorStatusT = 44
-	ErrorStatusChangeMessageCannotBeBlank     ErrorStatusT = 45
-	ErrorStatusCensorReasonCannotBeBlank      ErrorStatusT = 46
-	ErrorStatusCannotCensorComment            ErrorStatusT = 47
-	ErrorStatusUserNotAuthor                  ErrorStatusT = 48
-	ErrorStatusVoteNotAuthorized              ErrorStatusT = 49
-	ErrorStatusVoteAlreadyAuthorized          ErrorStatusT = 50
-	ErrorStatusInvalidAuthVoteAction          ErrorStatusT = 51
-	ErrorStatusUserDeactivated                ErrorStatusT = 52
-	ErrorStatusInvalidPropVoteBits            ErrorStatusT = 53
-	ErrorStatusInvalidPropVoteParams          ErrorStatusT = 54
-	ErrorStatusEmailNotVerified               ErrorStatusT = 55
-	ErrorStatusInvalidUUID                    ErrorStatusT = 56
-	ErrorStatusInvalidLikeCommentAction       ErrorStatusT = 57
-	ErrorStatusInvalidCensorshipToken         ErrorStatusT = 58
-	ErrorStatusEmailAlreadyVerified           ErrorStatusT = 59
+	ErrorStatusInvalid                     ErrorStatusT = 0
+	ErrorStatusInvalidEmailOrPassword      ErrorStatusT = 1
+	ErrorStatusMalformedEmail              ErrorStatusT = 2
+	ErrorStatusVerificationTokenInvalid    ErrorStatusT = 3
+	ErrorStatusVerificationTokenExpired    ErrorStatusT = 4
+	ErrorStatusProposalMissingFiles        ErrorStatusT = 5
+	ErrorStatusProposalNotFound            ErrorStatusT = 6
+	ErrorStatusProposalDuplicateFilenames  ErrorStatusT = 7
+	ErrorStatusProposalInvalidTitle        ErrorStatusT = 8
+	ErrorStatusMaxMDsExceededPolicy        ErrorStatusT = 9
+	ErrorStatusMaxImagesExceededPolicy     ErrorStatusT = 10
+	ErrorStatusMaxMDSizeExceededPolicy     ErrorStatusT = 11
+	ErrorStatusMaxImageSizeExceededPolicy  ErrorStatusT = 12
+	ErrorStatusMalformedPassword           ErrorStatusT = 13
+	ErrorStatusCommentNotFound             ErrorStatusT = 14
+	ErrorStatusInvalidFilename             ErrorStatusT = 15
+	ErrorStatusInvalidFileDigest           ErrorStatusT = 16
+	ErrorStatusInvalidBase64               ErrorStatusT = 17
+	ErrorStatusInvalidMIMEType             ErrorStatusT = 18
+	ErrorStatusUnsupportedMIMEType         ErrorStatusT = 19
+	ErrorStatusInvalidPropStatusTransition ErrorStatusT = 20
+	ErrorStatusInvalidPublicKey            ErrorStatusT = 21
+	ErrorStatusNoPublicKey                 ErrorStatusT = 22
+	ErrorStatusInvalidSignature            ErrorStatusT = 23
+	ErrorStatusInvalidInput                ErrorStatusT = 24
+	ErrorStatusInvalidSigningKey           ErrorStatusT = 25
+	ErrorStatusCommentLengthExceededPolicy ErrorStatusT = 26
+	ErrorStatusUserNotFound                ErrorStatusT = 27
+	ErrorStatusWrongStatus                 ErrorStatusT = 28
+	ErrorStatusNotLoggedIn                 ErrorStatusT = 29
+	ErrorStatusUserNotPaid                 ErrorStatusT = 30
+	ErrorStatusReviewerAdminEqualsAuthor   ErrorStatusT = 31
+	ErrorStatusMalformedUsername           ErrorStatusT = 32
+	ErrorStatusDuplicateUsername           ErrorStatusT = 33
+	ErrorStatusVerificationTokenUnexpired  ErrorStatusT = 34
+	ErrorStatusCannotVerifyPayment         ErrorStatusT = 35
+	ErrorStatusDuplicatePublicKey          ErrorStatusT = 36
+	ErrorStatusInvalidPropVoteStatus       ErrorStatusT = 37
+	ErrorStatusUserLocked                  ErrorStatusT = 38
+	ErrorStatusNoProposalCredits           ErrorStatusT = 39
+	ErrorStatusInvalidUserManageAction     ErrorStatusT = 40
+	ErrorStatusUserActionNotAllowed        ErrorStatusT = 41
+	ErrorStatusWrongVoteStatus             ErrorStatusT = 42
+	ErrorStatusCannotCommentOnProp         ErrorStatusT = 43
+	ErrorStatusCannotVoteOnPropComment     ErrorStatusT = 44
+	ErrorStatusChangeMessageCannotBeBlank  ErrorStatusT = 45
+	ErrorStatusCensorReasonCannotBeBlank   ErrorStatusT = 46
+	ErrorStatusCannotCensorComment         ErrorStatusT = 47
+	ErrorStatusUserNotAuthor               ErrorStatusT = 48
+	ErrorStatusVoteNotAuthorized           ErrorStatusT = 49
+	ErrorStatusVoteAlreadyAuthorized       ErrorStatusT = 50
+	ErrorStatusInvalidAuthVoteAction       ErrorStatusT = 51
+	ErrorStatusUserDeactivated             ErrorStatusT = 52
+	ErrorStatusInvalidPropVoteBits         ErrorStatusT = 53
+	ErrorStatusInvalidPropVoteParams       ErrorStatusT = 54
+	ErrorStatusEmailNotVerified            ErrorStatusT = 55
+	ErrorStatusInvalidUUID                 ErrorStatusT = 56
+	ErrorStatusInvalidLikeCommentAction    ErrorStatusT = 57
+	ErrorStatusInvalidCensorshipToken      ErrorStatusT = 58
+	ErrorStatusEmailAlreadyVerified        ErrorStatusT = 59
+
+	// CMS Errors
 	ErrorStatusMalformedName                  ErrorStatusT = 60
 	ErrorStatusMalformedLocation              ErrorStatusT = 61
 	ErrorStatusInvoiceNotFound                ErrorStatusT = 62
@@ -360,6 +362,7 @@ var (
 		ErrorStatusInvalidMonthYearRequest:        "month or year was set, while the other was not",
 		ErrorStatusInvalidInvoiceStatusTransition: "invalid invoice status",
 		ErrorStatusReasonNotProvided:              "reason for action not provided",
+		ErrorStatusMalformedInvoiceFile:           "submitted invoice file is malformed",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -360,7 +360,7 @@ var (
 		ErrorStatusMalformedLocation:              "malformed location",
 		ErrorStatusInvoiceNotFound:                "invoice cannot be found",
 		ErrorStatusInvalidMonthYearRequest:        "month or year was set, while the other was not",
-		ErrorStatusInvalidInvoiceStatusTransition: "invalid invoice status",
+		ErrorStatusInvalidInvoiceStatusTransition: "invalid invoice status transition",
 		ErrorStatusReasonNotProvided:              "reason for action not provided",
 		ErrorStatusMalformedInvoiceFile:           "submitted invoice file is malformed",
 	}

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -683,6 +683,29 @@ func (c *Client) NewInvoice(ni *cms.NewInvoice) (*cms.NewInvoiceReply, error) {
 	return &nir, nil
 }
 
+// EditInvoice edits the specified proposal with the logged in user.
+func (c *Client) EditInvoice(ei *cms.EditInvoice) (*cms.EditInvoiceReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteEditInvoice, ei)
+	if err != nil {
+		return nil, err
+	}
+
+	var eir cms.EditInvoiceReply
+	err = json.Unmarshal(responseBody, &eir)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal EditInvoiceReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(eir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &eir, nil
+}
+
 // ProposalDetails retrieves the specified proposal.
 func (c *Client) ProposalDetails(token string, pd *v1.ProposalsDetails) (*v1.ProposalDetailsReply, error) {
 	responseBody, err := c.makeRequest("GET", "/proposals/"+token, pd)
@@ -1436,6 +1459,30 @@ func (c *Client) InvoiceDetails(token string) (*cms.InvoiceDetailsReply, error) 
 	}
 
 	return &idr, nil
+}
+
+// SetInvoiceStatus changes the status of the specified invoice.
+func (c *Client) SetInvoiceStatus(sis *cms.SetInvoiceStatus) (*cms.SetInvoiceStatusReply, error) {
+	route := "/invoices/" + sis.Token + "/status"
+	responseBody, err := c.makeRequest("POST", route, sis)
+	if err != nil {
+		return nil, err
+	}
+
+	var sisr cms.SetInvoiceStatusReply
+	err = json.Unmarshal(responseBody, &sisr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal SetInvoiceStatusReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(sisr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &sisr, nil
 }
 
 // Close all client connections.

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -683,7 +683,7 @@ func (c *Client) NewInvoice(ni *cms.NewInvoice) (*cms.NewInvoiceReply, error) {
 	return &nir, nil
 }
 
-// EditInvoice edits the specified proposal with the logged in user.
+// EditInvoice edits the specified invoice with the logged in user.
 func (c *Client) EditInvoice(ei *cms.EditInvoice) (*cms.EditInvoiceReply, error) {
 	responseBody, err := c.makeRequest("POST", cms.RouteEditInvoice, ei)
 	if err != nil {

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -62,6 +62,7 @@ type Cmds struct {
 	CensorComment      CensorCommentCmd      `command:"censorcomment" description:"(admin)  censor a proposal comment"`
 	ChangePassword     ChangePasswordCmd     `command:"changepassword" description:"(user)   change the password for the logged in user"`
 	ChangeUsername     ChangeUsernameCmd     `command:"changeusername" description:"(user)   change the username for the logged in user"`
+	EditInvoice        EditInvoiceCmd        `command:"editinvoice" description:"(user)    edit a invoice"`
 	EditProposal       EditProposalCmd       `command:"editproposal" description:"(user)   edit a proposal"`
 	ManageUser         ManageUserCmd         `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
 	EditUser           EditUserCmd           `command:"edituser" description:"(user)   edit the  preferences of the logged in user"`
@@ -90,6 +91,7 @@ type Cmds struct {
 	ResetPassword      ResetPasswordCmd      `command:"resetpassword" description:"(public) reset the password for a user that is not logged in"`
 	Secret             SecretCmd             `command:"secret" description:"(user)   ping politeiawww"`
 	SendFaucetTx       SendFaucetTxCmd       `command:"sendfaucettx" description:"         send a DCR transaction using the Decred testnet faucet"`
+	SetInvoiceStatus   SetInvoiceStatusCmd   `command:"setinvoicestatus" description:"(admin)  set the status of an invoice"`
 	SetProposalStatus  SetProposalStatusCmd  `command:"setproposalstatus" description:"(admin)  set the status of a proposal"`
 	StartVote          StartVoteCmd          `command:"startvote" description:"(admin)  start the voting period on a proposal"`
 	Subscribe          SubscribeCmd          `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`

--- a/politeiawww/cmd/politeiawwwcli/commands/editinvoice.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/editinvoice.go
@@ -1,0 +1,178 @@
+package commands
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/decred/politeia/politeiad/api/v1/mime"
+	"github.com/decred/politeia/politeiawww/api/cms/v1"
+	www "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/util"
+)
+
+// EditInvoiceCmd edits an existing invoice.
+type EditInvoiceCmd struct {
+	Args struct {
+		Token       string   `positional-arg-name:"token" required:"true"` // Censorship token
+		CSV         string   `positional-arg-name:"csvfile"`               // Invoice CSV file
+		Attachments []string `positional-arg-name:"attachmentfiles"`       // Invoice attachments
+	} `positional-args:"true" optional:"true"`
+}
+
+// Execute executes the edit invoice command.
+func (cmd *EditInvoiceCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	csvFile := cmd.Args.CSV
+	attachmentFiles := cmd.Args.Attachments
+
+	if csvFile == "" {
+		return errInvoiceCSVNotFound
+	}
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	// Get server public key
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+
+	files := make([]www.File, 0, www.PolicyMaxImages+1)
+	// Read markdown file into memory and convert to type File
+	fpath := util.CleanAndExpandPath(csvFile)
+
+	csv, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return fmt.Errorf("ReadFile %v: %v", fpath, err)
+	}
+
+	f := www.File{
+		Name:    "invoice.csv",
+		MIME:    mime.DetectMimeType(csv),
+		Digest:  hex.EncodeToString(util.Digest(csv)),
+		Payload: base64.StdEncoding.EncodeToString(csv),
+	}
+
+	files = append(files, f)
+
+	// Read attachment files into memory and convert to type File
+	for _, file := range attachmentFiles {
+		path := util.CleanAndExpandPath(file)
+		attachment, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("ReadFile %v: %v", path, err)
+		}
+
+		f := www.File{
+			Name:    filepath.Base(file),
+			MIME:    mime.DetectMimeType(attachment),
+			Digest:  hex.EncodeToString(util.Digest(attachment)),
+			Payload: base64.StdEncoding.EncodeToString(attachment),
+		}
+
+		files = append(files, f)
+	}
+
+	// Compute merkle root and sign it
+	sig, err := signedMerkleRoot(files, cfg.Identity)
+	if err != nil {
+		return fmt.Errorf("SignMerkleRoot: %v", err)
+	}
+
+	// Setup edit invoice request
+	ei := &v1.EditInvoice{
+		Token:     token,
+		Files:     files,
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+		Signature: sig,
+	}
+
+	// Print request details
+	err = printJSON(ei)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	eir, err := client.EditInvoice(ei)
+	if err != nil {
+		return err
+	}
+
+	// Verify the censorship record
+	pr := www.ProposalRecord{
+		Files:            ei.Files,
+		PublicKey:        ei.PublicKey,
+		Signature:        ei.Signature,
+		CensorshipRecord: eir.Invoice.CensorshipRecord,
+	}
+	err = verifyProposal(pr, vr.PubKey)
+	if err != nil {
+		return fmt.Errorf("unable to verify invoice %v: %v",
+			eir.Invoice.CensorshipRecord.Token, err)
+	}
+
+	// Print response details
+	return printJSON(eir)
+}
+
+// editInvoiceHelpMsg is the output of the help command when 'editinvoice'
+// is specified.
+const editInvoiceHelpMsg = `editinvoice [flags] "token" "csvfile" "attachmentfiles" 
+
+Edit a invoice.
+
+Arguments:
+1. token             (string, required)   Invoice censorship token
+2. csvfile           (string, required)   Edited invoice 
+3. attachmentfiles   (string, optional)   Attachments 
+
+Request:
+{
+  "token":  (string)  Censorship token
+    "files": [
+      {
+        "name":      (string)  Filename 
+        "mime":      (string)  Mime type 
+        "digest":    (string)  File digest 
+        "payload":   (string)  File payload 
+      }
+    ],
+  "publickey": (string)  Public key used to sign invoice
+  "signature": (string)  Signature of the merkle root 
+}
+
+Response:
+{
+  "invoice": {
+    "name":          (string)       Suggested short invoice name 
+    "state":         (PropStateT)   Current state of invoice
+    "status":        (PropStatusT)  Current status of invoice
+    "timestamp":     (int64)        Timestamp of last update of invoice
+    "userid":        (string)       ID of user who submitted invoice
+    "username":      (string)       Username of user who submitted invoice
+    "publickey":     (string)       Public key used to sign invoice
+    "signature":     (string)       Signature of merkle root
+    "files": [
+      {
+        "name":      (string)       Filename 
+        "mime":      (string)       Mime type 
+        "digest":    (string)       File digest 
+        "payload":   (string)       File payload 
+      }
+    ],
+    "numcomments":   (uint)    Number of comments on the invoice
+    "version": 		 (string)  Version of invoice
+    "censorshiprecord": {	
+      "token":       (string)  Censorship token
+      "merkle":      (string)  Merkle root of invoice
+      "signature":   (string)  Server side signature of []byte(Merkle+Token)
+    }
+  }
+}`

--- a/politeiawww/cmd/politeiawwwcli/commands/editinvoice.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/editinvoice.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package commands
 
 import (
@@ -124,13 +128,13 @@ func (cmd *EditInvoiceCmd) Execute(args []string) error {
 	}
 
 	// Verify the censorship record
-	pr := www.ProposalRecord{
+	pr := v1.InvoiceRecord{
 		Files:            ei.Files,
 		PublicKey:        ei.PublicKey,
 		Signature:        ei.Signature,
 		CensorshipRecord: eir.Invoice.CensorshipRecord,
 	}
-	err = verifyProposal(pr, vr.PubKey)
+	err = verifyInvoice(pr, vr.PubKey)
 	if err != nil {
 		return fmt.Errorf("unable to verify invoice %v: %v",
 			eir.Invoice.CensorshipRecord.Token, err)
@@ -142,17 +146,20 @@ func (cmd *EditInvoiceCmd) Execute(args []string) error {
 
 // editInvoiceHelpMsg is the output of the help command when 'editinvoice'
 // is specified.
-const editInvoiceHelpMsg = `editinvoice [flags] "token" "csvfile" "attachmentfiles" 
+const editInvoiceHelpMsg = `editinvoice [flags] "month" "year" token" "csvfile" "attachmentfiles" 
 
 Edit a invoice.
 
 Arguments:
+1. month             (uint, required)     Invoice Month
+2. year              (uint, required)     Invoice Year
 1. token             (string, required)   Invoice censorship token
 2. csvfile           (string, required)   Edited invoice 
 3. attachmentfiles   (string, optional)   Attachments 
 
 Request:
 {
+  "month":  (uint)    Invoice Month
   "token":  (string)  Censorship token
     "files": [
       {
@@ -169,7 +176,8 @@ Request:
 Response:
 {
   "invoice": {
-    "name":          (string)       Suggested short invoice name 
+    "month":         (uint16)       Month of invoice
+    "year":          (uint16)       Year of invoice
     "state":         (PropStateT)   Current state of invoice
     "status":        (PropStatusT)  Current status of invoice
     "timestamp":     (int64)        Timestamp of last update of invoice

--- a/politeiawww/cmd/politeiawwwcli/commands/help.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/help.go
@@ -116,6 +116,10 @@ func (cmd *HelpCmd) Execute(args []string) error {
 		fmt.Printf("%s\n", newInvoiceHelpMsg)
 	case "invoicedetails":
 		fmt.Printf("%s\n", invoiceDetailsHelpMsg)
+	case "editinvoice":
+		fmt.Printf("%s\n", editInvoiceHelpMsg)
+	case "setinvoicestatus":
+		fmt.Printf("%s\n", setInvoiceStatusHelpMsg)
 	default:
 		fmt.Printf("invalid command: use 'politeiawwwcli -h' " +
 			"to view a list of valid commands\n")

--- a/politeiawww/cmd/politeiawwwcli/commands/setinvoicestatus.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/setinvoicestatus.go
@@ -23,10 +23,9 @@ type SetInvoiceStatusCmd struct {
 
 func (cmd *SetInvoiceStatusCmd) Execute(args []string) error {
 	InvoiceStatus := map[string]cms.InvoiceStatusT{
-		"updated":  cms.InvoiceStatusUpdated,
 		"rejected": cms.InvoiceStatusRejected,
 		"approved": cms.InvoiceStatusApproved,
-		"paid":     cms.InvoiceStatusPaid,
+		"disputed": cms.InvoiceStatusDisputed,
 	}
 	// Check for user identity
 	if cfg.Identity == nil {
@@ -64,3 +63,52 @@ func (cmd *SetInvoiceStatusCmd) Execute(args []string) error {
 
 	return printJSON(sisr)
 }
+
+// setInvoiceStatusHelpMsg is the output of the help command when
+// "setinvoicestatus" is specified.
+const setInvoiceStatusHelpMsg = `setinvoicestatus "token" "status"
+
+Set the status of a invoice. Requires admin privileges.
+
+Arguments:
+1. token      (string, required)   Invoice censorship token
+2. status     (string, required)   New status (approved, disputed, rejected)
+3. message    (string)             Status change message
+
+Request:
+{
+  "token":           (string)          Censorship token
+  "invoicestatus":   (InvoiceStatusT)  Invoice status code    
+  "signature":       (string)          Signature of invoice status change
+  "publickey":       (string)          Public key of user changing invoice status
+}
+
+Response:
+{
+  "invoice": {
+	  "month":         (uint16)       Month of invoice
+	  "year":          (uint16)       Year of invoice
+	  "state":         (PropStateT)   Current state of invoice
+	  "status":        (PropStatusT)  Current status of invoice
+	  "timestamp":     (int64)        Timestamp of last update of invoice
+	  "userid":        (string)       ID of user who submitted invoice
+	  "username":      (string)       Username of user who submitted invoice
+	  "publickey":     (string)       Public key used to sign invoice
+	  "signature":     (string)       Signature of merkle root
+	  "files": [
+		{
+		  "name":      (string)       Filename 
+		  "mime":      (string)       Mime type 
+		  "digest":    (string)       File digest 
+		  "payload":   (string)       File payload 
+		}
+	  ],
+	  "numcomments":   (uint)    Number of comments on the invoice
+	  "version": 		 (string)  Version of invoice
+	  "censorshiprecord": {	
+		"token":       (string)  Censorship token
+		"merkle":      (string)  Merkle root of invoice
+		"signature":   (string)  Server side signature of []byte(Merkle+Token)
+	  }
+	}
+}`

--- a/politeiawww/cmd/politeiawwwcli/commands/setinvoicestatus.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/setinvoicestatus.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+type SetInvoiceStatusCmd struct {
+	Args struct {
+		Token  string `positional-arg-name:"token"`
+		Status string `positional-arg-name:"status"`
+		Reason string `positional-arg-name:"reason"`
+	} `positional-args:"true" optional:"true"`
+}
+
+func (cmd *SetInvoiceStatusCmd) Execute(args []string) error {
+	InvoiceStatus := map[string]cms.InvoiceStatusT{
+		"updated":  cms.InvoiceStatusUpdated,
+		"rejected": cms.InvoiceStatusRejected,
+		"approved": cms.InvoiceStatusApproved,
+		"paid":     cms.InvoiceStatusPaid,
+	}
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	status, ok := InvoiceStatus[strings.ToLower(cmd.Args.Status)]
+	if !ok {
+		return fmt.Errorf("Invalid status: %v", cmd.Args.Status)
+	}
+
+	// Setup request
+	sig := cfg.Identity.SignMessage([]byte(cmd.Args.Token +
+		strconv.Itoa(int(status)) + cmd.Args.Reason))
+
+	sis := &cms.SetInvoiceStatus{
+		Token:     cmd.Args.Token,
+		Status:    status,
+		Reason:    cmd.Args.Reason,
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+		Signature: hex.EncodeToString(sig[:]),
+	}
+
+	// Print request details
+	err := printJSON(sis)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	sisr, err := client.SetInvoiceStatus(sis)
+	if err != nil {
+		return err
+	}
+
+	return printJSON(sisr)
+}

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/politeia/decredplugin"
 	database "github.com/decred/politeia/politeiawww/cmsdatabase"
 	"github.com/jinzhu/gorm"
@@ -39,7 +40,7 @@ type cockroachdb struct {
 // CreateInvoice satisfies the backend interface.
 func (c *cockroachdb) NewInvoice(dbInvoice *database.Invoice) error {
 	invoice := EncodeInvoice(dbInvoice)
-
+	spew.Dump(invoice)
 	log.Debugf("CreateInvoice: %v", invoice.Token)
 	return c.recordsdb.Create(invoice).Error
 }

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -21,8 +21,9 @@ const (
 	cmsVersion = "1"
 
 	// Database table names
-	tableNameInvoice  = "invoices"
-	tableNameLineItem = "line_items"
+	tableNameInvoice       = "invoices"
+	tableNameLineItem      = "line_items"
+	tableNameInvoiceChange = "invoice_change"
 
 	UserCMSDB = "invoices_cmsdb" // cmsdb user (read/write access)
 )
@@ -210,6 +211,12 @@ func createCmsTables(tx *gorm.DB) error {
 	}
 	if !tx.HasTable(tableNameLineItem) {
 		err := tx.CreateTable(&LineItem{}).Error
+		if err != nil {
+			return err
+		}
+	}
+	if !tx.HasTable(tableNameInvoiceChange) {
+		err := tx.CreateTable(&InvoiceChange{}).Error
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/politeia/decredplugin"
 	database "github.com/decred/politeia/politeiawww/cmsdatabase"
 	"github.com/jinzhu/gorm"
@@ -40,7 +39,7 @@ type cockroachdb struct {
 // CreateInvoice satisfies the backend interface.
 func (c *cockroachdb) NewInvoice(dbInvoice *database.Invoice) error {
 	invoice := EncodeInvoice(dbInvoice)
-	spew.Dump(invoice)
+
 	log.Debugf("CreateInvoice: %v", invoice.Token)
 	return c.recordsdb.Create(invoice).Error
 }

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -73,8 +73,6 @@ func DecodeInvoice(invoice *Invoice) (*database.Invoice, error) {
 	return &dbInvoice, nil
 }
 
-const lineItemSplitChar = "+"
-
 // EncodeInvoiceLineItem encodes a database.LineItem into a cockroachdb line item.
 func EncodeInvoiceLineItem(dbLineItem *database.LineItem) LineItem {
 	lineItem := LineItem{}

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -5,6 +5,7 @@
 package cockroachdb
 
 import (
+	"strconv"
 	"time"
 
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
@@ -72,9 +73,12 @@ func DecodeInvoice(invoice *Invoice) (*database.Invoice, error) {
 	return &dbInvoice, nil
 }
 
+const lineItemSplitChar = "+"
+
 // EncodeInvoiceLineItem encodes a database.LineItem into a cockroachdb line item.
 func EncodeInvoiceLineItem(dbLineItem *database.LineItem) LineItem {
 	lineItem := LineItem{}
+	lineItem.LineItemKey = dbLineItem.InvoiceToken + strconv.Itoa(int(dbLineItem.LineNumber))
 	lineItem.LineNumber = uint(dbLineItem.LineNumber)
 	lineItem.InvoiceToken = dbLineItem.InvoiceToken
 	lineItem.Type = dbLineItem.Type
@@ -89,8 +93,8 @@ func EncodeInvoiceLineItem(dbLineItem *database.LineItem) LineItem {
 // DecodeInvoiceLineItem decodes a cockroachdb line item into a generic database.LineItem
 func DecodeInvoiceLineItem(lineItem *LineItem) *database.LineItem {
 	dbLineItem := &database.LineItem{}
-	dbLineItem.LineNumber = uint16(lineItem.LineNumber)
 	dbLineItem.InvoiceToken = lineItem.InvoiceToken
+	dbLineItem.LineNumber = uint16(lineItem.LineNumber)
 	dbLineItem.Type = lineItem.Type
 	dbLineItem.Subtype = lineItem.Subtype
 	dbLineItem.Description = lineItem.Description

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -45,6 +45,10 @@ func EncodeInvoice(dbInvoice *database.Invoice) *Invoice {
 		invoice.LineItems = append(invoice.LineItems, invoiceLineItem)
 	}
 
+	for _, dbInvoiceChange := range dbInvoice.Changes {
+		invoiceChange := encodeInvoiceChange(&dbInvoiceChange)
+		invoice.Changes = append(invoice.Changes, invoiceChange)
+	}
 	return &invoice
 }
 
@@ -70,6 +74,10 @@ func DecodeInvoice(invoice *Invoice) (*database.Invoice, error) {
 		dbInvoice.LineItems = append(dbInvoice.LineItems, *dbInvoiceLineItem)
 	}
 
+	for _, invoiceChange := range invoice.Changes {
+		dbInvoiceChanges := decodeInvoiceChange(&invoiceChange)
+		dbInvoice.Changes = append(dbInvoice.Changes, *dbInvoiceChanges)
+	}
 	return &dbInvoice, nil
 }
 
@@ -101,6 +109,24 @@ func DecodeInvoiceLineItem(lineItem *LineItem) *database.LineItem {
 	dbLineItem.TotalCost = lineItem.TotalCost
 
 	return dbLineItem
+}
+
+func encodeInvoiceChange(dbInvoiceChange *database.InvoiceChange) InvoiceChange {
+	invoiceChange := InvoiceChange{}
+	invoiceChange.AdminPublicKey = dbInvoiceChange.AdminPublicKey
+	invoiceChange.NewStatus = uint(dbInvoiceChange.NewStatus)
+	invoiceChange.Reason = dbInvoiceChange.Reason
+	invoiceChange.Timestamp = time.Unix(dbInvoiceChange.Timestamp, 0)
+	return invoiceChange
+}
+
+func decodeInvoiceChange(invoiceChange *InvoiceChange) *database.InvoiceChange {
+	dbInvoiceChange := &database.InvoiceChange{}
+	dbInvoiceChange.AdminPublicKey = invoiceChange.AdminPublicKey
+	dbInvoiceChange.NewStatus = cms.InvoiceStatusT(invoiceChange.NewStatus)
+	dbInvoiceChange.Reason = invoiceChange.Reason
+	dbInvoiceChange.Timestamp = invoiceChange.Timestamp.Unix()
+	return dbInvoiceChange
 }
 
 // DecodeInvoices decodes an array of cockroachdb Invoice instances into

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -25,7 +25,7 @@ type Invoice struct {
 	ServerSignature    string    `gorm:"not null"`
 	Version            string    `gorm:"not null"`
 
-	LineItems []LineItem `gorm:"foreignkey:LineItemKey"`
+	LineItems []LineItem `gorm:"foreignkey:InvoiceToken"`
 }
 
 // TableName returns the table name of the invoices table.

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -25,7 +25,8 @@ type Invoice struct {
 	ServerSignature    string    `gorm:"not null"`
 	Version            string    `gorm:"not null"`
 
-	LineItems []LineItem `gorm:"foreignkey:InvoiceToken"`
+	LineItems []LineItem      `gorm:"foreignkey:InvoiceToken"`
+	Changes   []InvoiceChange `gorm:"foreignkey:InvoiceToken"`
 }
 
 // TableName returns the table name of the invoices table.
@@ -49,4 +50,19 @@ type LineItem struct {
 // TableName returns the table name of the line items table.
 func (LineItem) TableName() string {
 	return tableNameLineItem
+}
+
+// InvoiceChange contains entries for any status update that occurs to a given
+// invoice.  This will give a full history of an invoices history.
+type InvoiceChange struct {
+	InvoiceToken   string    `gorm:"not null"` // Censorship token of the invoice
+	AdminPublicKey string    `gorm:"not null"` // The public of the admin that processed the status change.
+	NewStatus      uint      `gorm:"not null"` // Updated status of the invoice.
+	Reason         string    `gorm:"not null"` // Reason for status updated (required if rejected)
+	Timestamp      time.Time `gorm:"not null"` // The timestamp of the status change.
+}
+
+// TableName returns the table name of the line items table.
+func (InvoiceChange) TableName() string {
+	return tableNameInvoiceChange
 }

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -25,7 +25,7 @@ type Invoice struct {
 	ServerSignature    string    `gorm:"not null"`
 	Version            string    `gorm:"not null"`
 
-	LineItems []LineItem `gorm:"not null"`
+	LineItems []LineItem `gorm:"foreignkey:LineItemKey"`
 }
 
 // TableName returns the table name of the invoices table.
@@ -35,14 +35,15 @@ func (Invoice) TableName() string {
 
 // LineItem is the database model for the database.LineItem type
 type LineItem struct {
-	LineNumber   uint    `gorm:"not null"` // LineNumber of each line item
-	InvoiceToken string  `gorm:"not null"` // Token of the Invoice that has this lineitem
-	Type         string  `gorm:"not null"` // Type of work performed
-	Subtype      string  `gorm:"not null"` // Subtype of work performed
-	Description  string  `gorm:"not null"` // Description of work performed
-	ProposalURL  string  `gorm:"not null"` // Link to politeia proposal that work is associated with
-	Hours        float64 `gorm:"not null"` // Number of Hours
-	TotalCost    float64 `gorm:"not null"` // Total cost of line item
+	LineItemKey  string  `gorm:"primary_key"` // Token of the Invoice + "-" + line number
+	LineNumber   uint    `gorm:"not null"`    // Line number of the line item
+	InvoiceToken string  `gorm:"not null"`    // Censorship token of the invoice
+	Type         string  `gorm:"not null"`    // Type of work performed
+	Subtype      string  `gorm:"not null"`    // Subtype of work performed
+	Description  string  `gorm:"not null"`    // Description of work performed
+	ProposalURL  string  `gorm:"not null"`    // Link to politeia proposal that work is associated with
+	Hours        float64 `gorm:"not null"`    // Number of Hours
+	TotalCost    float64 `gorm:"not null"`    // Total cost of line item
 }
 
 // TableName returns the table name of the line items table.

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -62,7 +62,8 @@ type Invoice struct {
 	ServerSignature    string
 	Version            string // Version number of this invoice
 
-	LineItems []LineItem
+	LineItems []LineItem      // All line items parsed from the raw invoice provided.
+	Changes   []InvoiceChange // All status changes that the invoice has had.
 }
 
 // LineItem contains information about the individual line items contained in an
@@ -76,4 +77,13 @@ type LineItem struct {
 	ProposalURL  string
 	Hours        float64
 	TotalCost    float64
+}
+
+// InvoiceChange contains entries for any status update that occurs to a given
+// invoice.  This will give a full history of an invoices history.
+type InvoiceChange struct {
+	AdminPublicKey string
+	NewStatus      cms.InvoiceStatusT
+	Reason         string
+	Timestamp      int64
 }

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -211,6 +211,8 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleNewComment, permissionLogin)
 	p.addRoute(http.MethodPost, cms.RouteNewInvoice,
 		p.handleNewInvoice, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteEditInvoice,
+		p.handleEditInvoice, permissionLogin)
 	p.addRoute(http.MethodGet, cms.RouteInvoiceDetails,
 		p.handleInvoiceDetails, permissionLogin)
 	p.addRoute(http.MethodGet, cms.RouteUserInvoices,
@@ -230,6 +232,8 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleCensorComment, permissionAdmin)
 	p.addRoute(http.MethodPost, cms.RouteAdminInvoices,
 		p.handleAdminInvoices, permissionAdmin)
+	p.addRoute(http.MethodPost, cms.RouteSetInvoiceStatus,
+		p.handleSetInvoiceStatus, permissionAdmin)
 
 	// Routes for Contractor Management System
 

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -62,8 +62,9 @@ func (p *politeiawww) handleRegisterUser(w http.ResponseWriter, r *http.Request)
 
 // handleNewInvoice handles the incoming new invoice command.
 func (p *politeiawww) handleNewInvoice(w http.ResponseWriter, r *http.Request) {
-	// Get the new proposal command.
 	log.Tracef("handleNewInvoice")
+
+	// Get the new invoice command.
 	var ni cms.NewInvoice
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&ni); err != nil {
@@ -94,10 +95,10 @@ func (p *politeiawww) handleNewInvoice(w http.ResponseWriter, r *http.Request) {
 // handleInvoiceDetails handles the incoming invoice details command. It fetches
 // the complete details for an existing invoice.
 func (p *politeiawww) handleInvoiceDetails(w http.ResponseWriter, r *http.Request) {
-	// Add the path param to the struct.
 	log.Tracef("handleInvoiceDetails")
-	var pd cms.InvoiceDetails
 
+	// Get the invoice details command
+	var pd cms.InvoiceDetails
 	// get version from query string parameters
 	err := util.ParseGetParams(r, &pd)
 	if err != nil {
@@ -108,7 +109,7 @@ func (p *politeiawww) handleInvoiceDetails(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Get proposal token from path parameters
+	// Get invoice token from path parameters
 	pathParams := mux.Vars(r)
 	pd.Token = pathParams["token"]
 
@@ -155,8 +156,9 @@ func (p *politeiawww) handleUserInvoices(w http.ResponseWriter, r *http.Request)
 
 // handleSetInvoiceStatus handles the incoming set invoice status command.
 func (p *politeiawww) handleSetInvoiceStatus(w http.ResponseWriter, r *http.Request) {
-	// Add the path param to the struct.
 	log.Tracef("handleSetInvoiceStatus")
+
+	// Get set invoice command
 	var sis cms.SetInvoiceStatus
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&sis); err != nil {
@@ -216,6 +218,9 @@ func (p *politeiawww) handleAdminInvoices(w http.ResponseWriter, r *http.Request
 
 // handleEditInvoice attempts to edit an invoice
 func (p *politeiawww) handleEditInvoice(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleEditInvoice")
+
+	// Get edit invoice command
 	var ei cms.EditInvoice
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&ei); err != nil {

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -516,7 +516,8 @@ func convertRecordFilesToWWW(f []pd.File) []www.File {
 	}
 	return files
 }
-func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) (*cms.InvoiceRecord, error) {
+
+func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) *cms.InvoiceRecord {
 	invRec := &cms.InvoiceRecord{}
 	invRec.Status = dbInvoice.Status
 	invRec.Timestamp = dbInvoice.Timestamp
@@ -525,7 +526,7 @@ func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) (*cms.
 	invRec.Year = dbInvoice.Year
 	invRec.PublicKey = dbInvoice.PublicKey
 	invRec.Version = dbInvoice.Version
-	return invRec, nil
+	return invRec
 }
 
 func convertRecordToDatabaseInvoice(p pd.Record) (*cmsdatabase.Invoice, error) {

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -464,7 +464,7 @@ func (p *politeiawww) processSetInvoiceStatus(sis cms.SetInvoiceStatus,
 	}
 
 	// Update the database with the metadata changes.
-	dbInvoice.Changes = append(dbInvoice.Changes, cmsdatabase.InvoiceChange{
+	dbInvoice.Changes = append(dbInvoice.Changes, database.InvoiceChange{
 		Timestamp:      changes.Timestamp,
 		AdminPublicKey: changes.AdminPublicKey,
 		NewStatus:      changes.NewStatus,

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -546,6 +546,22 @@ func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms
 		}
 	}
 
+	// Make sure that the edit being submitted is different than the current invoice.
+	// So check the Files to see if the digests are different at all.
+	if len(ei.Files) == len(invRec.Files) {
+		sameFiles := true
+		for i, recFile := range invRec.Files {
+			if recFile.Digest != ei.Files[i].Digest {
+				sameFiles = false
+			}
+		}
+		if sameFiles {
+			return nil, www.UserError{
+				ErrorCode: www.ErrorStatusInvoiceDuplicate,
+			}
+		}
+	}
+
 	// Validate invoice. Convert it to cms.NewInvoice so that
 	// we can reuse the function validateProposal.
 	ni := cms.NewInvoice{

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -689,6 +689,21 @@ func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms
 		return nil, err
 	}
 
+	// Update the cmsdb
+	dbInvoice, err := convertRecordToDatabaseInvoice(pd.Record{
+		Files:            convertPropFilesFromWWW(updatedInvoice.Files),
+		Metadata:         mds,
+		CensorshipRecord: convertInvoiceCensorFromWWW(invRec.CensorshipRecord),
+		Version:          invRec.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = p.cmsDb.UpdateInvoice(dbInvoice)
+	if err != nil {
+		return nil, err
+	}
 	/*
 		// Fire off edit proposal event
 		p.fireEvent(EventTypeProposalEdited,

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -382,37 +382,6 @@ func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails, user 
 	return &reply, nil
 }
 
-// handleSetInvoiceStatus handles the incoming set invoice status command.
-func (p *politeiawww) handleSetInvoiceStatus(w http.ResponseWriter, r *http.Request) {
-	// Add the path param to the struct.
-	log.Tracef("handleSetInvoiceStatus")
-	var sis cms.SetInvoiceStatus
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&sis); err != nil {
-		RespondWithError(w, r, 0, "handleSetInvoiceStatus: unmarshal", www.UserError{
-			ErrorCode: www.ErrorStatusInvalidInput,
-		})
-		return
-	}
-
-	user, err := p.getSessionUser(w, r)
-	if err != nil {
-		RespondWithError(w, r, 0,
-			"handleSetInvoiceStatus: getSessionUser %v", err)
-		return
-	}
-
-	reply, err := p.processSetInvoiceStatus(sis, user)
-	if err != nil {
-		RespondWithError(w, r, 0,
-			"handleSetInvoiceStatus: processSetInvoiceStatus %v", err)
-		return
-	}
-
-	// Reply with the challenge response and censorship token.
-	util.RespondWithJSON(w, http.StatusOK, reply)
-}
-
 // processNewInvoice tries to submit a new proposal to politeiad.
 func (p *politeiawww) processSetInvoiceStatus(sis cms.SetInvoiceStatus, u *user.User) (*cms.SetInvoiceStatusReply, error) {
 
@@ -559,37 +528,6 @@ func statusInSlice(arr []cms.InvoiceStatusT, status cms.InvoiceStatusT) bool {
 	}
 
 	return false
-}
-
-// handleEditInvoice attempts to edit an invoice
-func (p *politeiawww) handleEditInvoice(w http.ResponseWriter, r *http.Request) {
-	var ei cms.EditInvoice
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&ei); err != nil {
-		RespondWithError(w, r, 0, "handleEditInvoice: unmarshal",
-			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidInput,
-			})
-		return
-	}
-
-	user, err := p.getSessionUser(w, r)
-	if err != nil {
-		RespondWithError(w, r, 0,
-			"handleEditInvoice: getSessionUser %v", err)
-		return
-	}
-
-	log.Debugf("handleEditInvoice: %v", ei.Token)
-
-	epr, err := p.processEditInvoice(ei, user)
-	if err != nil {
-		RespondWithError(w, r, 0,
-			"handleEditInvoice: processEditInvoice %v", err)
-		return
-	}
-
-	util.RespondWithJSON(w, http.StatusOK, epr)
 }
 
 // processEditInvoice attempts to edit a proposal on politeiad.

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -700,7 +700,7 @@ func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms
 		return nil, err
 	}
 
-	err = p.cmsDb.UpdateInvoice(dbInvoice)
+	err = p.cmsDB.UpdateInvoice(dbInvoice)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -389,7 +389,9 @@ func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails, user 
 }
 
 // processNewInvoice tries to submit a new proposal to politeiad.
-func (p *politeiawww) processSetInvoiceStatus(sis cms.SetInvoiceStatus, u *user.User) (*cms.SetInvoiceStatusReply, error) {
+func (p *politeiawww) processSetInvoiceStatus(sis cms.SetInvoiceStatus,
+	u *user.User) (*cms.SetInvoiceStatusReply, error) {
+	log.Tracef("processSetInvoiceStatus")
 
 	err := checkPublicKeyAndSignature(u, sis.PublicKey, sis.Signature,
 		sis.Token, strconv.FormatUint(uint64(sis.Status), 10),
@@ -531,6 +533,7 @@ func statusInSlice(arr []cms.InvoiceStatusT, status cms.InvoiceStatusT) bool {
 // processEditInvoice attempts to edit a proposal on politeiad.
 func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms.EditInvoiceReply, error) {
 	log.Tracef("processEditInvoice %v", ei.Token)
+
 	invRec, err := p.getInvoice(ei.Token)
 	if err != nil {
 		return nil, err

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -27,16 +27,23 @@ import (
 )
 
 var (
+	// This covers the possible valid status transitions for any invoices.  If
+	// a current invoice's status does not fall into these 3 categories, then
+	// an admin will not be able to update their status.  For example,
+	// paid or approved invoices cannot have their status changed.
 	validStatusTransitions = map[cms.InvoiceStatusT][]cms.InvoiceStatusT{
+		// New invoices may only be updated to approved, rejected or disputed.
 		cms.InvoiceStatusNew: {
 			cms.InvoiceStatusApproved,
 			cms.InvoiceStatusRejected,
 			cms.InvoiceStatusDisputed,
 		},
+		// Rejected invoices may only be updated to approved or updated.
 		cms.InvoiceStatusRejected: {
 			cms.InvoiceStatusApproved,
 			cms.InvoiceStatusUpdated,
 		},
+		// Updated invoices may only be updated to approved, rejected or disputed.
 		cms.InvoiceStatusUpdated: {
 			cms.InvoiceStatusApproved,
 			cms.InvoiceStatusRejected,


### PR DESCRIPTION
~Requires #735~

EditInvoice allows users to update their invoices based on comments by
administrators.  This will change the status of the invoice back to
InvoiceStatusUpdated so the administrators will be notified that the
invoice must be reviewed again.

SetInvoiceStatus allows administrators to update the status of a given
invoice.  This can be set to updated, disputed, rejected or approved.

For either of these commands, a corresponding request is sent to the
politeiad backend to update the records and keep the updates journaled.