### PR TITLE
Add politeiaimport tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 politeiad/cmd/politeia/politeia
+politeiad/cmd/politeiaimport/politeiaimport
 politeiad/politeiad
 politeiavoter/politeiavoter
 politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -44,14 +44,14 @@ const (
 	LockDuration = 15 * time.Second
 
 	// defaultUnvettedPath is the landing zone for unvetted content.
-	defaultUnvettedPath = "unvetted"
+	DefaultUnvettedPath = "unvetted"
 
 	// defaultVettedPath is the publicly visible git vetted record repo.
-	defaultVettedPath = "vetted"
+	DefaultVettedPath = "vetted"
 
 	// defaultJournalsPath is the path where data is journaled and/or
 	// cached.
-	defaultJournalsPath = "journals" // XXX it looks like this belongs in plugins
+	DefaultJournalsPath = "journals" // XXX it looks like this belongs in plugins
 
 	// defaultRecordMetadataFilename is the filename of record record.
 	defaultRecordMetadataFilename = "recordmetadata.json"
@@ -2535,9 +2535,9 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 		activeNetParams: anp,
 		root:            root,
 		cron:            cron.New(),
-		unvetted:        filepath.Join(root, defaultUnvettedPath),
-		vetted:          filepath.Join(root, defaultVettedPath),
-		journals:        filepath.Join(root, defaultJournalsPath),
+		unvetted:        filepath.Join(root, DefaultUnvettedPath),
+		vetted:          filepath.Join(root, DefaultVettedPath),
+		journals:        filepath.Join(root, DefaultJournalsPath),
 		gitPath:         gitPath,
 		dcrtimeHost:     dcrtimeHost,
 		gitTrace:        gitTrace,

--- a/politeiad/cmd/politeiaimport/README.md
+++ b/politeiad/cmd/politeiaimport/README.md
@@ -1,0 +1,28 @@
+# politeiaimport
+
+`politeiaimport` is a tool to import data from a public politeia repo such as
+the [decred proposals repo](https://github.com/decred-proposals/mainnet/).
+
+## Usage 
+
+Install `politeiaimport`.
+
+    $ go install $GOPATH/src/github.com/decred/politeia/politeiad/cmd/politeiaimport
+
+Clone the repo you want to import.
+
+    $ git clone https://github.com/decred-proposals/mainnet.git ~/mainnet
+
+Import the repo data.  If you're importing testnet data you must use the 
+`--testnet` flag.
+
+    $ politeiaimport ~/mainnet 
+    You are about to delete     : ~/.politeiad/data/mainnet
+    It will be replaced with    : ~/mainnet
+    Continue? (n/no/y/yes) [no] : yes
+    Walking import directory...
+    Done!
+
+`politeiaimport` replaces the existing unvetted and vetted repos with the data
+from the import directory.  The journal files are then recreated using the
+import data.  The git history of the import directory is kept intact.

--- a/politeiad/cmd/politeiaimport/politeiaimport.go
+++ b/politeiad/cmd/politeiaimport/politeiaimport.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/politeia/politeiad/backend/gitbe"
+	"github.com/decred/politeia/politeiad/sharedconfig"
+	"github.com/decred/politeia/util"
+)
+
+const (
+	defaultDataDirname     = sharedconfig.DefaultDataDirname
+	defaultUnvettedDirname = gitbe.DefaultUnvettedPath
+	defaultVettedDirname   = gitbe.DefaultVettedPath
+	defaultJournalsDirname = gitbe.DefaultJournalsPath
+)
+
+var (
+	defaultHomeDir = sharedconfig.DefaultHomeDir
+
+	// CLI flags
+	homeDir = flag.String("homedir", defaultHomeDir, "politeiad home dir path")
+	testnet = flag.Bool("testnet", false, "import data is testnet data")
+)
+
+func _main() error {
+	flag.Parse()
+	if len(flag.Args()) == 0 {
+		return fmt.Errorf("must provide import directory")
+	}
+
+	// Parse import directory
+	importDir := util.CleanAndExpandPath(flag.Arg(0))
+	_, err := os.Stat(importDir)
+	if err != nil {
+		return err
+	}
+
+	// Set data directory
+	activeNet := chaincfg.MainNetParams.Name
+	if *testnet {
+		activeNet = chaincfg.TestNet3Params.Name
+	}
+
+	dataDir := filepath.Join(util.CleanAndExpandPath(*homeDir),
+		defaultDataDirname, activeNet)
+
+	// Get confirmation from the user that it's
+	// ok to delete the current data directory.
+	_, err = os.Stat(dataDir)
+	if err == nil {
+		r := bufio.NewReader(os.Stdin)
+
+		fmt.Printf("You are about to delete     : %v\n", dataDir)
+		fmt.Printf("It will be replaced with    : %v\n", importDir)
+		fmt.Printf("Continue? (n/no/y/yes) [no] : ")
+
+		input, err := r.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		i := strings.ToLower(strings.TrimSuffix(input, "\n"))
+		if i != "y" && i != "yes" {
+			fmt.Printf("Exiting\n")
+			return nil
+		}
+	}
+
+	journalsPath := filepath.Join(dataDir, defaultJournalsDirname)
+	unvettedPath := filepath.Join(dataDir, defaultUnvettedDirname)
+	vettedPath := filepath.Join(dataDir, defaultVettedDirname)
+
+	// Remove existing data dir
+	err = os.RemoveAll(journalsPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(unvettedPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(vettedPath)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Walking import directory...\n")
+
+	// Walk import directory and copy all relevant files over
+	// to the unvetted, vetted, and journal directories.
+	err = filepath.Walk(importDir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// Skip directories
+			if info.IsDir() {
+				return nil
+			}
+
+			// Get the file's parent directory path relative to
+			// the import directory.
+			r, err := filepath.Rel(importDir, filepath.Dir(path))
+			if err != nil {
+				return err
+			}
+
+			// Make sure the full parent directory path
+			// exists for both unvetted and vetted dirs.
+			u := filepath.Join(unvettedPath, r)
+			err = os.MkdirAll(u, 0774)
+			if err != nil {
+				return err
+			}
+
+			v := filepath.Join(vettedPath, r)
+			err = os.MkdirAll(v, 0774)
+			if err != nil {
+				return err
+			}
+
+			// Copy file to unvetted and vetted
+			b, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			uf := filepath.Join(u, info.Name())
+			err = ioutil.WriteFile(uf, b, 0774)
+			if err != nil {
+				return err
+			}
+
+			vf := filepath.Join(v, info.Name())
+			err = ioutil.WriteFile(vf, b, 0774)
+			if err != nil {
+				return err
+			}
+
+			// Check if the file is a journal
+			if !strings.HasSuffix(info.Name(), ".journal") {
+				// Not a journal; continue to next file
+				return nil
+			}
+
+			// Copy journal to the journals directory. Note that
+			// the journals use a different directory structure
+			// then unvetted/vetted.
+			//
+			// unvetted/[token]/plugin/decred/comments.journal
+			// journals/[token]/comments.journal
+
+			// Parse token dirname
+			var token string
+			dirs := strings.Split(r, "/")
+			for _, v := range dirs {
+				_, err = util.ConvertStringToken(v)
+				if err == nil {
+					token = v
+				}
+			}
+
+			// Copy journal
+			j := filepath.Join(journalsPath, token)
+			err = os.MkdirAll(j, 0774)
+			if err != nil {
+				return err
+			}
+
+			jf := filepath.Join(j, info.Name())
+			err = ioutil.WriteFile(jf, b, 0774)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("walk import dir: %v", err)
+	}
+
+	fmt.Printf("Done!\n")
+
+	return nil
+}
+
+func main() {
+	err := _main()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/politeiad/config.go
+++ b/politeiad/config.go
@@ -21,8 +21,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrtime/api/v1"
+	"github.com/decred/politeia/politeiad/sharedconfig"
 	"github.com/decred/politeia/util"
 	"github.com/decred/politeia/util/version"
 	flags "github.com/jessevdk/go-flags"
@@ -30,7 +30,7 @@ import (
 
 const (
 	defaultConfigFilename   = "politeiad.conf"
-	defaultDataDirname      = "data"
+	defaultDataDirname      = sharedconfig.DefaultDataDirname
 	defaultLogLevel         = "info"
 	defaultLogDirname       = "logs"
 	defaultLogFilename      = "politeiad.log"
@@ -41,7 +41,7 @@ const (
 )
 
 var (
-	defaultHomeDir       = dcrutil.AppDataDir("politeiad", false)
+	defaultHomeDir       = sharedconfig.DefaultHomeDir
 	defaultConfigFile    = filepath.Join(defaultHomeDir, defaultConfigFilename)
 	defaultDataDir       = filepath.Join(defaultHomeDir, defaultDataDirname)
 	defaultHTTPSKeyFile  = filepath.Join(defaultHomeDir, "https.key")

--- a/politeiad/sharedconfig/sharedconfig.go
+++ b/politeiad/sharedconfig/sharedconfig.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package sharedconfig
+
+import (
+	"github.com/decred/dcrd/dcrutil"
+)
+
+const (
+	DefaultDataDirname = "data"
+)
+
+var (
+	DefaultHomeDir = dcrutil.AppDataDir("politeiad", false)
+)


### PR DESCRIPTION
This commit adds the `politeiaimport` tool which allows you to import
data from a public politeia repo into politeiad.  It sets up the
unvetted and vetted repositories and recreates the journals.  The git
history from the import directory is kept intact.