### PR TITLE
www: improve performance of vote status endpoints

### DIFF
--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -158,11 +158,11 @@ func (StartVote) TableName() string {
 
 // CastVote is a decred plugin struct that is used to record a signed vote.
 type CastVote struct {
-	Key       uint   `gorm:"primary_key"`       // Primary key
-	Token     string `gorm:"not null;size:64"`  // Censorship token
-	Ticket    string `gorm:"not null"`          // Ticket ID
-	VoteBit   string `gorm:"not null"`          // Vote bit that was selected, this is encode in hex
-	Signature string `gorm:"not null;size:130"` // Signature of Token+Ticket+VoteBit
+	Key       uint   `gorm:"primary_key"`            // Primary key
+	Token     string `gorm:"not null;size:64;index"` // Censorship token
+	Ticket    string `gorm:"not null"`               // Ticket ID
+	VoteBit   string `gorm:"not null"`               // Hex encoded vote bit that was selected
+	Signature string `gorm:"not null;size:130"`      // Signature of Token+Ticket+VoteBit
 }
 
 // TableName returns the name of the CastVote database table.

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -116,6 +116,10 @@ type politeiawww struct {
 	userPaywallPool map[uuid.UUID]paywallPoolMember // [userid][paywallPoolMember]
 	commentScores   map[string]int64                // [token+commentID]resultVotes
 
+	// voteStatuses is a lazy loaded cache of the votes statuses of
+	// proposals whose voting period has ended.
+	voteStatuses map[string]www.VoteStatusReply // [token]VoteStatusReply
+
 	// cmsDB is only used during cmswww mode
 	cmsDB cmsdatabase.Database
 }

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -309,6 +309,7 @@ func _main() error {
 		userPubkeys:     make(map[string]string),
 		userPaywallPool: make(map[uuid.UUID]paywallPoolMember),
 		commentScores:   make(map[string]int64),
+		voteStatuses:    make(map[string]www.VoteStatusReply),
 		params:          activeNetParams.Params,
 	}
 


### PR DESCRIPTION
This commit focuses on improving the performance of the vote status API
endpoints.  It does so by:

1. Indexing the cast votes by token in the cache database.
2. Caching the vote results in politeiawww memory for proposals whose
   voting period has ended.

Indexing the cast votes by token in the cache database improved cast
vote lookup times by ~25%.

Most of the performance benefits come from caching the vote results in
memory for proposals whose voting period has ended.

Response times for the `/proposals/votestatus` route are included below.
The response times are the result of testing the route locally against
the pi production mainnet data.  Response times on my local machine are
significantly slower then the production site, so I've also included the
response time from the production site for a rough scale.

```
production pi - no cache : 10s

local - no cache         : 1m3s
local - cache            : 47s
local - cache & this PR  : 1.75s
```

Since only the proposals whose voting period has ended are cached in
memory, the more proposals that are actively being voted on, the slower
this route will be.  A very rough approximation is that each additional
proposal that is being actively voted on will add 0.5s to the production
site response time.  This will be addressed in a future PR.