### PR TITLE
[cms] Add new comment endpoint for invoices

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -16,6 +16,7 @@ server side notifications.  It does not render HTML.
 - [`Edit invoice`](#edit-invoice)
 - [`Set invoice status`](#set-invoice-status)
 - [`Generate payouts`](#generate-payouts)
+- [`Get invoice comments`](#get-invoice-comments)
 
 **Invoice status codes**
 
@@ -446,14 +447,13 @@ Note: This call requires admin privileges.
 | | Type | Description |
 |-|-|-|
 | payouts | array of [`Payout`](#payout)s | The page of invoices. |
-
+y
 **Example**
 
 Request:
 
 ```json
 {}
-```
 
 Reply:
 
@@ -473,6 +473,98 @@ Reply:
   ]
 }
 ```
+
+### `Get comments`
+
+Retrieve all comments for given invoice.  Note that the comments are not
+sorted.
+
+**Route:** `GET /v1/invoices/{token}/comments`
+
+**Params:**
+
+**Results:**
+
+| | Type | Description |
+| - | - | - |
+| Comments | Comment | Unsorted array of all comments |
+| AccessTime | int64 | UNIX timestamp of last access time. Omitted if no session cookie is present. |
+
+**Comment:**
+
+| | Type | Description |
+| - | - | - |
+| userid | string | Unique user identifier |
+| username | string | Unique username |
+| timestamp | int64 | UNIX time when comment was accepted |
+| commentid | string | Unique comment identifier |
+| parentid | string | Parent comment identifier |
+| token | string | Censorship token |
+| comment | string | Comment text |
+| publickey | string | Public key from the client side, sent to politeiawww for verification |
+| signature | string | Signature of Token, ParentID and Comment |
+| receipt | string | Server signature of the client Signature |
+| totalvotes | uint64 | Total number of up/down votes |
+| resultvotes | int64 | Vote score |
+
+**Example**
+
+Request:
+
+The request params should be provided within the URL:
+
+```
+/v1/invoices/f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde/comments
+```
+
+Reply:
+
+```json
+{
+  "comments": [{
+    "comment": "I dont like this invoice",
+    "commentid": "4",
+    "parentid": "0",
+    "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
+    "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
+    "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+    "timestamp": 1527277504,
+    "token": "abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+    "userid": "124",
+    "username": "admin",
+    "totalvotes": 0,
+    "resultvotes": 0
+  },{
+    "comment":"but i did some good work!",
+    "commentid": "4",
+    "parentid": "0",
+    "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
+    "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
+    "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+    "timestamp": 1527277504,
+    "token": "abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+    "userid": "122",
+    "username": "steve",
+    "totalvotes": 0,
+    "resultvotes": 0
+  },{
+    "comment":"you're right, approving",
+    "commentid": "4",
+    "parentid": "0",
+    "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
+    "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
+    "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+    "timestamp": 1527277504,
+    "token": "abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+    "userid": "124",
+    "username": "admin",
+    "totalvotes": 0,
+    "resultvotes": 0
+  }],
+  "accesstime": 1543539276
+}
+```
+
 ### Invoice status codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -16,7 +16,7 @@ server side notifications.  It does not render HTML.
 - [`Edit invoice`](#edit-invoice)
 - [`Set invoice status`](#set-invoice-status)
 - [`Generate payouts`](#generate-payouts)
-- [`Get invoice comments`](#get-invoice-comments)
+- [`Invoice comments`](#invoice-comments)
 
 **Invoice status codes**
 
@@ -447,7 +447,7 @@ Note: This call requires admin privileges.
 | | Type | Description |
 |-|-|-|
 | payouts | array of [`Payout`](#payout)s | The page of invoices. |
-y
+
 **Example**
 
 Request:
@@ -474,7 +474,7 @@ Reply:
 }
 ```
 
-### `Get comments`
+### `Invoice comments`
 
 Retrieve all comments for given invoice.  Note that the comments are not
 sorted.

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -10,16 +10,16 @@ type LineItemTypeT int
 const (
 
 	// Contractor Management Routes
-	RouteInviteNewUser      = "/invite"
-	RouteRegisterUser       = "/register"
-	RouteNewInvoice         = "/invoices/new"
-	RouteEditInvoice        = "/invoices/edit"
-	RouteInvoiceDetails     = "/invoices/{token:[A-z0-9]{64}}"
-	RouteSetInvoiceStatus   = "/invoices/{token:[A-z0-9]{64}}/status"
-	RouteUserInvoices       = "/user/invoices"
-	RouteAdminInvoices      = "/admin/invoices"
-	RouteGeneratePayouts    = "/admin/generatepayouts"
-	RouteCommentsInvoiceGet = "/invoices/{token:[A-z0-9]{64}}/comments"
+	RouteInviteNewUser    = "/invite"
+	RouteRegisterUser     = "/register"
+	RouteNewInvoice       = "/invoices/new"
+	RouteEditInvoice      = "/invoices/edit"
+	RouteInvoiceDetails   = "/invoices/{token:[A-z0-9]{64}}"
+	RouteSetInvoiceStatus = "/invoices/{token:[A-z0-9]{64}}/status"
+	RouteUserInvoices     = "/user/invoices"
+	RouteAdminInvoices    = "/admin/invoices"
+	RouteGeneratePayouts  = "/admin/generatepayouts"
+	RouteInvoiceComments  = "/invoices/{token:[A-z0-9]{64}}/comments"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -10,15 +10,16 @@ type LineItemTypeT int
 const (
 
 	// Contractor Management Routes
-	RouteInviteNewUser    = "/invite"
-	RouteRegisterUser     = "/register"
-	RouteNewInvoice       = "/invoices/new"
-	RouteEditInvoice      = "/invoices/edit"
-	RouteInvoiceDetails   = "/invoices/{token:[A-z0-9]{64}}"
-	RouteSetInvoiceStatus = "/invoices/{token:[A-z0-9]{64}}/status"
-	RouteUserInvoices     = "/user/invoices"
-	RouteAdminInvoices    = "/admin/invoices"
-	RouteGeneratePayouts  = "/admin/generatepayouts"
+	RouteInviteNewUser      = "/invite"
+	RouteRegisterUser       = "/register"
+	RouteNewInvoice         = "/invoices/new"
+	RouteEditInvoice        = "/invoices/edit"
+	RouteInvoiceDetails     = "/invoices/{token:[A-z0-9]{64}}"
+	RouteSetInvoiceStatus   = "/invoices/{token:[A-z0-9]{64}}/status"
+	RouteUserInvoices       = "/user/invoices"
+	RouteAdminInvoices      = "/admin/invoices"
+	RouteGeneratePayouts    = "/admin/generatepayouts"
+	RouteCommentsInvoiceGet = "/invoices/{token:[A-z0-9]{64}}/comments"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -1650,7 +1650,7 @@ Reply:
 
 ### `Get comments`
 
-Retrieve all comments for given proposal.  Not that the comments are not
+Retrieve all comments for given proposal.  Note that the comments are not
 sorted.
 
 **Route:** `GET /v1/proposals/{token}/comments`

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -942,6 +942,30 @@ func (c *Client) GetComments(token string) (*v1.GetCommentsReply, error) {
 	return &gcr, nil
 }
 
+// GetComments retrieves the comments for the specified proposal.
+func (c *Client) GetInvoiceComments(token string) (*v1.GetCommentsReply, error) {
+	responseBody, err := c.makeRequest("GET", "/invoices/"+token+"/comments",
+		nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var gcr v1.GetCommentsReply
+	err = json.Unmarshal(responseBody, &gcr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal GetCommentsReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(gcr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &gcr, nil
+}
+
 // UserCommentsLikes retrieves the comment likes (upvotes/downvotes) for the
 // specified proposal that are from the logged in user.
 func (c *Client) UserCommentsLikes(token string) (*v1.UserCommentsLikesReply, error) {

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -943,7 +943,7 @@ func (c *Client) GetComments(token string) (*v1.GetCommentsReply, error) {
 }
 
 // GetComments retrieves the comments for the specified proposal.
-func (c *Client) GetInvoiceComments(token string) (*v1.GetCommentsReply, error) {
+func (c *Client) InvoiceComments(token string) (*v1.GetCommentsReply, error) {
 	responseBody, err := c.makeRequest("GET", "/invoices/"+token+"/comments",
 		nil)
 	if err != nil {
@@ -953,7 +953,7 @@ func (c *Client) GetInvoiceComments(token string) (*v1.GetCommentsReply, error) 
 	var gcr v1.GetCommentsReply
 	err = json.Unmarshal(responseBody, &gcr)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal GetCommentsReply: %v", err)
+		return nil, fmt.Errorf("unmarshal InvoiceCommentsReply: %v", err)
 	}
 
 	if c.cfg.Verbose {

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -68,6 +68,7 @@ type Cmds struct {
 	EditUser           EditUserCmd           `command:"edituser" description:"(user)   edit the  preferences of the logged in user"`
 	GeneratePayouts    GeneratePayoutsCmd    `command:"generatepayouts" description:"(admin) generate a list of payouts with addresses and amounts to pay"`
 	Help               HelpCmd               `command:"help" description:"         print a detailed help message for a specific command"`
+	InvoiceComments    InvoiceCommentsCmd    `command:"invoicecomments" description:"(user) get the comments for a invoice"`
 	Inventory          InventoryCmd          `command:"inventory" description:"(public) get the proposals that are being voted on"`
 	InviteNewUser      InviteNewUserCmd      `command:"invite" description:"(admin)  invite a new user"`
 	InvoiceDetails     InvoiceDetailsCmd     `command:"invoicedetails" description:"(public) get the details of a proposal"`

--- a/politeiawww/cmd/politeiawwwcli/commands/help.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/help.go
@@ -120,6 +120,8 @@ func (cmd *HelpCmd) Execute(args []string) error {
 		fmt.Printf("%s\n", editInvoiceHelpMsg)
 	case "setinvoicestatus":
 		fmt.Printf("%s\n", setInvoiceStatusHelpMsg)
+	case "invoicecomments":
+		fmt.Printf("%s\n", invoiceCommentsHelpMsg)
 	default:
 		fmt.Printf("invalid command: use 'politeiawwwcli -h' " +
 			"to view a list of valid commands\n")

--- a/politeiawww/cmd/politeiawwwcli/commands/invoicecomments.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/invoicecomments.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+// InvoiceCommentsCmd retreives the comments for the specified invoice.
+type InvoiceCommentsCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"` // Censorship token
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the invoice comments command.
+func (cmd *InvoiceCommentsCmd) Execute(args []string) error {
+	gcr, err := client.GetInvoiceComments(cmd.Args.Token)
+	if err != nil {
+		return err
+	}
+	return printJSON(gcr)
+}
+
+// invoiceCommentsHelpMsg is the output for the help command when
+// 'invoicecomments' is specified.
+const invoiceCommentsHelpMsg = `invoicecomments "token" 
+
+Get the comments for a invoice.
+
+Arguments:
+1. token       (string, required)   Invoice censorship token
+
+Result:
+{
+  "comments": [
+    {
+      "token":        (string)  Censorship token
+      "parentid":     (string)  Id of comment (defaults to '0' (top-level))
+      "comment":      (string)  Comment
+      "signature":    (string)  Signature of token+parentID+comment
+      "publickey":    (string)  Public key of user 
+      "commentid":    (string)  Id of the comment
+      "receipt":      (string)  Server signature of the comment signature
+      "timestamp":    (int64)   Received UNIX timestamp
+      "totalvotes":   (uint64)  Total number of up/down votes
+      "resultvotes":  (int64)   Vote score
+      "censored":     (bool)    If comment has been censored
+      "userid":       (string)  User id
+      "username":     (string)  Username
+    }
+  ]
+}`

--- a/politeiawww/cmd/politeiawwwcli/commands/invoicecomments.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/invoicecomments.go
@@ -13,7 +13,7 @@ type InvoiceCommentsCmd struct {
 
 // Execute executes the invoice comments command.
 func (cmd *InvoiceCommentsCmd) Execute(args []string) error {
-	gcr, err := client.GetInvoiceComments(cmd.Args.Token)
+	gcr, err := client.InvoiceComments(cmd.Args.Token)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -314,6 +314,30 @@ func (p *politeiawww) handleNewCommentInvoice(w http.ResponseWriter, r *http.Req
 	util.RespondWithJSON(w, http.StatusOK, cr)
 }
 
+// handleCommentsGet handles batched comments get.
+func (p *politeiawww) handleCommentsInvoiceGet(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleCommentsGet")
+
+	pathParams := mux.Vars(r)
+	token := pathParams["token"]
+
+	user, err := p.getSessionUser(w, r)
+	if err != nil {
+		if err != ErrSessionUUIDNotFound {
+			RespondWithError(w, r, 0,
+				"handleCommentsGet: getSessionUser %v", err)
+			return
+		}
+	}
+	gcr, err := p.processCommentsInvoiceGet(token, user)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleCommentsGet: processCommentsGet %v", err)
+		return
+	}
+	util.RespondWithJSON(w, http.StatusOK, gcr)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -346,8 +370,8 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleInvoiceDetails, permissionLogin)
 	p.addRoute(http.MethodGet, cms.RouteUserInvoices,
 		p.handleUserInvoices, permissionLogin)
-	p.addRoute(http.MethodGet, www.RouteCommentsGet, p.handleCommentsGet,
-		permissionLogin)
+	p.addRoute(http.MethodGet, cms.RouteCommentsInvoiceGet,
+		p.handleCommentsInvoiceGet, permissionLogin)
 
 	// Unauthenticated websocket
 	p.addRoute("", www.RouteUnauthenticatedWebSocket,

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -334,8 +334,6 @@ func (p *politeiawww) setCMSWWWRoutes() {
 
 	p.addRoute(http.MethodGet, www.RoutePolicy, p.handlePolicy,
 		permissionPublic)
-	p.addRoute(http.MethodGet, www.RouteCommentsGet, p.handleCommentsGet,
-		permissionPublic)
 
 	// Routes that require being logged in.
 	p.addRoute(http.MethodPost, www.RouteNewComment,
@@ -348,6 +346,8 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleInvoiceDetails, permissionLogin)
 	p.addRoute(http.MethodGet, cms.RouteUserInvoices,
 		p.handleUserInvoices, permissionLogin)
+	p.addRoute(http.MethodGet, www.RouteCommentsGet, p.handleCommentsGet,
+		permissionLogin)
 
 	// Unauthenticated websocket
 	p.addRoute("", www.RouteUnauthenticatedWebSocket,

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -315,7 +315,7 @@ func (p *politeiawww) handleNewCommentInvoice(w http.ResponseWriter, r *http.Req
 }
 
 // handleCommentsGet handles batched comments get.
-func (p *politeiawww) handleCommentsInvoiceGet(w http.ResponseWriter, r *http.Request) {
+func (p *politeiawww) handleInvoiceComments(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleCommentsGet")
 
 	pathParams := mux.Vars(r)
@@ -329,7 +329,7 @@ func (p *politeiawww) handleCommentsInvoiceGet(w http.ResponseWriter, r *http.Re
 			return
 		}
 	}
-	gcr, err := p.processCommentsInvoiceGet(token, user)
+	gcr, err := p.processInvoiceComments(token, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleCommentsGet: processCommentsGet %v", err)
@@ -370,8 +370,8 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleInvoiceDetails, permissionLogin)
 	p.addRoute(http.MethodGet, cms.RouteUserInvoices,
 		p.handleUserInvoices, permissionLogin)
-	p.addRoute(http.MethodGet, cms.RouteCommentsInvoiceGet,
-		p.handleCommentsInvoiceGet, permissionLogin)
+	p.addRoute(http.MethodGet, cms.RouteInvoiceComments,
+		p.handleInvoiceComments, permissionLogin)
 
 	// Unauthenticated websocket
 	p.addRoute("", www.RouteUnauthenticatedWebSocket,

--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -312,7 +312,9 @@ func (p *politeiawww) processNewCommentInvoice(nc www.NewComment, u *user.User) 
 		}
 		return nil, err
 	}
+
 	_, ok := p.userPubkeys[ir.PublicKey]
+
 	// Check to make sure the user is either an admin or the creator of the invoice
 	if !u.Admin && !ok {
 		err := www.UserError{

--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/politeia/decredplugin"
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/cache"
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/user"
 	"github.com/decred/politeia/util"
@@ -228,6 +229,115 @@ func (p *politeiawww) processNewComment(nc www.NewComment, u *user.User) (*www.N
 	if getVoteStatus(avr, svr, bb) == www.PropVoteStatusFinished {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusWrongVoteStatus,
+		}
+	}
+
+	// Setup plugin command
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+
+	dnc := convertNewCommentToDecredPlugin(nc)
+	payload, err := decredplugin.EncodeNewComment(dnc)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        decredplugin.ID,
+		Command:   decredplugin.CmdNewComment,
+		CommandID: decredplugin.CmdNewComment,
+		Payload:   string(payload),
+	}
+
+	// Send polieiad request
+	responseBody, err := p.makeRequest(http.MethodPost,
+		pd.PluginCommandRoute, pc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle response
+	var reply pd.PluginCommandReply
+	err = json.Unmarshal(responseBody, &reply)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal "+
+			"PluginCommandReply: %v", err)
+	}
+
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, reply.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	ncr, err := decredplugin.DecodeNewCommentReply([]byte(reply.Payload))
+	if err != nil {
+		return nil, err
+	}
+
+	// Add comment to commentScores in-memory cache
+	p.Lock()
+	p.commentScores[nc.Token+ncr.CommentID] = 0
+	p.Unlock()
+
+	// Get comment from cache
+	c, err := p.getComment(nc.Token, ncr.CommentID)
+	if err != nil {
+		return nil, fmt.Errorf("getComment: %v", err)
+	}
+
+	// Fire off new comment event
+	p.fireEvent(EventTypeComment, EventDataComment{
+		Comment: c,
+	})
+
+	return &www.NewCommentReply{
+		Comment: *c,
+	}, nil
+}
+
+// processNewCommentInvoice sends a new comment decred plugin command to politeaid
+// then fetches the new comment from the cache and returns it.
+func (p *politeiawww) processNewCommentInvoice(nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
+	log.Tracef("processNewComment: %v %v", nc.Token, u.ID)
+
+	ir, err := p.getInvoice(nc.Token)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			err = www.UserError{
+				ErrorCode: www.ErrorStatusInvoiceNotFound,
+			}
+		}
+		return nil, err
+	}
+	_, ok := p.userPubkeys[ir.PublicKey]
+	// Check to make sure the user is either an admin or the creator of the invoice
+	if !u.Admin && !ok {
+		err := www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+		return nil, err
+	}
+
+	// Verify authenticity
+	err = checkPublicKeyAndSignature(u, nc.PublicKey, nc.Signature,
+		nc.Token, nc.ParentID, nc.Comment)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate comment
+	err = validateComment(nc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check to make sure that invoice isn't already approved or paid.
+	if ir.Status == cms.InvoiceStatusApproved || ir.Status == cms.InvoiceStatusPaid {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCannotCommentOnProp,
 		}
 	}
 

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1110,7 +1110,7 @@ func (p *politeiawww) processAdminInvoices(ai cms.AdminInvoices, user *user.User
 // processCommentsGet returns all comments for a given proposal. If the user is
 // logged in the user's last access time for the given comments will also be
 // returned.
-func (p *politeiawww) processCommentsInvoiceGet(token string, u *user.User) (*www.GetCommentsReply, error) {
+func (p *politeiawww) processInvoiceComments(token string, u *user.User) (*www.GetCommentsReply, error) {
 	log.Tracef("ProcessCommentGet: %v", token)
 
 	ir, err := p.getInvoice(token)

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1107,6 +1107,98 @@ func (p *politeiawww) processAdminInvoices(ai cms.AdminInvoices, user *user.User
 	return &reply, nil
 }
 
+// processCommentsGet returns all comments for a given proposal. If the user is
+// logged in the user's last access time for the given comments will also be
+// returned.
+func (p *politeiawww) processCommentsInvoiceGet(token string, u *user.User) (*www.GetCommentsReply, error) {
+	log.Tracef("ProcessCommentGet: %v", token)
+
+	ir, err := p.getInvoice(token)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			err = www.UserError{
+				ErrorCode: www.ErrorStatusInvoiceNotFound,
+			}
+		}
+		return nil, err
+	}
+
+	_, ok := p.userPubkeys[ir.PublicKey]
+
+	// Check to make sure the user is either an admin or the creator of the invoice
+	if !u.Admin && !ok {
+		err := www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+		return nil, err
+	}
+
+	// Fetch proposal comments from cache
+	c, err := p.getInvoiceComments(token)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the last time the user accessed these comments. This is
+	// a public route so a user may not exist.
+	var accessTime int64
+	if u != nil {
+		if u.ProposalCommentsAccessTimes == nil {
+			u.ProposalCommentsAccessTimes = make(map[string]int64)
+		}
+		accessTime = u.ProposalCommentsAccessTimes[token]
+		u.ProposalCommentsAccessTimes[token] = time.Now().Unix()
+		err = p.db.UserUpdate(*u)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &www.GetCommentsReply{
+		Comments:   c,
+		AccessTime: accessTime,
+	}, nil
+}
+
+func (p *politeiawww) getInvoiceComments(token string) ([]www.Comment, error) {
+	log.Tracef("getInvoiceComments: %v", token)
+
+	dc, err := p.decredGetComments(token)
+	if err != nil {
+		return nil, fmt.Errorf("decredGetComments: %v", err)
+	}
+
+	p.RLock()
+	defer p.RUnlock()
+
+	// Fill in politeiawww data. Cache usernames to reduce
+	// database lookups.
+	comments := make([]www.Comment, 0, len(dc))
+	usernames := make(map[string]string, len(dc)) // [userID]username
+	for _, v := range dc {
+		c := convertCommentFromDecred(v)
+
+		// Fill in author info
+		userID, ok := p.userPubkeys[c.PublicKey]
+		if !ok {
+			log.Errorf("getInvoiceComments: userID lookup failed "+
+				"pubkey:%v token:%v comment:%v", c.PublicKey,
+				c.Token, c.CommentID)
+		}
+		u, ok := usernames[userID]
+		if !ok && userID != "" {
+			u = p.getUsernameById(userID)
+			usernames[userID] = u
+		}
+		c.UserID = userID
+		c.Username = u
+
+		comments = append(comments, c)
+	}
+
+	return comments, nil
+}
+
 // backendInvoiceMetadata represents the general metadata for an invoice and is
 // stored in the metadata stream mdStreamInvoiceGeneral in politeiad.
 type backendInvoiceMetadata struct {


### PR DESCRIPTION
This adds a new NewCommentInvoice endpoint for cms.  Having a
fully separate version was done to avoid the paywall check and the 
proposal specific checks there.

Currently, only admins or the owner/creator of a given invoice should
be able to comment on that invoice.  And it must not be in Approved 
or Paid status.