### PR TITLE
Remove unused error status and update codes accordingly

### DIFF
--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -122,7 +122,6 @@ notifications.  It does not render HTML.
 - [`ErrorStatusInvoiceDuplicate`](#ErrorStatusInvoiceDuplicate)
 - [`ErrorStatusInvalidPaymentAddress`](#ErrorStatusInvalidPaymentAddress)
 - [`ErrorStatusMalformedLineItem`](#ErrorStatusMalformedLineItem)
-- [`ErrorStatusInvalidInvoiceInputVersion`](#ErrorStatusInvalidInvoiceInputVersion)
 - [`ErrorStatusInvoiceMissingName`](#ErrorStatusInvoiceMissingName)
 - [`ErrorStatusInvoiceMissingLocation`](#ErrorStatusInvoiceMissingLocation)
 - [`ErrorStatusInvoiceMissingContact`](#ErrorStatusInvoiceMissingContact)
@@ -2530,7 +2529,6 @@ Reply:
 | <a name="ErrorStatusInvoiceDuplicate">ErrorStatusInvoiceDuplicate</a> | 67 | Invoice is a duplicate. |
 | <a name="ErrorStatusInvalidPaymentAddress">ErrorStatusInvalidPaymentAddress</a> | 68 | Invalid payment address was submitted. |
 | <a name="ErrorStatusMalformedLineItem">ErrorStatusMalformedLineItem</a> | 69 | Line item in an invoice was malformed and invalid. |
-| <a name="ErrorStatusInvalidInvoiceInputVersion">ErrorStatusInvalidInvoiceInputVersion</a> | 70 | Invalid input version. |
 | <a name="ErrorStatusInvoiceMissingName">ErrorStatusInvoiceMissingName</a> | 71 | Submitted invoice missing contractor name. |
 | <a name="ErrorStatusInvoiceMissingLocation">ErrorStatusInvoiceMissingLocation</a> | 72 | Submitted invoice missing contractor location. |
 | <a name="ErrorStatusInvoiceMissingContact">ErrorStatusInvoiceMissingContact</a> | 73 | Submitted invoice missing contractor contact. |

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -214,18 +214,17 @@ const (
 	ErrorStatusInvoiceDuplicate               ErrorStatusT = 67
 	ErrorStatusInvalidPaymentAddress          ErrorStatusT = 68
 	ErrorStatusMalformedLineItem              ErrorStatusT = 69
-	ErrorStatusInvalidInvoiceInputVersion     ErrorStatusT = 70
-	ErrorStatusInvoiceMissingName             ErrorStatusT = 71
-	ErrorStatusInvoiceMissingLocation         ErrorStatusT = 72
-	ErrorStatusInvoiceMissingContact          ErrorStatusT = 73
-	ErrorStatusInvoiceMissingRate             ErrorStatusT = 74
-	ErrorStatusInvoiceInvalidRate             ErrorStatusT = 75
-	ErrorStatusInvoiceMalformedContact        ErrorStatusT = 76
-	ErrorStatusMalformedProposalToken         ErrorStatusT = 77
-	ErrorStatusMalformedDomain                ErrorStatusT = 78
-	ErrorStatusMalformedSubdomain             ErrorStatusT = 79
-	ErrorStatusMalformedDescription           ErrorStatusT = 80
-	ErrorStatusWrongInvoiceStatus             ErrorStatusT = 81
+	ErrorStatusInvoiceMissingName             ErrorStatusT = 70
+	ErrorStatusInvoiceMissingLocation         ErrorStatusT = 71
+	ErrorStatusInvoiceMissingContact          ErrorStatusT = 72
+	ErrorStatusInvoiceMissingRate             ErrorStatusT = 73
+	ErrorStatusInvoiceInvalidRate             ErrorStatusT = 74
+	ErrorStatusInvoiceMalformedContact        ErrorStatusT = 75
+	ErrorStatusMalformedProposalToken         ErrorStatusT = 76
+	ErrorStatusMalformedDomain                ErrorStatusT = 77
+	ErrorStatusMalformedSubdomain             ErrorStatusT = 78
+	ErrorStatusMalformedDescription           ErrorStatusT = 89
+	ErrorStatusWrongInvoiceStatus             ErrorStatusT = 80
 
 	// Proposal state codes
 	//


### PR DESCRIPTION
The error code `ErrorStatusInvalidInvoiceInputVersion`was removed from the "human readable" map but it was not removed from the list of status code. This was creating an unmatching between the errors codes and their respective message.
This PR fixes that and update the error codes.