### PR TITLE
Add new domain/subdomain line item fields

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -145,7 +145,8 @@ type InvoiceInput struct {
 // invoice input.
 type LineItemsInput struct {
 	Type          LineItemTypeT `json:"type"`          // Type of work performed
-	Subtype       string        `json:"subtype"`       // Subtype of work performed
+	Domain        string        `json:"domain"`        // Domain of work performed
+	Subdomain     string        `json:"subdomain"`     // Subdomain of work performed
 	Description   string        `json:"description"`   // Description of work performed
 	ProposalToken string        `json:"proposaltoken"` // Link to politeia proposal that work is associated with
 	Labor         uint          `json:"labor"`         // Number of minutes (if labor)

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -130,7 +130,8 @@ notifications.  It does not render HTML.
 - [`ErrorStatusInvoiceInvalidRate`](#ErrorStatusInvoiceInvalidRate)
 - [`ErrorStatusInvoiceMalformedContact`](#ErrorStatusInvoiceMalformedContact)
 - [`ErrorStatusMalformedProposalToken`](#ErrorStatusMalformedProposalToken)
-- [`ErrorStatusMalformedSubType`](#ErrorStatusMalformedSubType)
+- [`ErrorStatusMalformedDomain`](#ErrorStatusMalformedDomain)
+- [`ErrorStatusMalformedSubdomain`](#ErrorStatusMalformedSubdomain)
 - [`ErrorStatusMalformedDescription`](#ErrorStatusMalformedDescription) 
 
 **Proposal status codes**
@@ -2536,8 +2537,9 @@ Reply:
 | <a name="ErrorStatusInvoiceInvalidRate">ErrorStatusInvoiceInvalidRate</a> | 75 | Submitted contractor rate is invalid (either too high or low). |
 | <a name="ErrorStatusInvoiceMalformedContact">ErrorStatusInvoiceMalformedContact</a> | 76 | Malformed contractor contact was entered. |
 | <a name="ErrorStatusMalformedProposalToken">ErrorStatusMalformedProposalToken</a> | 77 | Malformed proposal token for a line item. |
-| <a name="ErrorStatusMalformedSubType">ErrorStatusMalformedSubType</a> | 78 | Malformed subtype for a line item. |
-| <a name="ErrorStatusMalformedDescription">ErrorStatusMalformedDescription</a> | 79 | Malformed description for a line item. |
+| <a name="ErrorStatusMalformedDomain">ErrorStatusMalformedDomain</a> | 78 | Malformed domain for a line item. |
+| <a name="ErrorStatusMalformedSubdomain">ErrorStatusMalformedSubdomain</a> | 79 | Malformed subdomain for a line item. |
+| <a name="ErrorStatusMalformedDescription">ErrorStatusMalformedDescription</a> | 80 | Malformed description for a line item. |
 
 
 ### Proposal status codes

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -131,7 +131,7 @@ const (
 	PolicyInvoiceFieldDelimiterChar rune = ','
 	// PolicyInvoiceLineItemCount is the number of expected fields in the raw
 	// csv line items
-	PolicyInvoiceLineItemCount = 6
+	PolicyInvoiceLineItemCount = 7
 
 	// ProposalListPageSize is the maximum number of proposals returned
 	// for the routes that return lists of proposals
@@ -222,8 +222,9 @@ const (
 	ErrorStatusInvoiceInvalidRate             ErrorStatusT = 75
 	ErrorStatusInvoiceMalformedContact        ErrorStatusT = 76
 	ErrorStatusMalformedProposalToken         ErrorStatusT = 77
-	ErrorStatusMalformedSubType               ErrorStatusT = 78
-	ErrorStatusMalformedDescription           ErrorStatusT = 79
+	ErrorStatusMalformedDomain                ErrorStatusT = 78
+	ErrorStatusMalformedSubdomain             ErrorStatusT = 79
+	ErrorStatusMalformedDescription           ErrorStatusT = 80
 
 	// Proposal state codes
 	//
@@ -395,7 +396,8 @@ var (
 		ErrorStatusInvoiceMissingRate:             "invoice missing contractor rate",
 		ErrorStatusInvoiceInvalidRate:             "invoice has invalid contractor rate",
 		ErrorStatusMalformedProposalToken:         "line item has malformed proposal token",
-		ErrorStatusMalformedSubType:               "line item has malformed subtype",
+		ErrorStatusMalformedDomain:                "line item has malformed domain",
+		ErrorStatusMalformedSubdomain:             "line item has malformed subdomain",
 		ErrorStatusMalformedDescription:           "line item has malformed description",
 	}
 

--- a/politeiawww/cmd/politeiawwwcli/commands/newinvoice.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newinvoice.go
@@ -223,12 +223,12 @@ func validateParseCSV(data []byte) (*v1.InvoiceInput, error) {
 				fmt.Errorf("invalid number of line items on line: %v want: %v got: %v",
 					i, www.PolicyInvoiceLineItemCount, len(lineContents))
 		}
-		hours, err := strconv.Atoi(lineContents[4])
+		hours, err := strconv.Atoi(lineContents[5])
 		if err != nil {
 			return invInput,
 				fmt.Errorf("invalid line item hours entered on line: %v", i)
 		}
-		cost, err := strconv.Atoi(lineContents[5])
+		cost, err := strconv.Atoi(lineContents[6])
 		if err != nil {
 			return invInput,
 				fmt.Errorf("invalid cost entered on line: %v", i)
@@ -241,9 +241,10 @@ func validateParseCSV(data []byte) (*v1.InvoiceInput, error) {
 		}
 
 		lineItem.Type = lineItemType
-		lineItem.Subtype = lineContents[1]
-		lineItem.Description = lineContents[2]
-		lineItem.ProposalToken = lineContents[3]
+		lineItem.Domain = lineContents[1]
+		lineItem.Subdomain = lineContents[2]
+		lineItem.Description = lineContents[3]
+		lineItem.ProposalToken = lineContents[4]
 		lineItem.Labor = uint(hours * 60)
 		lineItem.Expenses = uint(cost * 100)
 		lineItems = append(lineItems, lineItem)

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -97,7 +97,8 @@ func EncodeInvoiceLineItem(dbLineItem *database.LineItem) LineItem {
 	lineItem := LineItem{}
 	lineItem.InvoiceToken = dbLineItem.InvoiceToken
 	lineItem.Type = uint(dbLineItem.Type)
-	lineItem.Subtype = dbLineItem.Subtype
+	lineItem.Domain = dbLineItem.Domain
+	lineItem.Subdomain = dbLineItem.Subdomain
 	lineItem.Description = dbLineItem.Description
 	lineItem.ProposalURL = dbLineItem.ProposalURL
 	lineItem.Labor = dbLineItem.Labor
@@ -110,7 +111,8 @@ func DecodeInvoiceLineItem(lineItem *LineItem) *database.LineItem {
 	dbLineItem := &database.LineItem{}
 	dbLineItem.InvoiceToken = lineItem.InvoiceToken
 	dbLineItem.Type = cms.LineItemTypeT(lineItem.Type)
-	dbLineItem.Subtype = lineItem.Subtype
+	dbLineItem.Domain = lineItem.Domain
+	dbLineItem.Subdomain = lineItem.Subdomain
 	dbLineItem.Description = lineItem.Description
 	dbLineItem.ProposalURL = lineItem.ProposalURL
 	dbLineItem.Labor = lineItem.Labor

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -43,8 +43,9 @@ func (Invoice) TableName() string {
 type LineItem struct {
 	LineItemKey  string `gorm:"primary_key"` // Token of the Invoice + array index
 	InvoiceToken string `gorm:"not null"`    // Censorship token of the invoice
-	Type         uint   `gorm:"not null"`    // Type of work performed
-	Subtype      string `gorm:"not null"`    // Subtype of work performed
+	Type         uint   `gorm:"not null"`    // Type of line item
+	Domain       string `gorm:"not null"`    // Domain of the work performed (dev, marketing etc)
+	Subdomain    string `gorm:"not null"`    // Subdomain of the work performed (decrediton, event X etc)
 	Description  string `gorm:"not null"`    // Description of work performed
 	ProposalURL  string `gorm:"not null"`    // Link to politeia proposal that work is associated with
 	Labor        uint   `gorm:"not null"`    // Number of minutes worked

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -77,7 +77,8 @@ type LineItem struct {
 	LineNumber   uint
 	InvoiceToken string
 	Type         cms.LineItemTypeT
-	Subtype      string
+	Domain       string
+	Subdomain    string
 	Description  string
 	ProposalURL  string
 	Labor        uint

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -541,7 +541,8 @@ func convertLineItemsToDatabase(token string, l []cms.LineItemsInput) []cmsdatab
 		dl = append(dl, cmsdatabase.LineItem{
 			InvoiceToken: token,
 			Type:         v.Type,
-			Subtype:      v.Subtype,
+			Domain:       v.Domain,
+			Subdomain:    v.Subdomain,
 			Description:  v.Description,
 			ProposalURL:  v.ProposalToken,
 			Labor:        v.Labor,

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -418,10 +418,16 @@ func validateInvoice(ni cms.NewInvoice, u *user.User) error {
 
 			// Validate line items
 			for _, lineInput := range invInput.LineItems {
-				subtype := formatInvoiceField(lineInput.Subtype)
-				if !validateInvoiceField(subtype) {
+				domain := formatInvoiceField(lineInput.Domain)
+				if !validateInvoiceField(domain) {
 					return www.UserError{
-						ErrorCode: www.ErrorStatusMalformedSubType,
+						ErrorCode: www.ErrorStatusMalformedDomain,
+					}
+				}
+				subdomain := formatInvoiceField(lineInput.Subdomain)
+				if !validateInvoiceField(subdomain) {
+					return www.UserError{
+						ErrorCode: www.ErrorStatusMalformedSubdomain,
 					}
 				}
 


### PR DESCRIPTION
This gives us more flexibility when organizing expenditures for
public consumption down the road.

For example:
Domain: Development
Subdomain: Decrediton

This would allow us to group all spending for each domain and
subdomain, instead of purely "subtype".