### PR TITLE
www: set comments as read

### DIFF
--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -1663,6 +1663,7 @@ sorted.
 | - | - | - |
 | Comments | Comment | Unsorted array of all comments |
 | AccessTime | int64 | UNIX timestamp of last access time. Omitted if no session cookie is present. |
+| ReadComments | array of string | Array of read comments for the proposal. Omitted if no session cookie is present. |
 
 **Comment:**
 
@@ -2376,6 +2377,42 @@ Reply:
       }
    ]
 }
+```
+
+
+### `Set read comments`
+
+Allows a user to mark comments as read
+
+**Route** `POST v1/user/proposals/{token}/readcomments`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| readcomments | array of string | Proposal comments to be set as read | yes |
+
+**Results:** none
+
+**Example:**
+
+
+Request:
+
+```json
+{
+  "readcomments": [
+    "1",
+    "6",
+    "8",
+  ]
+}
+```
+
+Reply:
+
+```json
+{}
 ```
 
 ### `User Comments Likes`

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -29,6 +29,7 @@ const (
 	RouteUserProposals            = "/user/proposals"
 	RouteUserProposalCredits      = "/user/proposals/credits"
 	RouteUserCommentsLikes        = "/user/proposals/{token:[A-z0-9]{64}}/commentslikes"
+	RouteSetUserReadComments      = "/user/proposals/{token:[A-z0-9]{64}}/readcomments"
 	RouteVerifyUserPayment        = "/user/verifypayment"
 	RouteUserPaymentsRescan       = "/user/payments/rescan"
 	RouteUserDetails              = "/user/{userid:[0-9a-zA-Z-]{36}}"
@@ -647,7 +648,7 @@ type ResetPasswordReply struct {
 // that they have been spent.
 type UserProposalCredits struct{}
 
-// UserProposalCredits is used to reply to the UserProposalCredits command.
+// UserProposalCreditsReply is used to reply to the UserProposalCredits command.
 type UserProposalCreditsReply struct {
 	UnspentCredits []ProposalCredit `json:"unspentcredits"` // credits that the user has purchased, but have not yet been used to submit proposals (credit price in atoms)
 	SpentCredits   []ProposalCredit `json:"spentcredits"`   // credits that the user has purchased and that have already been used to submit proposals (credit price in atoms)
@@ -1035,8 +1036,9 @@ type GetComments struct {
 
 // GetCommentsReply returns the provided number of comments.
 type GetCommentsReply struct {
-	Comments   []Comment `json:"comments"`             // Comments
-	AccessTime int64     `json:"accesstime,omitempty"` // User Access Time
+	Comments     []Comment `json:"comments"`               // Comments
+	AccessTime   int64     `json:"accesstime,omitempty"`   // User Access Time
+	ReadComments []string  `json:"readcomments,omitempty"` // List of read commentIDs
 }
 
 // LikeComment allows a user to up or down vote a comment.
@@ -1090,6 +1092,15 @@ type UserCommentsLikes struct{}
 type UserCommentsLikesReply struct {
 	CommentsLikes []CommentLike `json:"commentslikes"`
 }
+
+// SetUserReadComments is a command to set the read comments
+// of a given proposal for an user
+type SetUserReadComments struct {
+	ReadComments []string `json:"readcomments"`
+}
+
+// SetUserReadCommentsReply is the reply for the SetUserReadComments command.
+type SetUserReadCommentsReply struct{}
 
 // VoteOptionResult is a structure that describes a VotingOption along with the
 // number of votes it has received

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -991,6 +991,31 @@ func (c *Client) LikeComment(lc *v1.LikeComment) (*v1.LikeCommentReply, error) {
 	return &lcr, nil
 }
 
+// SetUserReadComments casts a read comments action for the logged in
+// user.
+func (c *Client) SetUserReadComments(urc *v1.SetUserReadComments, token string) (*v1.SetUserReadCommentsReply, error) {
+	route := "/user/proposals/" + token + "/readcomments"
+	responseBody, err := c.makeRequest("POST", route, urc)
+	if err != nil {
+		return nil, err
+	}
+
+	var urcr v1.SetUserReadCommentsReply
+	err = json.Unmarshal(responseBody, &urcr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal SetUserReadCommentsReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(urcr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &urcr, nil
+}
+
 // CensorComment censors the specified proposal comment.
 func (c *Client) CensorComment(cc *v1.CensorComment) (*v1.CensorCommentReply, error) {
 	responseBody, err := c.makeRequest("POST", v1.RouteCensorComment, cc)

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -56,62 +56,62 @@ var (
 
 // Cmds is used to represent all of the politeiawwwcli commands.
 type Cmds struct {
-	AdminInvoices      AdminInvoicesCmd      `command:"admininvoices" description:"(admin) get all invoices (optional by month/year and/or status)"`
-	ActiveVotes        ActiveVotesCmd        `command:"activevotes" description:"(public) get the proposals that are being voted on"`
-	AuthorizeVote      AuthorizeVoteCmd      `command:"authorizevote" description:"(user)   authorize a proposal vote (must be proposal author)"`
-	CensorComment      CensorCommentCmd      `command:"censorcomment" description:"(admin)  censor a proposal comment"`
-	ChangePassword     ChangePasswordCmd     `command:"changepassword" description:"(user)   change the password for the logged in user"`
-	ChangeUsername     ChangeUsernameCmd     `command:"changeusername" description:"(user)   change the username for the logged in user"`
-	EditInvoice        EditInvoiceCmd        `command:"editinvoice" description:"(user)    edit a invoice"`
-	EditProposal       EditProposalCmd       `command:"editproposal" description:"(user)   edit a proposal"`
-	ManageUser         ManageUserCmd         `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
-	EditUser           EditUserCmd           `command:"edituser" description:"(user)   edit the  preferences of the logged in user"`
-	GeneratePayouts    GeneratePayoutsCmd    `command:"generatepayouts" description:"(admin) generate a list of payouts with addresses and amounts to pay"`
-	Help               HelpCmd               `command:"help" description:"         print a detailed help message for a specific command"`
-	Inventory          InventoryCmd          `command:"inventory" description:"(public) get the proposals that are being voted on"`
-	InviteNewUser      InviteNewUserCmd      `command:"invite" description:"(admin)  invite a new user"`
-	InvoiceDetails     InvoiceDetailsCmd     `command:"invoicedetails" description:"(public) get the details of a proposal"`
-	LikeComment        LikeCommentCmd        `command:"likecomment" description:"(user)   upvote/downvote a comment"`
-	Login              LoginCmd              `command:"login" description:"(public) login to Politeia"`
-	Logout             LogoutCmd             `command:"logout" description:"(public) logout of Politeia"`
-	Me                 MeCmd                 `command:"me" description:"(user)   get user details for the logged in user"`
-	NewInvoice         NewInvoiceCmd         `command:"newinvoice" description:"(user)   create a new invoice"`
-	NewProposal        NewProposalCmd        `command:"newproposal" description:"(user)   create a new proposal"`
-	NewComment         NewCommentCmd         `command:"newcomment" description:"(user)   create a new proposal comment"`
-	NewUser            NewUserCmd            `command:"newuser" description:"(public) create a new user"`
-	Policy             PolicyCmd             `command:"policy" description:"(public) get the server policy"`
-	ProposalComments   ProposalCommentsCmd   `command:"proposalcomments" description:"(public) get the comments for a proposal"`
-	ProposalDetails    ProposalDetailsCmd    `command:"proposaldetails" description:"(public) get the details of a proposal"`
-	ProposalPaywall    ProposalPaywallCmd    `command:"proposalpaywall" description:"(user)   get proposal paywall details for the logged in user"`
-	ProposalStats      ProposalStatsCmd      `command:"proposalstats" description:"(public) get statistics on the proposal inventory"`
-	UnvettedProposals  UnvettedProposalsCmd  `command:"unvettedproposals" description:"(admin)  get a page of unvetted proposals"`
-	VettedProposals    VettedProposalsCmd    `command:"vettedproposals" description:"(public) get a page of vetted proposals"`
-	RegisterUser       RegisterUserCmd       `command:"register" description:"(public) register an invited user to cms"`
-	RescanUserPayments RescanUserPaymentsCmd `command:"rescanuserpayments" description:"(admin)  rescan a user's payments to check for missed payments"`
-	ResendVerification ResendVerificationCmd `command:"resendverification" description:"(public) resend the user verification email"`
-	ResetPassword      ResetPasswordCmd      `command:"resetpassword" description:"(public) reset the password for a user that is not logged in"`
-	Secret             SecretCmd             `command:"secret" description:"(user)   ping politeiawww"`
-	SendFaucetTx       SendFaucetTxCmd       `command:"sendfaucettx" description:"         send a DCR transaction using the Decred testnet faucet"`
-	SetInvoiceStatus   SetInvoiceStatusCmd   `command:"setinvoicestatus" description:"(admin)  set the status of an invoice"`
-	SetProposalStatus  SetProposalStatusCmd  `command:"setproposalstatus" description:"(admin)  set the status of a proposal"`
-	StartVote          StartVoteCmd          `command:"startvote" description:"(admin)  start the voting period on a proposal"`
-	Subscribe          SubscribeCmd          `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`
-	Tally              TallyCmd              `command:"tally" description:"(public) get the vote tally for a proposal"`
-	TestRun            TestRunCmd            `command:"testrun" description:"         run a series of tests on the politeiawww routes (dev use only)"`
-	UpdateUserKey      UpdateUserKeyCmd      `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
-	UserDetails        UserDetailsCmd        `command:"userdetails" description:"(public) get the details of a user profile"`
-	UserLikeComments   UserLikeCommentsCmd   `command:"userlikecomments" description:"(user)   get the logged in user's comment upvotes/downvotes for a proposal"`
-	UserPendingPayment UserPendingPaymentCmd `command:"userpendingpayment" description:"(user)   get details for a pending payment for the logged in user"`
-	UserInvoices       UserInvoicesCmd       `command:"userinvoices" description:"(user) get all invoices submitted by a specific user"`
-	UserProposals      UserProposalsCmd      `command:"userproposals" description:"(public) get all proposals submitted by a specific user"`
-	Users              UsersCmd              `command:"users" description:"(admin)  get a list of users"`
-	VerifyUserEmail    VerifyUserEmailCmd    `command:"verifyuseremail" description:"(public) verify a user's email address"`
-	VerifyUserPayment  VerifyUserPaymentCmd  `command:"verifyuserpayment" description:"(user)   check if the logged in user has paid their user registration fee"`
-	Version            VersionCmd            `command:"version" description:"(public) get server info and CSRF token"`
-	Vote               VoteCmd               `command:"vote" description:"(public) cast votes for a proposal"`
-	VoteResults        VoteResultsCmd        `command:"voteresults" description:"(public) get vote results for a proposal"`
-	VoteStatus         VoteStatusCmd         `command:"votestatus" description:"(public) get the vote status of a proposal"`
-	VoteStatuses       VoteStatusesCmd       `command:"votestatuses" description:"(public) get the vote status for all public proposals"`
+	AdminInvoices       AdminInvoicesCmd       `command:"admininvoices" description:"(admin) get all invoices (optional by month/year and/or status)"`
+	ActiveVotes         ActiveVotesCmd         `command:"activevotes" description:"(public) get the proposals that are being voted on"`
+	AuthorizeVote       AuthorizeVoteCmd       `command:"authorizevote" description:"(user)   authorize a proposal vote (must be proposal author)"`
+	CensorComment       CensorCommentCmd       `command:"censorcomment" description:"(admin)  censor a proposal comment"`
+	ChangePassword      ChangePasswordCmd      `command:"changepassword" description:"(user)   change the password for the logged in user"`
+	ChangeUsername      ChangeUsernameCmd      `command:"changeusername" description:"(user)   change the username for the logged in user"`
+	EditInvoice         EditInvoiceCmd         `command:"editinvoice" description:"(user)    edit a invoice"`
+	EditProposal        EditProposalCmd        `command:"editproposal" description:"(user)   edit a proposal"`
+	ManageUser          ManageUserCmd          `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
+	EditUser            EditUserCmd            `command:"edituser" description:"(user)   edit the  preferences of the logged in user"`
+	Help                HelpCmd                `command:"help" description:"         print a detailed help message for a specific command"`
+	Inventory           InventoryCmd           `command:"inventory" description:"(public) get the proposals that are being voted on"`
+	InviteNewUser       InviteNewUserCmd       `command:"invite" description:"(admin)  invite a new user"`
+	InvoiceDetails      InvoiceDetailsCmd      `command:"invoicedetails" description:"(public) get the details of a proposal"`
+	LikeComment         LikeCommentCmd         `command:"likecomment" description:"(user)   upvote/downvote a comment"`
+	SetUserReadComments SetUserReadCommentsCmd `command:"setuserreadcomments" description:"(user) set comments as read"`
+	Login               LoginCmd               `command:"login" description:"(public) login to Politeia"`
+	Logout              LogoutCmd              `command:"logout" description:"(public) logout of Politeia"`
+	Me                  MeCmd                  `command:"me" description:"(user)   get user details for the logged in user"`
+	NewInvoice          NewInvoiceCmd          `command:"newinvoice" description:"(user)   create a new invoice"`
+	NewProposal         NewProposalCmd         `command:"newproposal" description:"(user)   create a new proposal"`
+	NewComment          NewCommentCmd          `command:"newcomment" description:"(user)   create a new proposal comment"`
+	NewUser             NewUserCmd             `command:"newuser" description:"(public) create a new user"`
+	Policy              PolicyCmd              `command:"policy" description:"(public) get the server policy"`
+	ProposalComments    ProposalCommentsCmd    `command:"proposalcomments" description:"(public) get the comments for a proposal"`
+	ProposalDetails     ProposalDetailsCmd     `command:"proposaldetails" description:"(public) get the details of a proposal"`
+	ProposalPaywall     ProposalPaywallCmd     `command:"proposalpaywall" description:"(user)   get proposal paywall details for the logged in user"`
+	ProposalStats       ProposalStatsCmd       `command:"proposalstats" description:"(public) get statistics on the proposal inventory"`
+	UnvettedProposals   UnvettedProposalsCmd   `command:"unvettedproposals" description:"(admin)  get a page of unvetted proposals"`
+	VettedProposals     VettedProposalsCmd     `command:"vettedproposals" description:"(public) get a page of vetted proposals"`
+	RegisterUser        RegisterUserCmd        `command:"register" description:"(public) register an invited user to cms"`
+	RescanUserPayments  RescanUserPaymentsCmd  `command:"rescanuserpayments" description:"(admin)  rescan a user's payments to check for missed payments"`
+	ResendVerification  ResendVerificationCmd  `command:"resendverification" description:"(public) resend the user verification email"`
+	ResetPassword       ResetPasswordCmd       `command:"resetpassword" description:"(public) reset the password for a user that is not logged in"`
+	Secret              SecretCmd              `command:"secret" description:"(user)   ping politeiawww"`
+	SendFaucetTx        SendFaucetTxCmd        `command:"sendfaucettx" description:"         send a DCR transaction using the Decred testnet faucet"`
+	SetInvoiceStatus    SetInvoiceStatusCmd    `command:"setinvoicestatus" description:"(admin)  set the status of an invoice"`
+	SetProposalStatus   SetProposalStatusCmd   `command:"setproposalstatus" description:"(admin)  set the status of a proposal"`
+	StartVote           StartVoteCmd           `command:"startvote" description:"(admin)  start the voting period on a proposal"`
+	Subscribe           SubscribeCmd           `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`
+	Tally               TallyCmd               `command:"tally" description:"(public) get the vote tally for a proposal"`
+	TestRun             TestRunCmd             `command:"testrun" description:"         run a series of tests on the politeiawww routes (dev use only)"`
+	UpdateUserKey       UpdateUserKeyCmd       `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
+	UserDetails         UserDetailsCmd         `command:"userdetails" description:"(public) get the details of a user profile"`
+	UserLikeComments    UserLikeCommentsCmd    `command:"userlikecomments" description:"(user)   get the logged in user's comment upvotes/downvotes for a proposal"`
+	UserPendingPayment  UserPendingPaymentCmd  `command:"userpendingpayment" description:"(user)   get details for a pending payment for the logged in user"`
+	UserInvoices        UserInvoicesCmd        `command:"userinvoices" description:"(user) get all invoices submitted by a specific user"`
+	UserProposals       UserProposalsCmd       `command:"userproposals" description:"(public) get all proposals submitted by a specific user"`
+	Users               UsersCmd               `command:"users" description:"(admin)  get a list of users"`
+	VerifyUserEmail     VerifyUserEmailCmd     `command:"verifyuseremail" description:"(public) verify a user's email address"`
+	VerifyUserPayment   VerifyUserPaymentCmd   `command:"verifyuserpayment" description:"(user)   check if the logged in user has paid their user registration fee"`
+	Version             VersionCmd             `command:"version" description:"(public) get server info and CSRF token"`
+	Vote                VoteCmd                `command:"vote" description:"(public) cast votes for a proposal"`
+	VoteResults         VoteResultsCmd         `command:"voteresults" description:"(public) get vote results for a proposal"`
+	VoteStatus          VoteStatusCmd          `command:"votestatus" description:"(public) get the vote status of a proposal"`
+	VoteStatuses        VoteStatusesCmd        `command:"votestatuses" description:"(public) get the vote status for all public proposals"`
 }
 
 // SetConfig sets the global config variable.

--- a/politeiawww/cmd/politeiawwwcli/commands/setuserreadcomments.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/setuserreadcomments.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"strings"
+
+	"github.com/decred/politeia/politeiawww/api/www/v1"
+)
+
+// SetUserReadCommentsCmd is used to upvote/downvote a proposal comment using the
+// logged in the user.
+type SetUserReadCommentsCmd struct {
+	Args struct {
+		Token      string `positional-arg-name:"token"`      // Censorship token
+		CommentIDs string `positional-arg-name:"commentIDs"` // Comment IDs
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the like comment command.
+func (cmd *SetUserReadCommentsCmd) Execute(args []string) error {
+
+	token := cmd.Args.Token
+	commentIDs := strings.Split(cmd.Args.CommentIDs, ",")
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	urc := &v1.SetUserReadComments{
+		ReadComments: commentIDs,
+	}
+
+	// Print request details
+	err := printJSON(urc)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	urcr, err := client.SetUserReadComments(urc, token)
+	if err != nil {
+		return err
+	}
+
+	// Print response details
+	return printJSON(urcr)
+}
+
+// setUserReadCommentsHelpMsg is the output for the help command when 'setuserreadcomments' is
+// specified.
+const setUserReadCommentsHelpMsg = `setuserreadcomments "token" "commentIDs"
+
+Vote on a comment.
+
+Arguments:
+1. token       (string, required)   Proposal censorship token
+2. commentIDs   (string, required)  Read Comments ids. Ex: 1,3,5,7
+
+Request:
+{
+  "token":      (string)  Censorship token
+  "commentids":  ([]string)  Read Comment IDs
+}
+
+Response:
+{}`

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1313,9 +1313,16 @@ func (p *politeiawww) processCommentsGet(token string, u *user.User) (*www.GetCo
 	// Get the last time the user accessed these comments. This is
 	// a public route so a user may not exist.
 	var accessTime int64
+	var readComments = []string{}
 	if u != nil {
 		if u.ProposalCommentsAccessTimes == nil {
 			u.ProposalCommentsAccessTimes = make(map[string]int64)
+		}
+		if u.ReadComments == nil {
+			u.ReadComments = make(map[string][]string)
+		}
+		if u.ReadComments[token] != nil {
+			readComments = u.ReadComments[token]
 		}
 		accessTime = u.ProposalCommentsAccessTimes[token]
 		u.ProposalCommentsAccessTimes[token] = time.Now().Unix()
@@ -1326,8 +1333,9 @@ func (p *politeiawww) processCommentsGet(token string, u *user.User) (*www.GetCo
 	}
 
 	return &www.GetCommentsReply{
-		Comments:   c,
-		AccessTime: accessTime,
+		Comments:     c,
+		AccessTime:   accessTime,
+		ReadComments: readComments,
 	}, nil
 }
 

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -524,6 +524,23 @@ func (p *politeiawww) processUserCommentsLikes(user *user.User, token string) (*
 	}, nil
 }
 
+// processSetUserReadComments sets comments read by user for the passed in
+// proposal.
+func (p *politeiawww) processSetUserReadComments(u *user.User, token string, rcs []string) (*www.SetUserReadCommentsReply, error) {
+	log.Tracef("processSetUserReadComments: %v %v", u.ID, token)
+
+	if u.ReadComments == nil {
+		u.ReadComments = make(map[string][]string)
+	}
+
+	u.ReadComments[token] = rcs
+	err := p.db.UserUpdate(*u)
+	if err != nil {
+		return nil, err
+	}
+	return &www.SetUserReadCommentsReply{}, nil
+}
+
 // login attempts to login a a user.
 func (p *politeiawww) login(l *www.Login) loginReplyWithError {
 	// Get user from db.

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -106,6 +106,10 @@ type User struct {
 	// a UNIX timestamp.
 	ProposalCommentsAccessTimes map[string]int64
 
+	// Read comments organized by proposal. Map keys are proposal tokens, and each
+	// element is an array of commentIDs.
+	ReadComments map[string][]string
+
 	// All identities the user has ever used.  User should only have one
 	// active key at a time.  We allow multiples in order to deal with key
 	// loss.


### PR DESCRIPTION
This commit adds the structure needed to control the read comments by the user.
    
The main motivation of this was described by **xaur** on https://github.com/decred/politeiagui/issues/1021
    
- Add a new route to set read comments, which will receive an array of comments that were marked as read
- The *read comments* array is stored on the db for each proposal, according to the following map:
```golang
ReadComments map[string][]string
```