### PR TITLE
politeiad: update cache in updateVettedMetadata

### DIFF
--- a/politeiad/cache/cache.go
+++ b/politeiad/cache/cache.go
@@ -166,6 +166,9 @@ type Cache interface {
 	UpdateRecordStatus(string, string, RecordStatusT, int64,
 		[]MetadataStream) error
 
+	// Update the metadata streams of a record
+	UpdateRecordMetadata(string, []MetadataStream) error
+
 	// Get the latest version of all records
 	Inventory() ([]Record, error)
 

--- a/politeiad/cache/cachestub/cachestub.go
+++ b/politeiad/cache/cachestub/cachestub.go
@@ -34,6 +34,10 @@ func (c *cachestub) UpdateRecordStatus(token, version string, status cache.Recor
 	return nil
 }
 
+func (c *cachestub) UpdateRecordMetadata(token string, ms []cache.MetadataStream) error {
+	return nil
+}
+
 // Inventory is a stub to satisfy the cache interface.
 func (c *cachestub) Inventory() ([]cache.Record, error) {
 	return make([]cache.Record, 0), nil

--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -19,12 +19,15 @@ func convertMDStreamFromCache(ms cache.MetadataStream) MetadataStream {
 	}
 }
 
-func convertRecordFromCache(r cache.Record, version uint64) Record {
-	metadata := make([]MetadataStream, 0, len(r.Metadata))
-	for _, ms := range r.Metadata {
-		metadata = append(metadata, convertMDStreamFromCache(ms))
+func convertMDStreamsFromCache(ms []cache.MetadataStream) []MetadataStream {
+	m := make([]MetadataStream, 0, len(ms))
+	for _, v := range ms {
+		m = append(m, convertMDStreamFromCache(v))
 	}
+	return m
+}
 
+func convertRecordFromCache(r cache.Record, version uint64) Record {
 	files := make([]File, 0, len(r.Files))
 	for _, f := range r.Files {
 		files = append(files,
@@ -44,7 +47,7 @@ func convertRecordFromCache(r cache.Record, version uint64) Record {
 		Timestamp: r.Timestamp,
 		Merkle:    r.CensorshipRecord.Merkle,
 		Signature: r.CensorshipRecord.Signature,
-		Metadata:  metadata,
+		Metadata:  convertMDStreamsFromCache(r.Metadata),
 		Files:     files,
 	}
 }


### PR DESCRIPTION
This commit adds a cache update to the politeiad route updateVettedMetadata. This route was not being used by politeiawww until recently so it was missed in the original cache implementation.