### PR TITLE
[cms] Add raw invoice to InvoiceRecord and remove extra

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -97,19 +97,13 @@ type InvoiceRecord struct {
 	Status             InvoiceStatusT `json:"status"`                       // Current status of invoice
 	StatusChangeReason string         `json:"statuschangereason,omitempty"` // Reason (if any) for the current status
 	Timestamp          int64          `json:"timestamp"`                    // Last update of invoice
-	Month              uint           `json:"month"`                        // The month that this invoice applies to
-	Year               uint           `json:"year"`                         // The year that this invoice applies to
 	UserID             string         `json:"userid"`                       // ID of user who submitted invoice
 	Username           string         `json:"username"`                     // Username of user who submitted invoice
 	PublicKey          string         `json:"publickey"`                    // User's public key, used to verify signature.
 	Signature          string         `json:"signature"`                    // Signature of file digest
 	Files              []www.File     `json:"file"`                         // Actual invoice file
 	Version            string         `json:"version"`                      // Record version
-	ContractorName     string         `json:"contractorname"`               // IRL name of contractor
-	ContractorLocation string         `json:"contractorlocation"`           // IRL location of contractor
-	ContractorContact  string         `json:"contractorcontact"`            // Contractor email contact
-	ContractorRate     uint           `json:"contractorrate"`               // Contractor Pay Rate in USD cents
-	PaymentAddress     string         `json:"paymentaddress"`               //  DCR payment address
+	RawInvoice         InvoiceInput   `json:"rawinvoice"`                   // Decoded invoice from invoice.json file
 
 	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
 }

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -103,7 +103,7 @@ type InvoiceRecord struct {
 	Signature          string         `json:"signature"`                    // Signature of file digest
 	Files              []www.File     `json:"file"`                         // Actual invoice file
 	Version            string         `json:"version"`                      // Record version
-	RawInvoice         InvoiceInput   `json:"rawinvoice"`                   // Decoded invoice from invoice.json file
+	Input              InvoiceInput   `json:"input"`                        // Decoded invoice from invoice.json file
 
 	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
 }

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -522,16 +522,32 @@ func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) *cms.I
 	invRec.Status = dbInvoice.Status
 	invRec.Timestamp = dbInvoice.Timestamp
 	invRec.UserID = dbInvoice.UserID
-	invRec.Month = dbInvoice.Month
-	invRec.Year = dbInvoice.Year
 	invRec.PublicKey = dbInvoice.PublicKey
 	invRec.Version = dbInvoice.Version
-	invRec.ContractorRate = dbInvoice.ContractorRate
-	invRec.ContractorContact = dbInvoice.ContractorContact
-	invRec.ContractorName = dbInvoice.ContractorName
-	invRec.ContractorLocation = dbInvoice.ContractorLocation
-	invRec.PaymentAddress = dbInvoice.PaymentAddress
 
+	invInput := cms.InvoiceInput{
+		ContractorContact:  dbInvoice.ContractorContact,
+		ContractorRate:     dbInvoice.ContractorRate,
+		ContractorName:     dbInvoice.ContractorName,
+		ContractorLocation: dbInvoice.ContractorLocation,
+		PaymentAddress:     dbInvoice.PaymentAddress,
+		Month:              dbInvoice.Month,
+		Year:               dbInvoice.Year,
+	}
+	invInputLineItems := make([]cms.LineItemsInput, 0, len(dbInvoice.LineItems))
+	for _, dbLineItem := range dbInvoice.LineItems {
+		lineItem := cms.LineItemsInput{
+			Type:          dbLineItem.Type,
+			Domain:        dbLineItem.Domain,
+			Subdomain:     dbLineItem.Subdomain,
+			Description:   dbLineItem.Description,
+			ProposalToken: dbLineItem.ProposalURL,
+			Labor:         dbLineItem.Labor,
+			Expenses:      dbLineItem.Expenses,
+		}
+		invInputLineItems = append(invInputLineItems, lineItem)
+	}
+	invRec.RawInvoice = invInput
 	return invRec
 }
 
@@ -697,23 +713,17 @@ func convertInvoiceFromCache(r cache.Record) cms.InvoiceRecord {
 		Status:             c.NewStatus,
 		StatusChangeReason: c.Reason,
 		Timestamp:          r.Timestamp,
-		Month:              ii.Month,
-		Year:               ii.Year,
 		UserID:             "",
 		Username:           "",
 		PublicKey:          md.PublicKey,
 		Signature:          md.Signature,
 		Files:              fs,
 		Version:            r.Version,
-		ContractorName:     ii.ContractorName,
-		ContractorLocation: ii.ContractorLocation,
-		ContractorContact:  ii.ContractorContact,
-		ContractorRate:     ii.ContractorRate,
-		PaymentAddress:     ii.PaymentAddress,
 		CensorshipRecord: www.CensorshipRecord{
 			Token:     r.CensorshipRecord.Token,
 			Merkle:    r.CensorshipRecord.Merkle,
 			Signature: r.CensorshipRecord.Signature,
 		},
+		RawInvoice: ii,
 	}
 }

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -547,7 +547,7 @@ func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) *cms.I
 		}
 		invInputLineItems = append(invInputLineItems, lineItem)
 	}
-	invRec.RawInvoice = invInput
+	invRec.Input = invInput
 	return invRec
 }
 
@@ -724,6 +724,6 @@ func convertInvoiceFromCache(r cache.Record) cms.InvoiceRecord {
 			Merkle:    r.CensorshipRecord.Merkle,
 			Signature: r.CensorshipRecord.Signature,
 		},
-		RawInvoice: ii,
+		Input: ii,
 	}
 }


### PR DESCRIPTION
This now allows us to directly decode the file into the InvoiceInput
therein.  This will allows any requests that return InvoiceRecords 
to have direct access to the parsed InvoiceInput and LineItemInput.

Also remove some extraneous fields that are already included in the 
InvoiceInput (Month, Year, ContractorName, Location etc)