### PR TITLE
Introduce LineItemType for better organization

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -27,6 +27,12 @@ server side notifications.  It does not render HTML.
 - [`InvoiceStatusApproved`](#InvoiceStatusApproved)
 - [`InvoiceStatusPaid`](#InvoiceStatusPaid)
 
+**Line item type codes**
+
+- [`LineItemTypeLabor`](#LineItemTypeLabor)
+- [`LineItemTypeExpense`](#LineItemTypeExpense)
+- [`LineItemTypeMisc`](#LineItemTypeMisc)
+
 ### `Invite new user`
 
 Create a new user on the cmswww server with a registration token and email
@@ -138,7 +144,7 @@ Submit a new invoice for the given month and year.
 |-|-|-|-|
 | month | int16 | A specific month, from 1 to 12. | Yes |
 | year | int16 | A specific year. | Yes |
-| files | [`[]File`](#file) | The invoice CSV file and any other attachments for line items. The first line should be a comment with the month and year, with the format: `# 2006-01` | Yes |
+| files | [`[]File`](#file) | The invoice json file and any other attachments for line items. | Yes |
 | publickey | string | The user's public key. | Yes |
 | signature | string | The signature of the string representation of the file payload. | Yes |
 
@@ -439,3 +445,11 @@ Reply:
 | <a name="InvoiceStatusRejected">InvoiceStatusRejected</a> | 5 | The invoice has been rejected by an admin. |
 | <a name="InvoiceStatusApproved">InvoiceStatusApproved</a> | 6 | The invoice has been approved by an admin. |
 | <a name="InvoiceStatusPaid">InvoiceStatusPaid</a> | 7 | The invoice has been paid. |
+
+### Line item type codes
+
+| Type | Value | Description |
+|-|-|-|
+| <a name="LineItemTypeLabor">LineItemTypeLabor</a>| 0 | Line items that correspond to laborious activities. |
+| <a name="LineItemTypeExpense">LineItemTypeExpense</a> | 1 | Line items that cover expensed costs. |
+| <a name="LineItemTypeMisc">LineItemTypeMisc</a> | 2 | Any line item that doesn't fall into the above 2 categories. |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -450,6 +450,7 @@ Reply:
 
 | Type | Value | Description |
 |-|-|-|
-| <a name="LineItemTypeLabor">LineItemTypeLabor</a>| 0 | Line items that correspond to laborious activities. |
-| <a name="LineItemTypeExpense">LineItemTypeExpense</a> | 1 | Line items that cover expensed costs. |
-| <a name="LineItemTypeMisc">LineItemTypeMisc</a> | 2 | Any line item that doesn't fall into the above 2 categories. |
+| <a name="LineItemTypeInvalid">LineItemTypeInvalid</a>| 0 | An invalid type. This shall be considered a bug. |
+| <a name="LineItemTypeLabor">LineItemTypeLabor</a>| 1 | Line items that correspond to laborious activities. |
+| <a name="LineItemTypeExpense">LineItemTypeExpense</a> | 2 | Line items that cover expensed costs. |
+| <a name="LineItemTypeMisc">LineItemTypeMisc</a> | 3 | Any line item that doesn't fall into the above 2 categories. |

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -5,6 +5,7 @@ import (
 )
 
 type InvoiceStatusT int
+type LineItemTypeT int
 
 const (
 
@@ -27,6 +28,11 @@ const (
 	InvoiceStatusRejected InvoiceStatusT = 5 // Invoice fully rejected and closed
 	InvoiceStatusApproved InvoiceStatusT = 6 // Invoice has been approved
 	InvoiceStatusPaid     InvoiceStatusT = 7 // Invoice has been paid
+
+	// Line item types
+	LineItemTypeLabor   LineItemTypeT = 0 // Labor line items
+	LineItemTypeExpense LineItemTypeT = 1 // Expenses incurred line items
+	LineItemTypeMisc    LineItemTypeT = 2 // Catch all for anything else
 )
 
 /// Contractor Management System Routes
@@ -125,13 +131,13 @@ type InvoiceInput struct {
 // LineItemsInput is the expected struct of line items contained within an users'
 // invoice input.
 type LineItemsInput struct {
-	LineNumber    uint16  `json:"linenum"`       // Line number of the line item
-	Type          string  `json:"type"`          // Type of work performed
-	Subtype       string  `json:"subtype"`       // Subtype of work performed
-	Description   string  `json:"description"`   // Description of work performed
-	ProposalToken string  `json:"proposaltoken"` // Link to politeia proposal that work is associated with
-	Hours         float64 `json:"hours"`         // Number of Hours
-	TotalCost     float64 `json:"totalcost"`     // Total cost of line item
+	LineNumber    uint16        `json:"linenum"`       // Line number of the line item
+	Type          LineItemTypeT `json:"type"`          // Type of work performed
+	Subtype       string        `json:"subtype"`       // Subtype of work performed
+	Description   string        `json:"description"`   // Description of work performed
+	ProposalToken string        `json:"proposaltoken"` // Link to politeia proposal that work is associated with
+	Hours         float64       `json:"hours"`         // Number of Hours
+	TotalCost     float64       `json:"totalcost"`     // Total cost of line item
 }
 
 // UserInvoices is used to get all of the invoices by userID.

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -30,9 +30,10 @@ const (
 	InvoiceStatusPaid     InvoiceStatusT = 7 // Invoice has been paid
 
 	// Line item types
-	LineItemTypeLabor   LineItemTypeT = 0 // Labor line items
-	LineItemTypeExpense LineItemTypeT = 1 // Expenses incurred line items
-	LineItemTypeMisc    LineItemTypeT = 2 // Catch all for anything else
+	LineItemTypeInvalid LineItemTypeT = 0 // Invalid type
+	LineItemTypeLabor   LineItemTypeT = 1 // Labor line items
+	LineItemTypeExpense LineItemTypeT = 2 // Expenses incurred line items
+	LineItemTypeMisc    LineItemTypeT = 3 // Catch all for anything else
 )
 
 /// Contractor Management System Routes

--- a/politeiawww/cmd/politeiawwwcli/commands/newinvoice.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newinvoice.go
@@ -156,6 +156,11 @@ func (cmd *NewInvoiceCmd) Execute(args []string) error {
 }
 
 func validateParseCSV(data []byte) (*v1.InvoiceInput, error) {
+	LineItemType := map[string]v1.LineItemTypeT{
+		"labor":   v1.LineItemTypeLabor,
+		"expense": v1.LineItemTypeExpense,
+		"misc":    v1.LineItemTypeMisc,
+	}
 	invInput := &v1.InvoiceInput{}
 
 	// Validate that the invoice is CSV-formatted.
@@ -192,7 +197,14 @@ func validateParseCSV(data []byte) (*v1.InvoiceInput, error) {
 			}
 		}
 		lineItem.LineNumber = uint16(i)
-		lineItem.Type = lineContents[0]
+
+		lineItemType, ok := LineItemType[strings.ToLower(lineContents[0])]
+		if !ok {
+			return invInput, www.UserError{
+				ErrorCode: www.ErrorStatusMalformedInvoiceFile,
+			}
+		}
+		lineItem.Type = lineItemType
 		lineItem.Subtype = lineContents[1]
 		lineItem.Description = lineContents[2]
 		lineItem.ProposalToken = lineContents[3]

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -87,7 +87,7 @@ func EncodeInvoiceLineItem(dbLineItem *database.LineItem) LineItem {
 	lineItem.LineItemKey = dbLineItem.InvoiceToken + strconv.Itoa(int(dbLineItem.LineNumber))
 	lineItem.LineNumber = uint(dbLineItem.LineNumber)
 	lineItem.InvoiceToken = dbLineItem.InvoiceToken
-	lineItem.Type = dbLineItem.Type
+	lineItem.Type = uint(dbLineItem.Type)
 	lineItem.Subtype = dbLineItem.Subtype
 	lineItem.Description = dbLineItem.Description
 	lineItem.ProposalURL = dbLineItem.ProposalURL
@@ -101,7 +101,7 @@ func DecodeInvoiceLineItem(lineItem *LineItem) *database.LineItem {
 	dbLineItem := &database.LineItem{}
 	dbLineItem.InvoiceToken = lineItem.InvoiceToken
 	dbLineItem.LineNumber = uint16(lineItem.LineNumber)
-	dbLineItem.Type = lineItem.Type
+	dbLineItem.Type = cms.LineItemTypeT(lineItem.Type)
 	dbLineItem.Subtype = lineItem.Subtype
 	dbLineItem.Description = lineItem.Description
 	dbLineItem.ProposalURL = lineItem.ProposalURL

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -39,7 +39,7 @@ type LineItem struct {
 	LineItemKey  string  `gorm:"primary_key"` // Token of the Invoice + "-" + line number
 	LineNumber   uint    `gorm:"not null"`    // Line number of the line item
 	InvoiceToken string  `gorm:"not null"`    // Censorship token of the invoice
-	Type         string  `gorm:"not null"`    // Type of work performed
+	Type         uint    `gorm:"not null"`    // Type of work performed
 	Subtype      string  `gorm:"not null"`    // Subtype of work performed
 	Description  string  `gorm:"not null"`    // Description of work performed
 	ProposalURL  string  `gorm:"not null"`    // Link to politeia proposal that work is associated with

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -71,7 +71,7 @@ type Invoice struct {
 type LineItem struct {
 	LineNumber   uint16
 	InvoiceToken string
-	Type         string
+	Type         cms.LineItemTypeT
 	Subtype      string
 	Description  string
 	ProposalURL  string


### PR DESCRIPTION
Instead of letting users enter in a variety of information,
we've created LineItemType to better organize the line items down
the road.  Currently, this includes 2 main types (labor/expense),
and 1 misc catch all.