### PR TITLE
www: Fix votestatus 400 error abandoned proposals

### DIFF
--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1389,7 +1389,7 @@ func (p *politeiawww) getVoteStatus(token string, bestBlock uint64) (*www.VoteSt
 func (p *politeiawww) processVoteStatus(token string) (*www.VoteStatusReply, error) {
 	log.Tracef("ProcessProposalVotingStatus: %v", token)
 
-	// Ensure proposal is public
+	// Ensure proposal is vetted
 	pr, err := p.getProp(token)
 	if err != nil {
 		if err == cache.ErrRecordNotFound {
@@ -1511,7 +1511,7 @@ func (p *politeiawww) processActiveVote() (*www.ActiveVoteReply, error) {
 func (p *politeiawww) processVoteResults(token string) (*www.VoteResultsReply, error) {
 	log.Tracef("processVoteResults: %v", token)
 
-	// Ensure proposal is public
+	// Ensure proposal is vetted
 	pr, err := p.getProp(token)
 	if err != nil {
 		if err == cache.ErrRecordNotFound {

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1399,7 +1399,7 @@ func (p *politeiawww) processVoteStatus(token string) (*www.VoteStatusReply, err
 		}
 		return nil, err
 	}
-	if pr.Status != www.PropStatusPublic {
+	if pr.Status != www.PropStatusPublic && pr.Status != www.PropStatusAbandoned {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusWrongStatus,
 		}

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1399,7 +1399,8 @@ func (p *politeiawww) processVoteStatus(token string) (*www.VoteStatusReply, err
 		}
 		return nil, err
 	}
-	if pr.Status != www.PropStatusPublic && pr.Status != www.PropStatusAbandoned {
+
+	if pr.State != www.PropStateVetted {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusWrongStatus,
 		}
@@ -1520,7 +1521,8 @@ func (p *politeiawww) processVoteResults(token string) (*www.VoteResultsReply, e
 		}
 		return nil, err
 	}
-	if pr.Status != www.PropStatusPublic {
+
+	if pr.State != www.PropStateVetted {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusWrongStatus,
 		}


### PR DESCRIPTION
Abandoned proposals are throwing a 400 error when votestatus is called.
This is because the abandoned status didn't exist when the votestatus
route was written. This commit fixes this by checking for abandoned
proposals in addition to public proposals and allowing both to be
accessed ( Closes #785 ).