### PR TITLE
cache: update version record lookup

### DIFF
--- a/politeiad/cache/cache.go
+++ b/politeiad/cache/cache.go
@@ -11,9 +11,12 @@ import (
 type RecordStatusT int
 
 var (
-	// ErrWrongVersion is emitted when the version of the cache tables
-	// does not match the version of the cache implementation.
-	ErrWrongVersion = errors.New("wrong cache version")
+	// ErrNoVersionRecord is emitted when no version record exists.
+	ErrNoVersionRecord = errors.New("no version record")
+
+	// ErrWrongVersion is emitted when the version record does not
+	// match the implementation version.
+	ErrWrongVersion = errors.New("wrong version")
 
 	// ErrShutdown is emitted when the cache is shutting down.
 	ErrShutdown = errors.New("cache is shutting down")

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -1129,7 +1129,10 @@ func _main() error {
 		net := filepath.Base(p.cfg.DataDir)
 		db, err := cockroachdb.New(cockroachdb.UserPoliteiad, p.cfg.CacheHost,
 			net, p.cfg.CacheRootCert, p.cfg.CacheCert, p.cfg.CacheKey)
-		if err == cache.ErrWrongVersion {
+		if err == cache.ErrNoVersionRecord || err == cache.ErrWrongVersion {
+			// The cache version record was either not found or
+			// is the wrong version which means that the cache
+			// needs to be built/rebuilt.
 			p.cfg.BuildCache = true
 		} else if err != nil {
 			return fmt.Errorf("cockroachdb new: %v", err)


### PR DESCRIPTION
This commit fixes a bug that was introduce in #800 that was preventing the cache from being properly setup when the version table did not exist.  It improves the version record lookup process by adding debug statements and differentiating between when an version record was not found and when the record was found but there was a version mismatch. 