### PR TITLE
www: simplify database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ You can also use the following default configurations:
     testnet=true
     enablecache=true
     cachehost=localhost:26257
-    cacherootcert="~/.cockroachdb/certs/clients/records_politeiad/ca.crt"
-    cachecert="~/.cockroachdb/certs/clients/records_politeiad/client.records_politeiad.crt"
-    cachekey="~/.cockroachdb/certs/clients/records_politeiad/client.records_politeiad.key"
+    cacherootcert="~/.cockroachdb/certs/clients/politeiad/ca.crt"
+    cachecert="~/.cockroachdb/certs/clients/politeiad/client.politeiad.crt"
+    cachekey="~/.cockroachdb/certs/clients/politeiad/client.politeiad.key"
 
 
 **politeiawww.conf**:
@@ -113,14 +113,10 @@ You can also use the following default configurations:
     testnet=true
     paywallxpub=tpubVobLtToNtTq6TZNw4raWQok35PRPZou53vegZqNubtBTJMMFmuMpWybFCfweJ52N8uZJPZZdHE5SRnBBuuRPfC5jdNstfKjiAs8JtbYG9jx
     paywallamount=10000000
-    cachehost=localhost:26257
-    cacherootcert="~/.cockroachdb/certs/clients/records_politeiawww/ca.crt"
-    cachecert="~/.cockroachdb/certs/clients/records_politeiawww/client.records_politeiawww.crt"
-    cachekey="~/.cockroachdb/certs/clients/records_politeiawww/client.records_politeiawww.key"
-    cmshost=localhost:26257
-    cmsrootcert="~/.cockroachdb/certs/clients/invoices_cmsdb/ca.crt"
-    cmscert="~/.cockroachdb/certs/clients/invoices_cmsdb/client.invoices_cmsdb.crt"
-    cmskey="~/.cockroachdb/certs/clients/invoices_cmsdb/client.invoices_cmsdb.key"
+    dbhost=localhost:26257
+    dbrootcert="~/.cockroachdb/certs/clients/politeiawww/ca.crt"
+    dbcert="~/.cockroachdb/certs/clients/politeiawww/client.politeiawww.crt"
+    dbkey="~/.cockroachdb/certs/clients/politeiawww/client.politeiawww.key"
 
 **Things to note:**
 
@@ -179,23 +175,32 @@ The script will create the following certificates and directories:
     └── certs
         ├── ca.crt
         ├── clients
-        │   └── root
-        │       ├── ca.crt
-        │       ├── client.root.crt
-        │       └── client.root.key
+        │    ├── politeiad
+        │    │   ├── ca.crt
+        │    │   ├── client.politeiad.crt
+        │    │   └── client.politeiad.key
+        │    ├── politeiawww
+        │    │   ├── ca.crt
+        │    │   ├── client.politeiawww.crt
+        │    │   └── client.politeiawww.key
+        │    └── root
+        │        ├── ca.crt
+        │        ├── client.root.crt
+        │        └── client.root.key
         └── node
             ├── ca.crt
             ├── node.crt
             └── node.key
 
 These are the certificates required to run a CockroachDB node locally. This
-includes creating a CA certificate, a node certificate, and a client
-certificate for the root user. The root user is used to setup the databases and
-can be used to open a sql shell.  Each client directory contains all of the
-certificates required to connect to the database with that user.  
+includes creating a CA certificate, a node certificate, and client certificates
+for the root user, politeiad user, and politeiawww user. The root user is used
+to setup the databases and can be used to open a sql shell.  Each client
+directory contains all of the certificates required to connect to the database
+with that user.
 
-The node directory contains the certificates for running a CockroachDB
-instance locally.  Directions for generating node certificates when deploying a
+The node directory contains the certificates for running a CockroachDB instance
+on localhost.  Directions for generating node certificates when deploying a
 CockroachDB cluster can be found in the [CockroachDB manual deployment
 docs](https://www.cockroachlabs.com/docs/stable/manual-deployment.html).
 
@@ -207,27 +212,11 @@ script that is run next requires that a CockroachDB is running.
       --listen-addr=localhost \
       --store=${HOME}/.cockroachdb/data
 
-Once CockroachDB is running, you can setup the cache databases and users using
-the commands below.
+Once CockroachDB is running, you can setup the cache databases using the
+commands below.
 
     cd $GOPATH/src/github.com/decred/politeia
     ./cachesetup.sh ~/.cockroachdb
-
-This script creates the client certificates for the politeiad and politeiawww
-users, creates the corresponding database users, sets up the cache databases,
-and assigns user privileges.
-
-    .cockroachdb
-    └─── certs
-        └─── clients
-            ├── records_politeiad
-            │   ├── ca.crt
-            │   ├── client.records_politeiad.crt
-            │   └── client.records_politeiad.key
-            └─── records_politeiawww
-                ├── ca.crt
-                ├── client.records_politeiawww.crt
-                └── client.records_politeiawww.key
 
 The database setup is now complete.  If you want to run database commands
 manually you can do so by opening a sql shell.
@@ -239,7 +228,7 @@ manually you can do so by opening a sql shell.
 #### 4a. Setup cms database:
 
 CMS uses both the cache database and its own database.  Once the cache database
-has been setup using the instructions above, you can setup the cms database
+has been setup using the instructions above, you can setup the CMS database
 using the script below.  CockroachDB must be running when you execute this
 script.
 

--- a/cachesetup.sh
+++ b/cachesetup.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-# This script sets up the CockroachDB databases and users for the Politeia
-# cache.  This includes creating the client certificates for the politeiad and
-# politeiawww users, creating the corresponding database users, setting up the
-# cache databases, and assigning user privileges.
+# This script sets up the CockroachDB databases and assigns user privileges.  
 # This script requires that you have already created CockroachDB certificates
 # using the cockroachcerts.sh script and that you have a CockroachDB instance
 # listening on the default port localhost:26257.
@@ -37,28 +34,8 @@ readonly DB_MAINNET="records_mainnet"
 readonly DB_TESTNET="records_testnet3"
 
 # Database usernames.
-readonly USER_POLITEIAD="records_politeiad"
-readonly USER_POLITEIAWWW="records_politeiawww"
-
-# Make directories for the politeiad and politeiawww client certs.
-mkdir -p "${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAD}"
-mkdir -p "${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAWWW}"
-
-# Create the client certificate and key for the politeiad user.
-cp "${COCKROACHDB_DIR}/certs/ca.crt" \
-  "${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAD}"
-
-cockroach cert create-client ${USER_POLITEIAD} \
-  --certs-dir="${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAD}" \
-  --ca-key="${COCKROACHDB_DIR}/ca.key"
-
-# Create the client certificate and key for politeiawww user.
-cp "${COCKROACHDB_DIR}/certs/ca.crt" \
-  "${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAWWW}"
-
-cockroach cert create-client ${USER_POLITEIAWWW} \
-  --certs-dir="${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAWWW}" \
-  --ca-key="${COCKROACHDB_DIR}/ca.key"
+readonly USER_POLITEIAD="politeiad"
+readonly USER_POLITEIAWWW="politeiawww"
 
 # Create the mainnet and testnet databases for the politeiad records cache.
 cockroach sql \

--- a/cmssetup.sh
+++ b/cmssetup.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-# This script sets up the CockroachDB databases and users for the cms database.
-# This includes creating the client certificates for the cms user, creating the
-# corresponding database user, setting up the cms databases, and assigning user
-# privileges.  
+# This script sets up the CockroachDB databases and assigns user privileges.
 # This script requires that you have already created CockroachDB certificates
 # using the cockroachcerts.sh script and that you have a CockroachDB instance
 # listening on the default port localhost:26257.
@@ -37,19 +34,7 @@ readonly DB_MAINNET="cms_mainnet"
 readonly DB_TESTNET="cms_testnet3"
 
 # Database usernames.
-readonly 	USER_CMS="invoices_cmsdb" 
-
-# Make directory for the cms client certs.
-mkdir -p "${COCKROACHDB_DIR}/certs/clients/$USER_CMS"
-
-# Create the client certificate and key for the cmsdb user.
-cp "${COCKROACHDB_DIR}/certs/ca.crt" \
-  "${COCKROACHDB_DIR}/certs/clients/${USER_CMS}"
-
-cockroach cert create-client ${USER_CMS} \
-  --certs-dir="${COCKROACHDB_DIR}/certs/clients/${USER_CMS}" \
-  --ca-key="${COCKROACHDB_DIR}/ca.key"
-
+readonly 	USER_POLITEIAWWW="politeiawww" 
 
 # Create the mainnet and testnet databases for the cms database.
 cockroach sql \
@@ -60,17 +45,17 @@ cockroach sql \
   --certs-dir="${ROOT_CERTS_DIR}" \
   --execute "CREATE DATABASE IF NOT EXISTS ${DB_TESTNET}"
 
-# Create the cmsdb user and assign privileges.
+# Create the politeiawww user and assign privileges.
 cockroach sql \
   --certs-dir="${ROOT_CERTS_DIR}" \
-  --execute "CREATE USER IF NOT EXISTS ${USER_CMS}"
+  --execute "CREATE USER IF NOT EXISTS ${USER_POLITEIAWWW}"
 
 cockroach sql \
   --certs-dir="${ROOT_CERTS_DIR}" \
   --execute "GRANT CREATE, SELECT, DROP, INSERT, DELETE, UPDATE \
-  ON DATABASE ${DB_MAINNET} TO  ${USER_CMS}"
+  ON DATABASE ${DB_MAINNET} TO  ${USER_POLITEIAWWW}"
 
 cockroach sql \
   --certs-dir="${ROOT_CERTS_DIR}" \
   --execute "GRANT CREATE, SELECT, DROP, INSERT, DELETE, UPDATE \
-  ON DATABASE ${DB_TESTNET} TO  ${USER_CMS}"
+  ON DATABASE ${DB_TESTNET} TO  ${USER_POLITEIAWWW}"

--- a/cockroachcerts.sh
+++ b/cockroachcerts.sh
@@ -9,6 +9,10 @@
 
 set -ex
 
+# Database usernames
+readonly USER_POLITEIAD="politeiad"
+readonly USER_POLITEIAWWW="politeiawww"
+
 # COCKROACHDB_DIR is where all of the certificates will be created.
 readonly COCKROACHDB_DIR=$1
 
@@ -20,6 +24,9 @@ fi
 # Create cockroachdb directories.
 mkdir -p "${COCKROACHDB_DIR}/certs/node"
 mkdir -p "${COCKROACHDB_DIR}/certs/clients/root"
+mkdir -p "${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAD}"
+mkdir -p "${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAWWW}"
+
 
 # Create CA certificate and key.
 cockroach cert create-ca \
@@ -47,4 +54,20 @@ cockroach cert create-node localhost \
 cp "${COCKROACHDB_DIR}/certs/ca.crt" "${COCKROACHDB_DIR}/certs/clients/root"
 cockroach cert create-client root \
   --certs-dir="${COCKROACHDB_DIR}/certs/clients/root" \
+  --ca-key="${COCKROACHDB_DIR}/ca.key"
+
+# Create the client certificate and key for the politeiad user.
+cp "${COCKROACHDB_DIR}/certs/ca.crt" \
+  "${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAD}"
+
+cockroach cert create-client ${USER_POLITEIAD} \
+  --certs-dir="${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAD}" \
+  --ca-key="${COCKROACHDB_DIR}/ca.key"
+
+# Create the client certificate and key for politeiawww user.
+cp "${COCKROACHDB_DIR}/certs/ca.crt" \
+  "${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAWWW}"
+
+cockroach cert create-client ${USER_POLITEIAWWW} \
+  --certs-dir="${COCKROACHDB_DIR}/certs/clients/${USER_POLITEIAWWW}" \
   --ca-key="${COCKROACHDB_DIR}/ca.key"

--- a/politeiad/cache/cockroachdb/cockroachdb.go
+++ b/politeiad/cache/cockroachdb/cockroachdb.go
@@ -29,8 +29,8 @@ const (
 	tableFiles           = "files"
 
 	// Database users
-	UserPoliteiad   = "records_politeiad"   // politeiad user (read/write access)
-	UserPoliteiawww = "records_politeiawww" // politeiawww user (read access)
+	UserPoliteiad   = "politeiad"   // politeiad user (read/write access)
+	UserPoliteiawww = "politeiawww" // politeiawww user (read access)
 )
 
 // cockroachdb implements the cache interface.

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -25,7 +25,7 @@ const (
 	tableNameLineItem      = "line_items"
 	tableNameInvoiceChange = "invoice_change"
 
-	UserCMSDB = "invoices_cmsdb" // cmsdb user (read/write access)
+	userPoliteiawww = "politeiawww" // cmsdb user (read/write access)
 )
 
 // cockroachdb implements the cache interface.
@@ -361,13 +361,14 @@ func buildQueryString(user, rootCert, cert, key string) string {
 }
 
 // New returns a new cockroachdb context that contains a connection to the
-// specified database that was made using the passed in user and certificates.
-func New(user, host, net, rootCert, cert, key string) (*cockroachdb, error) {
-	log.Tracef("New: %v %v %v %v %v %v", user, host, net, rootCert, cert, key)
+// specified database that was made using the politeiawww user and the passed
+// in certificates.
+func New(host, net, rootCert, cert, key string) (*cockroachdb, error) {
+	log.Tracef("New: %v %v %v %v %v", host, net, rootCert, cert, key)
 
 	// Connect to database
 	dbName := cacheID + "_" + net
-	h := "postgresql://" + user + "@" + host + "/" + dbName
+	h := "postgresql://" + userPoliteiawww + "@" + host + "/" + dbName
 	u, err := url.Parse(h)
 	if err != nil {
 		return nil, fmt.Errorf("parse url '%v': %v", h, err)

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -337,8 +337,8 @@ func _main() error {
 	cockroachdb.UseLogger(cockroachdbLog)
 	net := filepath.Base(p.cfg.DataDir)
 	p.cache, err = cockroachdb.New(cockroachdb.UserPoliteiawww,
-		p.cfg.CacheHost, net, p.cfg.CacheRootCert, p.cfg.CacheCert,
-		p.cfg.CacheKey)
+		p.cfg.DBHost, net, p.cfg.DBRootCert, p.cfg.DBCert,
+		p.cfg.DBKey)
 	if err != nil {
 		if err == cache.ErrWrongVersion {
 			err = fmt.Errorf("wrong cache version, restart politeiad " +
@@ -444,8 +444,8 @@ func _main() error {
 		p.setCMSWWWRoutes()
 		cmsdb.UseLogger(cockroachdbLog)
 		net := filepath.Base(p.cfg.DataDir)
-		p.cmsDB, err = cmsdb.New(cmsdb.UserCMSDB, p.cfg.CMSHost,
-			net, p.cfg.CMSRootCert, p.cfg.CMSCert, p.cfg.CMSKey)
+		p.cmsDB, err = cmsdb.New(p.cfg.DBHost, net, p.cfg.DBRootCert,
+			p.cfg.DBCert, p.cfg.DBKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit merges the politeiawww config settings for the cache
database and the cms database into a single set of parameters. It also
updates the database users.  There are now only two database users:
politeiad and politeiawww.  Permissions are set accordingly per
database.