### PR TITLE
Remove name, location and ext pubkey from userdb

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -93,9 +93,6 @@ Verifies email address of a user account invited via
 | publickey | string | The user's ed25519 public key. | Yes |
 | username | string | A unique username for the user. | Yes |
 | password | string | A password for the user. | Yes |
-| name | string | The user's full name. | Yes |
-| location | string | The user's physical location. | Yes |
-| xpublickey | string | The extended public key for the user's payment account. | Yes |
 
 **Results:** none
 
@@ -120,9 +117,6 @@ Request:
   "publickey": "5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
   "username": "foobar",
   "password": "69af376cca42cd9c",
-  "name": "John Smith",
-  "location": "Atlanta, GA, USA",
-  "xpublickey": "9e4b1018913610c12496ec3e482f2fb42129197001c5d35d4f5848b77d2b5e5071f79b18bcab4f371c5b378280bb478c153b696003ac3a627c3d8a088cd5f00d"
 }
 ```
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -58,9 +58,6 @@ type RegisterUser struct {
 	Email             string `json:"email"`
 	Username          string `json:"username"`
 	Password          string `json:"password"`
-	Name              string `json:"name"`       // User's full name
-	Location          string `json:"location"`   // User's physical location
-	ExtendedPublicKey string `json:"xpublickey"` // Extended public key for user's payment account
 	VerificationToken string `json:"verificationtoken"`
 	PublicKey         string `json:"publickey"`
 }

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -1175,9 +1175,6 @@ type User struct {
 	Identities                      []UserIdentity `json:"identities"`
 	ProposalCredits                 uint64         `json:"proposalcredits"`
 	EmailNotifications              uint64         `json:"emailnotifications"` // Notify the user via emails
-	Name                            string         `json:"name"`
-	Location                        string         `json:"location"`
-	ExtendedPublicKey               string         `json:"extpubkey"`
 }
 
 // UserIdentity represents a user's unique identity.

--- a/politeiawww/cmd/politeiawwwcli/commands/register.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/register.go
@@ -24,11 +24,8 @@ type RegisterUserCmd struct {
 		Email string `positional-arg-name:"email"`
 		Token string `positional-arg-name:"token"`
 	} `positional-args:"true" required:"true"`
-	Username          string `long:"username" optional:"true" description:"Username"`
-	Password          string `long:"password" optional:"true" description:"Password"`
-	Name              string `long:"name" optional:"true" description:"Full name"`
-	Location          string `long:"location" optional:"true" description:"Location (e.g. Dallas, TX, USA)"`
-	ExtendedPublicKey string `long:"xpubkey" optional:"true" description:"The extended public key for the payment account"`
+	Username string `long:"username" optional:"true" description:"Username"`
+	Password string `long:"password" optional:"true" description:"Password"`
 }
 
 // Execute executes the register user command
@@ -53,8 +50,7 @@ func (cmd *RegisterUserCmd) Execute(args []string) error {
 		return fmt.Errorf("Policy: %v", err)
 	}
 
-	if cmd.Username == "" || cmd.Password == "" || cmd.Name == "" ||
-		cmd.Location == "" || cmd.ExtendedPublicKey == "" {
+	if cmd.Username == "" || cmd.Password == "" {
 		reader := bufio.NewReader(os.Stdin)
 		if cmd.Username == "" {
 			fmt.Print("Create a username: ")
@@ -100,23 +96,6 @@ func (cmd *RegisterUserCmd) Execute(args []string) error {
 				break
 			}
 		}
-		if cmd.Name == "" {
-			fmt.Print("Enter your full name: ")
-			cmd.Name, _ = reader.ReadString('\n')
-		}
-		if cmd.Location == "" {
-			fmt.Print("Enter your location (e.g. Dallas, TX, USA): ")
-			cmd.Location, _ = reader.ReadString('\n')
-		}
-		if cmd.ExtendedPublicKey == "" {
-			fmt.Print("Enter the extended public key for your payment account: ")
-			cmd.ExtendedPublicKey, _ = reader.ReadString('\n')
-		}
-
-		fmt.Print("\nPlease carefully review your information and ensure it's " +
-			"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
-			"your registration.")
-		reader.ReadString('\n')
 	}
 
 	// Validate password
@@ -135,9 +114,6 @@ func (cmd *RegisterUserCmd) Execute(args []string) error {
 		Email:             email,
 		Username:          strings.TrimSpace(cmd.Username),
 		Password:          digestSHA3(cmd.Password),
-		Name:              strings.TrimSpace(cmd.Name),
-		Location:          strings.TrimSpace(cmd.Location),
-		ExtendedPublicKey: strings.TrimSpace(cmd.ExtendedPublicKey),
 		VerificationToken: strings.TrimSpace(cmd.Args.Token),
 		PublicKey:         hex.EncodeToString(id.Public.Key[:]),
 	}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -68,6 +68,8 @@ var (
 		},
 	}
 	validInvoiceField = regexp.MustCompile(createInvoiceFieldRegex())
+	validName         = regexp.MustCompile(createNameLocationRegex())
+	validLocation     = regexp.MustCompile(createNameLocationRegex())
 )
 
 // formatInvoiceField normalizes an invoice field without leading and
@@ -112,6 +114,26 @@ func createInvoiceFieldRegex() string {
 	}
 	buf.WriteString("]{0,")
 	buf.WriteString(strconv.Itoa(www.PolicyMaxInvoiceFieldLength) + "}$")
+
+	return buf.String()
+}
+
+// createUsernameRegex generates a regex based on the policy supplied valid
+// characters in a user's name or location.
+func createNameLocationRegex() string {
+	var buf bytes.Buffer
+	buf.WriteString("^[")
+
+	for _, supportedChar := range www.PolicyNameLocationSupportedChars {
+		if len(supportedChar) > 1 {
+			buf.WriteString(supportedChar)
+		} else {
+			buf.WriteString(`\` + supportedChar)
+		}
+	}
+	buf.WriteString("]{")
+	buf.WriteString(strconv.Itoa(www.PolicyMinUsernameLength) + ",")
+	buf.WriteString(strconv.Itoa(www.PolicyMaxUsernameLength) + "}$")
 
 	return buf.String()
 }

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -116,6 +116,56 @@ func createInvoiceFieldRegex() string {
 	return buf.String()
 }
 
+// formatName normalizes a contractor name to lowercase without leading and
+// trailing spaces.
+func formatName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func validateName(name string) error {
+	if len(name) < www.PolicyMinNameLength ||
+		len(name) > www.PolicyMaxNameLength {
+		log.Debugf("Name not within bounds: %s", name)
+		return www.UserError{
+			ErrorCode: www.ErrorStatusMalformedName,
+		}
+	}
+
+	if !validName.MatchString(name) {
+		log.Debugf("Name not valid: %s %s", name, validName.String())
+		return www.UserError{
+			ErrorCode: www.ErrorStatusMalformedName,
+		}
+	}
+
+	return nil
+}
+
+// formatLocation normalizes a contractor location to lowercase without leading and
+// trailing spaces.
+func formatLocation(location string) string {
+	return strings.ToLower(strings.TrimSpace(location))
+}
+
+func validateLocation(location string) error {
+	if len(location) < www.PolicyMinLocationLength ||
+		len(location) > www.PolicyMaxLocationLength {
+		log.Debugf("Location not within bounds: %s", location)
+		return www.UserError{
+			ErrorCode: www.ErrorStatusMalformedLocation,
+		}
+	}
+
+	if !validLocation.MatchString(location) {
+		log.Debugf("Location not valid: %s %s", location, validLocation.String())
+		return www.UserError{
+			ErrorCode: www.ErrorStatusMalformedLocation,
+		}
+	}
+
+	return nil
+}
+
 // processNewInvoice tries to submit a new proposal to politeiad.
 func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.NewInvoiceReply, error) {
 	log.Tracef("processNewInvoice")

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -224,56 +224,6 @@ func validatePubkey(publicKey string) ([]byte, error) {
 	return pk, nil
 }
 
-// formatName normalizes a contractor name to lowercase without leading and
-// trailing spaces.
-func formatName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
-}
-
-func validateName(name string) error {
-	if len(name) < www.PolicyMinNameLength ||
-		len(name) > www.PolicyMaxNameLength {
-		log.Debugf("Name not within bounds: %s", name)
-		return www.UserError{
-			ErrorCode: www.ErrorStatusMalformedName,
-		}
-	}
-
-	if !validName.MatchString(name) {
-		log.Debugf("Name not valid: %s %s", name, validName.String())
-		return www.UserError{
-			ErrorCode: www.ErrorStatusMalformedName,
-		}
-	}
-
-	return nil
-}
-
-// formatLocation normalizes a contractor location to lowercase without leading and
-// trailing spaces.
-func formatLocation(location string) string {
-	return strings.ToLower(strings.TrimSpace(location))
-}
-
-func validateLocation(location string) error {
-	if len(location) < www.PolicyMinLocationLength ||
-		len(location) > www.PolicyMaxLocationLength {
-		log.Debugf("Location not within bounds: %s", location)
-		return www.UserError{
-			ErrorCode: www.ErrorStatusMalformedLocation,
-		}
-	}
-
-	if !validLocation.MatchString(location) {
-		log.Debugf("Location not valid: %s %s", location, validLocation.String())
-		return www.UserError{
-			ErrorCode: www.ErrorStatusMalformedLocation,
-		}
-	}
-
-	return nil
-}
-
 // checkPublicKeyAndSignature validates the public key and signature.
 func checkPublicKeyAndSignature(u *user.User, publicKey string, signature string, elements ...string) error {
 	id, err := checkPublicKey(u, publicKey)

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/golangcrypto/bcrypt"
-	"github.com/decred/dcrd/hdkeychain"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
@@ -2318,40 +2317,12 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 		}
 	}
 
-	// Validate provided contractor name
-	name := formatName(u.Name)
-	err = validateName(name)
-	if err != nil {
-		return nil, err
-	}
-
-	// Validate provided contractor location
-	location := formatLocation(u.Location)
-	err = validateLocation(location)
-	if err != nil {
-		return nil, err
-	}
-
-	// Validate provided contractor extended public key
-	contractorKey, err := hdkeychain.NewKeyFromString(u.ExtendedPublicKey)
-	if err != nil {
-		return nil, fmt.Errorf("error processing extended public key: %v",
-			err)
-	}
-	if !contractorKey.IsForNet(activeNetParams.Params) {
-		return nil, fmt.Errorf("contractor extended public key is for the " +
-			"wrong network")
-	}
-
 	// Create a new database user with the provided information.
 	newUser := user.User{
-		Email:                     strings.ToLower(u.Email),
-		Username:                  username,
-		HashedPassword:            hashedPassword,
-		Admin:                     false,
-		Name:                      u.Name,
-		Location:                  u.Location,
-		ExtendedPublicKey:         u.ExtendedPublicKey,
+		Email:          strings.ToLower(u.Email),
+		Username:       username,
+		HashedPassword: hashedPassword,
+		Admin:          false,
 		NewUserVerificationToken:  nil,
 		NewUserVerificationExpiry: 0,
 	}

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -33,10 +33,6 @@ const (
 
 var (
 	validUsername = regexp.MustCompile(createUsernameRegex())
-	// XXX Need proper regex for name/location fields, possibly need to add
-	// new policy entries depending on how much we'd like it to differ.
-	validName     = regexp.MustCompile(createNameLocationRegex())
-	validLocation = regexp.MustCompile(createNameLocationRegex())
 
 	// MinimumLoginWaitTime is the minimum amount of time to wait before the
 	// server sends a response to the client for the login route. This is done
@@ -58,26 +54,6 @@ func createUsernameRegex() string {
 	buf.WriteString("^[")
 
 	for _, supportedChar := range www.PolicyUsernameSupportedChars {
-		if len(supportedChar) > 1 {
-			buf.WriteString(supportedChar)
-		} else {
-			buf.WriteString(`\` + supportedChar)
-		}
-	}
-	buf.WriteString("]{")
-	buf.WriteString(strconv.Itoa(www.PolicyMinUsernameLength) + ",")
-	buf.WriteString(strconv.Itoa(www.PolicyMaxUsernameLength) + "}$")
-
-	return buf.String()
-}
-
-// createNameLocationRegex generates a regex based on the policy supplied valid
-// characters in a user name.
-func createNameLocationRegex() string {
-	var buf bytes.Buffer
-	buf.WriteString("^[")
-
-	for _, supportedChar := range www.PolicyNameLocationSupportedChars {
 		if len(supportedChar) > 1 {
 			buf.WriteString(supportedChar)
 		} else {
@@ -2269,10 +2245,10 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 
 	// Create a new database user with the provided information.
 	newUser := user.User{
-		Email:          strings.ToLower(u.Email),
-		Username:       username,
-		HashedPassword: hashedPassword,
-		Admin:          false,
+		Email:                     strings.ToLower(u.Email),
+		Username:                  username,
+		HashedPassword:            hashedPassword,
+		Admin:                     false,
 		NewUserVerificationToken:  nil,
 		NewUserVerificationExpiry: 0,
 	}


### PR DESCRIPTION
This is the first in a series of PRs to address issue #765 

We will no longer be storing this information within the userdb and
instead will be entered per invoice.  