### PR TITLE
Add GeneratePayouts admin request

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -15,6 +15,7 @@ server side notifications.  It does not render HTML.
 - [`Admin invoices`](#admin-invoices)
 - [`Edit invoice`](#edit-invoice)
 - [`Set invoice status`](#set-invoice-status)
+- [`Generate payouts`](#generate-payouts)
 
 **Invoice status codes**
 
@@ -427,6 +428,51 @@ Reply:
 }
 ```
 
+### `Generate payouts`
+
+Generates a list of payout information for currently approved invoices.
+
+Note: This call requires admin privileges.
+
+**Route:** `POST /v1/admin/generatepayouts`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| payouts | array of [`Payout`](#payout)s | The page of invoices. |
+
+**Example**
+
+Request:
+
+```json
+{}
+```
+
+Reply:
+
+```json
+{
+  "payouts": [
+    {
+      "contractorname": "bill",
+      "username": "bill0012",
+      "month": 1,
+      "year": 2019,
+      "token": "123afed4609f21f4e3262420a875405440f42dcdaa98c163c6610fd9d6b7e855",
+      "address": "TsfDLrRkk9ciUuwfp2b8PawwnukYD7yAjGd",
+      "labortotal": 120000,
+      "expensetotal": 400
+    }
+  ]
+}
+```
 ### Invoice status codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -188,7 +188,6 @@ type SetInvoiceStatusReply struct {
 // GeneratePayouts is used to generate a list of addresses and amounts of
 // approved invoices that need to be paid.
 type GeneratePayouts struct {
-	DCRUSDRate uint `json:"dcrusdrate"` // User provided average dcr/usd rate for generating payouts
 }
 
 type GeneratePayoutsReply struct {
@@ -198,9 +197,13 @@ type GeneratePayoutsReply struct {
 // Payout contains an address and an amount to be paid
 type Payout struct {
 	ContractorName string `json:"contractorname"`
+	Username       string `json:"username"`
+	Month          uint   `json:"month"`
+	Year           uint   `json:"year"`
 	Token          string `json:"token"`
 	Address        string `json:"address"`
-	Amount         uint   `json:"amount"`
+	LaborTotal     uint   `json:"labortotal"`
+	ExpenseTotal   uint   `json:"expensetotal"`
 }
 
 // PayInvoices is used for an administrator to pay invoices

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -190,6 +190,7 @@ type SetInvoiceStatusReply struct {
 type GeneratePayouts struct {
 }
 
+// GeneratePayoutsReply is used to replay to a GeneratePayouts command.
 type GeneratePayoutsReply struct {
 	Payouts []Payout `json:"payouts"`
 }
@@ -205,12 +206,4 @@ type Payout struct {
 	Address        string `json:"address"`
 	LaborTotal     uint   `json:"labortotal"`
 	ExpenseTotal   uint   `json:"expensetotal"`
-}
-
-// PayInvoices is used for an administrator to pay invoices
-type PayInvoices struct {
-	Tokens []string `json:"tokens"`
-}
-
-type PayInvoicesReply struct {
 }

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -18,6 +18,7 @@ const (
 	RouteSetInvoiceStatus = "/invoices/{token:[A-z0-9]{64}}/status"
 	RouteUserInvoices     = "/user/invoices"
 	RouteAdminInvoices    = "/admin/invoices"
+	RouteGeneratePayouts  = "/admin/generatepayouts"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status
@@ -182,4 +183,28 @@ type SetInvoiceStatus struct {
 // SetInvoiceStatusReply is used to reply to a SetInvoiceStatus command.
 type SetInvoiceStatusReply struct {
 	Invoice InvoiceRecord `json:"invoice"`
+}
+
+// GeneratePayouts is used to generate a list of addresses and amounts of
+// approved invoices that need to be paid.
+type GeneratePayouts struct {
+	DCRUSDRate uint `json:"dcrusdrate"` // User provided average dcr/usd rate for generating payouts
+}
+
+type GeneratePayoutsReply struct {
+	Payouts []Payout `json:"payouts"`
+}
+
+// Payout contains an address and an amount to be paid
+type Payout struct {
+	Address string `json:"address"`
+	Amount  uint   `json:"amount"`
+}
+
+// PayInvoices is used for an administrator to pay invoices
+type PayInvoices struct {
+	Tokens []string `json:"tokens"`
+}
+
+type PayInvoicesReply struct {
 }

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -197,8 +197,10 @@ type GeneratePayoutsReply struct {
 
 // Payout contains an address and an amount to be paid
 type Payout struct {
-	Address string `json:"address"`
-	Amount  uint   `json:"amount"`
+	ContractorName string `json:"contractorname"`
+	Token          string `json:"token"`
+	Address        string `json:"address"`
+	Amount         uint   `json:"amount"`
 }
 
 // PayInvoices is used for an administrator to pay invoices

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -197,6 +197,7 @@ type GeneratePayoutsReply struct {
 // Payout contains an address and an amount to be paid
 type Payout struct {
 	ContractorName string `json:"contractorname"`
+	ContractorRate uint   `json:"contractorrate"`
 	Username       string `json:"username"`
 	Month          uint   `json:"month"`
 	Year           uint   `json:"year"`

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -804,7 +804,7 @@ func (c *Client) AdminInvoices(ai *cms.AdminInvoices) (*cms.AdminInvoicesReply, 
 // GeneratePayouts generates a list of payouts for all approved invoices that
 // contain an address and amount for an admin to the process
 func (c *Client) GeneratePayouts(gp *cms.GeneratePayouts) (*cms.GeneratePayoutsReply, error) {
-	responseBody, err := c.makeRequest("POST", cms.RouteAdminInvoices, gp)
+	responseBody, err := c.makeRequest("POST", cms.RouteGeneratePayouts, gp)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -777,8 +777,8 @@ func (c *Client) UserInvoices(up *cms.UserInvoices) (*cms.UserInvoicesReply, err
 	return &upr, nil
 }
 
-// AdminInvoices retrieves the proposals that have been submitted by the
-// specified user.
+// AdminInvoices retrieves invoices base on possible field set in the request
+// month/year and/or status
 func (c *Client) AdminInvoices(ai *cms.AdminInvoices) (*cms.AdminInvoicesReply, error) {
 	responseBody, err := c.makeRequest("POST", cms.RouteAdminInvoices, ai)
 	if err != nil {
@@ -799,6 +799,30 @@ func (c *Client) AdminInvoices(ai *cms.AdminInvoices) (*cms.AdminInvoicesReply, 
 	}
 
 	return &air, nil
+}
+
+// GeneratePayouts generates a list of payouts for all approved invoices that
+// contain an address and amount for an admin to the process
+func (c *Client) GeneratePayouts(gp *cms.GeneratePayouts) (*cms.GeneratePayoutsReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteAdminInvoices, gp)
+	if err != nil {
+		return nil, err
+	}
+
+	var gpr cms.GeneratePayoutsReply
+	err = json.Unmarshal(responseBody, &gpr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal GeneratePayoutsReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(gpr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &gpr, nil
 }
 
 // SetProposalStatus changes the status of the specified proposal.

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -66,6 +66,7 @@ type Cmds struct {
 	EditProposal       EditProposalCmd       `command:"editproposal" description:"(user)   edit a proposal"`
 	ManageUser         ManageUserCmd         `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
 	EditUser           EditUserCmd           `command:"edituser" description:"(user)   edit the  preferences of the logged in user"`
+	GeneratePayouts    GeneratePayoutsCmd    `command:"generatepayouts" description:"(admin) generate a list of payouts with addresses and amounts to pay"`
 	Help               HelpCmd               `command:"help" description:"         print a detailed help message for a specific command"`
 	Inventory          InventoryCmd          `command:"inventory" description:"(public) get the proposals that are being voted on"`
 	InviteNewUser      InviteNewUserCmd      `command:"invite" description:"(admin)  invite a new user"`

--- a/politeiawww/cmd/politeiawwwcli/commands/generatepayouts.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/generatepayouts.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// GeneratePayoutsCmd
+type GeneratePayoutsCmd struct {
+	Args struct {
+		Rate uint `positional-arg-name:"rate"` // DCRUSDRate (in USD per 1 DCR)
+	}
+}
+
+// Execute executes the generate payouts command.
+func (cmd *GeneratePayoutsCmd) Execute(args []string) error {
+
+	// Generate payouts
+	gpr, err := client.GeneratePayouts(
+		&v1.GeneratePayouts{
+			DCRUSDRate: cmd.Args.Rate,
+		})
+	if err != nil {
+		return err
+	}
+
+	// Print user invoices
+	return printJSON(gpr)
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/generatepayouts.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/generatepayouts.go
@@ -10,9 +10,6 @@ import (
 
 // GeneratePayoutsCmd
 type GeneratePayoutsCmd struct {
-	Args struct {
-		Rate uint `positional-arg-name:"rate"` // DCRUSDRate (in USD per 1 DCR)
-	}
 }
 
 // Execute executes the generate payouts command.
@@ -20,9 +17,7 @@ func (cmd *GeneratePayoutsCmd) Execute(args []string) error {
 
 	// Generate payouts
 	gpr, err := client.GeneratePayouts(
-		&v1.GeneratePayouts{
-			DCRUSDRate: cmd.Args.Rate,
-		})
+		&v1.GeneratePayouts{})
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -69,7 +69,6 @@ func (c *cockroachdb) InvoicesByUserID(userid string) ([]database.Invoice, error
 		return nil, err
 	}
 
-	// XXX this could be done in a more efficient way
 	tokens := make([]string, 0, len(invoices))
 	for _, r := range invoices {
 		tokens = append(tokens, r.Token)
@@ -126,7 +125,6 @@ func (c *cockroachdb) InvoicesByMonthYearStatus(month, year uint16, status int) 
 		return nil, err
 	}
 
-	// XXX this could be done in a more efficient way
 	tokens := make([]string, 0, len(invoices))
 	for _, r := range invoices {
 		tokens = append(tokens, r.Token)
@@ -165,7 +163,6 @@ func (c *cockroachdb) InvoicesByMonthYear(month, year uint16) ([]database.Invoic
 		return nil, err
 	}
 
-	// XXX this could be done in a more efficient way
 	tokens := make([]string, 0, len(invoices))
 	for _, r := range invoices {
 		tokens = append(tokens, r.Token)
@@ -204,7 +201,6 @@ func (c *cockroachdb) InvoicesByStatus(status int) ([]database.Invoice, error) {
 		return nil, err
 	}
 
-	// XXX this could be done in a more efficient way
 	tokens := make([]string, 0, len(invoices))
 	for _, r := range invoices {
 		tokens = append(tokens, r.Token)
@@ -242,7 +238,6 @@ func (c *cockroachdb) InvoicesAll() ([]database.Invoice, error) {
 		return nil, err
 	}
 
-	// XXX this could be done in a more efficient way
 	tokens := make([]string, 0, len(invoices))
 	for _, r := range invoices {
 		tokens = append(tokens, r.Token)

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -69,6 +69,21 @@ func (c *cockroachdb) InvoicesByUserID(userid string) ([]database.Invoice, error
 		return nil, err
 	}
 
+	// XXX this could be done in a more efficient way
+	tokens := make([]string, 0, len(invoices))
+	for _, r := range invoices {
+		tokens = append(tokens, r.Token)
+	}
+	err = c.recordsdb.
+		Preload("LineItems").
+		Preload("Changes").
+		Where(tokens).
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
 	dbInvoices := make([]database.Invoice, 0, len(invoices))
 	for _, v := range invoices {
 		dbInvoice, err := DecodeInvoice(&v)
@@ -111,6 +126,21 @@ func (c *cockroachdb) InvoicesByMonthYearStatus(month, year uint16, status int) 
 		return nil, err
 	}
 
+	// XXX this could be done in a more efficient way
+	tokens := make([]string, 0, len(invoices))
+	for _, r := range invoices {
+		tokens = append(tokens, r.Token)
+	}
+	err = c.recordsdb.
+		Preload("LineItems").
+		Preload("Changes").
+		Where(tokens).
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
 	dbInvoices := make([]database.Invoice, 0, len(invoices))
 	for _, v := range invoices {
 		dbInvoice, err := DecodeInvoice(&v)
@@ -129,6 +159,21 @@ func (c *cockroachdb) InvoicesByMonthYear(month, year uint16) ([]database.Invoic
 	invoices := make([]Invoice, 0, 1024) // PNOOMA
 	err := c.recordsdb.
 		Where("month = ? AND year = ?", month, year).
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	// XXX this could be done in a more efficient way
+	tokens := make([]string, 0, len(invoices))
+	for _, r := range invoices {
+		tokens = append(tokens, r.Token)
+	}
+	err = c.recordsdb.
+		Preload("LineItems").
+		Preload("Changes").
+		Where(tokens).
 		Find(&invoices).
 		Error
 	if err != nil {
@@ -159,6 +204,21 @@ func (c *cockroachdb) InvoicesByStatus(status int) ([]database.Invoice, error) {
 		return nil, err
 	}
 
+	// XXX this could be done in a more efficient way
+	tokens := make([]string, 0, len(invoices))
+	for _, r := range invoices {
+		tokens = append(tokens, r.Token)
+	}
+	err = c.recordsdb.
+		Preload("LineItems").
+		Preload("Changes").
+		Where(tokens).
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
 	dbInvoices := make([]database.Invoice, 0, len(invoices))
 	for _, v := range invoices {
 		dbInvoice, err := DecodeInvoice(&v)
@@ -176,6 +236,21 @@ func (c *cockroachdb) InvoicesAll() ([]database.Invoice, error) {
 
 	invoices := make([]Invoice, 0, 1024) // PNOOMA
 	err := c.recordsdb.
+		Find(&invoices).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	// XXX this could be done in a more efficient way
+	tokens := make([]string, 0, len(invoices))
+	for _, r := range invoices {
+		tokens = append(tokens, r.Token)
+	}
+	err = c.recordsdb.
+		Preload("LineItems").
+		Preload("Changes").
+		Where(tokens).
 		Find(&invoices).
 		Error
 	if err != nil {

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -972,13 +972,16 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 				totalExpenses += lineItem.Expenses
 			}
 		}
-		fmt.Println(len(inv.LineItems))
-		payout.LaborTotal = totalLaborHours * inv.ContractorRate
-		payout.ExpenseTotal = totalExpenses
 
+		// Divide by 100 to get amounts in USD
+		payout.LaborTotal = totalLaborHours * inv.ContractorRate / 100
+		payout.ContractorRate = inv.ContractorRate / 100
+
+		payout.ExpenseTotal = totalExpenses
 		payout.Address = inv.PaymentAddress
 		payout.Token = inv.Token
 		payout.ContractorName = inv.ContractorName
+
 		payout.Username = p.getUsernameById(inv.UserID)
 		payout.Month = inv.Month
 		payout.Year = inv.Year

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -967,6 +967,9 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 		}
 		payout.Amount = amount
 		payout.Address = inv.PaymentAddress
+		payout.Token = inv.Token
+		payout.ContractorName = inv.ContractorName
+
 		payouts = append(payouts, payout)
 	}
 	reply.Payouts = payouts

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -954,8 +954,6 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 		return nil, err
 	}
 
-	// XXX ? Should we trust the dbInvs or should we take the token and get the
-	// raw invoice.json from the cache to get address and calc amount?
 	reply := &cms.GeneratePayoutsReply{}
 	payouts := make([]cms.Payout, 0, len(dbInvs))
 	for _, inv := range dbInvs {


### PR DESCRIPTION
This request is mostly a place holder for payment handling by admins.
It returns the payout information for all currently approved invoices.
With this information admins can do a final audit of the payout and
then construct the on-chain transaction to complete the invoice.

In the future, much of this payout system will be automated and will
require no intervention by an administrator.