### PR TITLE
www: Add proposal tests

### DIFF
--- a/politeiad/cache/testcache/decred.go
+++ b/politeiad/cache/testcache/decred.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package testcache
+
+import (
+	decred "github.com/decred/politeia/decredplugin"
+	"github.com/decred/politeia/politeiad/cache"
+)
+
+func (c *testcache) getComments(payload string) (string, error) {
+	gc, err := decred.DecodeGetComments([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	c.RLock()
+	defer c.RUnlock()
+
+	gcrb, err := decred.EncodeGetCommentsReply(
+		decred.GetCommentsReply{
+			Comments: c.comments[gc.Token],
+		})
+	if err != nil {
+		return "", err
+	}
+
+	return string(gcrb), nil
+}
+
+func (c *testcache) authorizeVote(cmdPayload, replyPayload string) (string, error) {
+	av, err := decred.DecodeAuthorizeVote([]byte(cmdPayload))
+	if err != nil {
+		return "", err
+	}
+
+	avr, err := decred.DecodeAuthorizeVoteReply([]byte(replyPayload))
+	if err != nil {
+		return "", err
+	}
+
+	av.Receipt = avr.Receipt
+	av.Timestamp = avr.Timestamp
+
+	c.Lock()
+	defer c.Unlock()
+
+	_, ok := c.authorizeVotes[av.Token]
+	if !ok {
+		c.authorizeVotes[av.Token] = make(map[string]decred.AuthorizeVote)
+	}
+
+	c.authorizeVotes[av.Token][avr.RecordVersion] = *av
+
+	return replyPayload, nil
+}
+
+func (c *testcache) startVote(cmdPayload, replyPayload string) (string, error) {
+	sv, err := decred.DecodeStartVote([]byte(cmdPayload))
+	if err != nil {
+		return "", err
+	}
+
+	svr, err := decred.DecodeStartVoteReply([]byte(replyPayload))
+	if err != nil {
+		return "", err
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	// Store start vote data
+	c.startVotes[sv.Vote.Token] = *sv
+	c.startVoteReplies[sv.Vote.Token] = *svr
+
+	return replyPayload, nil
+}
+
+func (c *testcache) voteDetails(payload string) (string, error) {
+	vd, err := decred.DecodeVoteDetails([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	// Lookup the latest record version
+	r, err := c.record(vd.Token)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare reply
+	_, ok := c.authorizeVotes[vd.Token]
+	if !ok {
+		c.authorizeVotes[vd.Token] = make(map[string]decred.AuthorizeVote)
+	}
+
+	vdb, err := decred.EncodeVoteDetailsReply(
+		decred.VoteDetailsReply{
+			AuthorizeVote:  c.authorizeVotes[vd.Token][r.Version],
+			StartVote:      c.startVotes[vd.Token],
+			StartVoteReply: c.startVoteReplies[vd.Token],
+		})
+	if err != nil {
+		return "", err
+	}
+
+	return string(vdb), nil
+}
+
+func (c *testcache) decredExec(cmd, cmdPayload, replyPayload string) (string, error) {
+	switch cmd {
+	case decred.CmdGetComments:
+		return c.getComments(cmdPayload)
+	case decred.CmdAuthorizeVote:
+		return c.authorizeVote(cmdPayload, replyPayload)
+	case decred.CmdStartVote:
+		return c.startVote(cmdPayload, replyPayload)
+	case decred.CmdVoteDetails:
+		return c.voteDetails(cmdPayload)
+	}
+
+	return "", cache.ErrInvalidPluginCmd
+}

--- a/politeiad/cache/testcache/testcache.go
+++ b/politeiad/cache/testcache/testcache.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package testcache
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	decred "github.com/decred/politeia/decredplugin"
+	"github.com/decred/politeia/politeiad/cache"
+)
+
+// testcache provides a implementation of the cache interface that stores
+// records in memory and that can be used for testing.
+type testcache struct {
+	sync.RWMutex
+	records map[string]map[string]cache.Record // [token][version]Record
+
+	// Decred plugin
+	comments         map[string][]decred.Comment                // [token][]Comment
+	authorizeVotes   map[string]map[string]decred.AuthorizeVote // [token][version]AuthorizeVote
+	startVotes       map[string]decred.StartVote                // [token]StartVote
+	startVoteReplies map[string]decred.StartVoteReply           // [token]StartVoteReply
+}
+
+// NewRecords adds a record to the cache.
+func (c *testcache) NewRecord(r cache.Record) error {
+	c.Lock()
+	defer c.Unlock()
+
+	token := r.CensorshipRecord.Token
+	_, ok := c.records[token]
+	if !ok {
+		c.records[token] = make(map[string]cache.Record)
+	}
+
+	c.records[token][r.Version] = r
+	return nil
+}
+
+// record returns the most recent version of a record from the memory cache.
+//
+// This function must be called with the lock held.
+func (c *testcache) record(token string) (*cache.Record, error) {
+	records, ok := c.records[token]
+	if !ok {
+		return nil, cache.ErrRecordNotFound
+	}
+
+	var latest int
+	for version := range records {
+		v, err := strconv.Atoi(version)
+		if err != nil {
+			return nil, fmt.Errorf("parse version '%v' failed: %v",
+				version, err)
+		}
+
+		if v > latest {
+			latest = v
+		}
+	}
+
+	// Sanity check
+	if latest == 0 {
+		return nil, cache.ErrRecordNotFound
+	}
+
+	r := records[strconv.Itoa(latest)]
+	return &r, nil
+}
+
+// Record returns the most recent version of the record.
+func (c *testcache) Record(token string) (*cache.Record, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.record(token)
+}
+
+// recordVersion retreives a specific version of a record from the memory
+// cache.
+//
+// This function must be called with the lock held.
+func (c *testcache) recordVersion(token, version string) (*cache.Record, error) {
+	_, ok := c.records[token]
+	if !ok {
+		return nil, cache.ErrRecordNotFound
+	}
+
+	r, ok := c.records[token][version]
+	if !ok {
+		return nil, cache.ErrRecordNotFound
+	}
+
+	return &r, nil
+}
+
+// RecordVersion returns a specific version of a record.
+func (c *testcache) RecordVersion(token, version string) (*cache.Record, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.recordVersion(token, version)
+}
+
+// UpdateRecord is a stub to satisfy the cache interface.
+func (c *testcache) UpdateRecord(r cache.Record) error {
+	return nil
+}
+
+// UpdateRecordStatus updates the status of a record.
+func (c *testcache) UpdateRecordStatus(token, version string, status cache.RecordStatusT, timestamp int64, metadata []cache.MetadataStream) error {
+	c.Lock()
+	defer c.Unlock()
+
+	// Lookup record
+	r, err := c.recordVersion(token, version)
+	if err != nil {
+		return err
+	}
+
+	// Update record
+	r.Status = status
+	r.Timestamp = timestamp
+	r.Metadata = metadata
+	c.records[token][version] = *r
+
+	return nil
+}
+
+// UpdateRecordMetadata is a stub to satisfy the cache interface.
+func (c *testcache) UpdateRecordMetadata(token string, md []cache.MetadataStream) error {
+	return nil
+}
+
+// Inventory is a stub to satisfy the cache interface.
+func (c *testcache) Inventory() ([]cache.Record, error) {
+	return make([]cache.Record, 0), nil
+}
+
+// InventoryStats is a stub to satisfy the cache interface.
+func (c *testcache) InventoryStats() (*cache.InventoryStats, error) {
+	return &cache.InventoryStats{}, nil
+}
+
+// Setup is a stub to satisfy the cache interface.
+func (c *testcache) Setup() error {
+	return nil
+}
+
+// Build is a stub to satisfy the cache interface.
+func (c *testcache) Build(records []cache.Record) error {
+	return nil
+}
+
+func (c *testcache) RegisterPlugin(p cache.Plugin) error {
+	return nil
+}
+
+// PluginSetup is a stub to satisfy the cache interface.
+func (c *testcache) PluginSetup(id string) error {
+	return nil
+}
+
+// PluginBuild is a stub to satisfy the cache interface.
+func (c *testcache) PluginBuild(id, payload string) error {
+	return nil
+}
+
+// PluginExec is a stub to satisfy the cache interface.
+func (c *testcache) PluginExec(pc cache.PluginCommand) (*cache.PluginCommandReply, error) {
+	var payload string
+	var err error
+	switch pc.ID {
+	case decred.ID:
+		payload, err = c.decredExec(pc.Command,
+			pc.CommandPayload, pc.ReplyPayload)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &cache.PluginCommandReply{
+		ID:      pc.ID,
+		Command: pc.Command,
+		Payload: payload,
+	}, nil
+}
+
+// Close is a stub to satisfy the cache interface.
+func (c *testcache) Close() {}
+
+// New returns a new testcache context.
+func New() *testcache {
+	return &testcache{
+		records:          make(map[string]map[string]cache.Record),
+		comments:         make(map[string][]decred.Comment),
+		authorizeVotes:   make(map[string]map[string]decred.AuthorizeVote),
+		startVotes:       make(map[string]decred.StartVote),
+		startVoteReplies: make(map[string]decred.StartVoteReply),
+	}
+}

--- a/politeiad/testpoliteiad/convert.go
+++ b/politeiad/testpoliteiad/convert.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package testpoliteiad
+
+import (
+	v1 "github.com/decred/politeia/politeiad/api/v1"
+	"github.com/decred/politeia/politeiad/cache"
+)
+
+func convertRecordStatusToCache(status v1.RecordStatusT) cache.RecordStatusT {
+	s := cache.RecordStatusInvalid
+	switch status {
+	case v1.RecordStatusInvalid:
+		s = cache.RecordStatusInvalid
+	case v1.RecordStatusNotReviewed:
+		s = cache.RecordStatusNotReviewed
+	case v1.RecordStatusPublic:
+		s = cache.RecordStatusPublic
+	case v1.RecordStatusCensored:
+		s = cache.RecordStatusCensored
+	case v1.RecordStatusUnreviewedChanges:
+		s = cache.RecordStatusUnreviewedChanges
+	case v1.RecordStatusArchived:
+		s = cache.RecordStatusArchived
+	}
+	return s
+}
+
+func convertCensorshipRecordToCache(r v1.CensorshipRecord) cache.CensorshipRecord {
+	return cache.CensorshipRecord{
+		Token:     r.Token,
+		Merkle:    r.Merkle,
+		Signature: r.Signature,
+	}
+}
+
+func convertMetadataStreamsToCache(m []v1.MetadataStream) []cache.MetadataStream {
+	cm := make([]cache.MetadataStream, 0, len(m))
+	for _, v := range m {
+		cm = append(cm, cache.MetadataStream{
+			ID:      v.ID,
+			Payload: v.Payload,
+		})
+	}
+	return cm
+}
+
+func convertFileToCache(f v1.File) cache.File {
+	return cache.File{
+		Name:    f.Name,
+		MIME:    f.MIME,
+		Digest:  f.Digest,
+		Payload: f.Payload,
+	}
+}
+
+func convertFilesToCache(f []v1.File) []cache.File {
+	files := make([]cache.File, 0, len(f))
+	for _, v := range f {
+		files = append(files, convertFileToCache(v))
+	}
+	return files
+}
+
+func convertRecordToCache(r v1.Record) cache.Record {
+	return cache.Record{
+		Version:          r.Version,
+		Status:           convertRecordStatusToCache(r.Status),
+		Timestamp:        r.Timestamp,
+		CensorshipRecord: convertCensorshipRecordToCache(r.CensorshipRecord),
+		Metadata:         convertMetadataStreamsToCache(r.Metadata),
+		Files:            convertFilesToCache(r.Files),
+	}
+}

--- a/politeiad/testpoliteiad/decred.go
+++ b/politeiad/testpoliteiad/decred.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package testpoliteiad
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+
+	decred "github.com/decred/politeia/decredplugin"
+	v1 "github.com/decred/politeia/politeiad/api/v1"
+)
+
+const (
+	bestBlock uint32 = 1000
+)
+
+func (p *TestPoliteiad) authorizeVote(payload string) (string, error) {
+	av, err := decred.DecodeAuthorizeVote([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	// Sign authorize vote
+	s := p.identity.SignMessage([]byte(av.Signature))
+	av.Receipt = hex.EncodeToString(s[:])
+	av.Timestamp = time.Now().Unix()
+	av.Version = decred.VersionAuthorizeVote
+
+	p.Lock()
+	defer p.Unlock()
+
+	// Store authorize vote
+	_, ok := p.authorizeVotes[av.Token]
+	if !ok {
+		p.authorizeVotes[av.Token] = make(map[string]decred.AuthorizeVote)
+	}
+
+	r, err := p.record(av.Token)
+	if err != nil {
+		return "", err
+	}
+
+	p.authorizeVotes[av.Token][r.Version] = *av
+
+	// Prepare reply
+	avrb, err := decred.EncodeAuthorizeVoteReply(
+		decred.AuthorizeVoteReply{
+			Action:        av.Action,
+			RecordVersion: r.Version,
+			Receipt:       av.Receipt,
+			Timestamp:     av.Timestamp,
+		})
+	if err != nil {
+		return "", err
+	}
+
+	return string(avrb), nil
+}
+
+func (p *TestPoliteiad) startVote(payload string) (string, error) {
+	sv, err := decred.DecodeStartVote([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	// Store start vote
+	p.startVotes[sv.Vote.Token] = *sv
+
+	// Prepare reply
+	endHeight := bestBlock + sv.Vote.Duration
+	svr := decred.StartVoteReply{
+		Version:          decred.VersionStartVoteReply,
+		StartBlockHeight: strconv.FormatUint(uint64(bestBlock), 10),
+		EndHeight:        strconv.FormatUint(uint64(endHeight), 10),
+		EligibleTickets:  []string{},
+	}
+	svrb, err := decred.EncodeStartVoteReply(svr)
+	if err != nil {
+		return "", err
+	}
+
+	// Store reply
+	p.startVoteReplies[sv.Vote.Token] = svr
+
+	return string(svrb), nil
+}
+
+// decredExec executes the passed in plugin command.
+func (p *TestPoliteiad) decredExec(pc v1.PluginCommand) (string, error) {
+	switch pc.Command {
+	case decred.CmdStartVote:
+		return p.startVote(pc.Payload)
+	case decred.CmdAuthorizeVote:
+		return p.authorizeVote(pc.Payload)
+	}
+	return "", fmt.Errorf("invalid plugin command")
+}

--- a/politeiad/testpoliteiad/testpoliteiad.go
+++ b/politeiad/testpoliteiad/testpoliteiad.go
@@ -1,0 +1,419 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package testpoliteiad
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrtime/merkle"
+	decred "github.com/decred/politeia/decredplugin"
+	v1 "github.com/decred/politeia/politeiad/api/v1"
+	"github.com/decred/politeia/politeiad/api/v1/identity"
+	"github.com/decred/politeia/politeiad/cache"
+	"github.com/decred/politeia/util"
+	"github.com/gorilla/mux"
+)
+
+var (
+	errRecordNotFound = errors.New("record not found")
+)
+
+// TestPoliteiad provides an implementation of the politeiad api that can be
+// used for testing politeiad clients.  The api is implemented using an
+// httptest server and all records and plugin data is stored in memory.
+type TestPoliteiad struct {
+	sync.RWMutex
+
+	URL            string // Base url of form http://ipaddr:port
+	PublicIdentity *identity.PublicIdentity
+
+	identity *identity.FullIdentity
+	server   *httptest.Server
+	cache    cache.Cache
+	records  map[string]map[string]v1.Record // [token][version]Record
+
+	// Decred plugin
+	authorizeVotes   map[string]map[string]decred.AuthorizeVote // [token][version]AuthorizeVote
+	startVotes       map[string]decred.StartVote                // [token]StartVote
+	startVoteReplies map[string]decred.StartVoteReply           // [token]StartVoteReply
+}
+
+func respondWithUserError(w http.ResponseWriter,
+	errorCode v1.ErrorStatusT, errorContext []string) {
+	util.RespondWithJSON(w, http.StatusBadRequest, v1.UserErrorReply{
+		ErrorCode:    errorCode,
+		ErrorContext: errorContext,
+	})
+}
+
+// merkleRoot returns a hex encoded merkle root of the passed in files.
+func merkleRoot(files []v1.File) (string, error) {
+	if len(files) == 0 {
+		return "", fmt.Errorf("no files")
+	}
+
+	digests := make([]*[sha256.Size]byte, len(files))
+	for i, f := range files {
+		// Compute file digest
+		b, err := base64.StdEncoding.DecodeString(f.Payload)
+		if err != nil {
+			return "", fmt.Errorf("decode payload for file %v: %v",
+				f.Name, err)
+		}
+		digest := util.Digest(b)
+
+		// Compare against digest that came with the file
+		d, ok := util.ConvertDigest(f.Digest)
+		if !ok {
+			return "", fmt.Errorf("invalid digest: file:%v digest:%v",
+				f.Name, f.Digest)
+		}
+		if !bytes.Equal(digest, d[:]) {
+			return "", fmt.Errorf("digests do not match for file %v",
+				f.Name)
+		}
+
+		// Digest is valid
+		digests[i] = &d
+	}
+
+	// Compute merkle root
+	return hex.EncodeToString(merkle.Root(digests)[:]), nil
+}
+
+// addRecord adds a record to the records store.
+//
+// This function must be called without the lock held.
+func (p *TestPoliteiad) addRecord(r v1.Record) {
+	p.Lock()
+	defer p.Unlock()
+
+	_, ok := p.records[r.CensorshipRecord.Token]
+	if !ok {
+		p.records[r.CensorshipRecord.Token] = make(map[string]v1.Record)
+	}
+
+	p.records[r.CensorshipRecord.Token][r.Version] = r
+}
+
+// record returns the latest version of the specified record.
+//
+// This function must be called with the lock held.
+func (p *TestPoliteiad) record(token string) (*v1.Record, error) {
+	records, ok := p.records[token]
+	if !ok {
+		return nil, errRecordNotFound
+	}
+
+	var latest int
+	for version := range records {
+		v, err := strconv.Atoi(version)
+		if err != nil {
+			return nil, fmt.Errorf("parse version '%v' failed: %v",
+				version, err)
+		}
+
+		if v > latest {
+			latest = v
+		}
+	}
+
+	// Sanity check
+	if latest == 0 {
+		return nil, errRecordNotFound
+	}
+
+	r := records[strconv.Itoa(latest)]
+	return &r, nil
+}
+
+func (p *TestPoliteiad) handleNewRecord(w http.ResponseWriter, r *http.Request) {
+	// Decode request
+	var t v1.NewRecord
+	d := json.NewDecoder(r.Body)
+	if err := d.Decode(&t); err != nil {
+		util.RespondWithJSON(w, http.StatusBadRequest, err)
+		return
+	}
+
+	// Verify challenge
+	challenge, err := hex.DecodeString(t.Challenge)
+	if err != nil || len(challenge) != v1.ChallengeSize {
+		respondWithUserError(w, v1.ErrorStatusInvalidChallenge, nil)
+		return
+	}
+
+	// Prepare response
+	tokenb, err := util.Random(v1.TokenSize)
+	if err != nil {
+		util.RespondWithJSON(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	merkle, err := merkleRoot(t.Files)
+	if err != nil {
+		util.RespondWithJSON(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	token := hex.EncodeToString(tokenb)
+	sig := p.identity.SignMessage([]byte(merkle + token))
+	resp := p.identity.SignMessage(challenge)
+	cr := v1.CensorshipRecord{
+		Merkle:    merkle,
+		Token:     token,
+		Signature: hex.EncodeToString(sig[:]),
+	}
+
+	// Add record to politeiad store
+	p.addRecord(v1.Record{
+		Status:           v1.RecordStatusNotReviewed,
+		Timestamp:        time.Now().Unix(),
+		Version:          "1",
+		Metadata:         t.Metadata,
+		Files:            t.Files,
+		CensorshipRecord: cr,
+	})
+
+	// Send response
+	util.RespondWithJSON(w, http.StatusOK, v1.NewRecordReply{
+		Response:         hex.EncodeToString(resp[:]),
+		CensorshipRecord: cr,
+	})
+}
+
+func (p *TestPoliteiad) handleSetUnvettedStatus(w http.ResponseWriter, r *http.Request) {
+	// Decode request
+	var t v1.SetUnvettedStatus
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&t); err != nil {
+		respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
+
+	// Verify challenge
+	challenge, err := hex.DecodeString(t.Challenge)
+	if err != nil || len(challenge) != v1.ChallengeSize {
+		respondWithUserError(w, v1.ErrorStatusInvalidChallenge, nil)
+		return
+	}
+	response := p.identity.SignMessage(challenge)
+
+	// Validate token
+	_, err = util.ConvertStringToken(t.Token)
+	if err != nil {
+		respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
+
+	// Lookup record
+	rc, err := p.record(t.Token)
+	if err != nil {
+		if err == errRecordNotFound {
+			respondWithUserError(w, v1.ErrorStatusRecordFound, nil)
+			return
+		}
+
+		util.RespondWithJSON(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// Overwrite specified metadata
+	for i, j := range rc.Metadata {
+		for _, v := range t.MDOverwrite {
+			if j.ID == v.ID {
+				rc.Metadata[i] = v
+			}
+		}
+	}
+
+	// Update record
+	rc.Status = t.Status
+	rc.Timestamp = time.Now().Unix()
+	rc.Metadata = append(rc.Metadata, t.MDAppend...)
+	p.addRecord(*rc)
+
+	// Update cache
+	s := convertRecordStatusToCache(rc.Status)
+	m := convertMetadataStreamsToCache(rc.Metadata)
+	err = p.cache.UpdateRecordStatus(t.Token, rc.Version,
+		s, rc.Timestamp, m)
+	if err != nil {
+		log.Printf("cache update record status: %v", err)
+	}
+
+	// Send response
+	util.RespondWithJSON(w, http.StatusOK,
+		v1.SetUnvettedStatusReply{
+			Response: hex.EncodeToString(response[:]),
+		})
+}
+
+func (p *TestPoliteiad) handleSetVettedStatus(w http.ResponseWriter, r *http.Request) {
+	// Decode request
+	var t v1.SetVettedStatus
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&t); err != nil {
+		respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
+
+	// Verify challenge
+	challenge, err := hex.DecodeString(t.Challenge)
+	if err != nil || len(challenge) != v1.ChallengeSize {
+		respondWithUserError(w, v1.ErrorStatusInvalidChallenge, nil)
+		return
+	}
+	response := p.identity.SignMessage(challenge)
+
+	// Validate token
+	_, err = util.ConvertStringToken(t.Token)
+	if err != nil {
+		respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
+
+	// Lookup record
+	rc, err := p.record(t.Token)
+	if err != nil {
+		if err == errRecordNotFound {
+			respondWithUserError(w, v1.ErrorStatusRecordFound, nil)
+			return
+		}
+
+		util.RespondWithJSON(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// Overwrite specified metadata
+	for i, j := range rc.Metadata {
+		for _, v := range t.MDOverwrite {
+			if j.ID == v.ID {
+				rc.Metadata[i] = v
+			}
+		}
+	}
+
+	// Update record
+	rc.Status = t.Status
+	rc.Timestamp = time.Now().Unix()
+	rc.Metadata = append(rc.Metadata, t.MDAppend...)
+	p.addRecord(*rc)
+
+	// Update cache
+	s := convertRecordStatusToCache(rc.Status)
+	m := convertMetadataStreamsToCache(rc.Metadata)
+	err = p.cache.UpdateRecordStatus(t.Token, rc.Version,
+		s, rc.Timestamp, m)
+	if err != nil {
+		log.Printf("cache update record status: %v", err)
+	}
+
+	// Send response
+	util.RespondWithJSON(w, http.StatusOK,
+		v1.SetUnvettedStatusReply{
+			Response: hex.EncodeToString(response[:]),
+		})
+}
+
+// Plugin is a pass through function for plugin commands. The plugin command
+// is executed in politeiad and is then passed to the cache. This function
+// is intended to be used as a way to setup test data.
+func (p *TestPoliteiad) Plugin(t *testing.T, pc v1.PluginCommand) {
+	t.Helper()
+
+	// Execute plugin command
+	var payload string
+	var err error
+	switch pc.ID {
+	case decred.ID:
+		payload, err = p.decredExec(pc)
+	default:
+		t.Fatalf("invalid plugin")
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send plugin cmd to cache
+	_, err = p.cache.PluginExec(
+		cache.PluginCommand{
+			ID:             pc.ID,
+			Command:        pc.Command,
+			CommandPayload: pc.Payload,
+			ReplyPayload:   payload,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AddRecord adds a record to the politeiad records store and to the cache.
+// This function is intended to be used as a way to setup test data.
+func (p *TestPoliteiad) AddRecord(t *testing.T, r v1.Record) {
+	t.Helper()
+
+	// Add record to memory store
+	p.addRecord(r)
+
+	// Add record to cache
+	err := p.cache.NewRecord(convertRecordToCache(r))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Close shuts down the httptest server.
+func (p *TestPoliteiad) Close() {
+	p.server.Close()
+}
+
+// New returns a new TestPoliteiad context.
+func New(t *testing.T, c cache.Cache) *TestPoliteiad {
+	t.Helper()
+
+	// Setup politeiad identity
+	id, err := identity.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Init context
+	p := TestPoliteiad{
+		PublicIdentity:   &id.Public,
+		identity:         id,
+		cache:            c,
+		records:          make(map[string]map[string]v1.Record),
+		authorizeVotes:   make(map[string]map[string]decred.AuthorizeVote),
+		startVotes:       make(map[string]decred.StartVote),
+		startVoteReplies: make(map[string]decred.StartVoteReply),
+	}
+
+	// Setup routes
+	router := mux.NewRouter()
+	router.HandleFunc(v1.NewRecordRoute, p.handleNewRecord)
+	router.HandleFunc(v1.SetUnvettedStatusRoute, p.handleSetUnvettedStatus)
+	router.HandleFunc(v1.SetVettedStatusRoute, p.handleSetVettedStatus)
+
+	// Setup the test server
+	p.server = httptest.NewServer(router)
+	p.URL = p.server.URL
+
+	return &p
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -32,19 +32,19 @@ var (
 	cfg    *config.Config
 	client *wwwclient.Client
 
-	// errUserIdentityNotFound is emitted when a user identity is
-	// required but the config object does not contain one.
-	errUserIdentityNotFound = errors.New("user identity not found.  You must " +
+	// errUserIdentityNotFound is emitted when a user identity is required
+	// but the config object does not contain one.
+	errUserIdentityNotFound = errors.New("user identity not found; you must " +
 		"either create a new user or use the updateuserkey command to generate " +
-		"a new identity for the logged in user.")
+		"a new identity for the logged in user")
 
-	// errProposalMDNotFound is emitted when a proposal markdown file
-	// is required but has not been passed into the command.
-	errProposalMDNotFound = errors.New("proposal markdown file not found.  " +
-		"You must either provide a markdown file or use the --random flag.")
+	// errProposalMDNotFound is emitted when a proposal markdown file is
+	// required but has not been passed into the command.
+	errProposalMDNotFound = errors.New("proposal markdown file not found; " +
+		"you must either provide a markdown file or use the --random flag")
 
-	// errInvalidBeforeAfterUsage is emitted when the command flags
-	// 'before' and 'after' are used at the same time.
+	// errInvalidBeforeAfterUsage is emitted when the command flags 'before'
+	// and 'after' are used at the same time.
 	errInvalidBeforeAfterUsage = errors.New("the 'before' and 'after' flags " +
 		"cannot be used at the same time")
 
@@ -153,7 +153,7 @@ func printJSON(body interface{}) error {
 	return nil
 }
 
-// PromptPassphrase is used to prompt the user for the private passphrase to
+// promptPassphrase is used to prompt the user for the private passphrase to
 // their wallet.
 func promptPassphrase() ([]byte, error) {
 	prompt := "Enter the private passphrase of your wallet: "

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -158,6 +158,14 @@ func convertPropCensorFromPD(f pd.CensorshipRecord) www.CensorshipRecord {
 	}
 }
 
+func convertPropCensorFromWWW(f www.CensorshipRecord) pd.CensorshipRecord {
+	return pd.CensorshipRecord{
+		Token:     f.Token,
+		Merkle:    f.Merkle,
+		Signature: f.Signature,
+	}
+}
+
 func convertErrorStatusFromPD(s int) www.ErrorStatusT {
 	switch pd.ErrorStatusT(s) {
 	case pd.ErrorStatusInvalidFileDigest:

--- a/politeiawww/events.go
+++ b/politeiawww/events.go
@@ -120,6 +120,10 @@ func (p *politeiawww) getProposalAndAuthor(token string) (*www.ProposalRecord, *
 //
 // This function must be called WITHOUT the mutex held.
 func (p *politeiawww) fireEvent(eventType EventT, data interface{}) {
+	if p.test {
+		return
+	}
+
 	p.Lock()
 	defer p.Unlock()
 

--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -267,7 +267,7 @@ func ProposalCreditBalance(u *user.User) uint64 {
 // credits.
 func (p *politeiawww) UserHasProposalCredits(u *user.User) bool {
 	// Return true when running unit tests or if paywall is disabled
-	if p.test || !p.paywallIsEnabled() {
+	if !p.paywallIsEnabled() {
 		return true
 	}
 	return ProposalCreditBalance(u) > 0
@@ -278,7 +278,7 @@ func (p *politeiawww) UserHasProposalCredits(u *user.User) bool {
 // list, and then updates the user database.
 func (p *politeiawww) SpendProposalCredit(u *user.User, token string) error {
 	// Skip when running unit tests or if paywall is disabled.
-	if p.test || !p.paywallIsEnabled() {
+	if !p.paywallIsEnabled() {
 		return nil
 	}
 

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -16,10 +16,14 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/decred/dcrtime/merkle"
+	"github.com/decred/politeia/decredplugin"
+	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiad/api/v1/mime"
+	"github.com/decred/politeia/politeiad/testpoliteiad"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/user"
 	"github.com/decred/politeia/util"
@@ -89,6 +93,37 @@ func createFileMD(t *testing.T, size int, title string) *www.File {
 	}
 }
 
+// newFileRandomMD returns a File with the name index.md that contains random
+// base64 text.
+func newFileRandomMD(t *testing.T) www.File {
+	t.Helper()
+
+	r, err := util.Random(www.PolicyMinProposalNameLength)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	title := fmt.Sprintf("%s\n\n", hex.EncodeToString(r))
+	b.WriteString(title)
+
+	// Add ten lines of random base64 text.
+	for i := 0; i < 10; i++ {
+		r, err := util.Random(32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.WriteString(base64.StdEncoding.EncodeToString(r) + "\n")
+	}
+
+	return www.File{
+		Name:    "index.md",
+		MIME:    mime.DetectMimeType(b.Bytes()),
+		Digest:  hex.EncodeToString(util.Digest(b.Bytes())),
+		Payload: base64.StdEncoding.EncodeToString(b.Bytes()),
+	}
+}
+
 // createNewProposal computes the merkle root of the given files, signs the
 // merkle root with the given identity then returns a NewProposal object.
 func createNewProposal(t *testing.T, id *identity.FullIdentity, files []www.File) *www.NewProposal {
@@ -119,10 +154,226 @@ func createNewProposal(t *testing.T, id *identity.FullIdentity, files []www.File
 	}
 }
 
+// merkleRoot returns a hex encoded merkle root of the passed in files.
+func merkleRoot(t *testing.T, files []www.File) string {
+	t.Helper()
+
+	if len(files) == 0 {
+		t.Fatalf("no files")
+	}
+
+	digests := make([]*[sha256.Size]byte, len(files))
+	for i, f := range files {
+		// Compute file digest
+		b, err := base64.StdEncoding.DecodeString(f.Payload)
+		if err != nil {
+			t.Fatalf("decode payload for file %v: %v",
+				f.Name, err)
+		}
+		digest := util.Digest(b)
+
+		// Compare against digest that came with the file
+		d, ok := util.ConvertDigest(f.Digest)
+		if !ok {
+			t.Fatalf("invalid digest: file:%v digest:%v",
+				f.Name, f.Digest)
+		}
+		if !bytes.Equal(digest, d[:]) {
+			t.Fatalf("digests do not match for file %v",
+				f.Name)
+		}
+
+		// Digest is valid
+		digests[i] = &d
+	}
+
+	// Compute merkle root
+	return hex.EncodeToString(merkle.Root(digests)[:])
+}
+
+func newStartVote(t *testing.T, token string, id *identity.FullIdentity) www.StartVote {
+	sig := id.SignMessage([]byte(token))
+	return www.StartVote{
+		Signature: hex.EncodeToString(sig[:]),
+		PublicKey: hex.EncodeToString(id.Public.Key[:]),
+		Vote: www.Vote{
+			Token:            token,
+			Mask:             0x03, // bit 0 no, bit 1 yes
+			Duration:         2016,
+			QuorumPercentage: 10,
+			PassPercentage:   75,
+			Options: []www.VoteOption{
+				{
+					Id:          "no",
+					Description: "Don't approve proposal",
+					Bits:        0x01,
+				},
+				{
+					Id:          "yes",
+					Description: "Approve proposal",
+					Bits:        0x02,
+				},
+			},
+		},
+	}
+}
+
+func newStartVoteCmd(t *testing.T, token string, id *identity.FullIdentity) pd.PluginCommand {
+	sv := newStartVote(t, token, id)
+	dsv := convertStartVoteFromWWW(sv)
+	payload, err := decredplugin.EncodeStartVote(dsv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        decredplugin.ID,
+		Command:   decredplugin.CmdStartVote,
+		CommandID: decredplugin.CmdStartVote + " " + sv.Vote.Token,
+		Payload:   string(payload),
+	}
+}
+
+func newAuthorizeVote(token, version, action string, id *identity.FullIdentity) www.AuthorizeVote {
+	sig := id.SignMessage([]byte(token + version + action))
+	return www.AuthorizeVote{
+		Action:    action,
+		Token:     token,
+		Signature: hex.EncodeToString(sig[:]),
+		PublicKey: hex.EncodeToString(id.Public.Key[:]),
+	}
+}
+
+func newAuthorizeVoteCmd(t *testing.T, token, version, action string, id *identity.FullIdentity) pd.PluginCommand {
+	av := newAuthorizeVote(token, version, action, id)
+	dav := convertAuthorizeVoteFromWWW(av)
+	payload, err := decredplugin.EncodeAuthorizeVote(dav)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        decredplugin.ID,
+		Command:   decredplugin.CmdAuthorizeVote,
+		CommandID: decredplugin.CmdAuthorizeVote + " " + av.Token,
+		Payload:   string(payload),
+	}
+}
+
+func newProposalRecord(t *testing.T, u *user.User, id *identity.FullIdentity, s www.PropStatusT) www.ProposalRecord {
+	t.Helper()
+
+	f := newFileRandomMD(t)
+	files := []www.File{f}
+	m := merkleRoot(t, files)
+	sig := id.SignMessage([]byte(m))
+
+	title, err := util.GetProposalName(f.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		publishedAt int64
+		censoredAt  int64
+		abandonedAt int64
+		changeMsg   string
+	)
+
+	switch s {
+	case www.PropStatusCensored:
+		changeMsg = "did not adhere to guidelines"
+		censoredAt = time.Now().Unix()
+	case www.PropStatusPublic:
+		publishedAt = time.Now().Unix()
+	case www.PropStatusAbandoned:
+		changeMsg = "no activity"
+		publishedAt = time.Now().Unix()
+		abandonedAt = time.Now().Unix()
+	}
+
+	tokenb, err := util.Random(pd.TokenSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The token is typically generated in politeiad. This function
+	// generates the token locally to make setting up tests easier.
+	// The censorship record signature is left intentionally blank.
+	return www.ProposalRecord{
+		Name:                title,
+		State:               convertPropStatusToState(s),
+		Status:              s,
+		Timestamp:           time.Now().Unix(),
+		UserId:              u.ID.String(),
+		Username:            u.Username,
+		PublicKey:           u.PublicKey(),
+		Signature:           hex.EncodeToString(sig[:]),
+		Files:               files,
+		NumComments:         0,
+		Version:             "1",
+		StatusChangeMessage: changeMsg,
+		PublishedAt:         publishedAt,
+		CensoredAt:          censoredAt,
+		AbandonedAt:         abandonedAt,
+		CensorshipRecord: www.CensorshipRecord{
+			Token:     hex.EncodeToString(tokenb),
+			Merkle:    m,
+			Signature: "",
+		},
+	}
+}
+
+func convertPropToPD(t *testing.T, p www.ProposalRecord) pd.Record {
+	t.Helper()
+
+	name, err := getProposalName(p.Files)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	md, err := encodeBackendProposalMetadata(BackendProposalMetadata{
+		Version:   BackendProposalMetadataVersion,
+		Timestamp: time.Now().Unix(),
+		Name:      name,
+		PublicKey: p.PublicKey,
+		Signature: p.Signature,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mdStreams := []pd.MetadataStream{{
+		ID:      mdStreamGeneral,
+		Payload: string(md),
+	}}
+
+	return pd.Record{
+		Status:           convertPropStatusFromWWW(p.Status),
+		Timestamp:        p.Timestamp,
+		Version:          p.Version,
+		Metadata:         mdStreams,
+		CensorshipRecord: convertPropCensorFromWWW(p.CensorshipRecord),
+		Files:            convertPropFilesFromWWW(p.Files),
+	}
+}
+
 func TestValidateProposal(t *testing.T) {
 	// Setup politeiawww and a test user
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	usr, id := newUser(t, p, true, false)
 
@@ -432,6 +683,427 @@ func TestFilterProposals(t *testing.T) {
 
 		fail:
 			t.Errorf("got %v, want %v", got, want)
+		})
+	}
+}
+
+func TestProcessNewProposal(t *testing.T) {
+	// Setup test environment
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
+
+	td := testpoliteiad.New(t, p.cache)
+	defer td.Close()
+
+	p.cfg.RPCHost = td.URL
+	p.cfg.Identity = td.PublicIdentity
+
+	// Create a user that has not paid their registration fee.
+	usrUnpaid, _ := newUser(t, p, true, false)
+
+	// Create a user that has paid their registration
+	// fee but does not have any proposal credits.
+	usrNoCredits, _ := newUser(t, p, true, false)
+	payRegistrationFee(t, p, usrNoCredits)
+
+	// Create a user that has paid their registration
+	// fee and has purchased proposal credits.
+	usrValid, id := newUser(t, p, true, false)
+	payRegistrationFee(t, p, usrValid)
+	addProposalCredits(t, p, usrValid, 10)
+
+	// Create a NewProposal
+	f := newFileRandomMD(t)
+	np := createNewProposal(t, id, []www.File{f})
+
+	// Setup tests
+	var tests = []struct {
+		name string
+		np   *www.NewProposal
+		usr  *user.User
+		want error
+	}{
+		{"unpaid registration fee", np, usrUnpaid,
+			www.UserError{
+				ErrorCode: www.ErrorStatusUserNotPaid,
+			}},
+
+		{"no proposal credits", np, usrNoCredits,
+			www.UserError{
+				ErrorCode: www.ErrorStatusNoProposalCredits,
+			}},
+
+		{"invalid proposal",
+			&www.NewProposal{
+				Files:     np.Files,
+				PublicKey: np.PublicKey,
+				Signature: "",
+			},
+			usrValid,
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidSignature,
+			}},
+
+		{"success", np, usrValid, nil},
+	}
+
+	// Run tests
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			npr, err := p.processNewProposal(*v.np, v.usr)
+			got := errToStr(err)
+			want := errToStr(v.want)
+
+			if got != want {
+				t.Errorf("got error %v, want %v",
+					got, want)
+			}
+
+			if v.want != nil {
+				// Test case passes
+				return
+			}
+
+			// Validate success case
+			if npr == nil {
+				t.Errorf("NewProposalReply is nil")
+			}
+
+			// Ensure a proposal credit has been deducted
+			// from the user's account.
+			u, err := p.db.UserGet(v.usr.Email)
+			if err != nil {
+				t.Error(err)
+			}
+
+			gotCredits := len(u.UnspentProposalCredits)
+			wantCredits := len(v.usr.UnspentProposalCredits)
+			if gotCredits != wantCredits {
+				t.Errorf("got num proposal credits %v, want %v",
+					gotCredits, wantCredits)
+			}
+		})
+	}
+}
+
+func TestVerifyStatusChange(t *testing.T) {
+	invalid := www.PropStatusInvalid
+	notFound := www.PropStatusNotFound
+	notReviewed := www.PropStatusNotReviewed
+	censored := www.PropStatusCensored
+	public := www.PropStatusPublic
+	unreviewedChanges := www.PropStatusUnreviewedChanges
+	abandoned := www.PropStatusAbandoned
+
+	// Setup tests
+	var tests = []struct {
+		name      string
+		current   www.PropStatusT
+		next      www.PropStatusT
+		wantError bool
+	}{
+		{"not reviewed to invalid", notReviewed, invalid, true},
+		{"not reviewed to not found", notReviewed, notFound, true},
+		{"not reviewed to censored", notReviewed, censored, false},
+		{"not reviewed to public", notReviewed, public, false},
+		{"not reviewed to unreviewed changes", notReviewed, unreviewedChanges,
+			true},
+		{"not reviewed to abandoned", notReviewed, abandoned, true},
+		{"censored to invalid", censored, invalid, true},
+		{"censored to not found", censored, notFound, true},
+		{"censored to not reviewed", censored, notReviewed, true},
+		{"censored to public", censored, public, true},
+		{"censored to unreviewed changes", censored, unreviewedChanges, true},
+		{"censored to abandoned", censored, abandoned, true},
+		{"public to invalid", public, invalid, true},
+		{"public to not found", public, notFound, true},
+		{"public to not reviewed", public, notReviewed, true},
+		{"public to censored", public, censored, true},
+		{"public to unreviewed changes", public, unreviewedChanges, true},
+		{"public to abandoned", public, abandoned, false},
+		{"unreviewed changes to invalid", unreviewedChanges, invalid, true},
+		{"unreviewed changes to not found", unreviewedChanges, notFound, true},
+		{"unreviewed changes to not reviewed", unreviewedChanges, notReviewed,
+			true},
+		{"unreviewed changes to censored", unreviewedChanges, censored, false},
+		{"unreviewed changes to public", unreviewedChanges, public, false},
+		{"unreviewed changes to abandoned", unreviewedChanges, abandoned, true},
+		{"abandoned to invalid", abandoned, invalid, true},
+		{"abandoned to not found", abandoned, notFound, true},
+		{"abandoned to not reviewed", abandoned, notReviewed, true},
+		{"abandoned to censored", abandoned, censored, true},
+		{"abandoned to public", abandoned, public, true},
+		{"abandoned to unreviewed changes", abandoned, unreviewedChanges, true},
+	}
+
+	// Run tests
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			err := verifyStatusChange(v.current, v.next)
+			got := errToStr(err)
+			if v.wantError {
+				want := www.ErrorStatus[www.ErrorStatusInvalidPropStatusTransition]
+				if got != want {
+					t.Errorf("got error %v, want %v",
+						got, want)
+				}
+
+				// Test case passes
+				return
+			}
+
+			if err != nil {
+				t.Errorf("got error %v, want nil",
+					got)
+			}
+		})
+	}
+}
+
+func TestProcessSetProposalStatus(t *testing.T) {
+	// Setup test environment
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
+
+	d := newTestPoliteiad(t, p)
+	defer d.Close()
+
+	// Create test data
+	admin, id := newUser(t, p, true, true)
+
+	changeMsgCensored := "proposal did not meet guidelines"
+	changeMsgAbandoned := "no activity"
+
+	statusPublic := strconv.Itoa(int(www.PropStatusPublic))
+	statusCensored := strconv.Itoa(int(www.PropStatusCensored))
+	statusAbandoned := strconv.Itoa(int(www.PropStatusAbandoned))
+
+	propNotReviewed := newProposalRecord(t, admin, id, www.PropStatusNotReviewed)
+	propPublic := newProposalRecord(t, admin, id, www.PropStatusPublic)
+
+	tokenNotReviewed := propNotReviewed.CensorshipRecord.Token
+	tokenPublic := propPublic.CensorshipRecord.Token
+	tokenNotFound := "abc"
+
+	msg := fmt.Sprintf("%s%s", tokenNotReviewed, statusPublic)
+	s := id.SignMessage([]byte(msg))
+	sigNotReviewedToPublic := hex.EncodeToString(s[:])
+
+	msg = fmt.Sprintf("%s%s%s", tokenNotReviewed,
+		statusCensored, changeMsgCensored)
+	s = id.SignMessage([]byte(msg))
+	sigNotReviewedToCensored := hex.EncodeToString(s[:])
+
+	msg = fmt.Sprintf("%s%s%s", tokenPublic,
+		statusAbandoned, changeMsgAbandoned)
+	s = id.SignMessage([]byte(msg))
+	sigPublicToAbandoned := hex.EncodeToString(s[:])
+
+	msg = fmt.Sprintf("%s%s", tokenNotFound, statusPublic)
+	s = id.SignMessage([]byte(msg))
+	sigNotFound := hex.EncodeToString(s[:])
+
+	msg = fmt.Sprintf("%s%s%s", tokenNotReviewed,
+		statusAbandoned, changeMsgAbandoned)
+	s = id.SignMessage([]byte(msg))
+	sigNotReviewedToAbandoned := hex.EncodeToString(s[:])
+
+	// Add success case proposals to politeiad
+	d.AddRecord(t, convertPropToPD(t, propNotReviewed))
+	d.AddRecord(t, convertPropToPD(t, propPublic))
+
+	// Create a proposal whose vote has been authorized
+	propVoteAuthorized := newProposalRecord(t, admin, id, www.PropStatusPublic)
+	tokenVoteAuthorized := propVoteAuthorized.CensorshipRecord.Token
+
+	msg = fmt.Sprintf("%s%s%s", tokenVoteAuthorized,
+		statusAbandoned, changeMsgAbandoned)
+	s = id.SignMessage([]byte(msg))
+	sigVoteAuthorizedToAbandoned := hex.EncodeToString(s[:])
+
+	d.AddRecord(t, convertPropToPD(t, propVoteAuthorized))
+	cmd := newAuthorizeVoteCmd(t, tokenVoteAuthorized,
+		propVoteAuthorized.Version, www.AuthVoteActionAuthorize, id)
+	d.Plugin(t, cmd)
+
+	// Create a proposal whose voting period has started
+	propVoteStarted := newProposalRecord(t, admin, id, www.PropStatusPublic)
+	tokenVoteStarted := propVoteStarted.CensorshipRecord.Token
+
+	msg = fmt.Sprintf("%s%s%s", tokenVoteStarted,
+		statusAbandoned, changeMsgAbandoned)
+	s = id.SignMessage([]byte(msg))
+	sigVoteStartedToAbandoned := hex.EncodeToString(s[:])
+
+	d.AddRecord(t, convertPropToPD(t, propVoteStarted))
+	cmd = newStartVoteCmd(t, tokenVoteStarted, id)
+	d.Plugin(t, cmd)
+
+	// Ensure that admins are not allowed to change the status of
+	// their own proposal on mainnet. This is run individually
+	// because it requires flipping the testnet config setting.
+	t.Run("admin is author", func(t *testing.T) {
+		p.cfg.TestNet = false
+		defer func() {
+			p.cfg.TestNet = true
+		}()
+
+		sps := www.SetProposalStatus{
+			Token:          tokenNotReviewed,
+			ProposalStatus: www.PropStatusPublic,
+			Signature:      sigNotReviewedToPublic,
+			PublicKey:      admin.PublicKey(),
+		}
+
+		_, err := p.processSetProposalStatus(sps, admin)
+		got := errToStr(err)
+		want := www.ErrorStatus[www.ErrorStatusReviewerAdminEqualsAuthor]
+		if got != want {
+			t.Errorf("got error %v, want %v",
+				got, want)
+		}
+	})
+
+	// Setup tests
+	var tests = []struct {
+		name string
+		usr  *user.User
+		sps  www.SetProposalStatus
+		want error
+	}{
+		// This is an admin route so it can be assumed that the
+		// user has been validated and is an admin.
+
+		{"no change message for censored", admin,
+			www.SetProposalStatus{
+				Token:          tokenNotReviewed,
+				ProposalStatus: www.PropStatusCensored,
+				Signature:      sigNotReviewedToCensored,
+				PublicKey:      admin.PublicKey(),
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusChangeMessageCannotBeBlank,
+			}},
+
+		{"no change message for abandoned", admin,
+			www.SetProposalStatus{
+				Token:          tokenPublic,
+				ProposalStatus: www.PropStatusAbandoned,
+				Signature:      sigPublicToAbandoned,
+				PublicKey:      admin.PublicKey(),
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusChangeMessageCannotBeBlank,
+			}},
+
+		{"invalid public key", admin,
+			www.SetProposalStatus{
+				Token:          tokenNotReviewed,
+				ProposalStatus: www.PropStatusPublic,
+				Signature:      sigNotReviewedToPublic,
+				PublicKey:      "",
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidSigningKey,
+			}},
+
+		{"invalid signature", admin,
+			www.SetProposalStatus{
+				Token:          tokenNotReviewed,
+				ProposalStatus: www.PropStatusPublic,
+				Signature:      "",
+				PublicKey:      admin.PublicKey(),
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidSignature,
+			}},
+
+		{"proposal not found", admin,
+			www.SetProposalStatus{
+				Token:          tokenNotFound,
+				ProposalStatus: www.PropStatusPublic,
+				Signature:      sigNotFound,
+				PublicKey:      admin.PublicKey(),
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusProposalNotFound,
+			}},
+
+		{"invalid status change", admin,
+			www.SetProposalStatus{
+				Token:               tokenNotReviewed,
+				ProposalStatus:      www.PropStatusAbandoned,
+				StatusChangeMessage: changeMsgAbandoned,
+				Signature:           sigNotReviewedToAbandoned,
+				PublicKey:           admin.PublicKey(),
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidPropStatusTransition,
+			}},
+
+		{"unvetted success", admin,
+			www.SetProposalStatus{
+				Token:          tokenNotReviewed,
+				ProposalStatus: www.PropStatusPublic,
+				Signature:      sigNotReviewedToPublic,
+				PublicKey:      admin.PublicKey(),
+			}, nil},
+
+		{"vote already authorized", admin,
+			www.SetProposalStatus{
+				Token:               tokenVoteAuthorized,
+				ProposalStatus:      www.PropStatusAbandoned,
+				StatusChangeMessage: changeMsgAbandoned,
+				Signature:           sigVoteAuthorizedToAbandoned,
+				PublicKey:           admin.PublicKey(),
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusVoteAlreadyAuthorized,
+			}},
+
+		{"vote already started", admin,
+			www.SetProposalStatus{
+				Token:               tokenVoteStarted,
+				ProposalStatus:      www.PropStatusAbandoned,
+				StatusChangeMessage: changeMsgAbandoned,
+				Signature:           sigVoteStartedToAbandoned,
+				PublicKey:           admin.PublicKey(),
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusWrongVoteStatus,
+			}},
+
+		{"vetted success", admin,
+			www.SetProposalStatus{
+				Token:               tokenPublic,
+				ProposalStatus:      www.PropStatusAbandoned,
+				StatusChangeMessage: changeMsgAbandoned,
+				Signature:           sigPublicToAbandoned,
+				PublicKey:           admin.PublicKey(),
+			}, nil},
+	}
+
+	// Run tests
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			reply, err := p.processSetProposalStatus(v.sps, v.usr)
+			got := errToStr(err)
+			want := errToStr(v.want)
+			if got != want {
+				t.Errorf("got error %v, want %v",
+					got, want)
+			}
+
+			if err != nil {
+				// Test case passes
+				return
+			}
+
+			// Validate updated proposal
+			if reply.Proposal.Status != v.sps.ProposalStatus {
+				t.Errorf("got proposal status %v, want %v",
+					reply.Proposal.Status, v.sps.ProposalStatus)
+			}
 		})
 	}
 }

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -264,7 +264,6 @@ func (p *politeiawww) removeUserPubkeyAssociaton(u *user.User, publicKey string)
 // checkSignature validates an incoming signature against the specified user's
 // pubkey.
 func checkSignature(id []byte, signature string, elements ...string) error {
-	// Check incoming signature verify(token+string(ProposalStatus))
 	sig, err := util.ConvertSignature(signature)
 	if err != nil {
 		return www.UserError{
@@ -2045,11 +2044,6 @@ func (p *politeiawww) GenerateNewUserPaywall(u *user.User) error {
 
 // HasUserPaid checks that a user has paid the paywall
 func (p *politeiawww) HasUserPaid(u *user.User) bool {
-	// Return true when running unit tests
-	if p.test {
-		return true
-	}
-
 	// Return true if paywall is disabled
 	if !p.paywallIsEnabled() {
 		return true

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -17,9 +17,6 @@ import (
 )
 
 func TestValidatePubkey(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
-
 	id, err := identity.New()
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -79,9 +76,6 @@ func TestValidatePubkey(t *testing.T) {
 }
 
 func TestValidateUsername(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
-
 	// Username under the min length requirement
 	var underMin string
 	for i := 0; i < www.PolicyMinUsernameLength-1; i++ {
@@ -158,9 +152,6 @@ func TestValidateUsername(t *testing.T) {
 }
 
 func TestValidatePassword(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
-
 	// Password under the min length requirement
 	var minPass string
 	for i := 0; i < www.PolicyMinPasswordLength-1; i++ {
@@ -194,8 +185,8 @@ func TestValidatePassword(t *testing.T) {
 }
 
 func TestProcessNewUser(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a verified user
 	usrVerified, _ := newUser(t, p, true, false)
@@ -346,8 +337,8 @@ func TestProcessNewUser(t *testing.T) {
 }
 
 func TestProcessVerifyNewUser(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a user with a valid, unexpired verification
 	// token.
@@ -474,8 +465,8 @@ func TestProcessVerifyNewUser(t *testing.T) {
 }
 
 func TestProcessResendVerification(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a verified user
 	usrVerified, id := newUser(t, p, true, false)
@@ -579,8 +570,8 @@ func TestProcessResendVerification(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// newUser() sets the password to be the username, which is
 	// why we keep setting the passwords to be the the usernames.
@@ -701,15 +692,18 @@ func TestLogin(t *testing.T) {
 }
 
 func TestProcessLogin(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// MinimumLoginWaitTime is a global variable that is used to
 	// prevent timing attacks on login requests. Its normally set
-	// to 500 milliseconds. We reduce it to 100ms for these tests
-	// because 100ms still serves the intended purpose in a test
-	// environment.
+	// to 500 milliseconds. We temporarily reduce it to 100ms for
+	// these tests so that they don't take as long to run.
+	m := MinimumLoginWaitTime
 	MinimumLoginWaitTime = 100 * time.Millisecond
+	defer func() {
+		MinimumLoginWaitTime = m
+	}()
 
 	// Test the incorrect email error path because it's
 	// the quickest failure path for the login route.
@@ -756,8 +750,8 @@ func TestProcessLogin(t *testing.T) {
 }
 
 func TestProcessChangePassword(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a new user. newUser() sets the password
 	// as the username, which is why currPass is set
@@ -817,8 +811,8 @@ func TestProcessChangePassword(t *testing.T) {
 }
 
 func TestProcessResetPassword(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a normal user that we can test against
 	usr, _ := newUser(t, p, true, false)
@@ -968,8 +962,8 @@ func TestProcessResetPassword(t *testing.T) {
 }
 
 func TestProcessChangeUsername(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a new user. newUser() sets
 	// the password to be the username.
@@ -1031,8 +1025,8 @@ func TestProcessChangeUsername(t *testing.T) {
 }
 
 func TestProcessUserDetails(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a new user. This is the UUID that
 	// we'll use to test the UserDetails route.
@@ -1106,8 +1100,8 @@ func TestProcessUserDetails(t *testing.T) {
 }
 
 func TestProcessEditUser(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a new user. This is the user
 	// that we will be editing.

--- a/politeiawww/userwww_test.go
+++ b/politeiawww/userwww_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 func TestHandleNewUser(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	id, err := identity.New()
 	if err != nil {
@@ -96,8 +96,8 @@ func TestHandleNewUser(t *testing.T) {
 }
 
 func TestHandleVerifyNewUser(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create an unverified user to test against
 	usr, id := newUser(t, p, false, false)
@@ -209,8 +209,8 @@ func TestHandleVerifyNewUser(t *testing.T) {
 }
 
 func TestHandleResendVerification(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a verified user
 	usrVerified, _ := newUser(t, p, true, false)
@@ -314,13 +314,18 @@ func TestHandleResendVerification(t *testing.T) {
 }
 
 func TestHandleLogin(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// MinimumLoginWaitTime is a global variable used to
 	// prevent timing attacks. We're not testing it here
-	// so we zero it out to make the tests run faster.
+	// so we temporarily zero it out to make the tests
+	// run faster.
+	m := MinimumLoginWaitTime
 	MinimumLoginWaitTime = 0
+	defer func() {
+		MinimumLoginWaitTime = m
+	}()
 
 	// Create a user to test against. newUser() sets the
 	// password to be the same as the username.
@@ -418,8 +423,8 @@ func TestHandleLogin(t *testing.T) {
 }
 
 func TestHandleChangePassword(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a user to test against. newUser()
 	// sets the password to be the username.
@@ -506,8 +511,8 @@ func TestHandleChangePassword(t *testing.T) {
 }
 
 func TestHandleResetPassword(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a user that has already been assigned a reset
 	// password verification token.
@@ -598,8 +603,8 @@ func TestHandleResetPassword(t *testing.T) {
 }
 
 func TestHandleChangeUsername(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a user to test against. newUser()
 	// sets the password to be the username.
@@ -682,8 +687,8 @@ func TestHandleChangeUsername(t *testing.T) {
 }
 
 func TestHandleUserDetails(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	// Create a user whose details we can fetch
 	usr, _ := newUser(t, p, true, false)
@@ -767,8 +772,8 @@ func TestHandleUserDetails(t *testing.T) {
 }
 
 func TestHandleEditUser(t *testing.T) {
-	p := newTestPoliteiawww(t)
-	defer cleanupTestPoliteiawww(t, p)
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
 
 	var notif uint64 = 0x01
 	usr, _ := newUser(t, p, true, true)


### PR DESCRIPTION
This commit adds a few things related to politeiawww testing.

- Adds a testpoliteiad package.  testpoliteiad is a httptest server that
implements the politeiad api.

- Adds a testcache package.  testcache is an implementation of the Cache
interface that stores records in memory and that can be used for
testing.

testpoliteiad and testcache allow us to fake the responses from
politeiad and the cache so that we can fully test the politeiawww
routes.

This commit also adds test coverage to processNewProposal,
setProposalStatus, and verifyStatusChange.

This commit increases politeiawww test coverage from 15.7% to 21.6%.