### PR TITLE
Add UserInvoices and AdminInvoices routes

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -230,7 +230,7 @@ Retrieve a page of invoices given the month and year and status.
 
 Note: This call requires admin privileges.
 
-**Route:** `GET /v1/admin/invoices`
+**Route:** `POST /v1/admin/invoices`
 
 **Params:**
 

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -186,7 +186,6 @@ Returns a page of the user's invoices.
 
 | Parameter | Type | Description | Required |
 |-|-|-|-|
-| status | int64 | An optional filter for the list; this should be an [invoice status](#invoice-status-codes). | |
 
 **Results:**
 
@@ -199,9 +198,7 @@ Returns a page of the user's invoices.
 Request:
 
 ```json
-{
-  "status": 4
-}
+{}
 ```
 
 Reply:

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -9,8 +9,11 @@ server side notifications.  It does not render HTML.
 
 ***Contractor Management Routes***
 - [`Register`](#register)
-- [`Invite new user`](#invitenewuser)
-- [`New invoice`](#newinvoice)
+- [`Invite new user`](#invite-new-user)
+- [`New invoice`](#new-invoice)
+- [`User invoices`](#user-invoices)
+- [`Admin invoices`](#admin-invoices)
+
 
 
 ### `Invite new user`
@@ -170,5 +173,112 @@ Reply:
     "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
     "signature": "fcc92e26b8f38b90c2887259d88ce614654f32ecd76ade1438a0def40d360e461d995c796f16a17108fad226793fd4f52ff013428eda3b39cd504ed5f1811d0d"
   }
+}
+```
+
+### `User invoices`
+
+Returns a page of the user's invoices.
+
+**Route:** `GET /v1/user/invoices`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| status | int64 | An optional filter for the list; this should be an [invoice status](#invoice-status-codes). | |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| invoices | array of [`Invoice`](#invoice)s | The page of invoices. |
+
+**Example**
+
+Request:
+
+```json
+{
+  "status": 4
+}
+```
+
+Reply:
+
+```json
+{
+  "invoices": [{
+    "status": 4,
+    "month": 12,
+    "year": 2018,
+    "timestamp": 1508296860781,
+    "userid": "0",
+    "username": "foobar",
+    "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+    "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e",
+    "version": "1",
+    "censorshiprecord": {
+      "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+      "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+      "signature": "fcc92e26b8f38b90c2887259d88ce614654f32ecd76ade1438a0def40d360e461d995c796f16a17108fad226793fd4f52ff013428eda3b39cd504ed5f1811d0d"
+    }
+  }]
+}
+```
+
+### `Admin invoices`
+
+Retrieve a page of invoices given the month and year and status.
+
+Note: This call requires admin privileges.
+
+**Route:** `GET /v1/admin/invoices`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| month | int16 | An optional filter that can be set (along with year) to return invoices from a given month, from 1 to 12. | |
+| year | int16 | An optional filter that can be set (along with month) to return invoices from a given year. | |
+| status | int64 | An optional filter for the list; this should be an [invoice status](#invoice-status-codes). | |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| invoices | array of [`Invoice`](#invoice)s | The page of invoices. |
+
+**Example**
+
+Request:
+
+```json
+{
+  "month": 12,
+  "year": 2018
+}
+```
+
+Reply:
+
+```json
+{
+  "invoices": [{
+    "status": 4,
+    "month": 12,
+    "year": 2018,
+    "timestamp": 1508296860781,
+    "userid": "0",
+    "username": "foobar",
+    "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+    "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e",
+    "version": "1",
+    "censorshiprecord": {
+      "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+      "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+      "signature": "fcc92e26b8f38b90c2887259d88ce614654f32ecd76ade1438a0def40d360e461d995c796f16a17108fad226793fd4f52ff013428eda3b39cd504ed5f1811d0d"
+    }
+  }]
 }
 ```

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -14,6 +14,8 @@ const (
 	RouteRegisterUser   = "/register"
 	RouteNewInvoice     = "/invoices/new"
 	RouteInvoiceDetails = "/invoices/{token:[A-z0-9]{64}}"
+	RouteUserInvoices   = "/user/invoices"
+	RouteAdminInvoices  = "/admin/invoices"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status
@@ -116,4 +118,24 @@ type LineItemsInput struct {
 	ProposalToken string  `json:"proposaltoken"` // Link to politeia proposal that work is associated with
 	Hours         float64 `json:"hours"`         // Number of Hours
 	TotalCost     float64 `json:"totalcost"`     // Total cost of line item
+}
+
+// UserInvoices is used to get all of the invoices by userID.
+type UserInvoices struct{}
+
+// UserInvoicesReply is used to reply to a user invoices commands.
+type UserInvoicesReply struct {
+	Invoices []InvoiceRecord `json:"invoices"`
+}
+
+// AdminInvoices is used to get all invoices from all users
+type AdminInvoices struct {
+	Month  uint16         `json:"month"`  // Month of Invoice
+	Year   uint16         `json:"year"`   // Year of Invoice
+	Status InvoiceStatusT `json:"status"` // Current status of invoice
+}
+
+// AdminInvoiceReply is used to reply to an admin invoices command.
+type AdminInvoicesReply struct {
+	Invoices []InvoiceRecord `json:"invoices"`
 }

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -202,10 +202,8 @@ const (
 	ErrorStatusMalformedName               ErrorStatusT = 60
 	ErrorStatusMalformedLocation           ErrorStatusT = 61
 	ErrorStatusInvoiceNotFound             ErrorStatusT = 62
-
-	// CMS Errors
-
-	ErrorStatusMalformedInvoiceFile ErrorStatusT = 59
+	ErrorStatusInvalidMonthYearRequest     ErrorStatusT = 63
+	ErrorStatusMalformedInvoiceFile        ErrorStatusT = 64
 
 	// Proposal state codes
 	//
@@ -357,6 +355,7 @@ var (
 		ErrorStatusMalformedName:               "malformed name",
 		ErrorStatusMalformedLocation:           "malformed location",
 		ErrorStatusInvoiceNotFound:             "invoice cannot be found",
+		ErrorStatusInvalidMonthYearRequest:     "month or year was set, while the other was not",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -730,6 +730,54 @@ func (c *Client) UserProposals(up *v1.UserProposals) (*v1.UserProposalsReply, er
 	return &upr, nil
 }
 
+// UserInvoices retrieves the proposals that have been submitted by the
+// specified user.
+func (c *Client) UserInvoices(up *cms.UserInvoices) (*cms.UserInvoicesReply, error) {
+	responseBody, err := c.makeRequest("GET", cms.RouteUserInvoices, up)
+	if err != nil {
+		return nil, err
+	}
+
+	var upr cms.UserInvoicesReply
+	err = json.Unmarshal(responseBody, &upr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal UserInvoicesReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(upr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &upr, nil
+}
+
+// AdminInvoices retrieves the proposals that have been submitted by the
+// specified user.
+func (c *Client) AdminInvoices(ai *cms.AdminInvoices) (*cms.AdminInvoicesReply, error) {
+	responseBody, err := c.makeRequest("GET", cms.RouteAdminInvoices, ai)
+	if err != nil {
+		return nil, err
+	}
+
+	var air cms.AdminInvoicesReply
+	err = json.Unmarshal(responseBody, &air)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal AdminInvoicesReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(air)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &air, nil
+}
+
 // SetProposalStatus changes the status of the specified proposal.
 func (c *Client) SetProposalStatus(sps *v1.SetProposalStatus) (*v1.SetProposalStatusReply, error) {
 	route := "/proposals/" + sps.Token + "/status"

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -757,7 +757,7 @@ func (c *Client) UserInvoices(up *cms.UserInvoices) (*cms.UserInvoicesReply, err
 // AdminInvoices retrieves the proposals that have been submitted by the
 // specified user.
 func (c *Client) AdminInvoices(ai *cms.AdminInvoices) (*cms.AdminInvoicesReply, error) {
-	responseBody, err := c.makeRequest("GET", cms.RouteAdminInvoices, ai)
+	responseBody, err := c.makeRequest("POST", cms.RouteAdminInvoices, ai)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/cmd/politeiawwwcli/commands/admininvoices.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/admininvoices.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// AdminInvoicesCmd gets all invoices by month/year and/or status.
+type AdminInvoicesCmd struct {
+	Args struct {
+		Month  int `long:"month"`
+		Year   int `long:"year"`
+		Status int `long:"status"`
+	}
+}
+
+// Execute executes the admin invoices command.
+func (cmd *AdminInvoicesCmd) Execute(args []string) error {
+	// Get server public key
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+
+	// Get admin invoices
+	uir, err := client.AdminInvoices(
+		&v1.AdminInvoices{
+			Month:  uint16(cmd.Args.Month),
+			Year:   uint16(cmd.Args.Year),
+			Status: v1.InvoiceStatusT(cmd.Args.Status),
+		})
+	if err != nil {
+		return err
+	}
+
+	// Verify invoice censorship records
+	for _, p := range uir.Invoices {
+		err := verifyInvoice(p, vr.PubKey)
+		if err != nil {
+			return fmt.Errorf("unable to verify invoice %v: %v",
+				p.CensorshipRecord.Token, err)
+		}
+	}
+
+	// Print user invoices
+	return printJSON(uir)
+}
+
+// userProposalsHelpMsg is the output of the help command when 'userinvoices'
+// is specified.
+const adminInvoicesHelpMsg = `userinvoices "userID" 
+
+Fetch all invoices submitted by a specific user.
+
+Arguments:
+1. userID      (string, required)   User id
+
+Result:
+{
+  "invoices": [
+		{
+			...
+    }
+  ]
+}`

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -56,6 +56,7 @@ var (
 
 // Cmds is used to represent all of the politeiawwwcli commands.
 type Cmds struct {
+	AdminInvoices      AdminInvoicesCmd      `command:"admininvoices" description:"(admin) get all invoices (optional by month/year and/or status)"`
 	ActiveVotes        ActiveVotesCmd        `command:"activevotes" description:"(public) get the proposals that are being voted on"`
 	AuthorizeVote      AuthorizeVoteCmd      `command:"authorizevote" description:"(user)   authorize a proposal vote (must be proposal author)"`
 	CensorComment      CensorCommentCmd      `command:"censorcomment" description:"(admin)  censor a proposal comment"`
@@ -98,6 +99,7 @@ type Cmds struct {
 	UserDetails        UserDetailsCmd        `command:"userdetails" description:"(public) get the details of a user profile"`
 	UserLikeComments   UserLikeCommentsCmd   `command:"userlikecomments" description:"(user)   get the logged in user's comment upvotes/downvotes for a proposal"`
 	UserPendingPayment UserPendingPaymentCmd `command:"userpendingpayment" description:"(user)   get details for a pending payment for the logged in user"`
+	UserInvoices       UserInvoicesCmd       `command:"userinvoices" description:"(user) get all invoices submitted by a specific user"`
 	UserProposals      UserProposalsCmd      `command:"userproposals" description:"(public) get all proposals submitted by a specific user"`
 	Users              UsersCmd              `command:"users" description:"(admin)  get a list of users"`
 	VerifyUserEmail    VerifyUserEmailCmd    `command:"verifyuseremail" description:"(public) verify a user's email address"`

--- a/politeiawww/cmd/politeiawwwcli/commands/userinvoices.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/userinvoices.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// UserInvoicesCmd gets the invoices for the specified user.
+type UserInvoicesCmd struct {
+	Args struct {
+		//UserID string `positional-arg-name:"userID"` // User ID
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the user invoices command.
+func (cmd *UserInvoicesCmd) Execute(args []string) error {
+	// Get server public key
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+
+	// Get user invoices
+	uir, err := client.UserInvoices(
+		&v1.UserInvoices{})
+	if err != nil {
+		return err
+	}
+
+	// Verify invoice censorship records
+	for _, p := range uir.Invoices {
+		err := verifyInvoice(p, vr.PubKey)
+		if err != nil {
+			return fmt.Errorf("unable to verify invoice %v: %v",
+				p.CensorshipRecord.Token, err)
+		}
+	}
+
+	// Print user invoices
+	return printJSON(uir)
+}
+
+// userInvoicesHelpMsg is the output of the help command when 'userinvoices'
+// is specified.
+const userInvoicesHelpMsg = `userinvoices "userID" 
+
+Fetch all invoices submitted by a specific user.
+
+Arguments:
+1. userID      (string, required)   User id
+
+Result:
+{
+  "invoices": [
+		{
+			...
+    }
+  ]
+}`

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -103,7 +103,7 @@ func (c *cockroachdb) InvoicesByMonthYearStatus(month, year uint16, status int) 
 
 	invoices := make([]Invoice, 0, 1024) // PNOOMA
 	err := c.recordsdb.
-		Where("month = ? && year = ? && status == ?", month, year, status).
+		Where("month = ? AND year = ? AND status = ?", month, year, status).
 		Find(&invoices).
 		Error
 	if err != nil {
@@ -127,7 +127,7 @@ func (c *cockroachdb) InvoicesByMonthYear(month, year uint16) ([]database.Invoic
 
 	invoices := make([]Invoice, 0, 1024) // PNOOMA
 	err := c.recordsdb.
-		Where("month = ? && year = ?", month, year).
+		Where("month = ? AND year = ?", month, year).
 		Find(&invoices).
 		Error
 	if err != nil {

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -55,6 +55,30 @@ func (c *cockroachdb) UpdateInvoice(dbInvoice *database.Invoice) error {
 	return c.recordsdb.Save(invoice).Error
 }
 
+// Return all invoices by userid
+func (c *cockroachdb) InvoicesByUserID(userid string) ([]database.Invoice, error) {
+	log.Tracef("InvoicesByUserID")
+
+	invoices := make([]Invoice, 0, 1024) // PNOOMA
+	err := c.recordsdb.
+		Where("user_id = ?", userid).
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	dbInvoices := make([]database.Invoice, 0, len(invoices))
+	for _, v := range invoices {
+		dbInvoice, err := DecodeInvoice(&v)
+		if err != nil {
+			return nil, err
+		}
+		dbInvoices = append(dbInvoices, *dbInvoice)
+	}
+	return dbInvoices, nil
+}
+
 // Return invoice by its token.
 func (c *cockroachdb) InvoiceByToken(token string) (*database.Invoice, error) {
 	log.Debugf("InvoiceByToken: %v", token)
@@ -71,6 +95,101 @@ func (c *cockroachdb) InvoiceByToken(token string) (*database.Invoice, error) {
 	}
 
 	return DecodeInvoice(&invoice)
+}
+
+// Return all invoices by month year and status
+func (c *cockroachdb) InvoicesByMonthYearStatus(month, year uint16, status int) ([]database.Invoice, error) {
+	log.Tracef("InvoicesByMonthYearStatus")
+
+	invoices := make([]Invoice, 0, 1024) // PNOOMA
+	err := c.recordsdb.
+		Where("month = ? && year = ? && status == ?", month, year, status).
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	dbInvoices := make([]database.Invoice, 0, len(invoices))
+	for _, v := range invoices {
+		dbInvoice, err := DecodeInvoice(&v)
+		if err != nil {
+			return nil, err
+		}
+		dbInvoices = append(dbInvoices, *dbInvoice)
+	}
+	return dbInvoices, nil
+}
+
+// Return all invoices by month/year
+func (c *cockroachdb) InvoicesByMonthYear(month, year uint16) ([]database.Invoice, error) {
+	log.Tracef("InvoicesByMonthYear")
+
+	invoices := make([]Invoice, 0, 1024) // PNOOMA
+	err := c.recordsdb.
+		Where("month = ? && year = ?", month, year).
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	dbInvoices := make([]database.Invoice, 0, len(invoices))
+	for _, v := range invoices {
+		dbInvoice, err := DecodeInvoice(&v)
+		if err != nil {
+			return nil, err
+		}
+		dbInvoices = append(dbInvoices, *dbInvoice)
+	}
+	return dbInvoices, nil
+}
+
+// Return all invoices by status
+func (c *cockroachdb) InvoicesByStatus(status int) ([]database.Invoice, error) {
+	log.Tracef("InvoicesByStatus")
+
+	invoices := make([]Invoice, 0, 1024) // PNOOMA
+	err := c.recordsdb.
+		Where("status = ?", status).
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	dbInvoices := make([]database.Invoice, 0, len(invoices))
+	for _, v := range invoices {
+		dbInvoice, err := DecodeInvoice(&v)
+		if err != nil {
+			return nil, err
+		}
+		dbInvoices = append(dbInvoices, *dbInvoice)
+	}
+	return dbInvoices, nil
+}
+
+// Return all invoices
+func (c *cockroachdb) InvoicesAll() ([]database.Invoice, error) {
+	log.Tracef("InvoicesAll")
+
+	invoices := make([]Invoice, 0, 1024) // PNOOMA
+	err := c.recordsdb.
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	dbInvoices := make([]database.Invoice, 0, len(invoices))
+	for _, v := range invoices {
+		dbInvoice, err := DecodeInvoice(&v)
+		if err != nil {
+			return nil, err
+		}
+		dbInvoices = append(dbInvoices, *dbInvoice)
+	}
+	return dbInvoices, nil
 }
 
 // Close satisfies the backend interface.

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -27,8 +27,13 @@ type Database interface {
 	NewInvoice(*Invoice) error // Create new invoice
 
 	UpdateInvoice(*Invoice) error // Update existing invoice
-
+	InvoicesByUserID(string) ([]Invoice, error)
 	InvoiceByToken(string) (*Invoice, error) // Return invoice given its token
+
+	InvoicesByMonthYearStatus(uint16, uint16, int) ([]Invoice, error) // Returns all invoices by month, year and status
+	InvoicesByMonthYear(uint16, uint16) ([]Invoice, error)            // Returns all invoice by month, year
+	InvoicesByStatus(int) ([]Invoice, error)                          // Returns all invoices by status
+	InvoicesAll() ([]Invoice, error)                                  // Returns all invoices
 
 	// Setup the invoice tables
 	Setup() error

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -426,6 +426,13 @@ func (p *politeiawww) processUserInvoices(user *user.User) (*cms.UserInvoicesRep
 // processAdminInvoices fetches all invoices that are currently stored in the
 // cmsdb.
 func (p *politeiawww) processAdminInvoices(ai cms.AdminInvoices, user *user.User) (*cms.UserInvoicesReply, error) {
+
+	if (ai.Month == 0 && ai.Year != 0) || (ai.Month != 0 && ai.Year == 0) {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusInvalidMonthYearRequest,
+		}
+	}
+
 	var dbInvs []database.Invoice
 	var err error
 	if (ai.Month != 0 && ai.Year != 0) && ai.Status != 0 {

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -428,17 +428,17 @@ func (p *politeiawww) processUserInvoices(user *user.User) (*cms.UserInvoicesRep
 func (p *politeiawww) processAdminInvoices(ai cms.AdminInvoices, user *user.User) (*cms.UserInvoicesReply, error) {
 	dbInvs := make([]database.Invoice, 0, 1024)
 	var err error
-	if (ai.Month != 0 && ai.Year != 0) && ai.Status != -1 {
+	if (ai.Month != 0 && ai.Year != 0) && ai.Status != 0 {
 		dbInvs, err = p.cmsDB.InvoicesByMonthYearStatus(ai.Month, ai.Year, int(ai.Status))
 		if err != nil {
 			return nil, err
 		}
-	} else if (ai.Month != 0 && ai.Year != 0) && ai.Status == -1 {
+	} else if (ai.Month != 0 && ai.Year != 0) && ai.Status == 0 {
 		dbInvs, err = p.cmsDB.InvoicesByMonthYear(ai.Month, ai.Year)
 		if err != nil {
 			return nil, err
 		}
-	} else if (ai.Month == 0 && ai.Year == 0) && ai.Status != -1 {
+	} else if (ai.Month == 0 && ai.Year == 0) && ai.Status != 0 {
 		dbInvs, err = p.cmsDB.InvoicesByStatus(int(ai.Status))
 		if err != nil {
 			return nil, err

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -426,7 +426,7 @@ func (p *politeiawww) processUserInvoices(user *user.User) (*cms.UserInvoicesRep
 // processAdminInvoices fetches all invoices that are currently stored in the
 // cmsdb.
 func (p *politeiawww) processAdminInvoices(ai cms.AdminInvoices, user *user.User) (*cms.UserInvoicesReply, error) {
-	dbInvs := make([]database.Invoice, 0, 1024)
+	var dbInvs []database.Invoice
 	var err error
 	if (ai.Month != 0 && ai.Year != 0) && ai.Status != 0 {
 		dbInvs, err = p.cmsDB.InvoicesByMonthYearStatus(ai.Month, ai.Year, int(ai.Status))

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -346,8 +346,7 @@ func validateInvoice(ni cms.NewInvoice, u *user.User) error {
 
 // processInvoiceDetails fetches a specific proposal version from the records
 // cache and returns it.
-func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails,
-	user *user.User) (*cms.InvoiceDetailsReply, error) {
+func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails, user *user.User) (*cms.InvoiceDetailsReply, error) {
 	log.Tracef("processInvoiceDetails")
 
 	inv, err := p.cmsDB.InvoiceByToken(invDetails.Token)
@@ -426,8 +425,7 @@ func (p *politeiawww) processUserInvoices(user *user.User) (*cms.UserInvoicesRep
 
 // processAdminInvoices fetches all invoices that are currently stored in the
 // cmsdb for an administrator, based on request fields (month/year and/or status).
-func (p *politeiawww) processAdminInvoices(ai cms.AdminInvoices,
-	user *user.User) (*cms.UserInvoicesReply, error) {
+func (p *politeiawww) processAdminInvoices(ai cms.AdminInvoices, user *user.User) (*cms.UserInvoicesReply, error) {
 	log.Tracef("processAdminInvoices")
 
 	// Make sure month AND year are set, if any.


### PR DESCRIPTION
This commit adds the UserInvoices and AdminInvoices routes that allow
for users and administrators to request invoices based on certain
criteria.

Currently UserInvoices simply responds with all of the currently logged
in user's invoices. While the AdminInvoices request requires an admin
to be logged in.  AdminInvoices allows searching by month/year and/or
status.  If none of these fields are used, then all of the current
invoices will be returned.