### PR TITLE
politeiawww: Corrects OS reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can also use the following default configurations:
 
 **Things to note:**
 
-* The `rpccert` path is referencing a macOS path. See above for
+* The `rpccert` path is referencing a Linux path. See above for
 more OS paths.
 
 * politeiawww uses an email server to send verification codes for


### PR DESCRIPTION
In the README, we say a line in `politeiawww.conf` references a mac OS path; it's actually referencing Linux. This commit fixes the wording ( Closes #760 ). 