### PR TITLE
wwwcli: Fix cms register bug

### DIFF
--- a/politeiawww/cmd/politeiawwwcli/commands/register.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/register.go
@@ -176,5 +176,7 @@ func (cmd *RegisterUserCmd) Execute(args []string) error {
 		return err
 	}
 
-	return err
+	// Update the logged in username that we store
+	// on disk to know what identity to load.
+	return cfg.SaveLoggedInUsername(ru.Username)
 }

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -2345,6 +2345,7 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 
 	// Create a new database user with the provided information.
 	newUser := user.User{
+		ID:                        existingUser.ID,
 		Email:                     strings.ToLower(u.Email),
 		Username:                  username,
 		HashedPassword:            hashedPassword,
@@ -2361,11 +2362,8 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 		Activated: time.Now().Unix(),
 	}}
 	copy(newUser.Identities[0].Key[:], pk)
-	existingPublicKey := hex.EncodeToString(newUser.Identities[0].Key[:])
-	p.removeUserPubkeyAssociaton(existingUser, existingPublicKey)
 
 	// Update the user in the db.
-	newUser.ID = existingUser.ID
 	err = p.db.UserUpdate(newUser)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit fixes a bug in the `politeiawwwcli register` command. The
command was logging in the user after registration but was not saving
the logged in user to disk, which is required so wwwcli knows which
identity to load.

It also removes some unnecessary code in the processRegisterUser
function.