### PR TITLE
[cms] Add invoice exchange rate endpoint

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -17,6 +17,7 @@ server side notifications.  It does not render HTML.
 - [`Set invoice status`](#set-invoice-status)
 - [`Generate payouts`](#generate-payouts)
 - [`Invoice comments`](#invoice-comments)
+- [`Invoice exchange rate`](#invoice-exchange-rate)
 
 **Invoice status codes**
 
@@ -564,6 +565,45 @@ Reply:
   "accesstime": 1543539276
 }
 ```
+
+### `Invoice exchange rate`
+
+Retrieve the calculated monthly exchange rate for a given month/year
+
+**Route:** `POST /v1/invoices/exchangerate`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| month | int16 | A specific month, from 1 to 12. | Yes |
+| year | int16 | A specific year. | Yes |
+
+**Results:**
+
+| | Type | Description |
+| - | - | - |
+| ExchangeRate | float64 | The calculated monthly average exchange rate |
+
+**Example**
+
+Request:
+
+```json
+{
+  "month": 12,
+  "year": 2018
+}
+```
+
+Reply:
+
+```json
+{
+  "exchangerate": "17.50659503883639"
+}
+```
+
 
 ### Invoice status codes
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -10,17 +10,17 @@ type LineItemTypeT int
 const (
 
 	// Contractor Management Routes
-	RouteInviteNewUser    = "/invite"
-	RouteRegisterUser     = "/register"
-	RouteNewInvoice       = "/invoices/new"
-	RouteEditInvoice      = "/invoices/edit"
-	RouteInvoiceDetails   = "/invoices/{token:[A-z0-9]{64}}"
-	RouteSetInvoiceStatus = "/invoices/{token:[A-z0-9]{64}}/status"
-	RouteUserInvoices     = "/user/invoices"
-	RouteAdminInvoices    = "/admin/invoices"
-	RouteGeneratePayouts  = "/admin/generatepayouts"
-	RouteInvoiceComments  = "/invoices/{token:[A-z0-9]{64}}/comments"
-	RouteExchangeRate     = "/invoices/exchangerate"
+	RouteInviteNewUser       = "/invite"
+	RouteRegisterUser        = "/register"
+	RouteNewInvoice          = "/invoices/new"
+	RouteEditInvoice         = "/invoices/edit"
+	RouteInvoiceDetails      = "/invoices/{token:[A-z0-9]{64}}"
+	RouteSetInvoiceStatus    = "/invoices/{token:[A-z0-9]{64}}/status"
+	RouteUserInvoices        = "/user/invoices"
+	RouteAdminInvoices       = "/admin/invoices"
+	RouteGeneratePayouts     = "/admin/generatepayouts"
+	RouteInvoiceComments     = "/invoices/{token:[A-z0-9]{64}}/comments"
+	RouteInvoiceExchangeRate = "/invoices/exchangerate"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -20,6 +20,7 @@ const (
 	RouteAdminInvoices    = "/admin/invoices"
 	RouteGeneratePayouts  = "/admin/generatepayouts"
 	RouteInvoiceComments  = "/invoices/{token:[A-z0-9]{64}}/comments"
+	RouteExchangeRate     = "/invoices/exchangerate"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status
@@ -201,4 +202,15 @@ type Payout struct {
 	Address        string `json:"address"`
 	LaborTotal     uint   `json:"labortotal"`
 	ExpenseTotal   uint   `json:"expensetotal"`
+}
+
+// InvoiceExchangeRate contains the request to receive a monthly exchange rate
+type InvoiceExchangeRate struct {
+	Month uint `json:"month"`
+	Year  uint `json:"year"`
+}
+
+// InvoiceExchangeRateReply returns the calculated monthly exchange rate
+type InvoiceExchangeRateReply struct {
+	ExchangeRate float64 `json:"exchangerate"`
 }

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -1557,6 +1557,28 @@ func (c *Client) TokenInventory() (*v1.TokenInventoryReply, error) {
 	return &tir, nil
 }
 
+// InvoiceExchangeRate changes the status of the specified invoice.
+func (c *Client) InvoiceExchangeRate(ier *cms.InvoiceExchangeRate) (*cms.InvoiceExchangeRateReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteInvoiceExchangeRate, ier)
+	if err != nil {
+		return nil, err
+	}
+
+	var ierr cms.InvoiceExchangeRateReply
+	err = json.Unmarshal(responseBody, &ierr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal SetInvoiceStatusReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(ierr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &ierr, nil
+}
+
 // Close all client connections.
 func (c *Client) Close() {
 	if c.conn != nil {

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -56,64 +56,65 @@ var (
 
 // Cmds is used to represent all of the politeiawwwcli commands.
 type Cmds struct {
-	AdminInvoices      AdminInvoicesCmd      `command:"admininvoices" description:"(admin) get all invoices (optional by month/year and/or status)"`
-	ActiveVotes        ActiveVotesCmd        `command:"activevotes" description:"(public) get the proposals that are being voted on"`
-	AuthorizeVote      AuthorizeVoteCmd      `command:"authorizevote" description:"(user)   authorize a proposal vote (must be proposal author)"`
-	CensorComment      CensorCommentCmd      `command:"censorcomment" description:"(admin)  censor a proposal comment"`
-	ChangePassword     ChangePasswordCmd     `command:"changepassword" description:"(user)   change the password for the logged in user"`
-	ChangeUsername     ChangeUsernameCmd     `command:"changeusername" description:"(user)   change the username for the logged in user"`
-	EditInvoice        EditInvoiceCmd        `command:"editinvoice" description:"(user)    edit a invoice"`
-	EditProposal       EditProposalCmd       `command:"editproposal" description:"(user)   edit a proposal"`
-	ManageUser         ManageUserCmd         `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
-	EditUser           EditUserCmd           `command:"edituser" description:"(user)   edit the  preferences of the logged in user"`
-	GeneratePayouts    GeneratePayoutsCmd    `command:"generatepayouts" description:"(admin) generate a list of payouts with addresses and amounts to pay"`
-	Help               HelpCmd               `command:"help" description:"         print a detailed help message for a specific command"`
-	InvoiceComments    InvoiceCommentsCmd    `command:"invoicecomments" description:"(user) get the comments for a invoice"`
-	Inventory          InventoryCmd          `command:"inventory" description:"(public) get the proposals that are being voted on"`
-	InviteNewUser      InviteNewUserCmd      `command:"invite" description:"(admin)  invite a new user"`
-	InvoiceDetails     InvoiceDetailsCmd     `command:"invoicedetails" description:"(public) get the details of a proposal"`
-	LikeComment        LikeCommentCmd        `command:"likecomment" description:"(user)   upvote/downvote a comment"`
-	Login              LoginCmd              `command:"login" description:"(public) login to Politeia"`
-	Logout             LogoutCmd             `command:"logout" description:"(public) logout of Politeia"`
-	Me                 MeCmd                 `command:"me" description:"(user)   get user details for the logged in user"`
-	NewInvoice         NewInvoiceCmd         `command:"newinvoice" description:"(user)   create a new invoice"`
-	NewProposal        NewProposalCmd        `command:"newproposal" description:"(user)   create a new proposal"`
-	NewComment         NewCommentCmd         `command:"newcomment" description:"(user)   create a new proposal comment"`
-	NewUser            NewUserCmd            `command:"newuser" description:"(public) create a new user"`
-	Policy             PolicyCmd             `command:"policy" description:"(public) get the server policy"`
-	ProposalComments   ProposalCommentsCmd   `command:"proposalcomments" description:"(public) get the comments for a proposal"`
-	ProposalDetails    ProposalDetailsCmd    `command:"proposaldetails" description:"(public) get the details of a proposal"`
-	ProposalPaywall    ProposalPaywallCmd    `command:"proposalpaywall" description:"(user)   get proposal paywall details for the logged in user"`
-	ProposalStats      ProposalStatsCmd      `command:"proposalstats" description:"(public) get statistics on the proposal inventory"`
-	UnvettedProposals  UnvettedProposalsCmd  `command:"unvettedproposals" description:"(admin)  get a page of unvetted proposals"`
-	VettedProposals    VettedProposalsCmd    `command:"vettedproposals" description:"(public) get a page of vetted proposals"`
-	RegisterUser       RegisterUserCmd       `command:"register" description:"(public) register an invited user to cms"`
-	RescanUserPayments RescanUserPaymentsCmd `command:"rescanuserpayments" description:"(admin)  rescan a user's payments to check for missed payments"`
-	ResendVerification ResendVerificationCmd `command:"resendverification" description:"(public) resend the user verification email"`
-	ResetPassword      ResetPasswordCmd      `command:"resetpassword" description:"(public) reset the password for a user that is not logged in"`
-	Secret             SecretCmd             `command:"secret" description:"(user)   ping politeiawww"`
-	SendFaucetTx       SendFaucetTxCmd       `command:"sendfaucettx" description:"         send a DCR transaction using the Decred testnet faucet"`
-	SetInvoiceStatus   SetInvoiceStatusCmd   `command:"setinvoicestatus" description:"(admin)  set the status of an invoice"`
-	SetProposalStatus  SetProposalStatusCmd  `command:"setproposalstatus" description:"(admin)  set the status of a proposal"`
-	StartVote          StartVoteCmd          `command:"startvote" description:"(admin)  start the voting period on a proposal"`
-	Subscribe          SubscribeCmd          `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`
-	Tally              TallyCmd              `command:"tally" description:"(public) get the vote tally for a proposal"`
-	TestRun            TestRunCmd            `command:"testrun" description:"         run a series of tests on the politeiawww routes (dev use only)"`
-	TokenInventory     TokenInventoryCmd     `command:"tokeninventory" description:"(public) get the censorship record tokens of all proposals"`
-	UpdateUserKey      UpdateUserKeyCmd      `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
-	UserDetails        UserDetailsCmd        `command:"userdetails" description:"(public) get the details of a user profile"`
-	UserLikeComments   UserLikeCommentsCmd   `command:"userlikecomments" description:"(user)   get the logged in user's comment upvotes/downvotes for a proposal"`
-	UserPendingPayment UserPendingPaymentCmd `command:"userpendingpayment" description:"(user)   get details for a pending payment for the logged in user"`
-	UserInvoices       UserInvoicesCmd       `command:"userinvoices" description:"(user) get all invoices submitted by a specific user"`
-	UserProposals      UserProposalsCmd      `command:"userproposals" description:"(public) get all proposals submitted by a specific user"`
-	Users              UsersCmd              `command:"users" description:"(admin)  get a list of users"`
-	VerifyUserEmail    VerifyUserEmailCmd    `command:"verifyuseremail" description:"(public) verify a user's email address"`
-	VerifyUserPayment  VerifyUserPaymentCmd  `command:"verifyuserpayment" description:"(user)   check if the logged in user has paid their user registration fee"`
-	Version            VersionCmd            `command:"version" description:"(public) get server info and CSRF token"`
-	Vote               VoteCmd               `command:"vote" description:"(public) cast votes for a proposal"`
-	VoteResults        VoteResultsCmd        `command:"voteresults" description:"(public) get vote results for a proposal"`
-	VoteStatus         VoteStatusCmd         `command:"votestatus" description:"(public) get the vote status of a proposal"`
-	VoteStatuses       VoteStatusesCmd       `command:"votestatuses" description:"(public) get the vote status for all public proposals"`
+	AdminInvoices       AdminInvoicesCmd       `command:"admininvoices" description:"(admin) get all invoices (optional by month/year and/or status)"`
+	ActiveVotes         ActiveVotesCmd         `command:"activevotes" description:"(public) get the proposals that are being voted on"`
+	AuthorizeVote       AuthorizeVoteCmd       `command:"authorizevote" description:"(user)   authorize a proposal vote (must be proposal author)"`
+	CensorComment       CensorCommentCmd       `command:"censorcomment" description:"(admin)  censor a proposal comment"`
+	ChangePassword      ChangePasswordCmd      `command:"changepassword" description:"(user)   change the password for the logged in user"`
+	ChangeUsername      ChangeUsernameCmd      `command:"changeusername" description:"(user)   change the username for the logged in user"`
+	EditInvoice         EditInvoiceCmd         `command:"editinvoice" description:"(user)    edit a invoice"`
+	EditProposal        EditProposalCmd        `command:"editproposal" description:"(user)   edit a proposal"`
+	ManageUser          ManageUserCmd          `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
+	EditUser            EditUserCmd            `command:"edituser" description:"(user)   edit the  preferences of the logged in user"`
+	GeneratePayouts     GeneratePayoutsCmd     `command:"generatepayouts" description:"(admin) generate a list of payouts with addresses and amounts to pay"`
+	Help                HelpCmd                `command:"help" description:"         print a detailed help message for a specific command"`
+	InvoiceComments     InvoiceCommentsCmd     `command:"invoicecomments" description:"(user) get the comments for a invoice"`
+	InvoiceExchangeRate InvoiceExchangeRateCmd `command:"invoiceexchangerate" description:"(user) get exchange rate for a given month/year"`
+	Inventory           InventoryCmd           `command:"inventory" description:"(public) get the proposals that are being voted on"`
+	InviteNewUser       InviteNewUserCmd       `command:"invite" description:"(admin)  invite a new user"`
+	InvoiceDetails      InvoiceDetailsCmd      `command:"invoicedetails" description:"(public) get the details of a proposal"`
+	LikeComment         LikeCommentCmd         `command:"likecomment" description:"(user)   upvote/downvote a comment"`
+	Login               LoginCmd               `command:"login" description:"(public) login to Politeia"`
+	Logout              LogoutCmd              `command:"logout" description:"(public) logout of Politeia"`
+	Me                  MeCmd                  `command:"me" description:"(user)   get user details for the logged in user"`
+	NewInvoice          NewInvoiceCmd          `command:"newinvoice" description:"(user)   create a new invoice"`
+	NewProposal         NewProposalCmd         `command:"newproposal" description:"(user)   create a new proposal"`
+	NewComment          NewCommentCmd          `command:"newcomment" description:"(user)   create a new proposal comment"`
+	NewUser             NewUserCmd             `command:"newuser" description:"(public) create a new user"`
+	Policy              PolicyCmd              `command:"policy" description:"(public) get the server policy"`
+	ProposalComments    ProposalCommentsCmd    `command:"proposalcomments" description:"(public) get the comments for a proposal"`
+	ProposalDetails     ProposalDetailsCmd     `command:"proposaldetails" description:"(public) get the details of a proposal"`
+	ProposalPaywall     ProposalPaywallCmd     `command:"proposalpaywall" description:"(user)   get proposal paywall details for the logged in user"`
+	ProposalStats       ProposalStatsCmd       `command:"proposalstats" description:"(public) get statistics on the proposal inventory"`
+	UnvettedProposals   UnvettedProposalsCmd   `command:"unvettedproposals" description:"(admin)  get a page of unvetted proposals"`
+	VettedProposals     VettedProposalsCmd     `command:"vettedproposals" description:"(public) get a page of vetted proposals"`
+	RegisterUser        RegisterUserCmd        `command:"register" description:"(public) register an invited user to cms"`
+	RescanUserPayments  RescanUserPaymentsCmd  `command:"rescanuserpayments" description:"(admin)  rescan a user's payments to check for missed payments"`
+	ResendVerification  ResendVerificationCmd  `command:"resendverification" description:"(public) resend the user verification email"`
+	ResetPassword       ResetPasswordCmd       `command:"resetpassword" description:"(public) reset the password for a user that is not logged in"`
+	Secret              SecretCmd              `command:"secret" description:"(user)   ping politeiawww"`
+	SendFaucetTx        SendFaucetTxCmd        `command:"sendfaucettx" description:"         send a DCR transaction using the Decred testnet faucet"`
+	SetInvoiceStatus    SetInvoiceStatusCmd    `command:"setinvoicestatus" description:"(admin)  set the status of an invoice"`
+	SetProposalStatus   SetProposalStatusCmd   `command:"setproposalstatus" description:"(admin)  set the status of a proposal"`
+	StartVote           StartVoteCmd           `command:"startvote" description:"(admin)  start the voting period on a proposal"`
+	Subscribe           SubscribeCmd           `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`
+	Tally               TallyCmd               `command:"tally" description:"(public) get the vote tally for a proposal"`
+	TestRun             TestRunCmd             `command:"testrun" description:"         run a series of tests on the politeiawww routes (dev use only)"`
+	TokenInventory      TokenInventoryCmd      `command:"tokeninventory" description:"(public) get the censorship record tokens of all proposals"`
+	UpdateUserKey       UpdateUserKeyCmd       `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
+	UserDetails         UserDetailsCmd         `command:"userdetails" description:"(public) get the details of a user profile"`
+	UserLikeComments    UserLikeCommentsCmd    `command:"userlikecomments" description:"(user)   get the logged in user's comment upvotes/downvotes for a proposal"`
+	UserPendingPayment  UserPendingPaymentCmd  `command:"userpendingpayment" description:"(user)   get details for a pending payment for the logged in user"`
+	UserInvoices        UserInvoicesCmd        `command:"userinvoices" description:"(user) get all invoices submitted by a specific user"`
+	UserProposals       UserProposalsCmd       `command:"userproposals" description:"(public) get all proposals submitted by a specific user"`
+	Users               UsersCmd               `command:"users" description:"(admin)  get a list of users"`
+	VerifyUserEmail     VerifyUserEmailCmd     `command:"verifyuseremail" description:"(public) verify a user's email address"`
+	VerifyUserPayment   VerifyUserPaymentCmd   `command:"verifyuserpayment" description:"(user)   check if the logged in user has paid their user registration fee"`
+	Version             VersionCmd             `command:"version" description:"(public) get server info and CSRF token"`
+	Vote                VoteCmd                `command:"vote" description:"(public) cast votes for a proposal"`
+	VoteResults         VoteResultsCmd         `command:"voteresults" description:"(public) get vote results for a proposal"`
+	VoteStatus          VoteStatusCmd          `command:"votestatus" description:"(public) get the vote status of a proposal"`
+	VoteStatuses        VoteStatusesCmd        `command:"votestatuses" description:"(public) get the vote status for all public proposals"`
 }
 
 // SetConfig sets the global config variable.

--- a/politeiawww/cmd/politeiawwwcli/commands/invoiceexchangerate.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/invoiceexchangerate.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// NewInvoiceCmd submits a new invoice.
+type InvoiceExchangeRateCmd struct {
+	Args struct {
+		Month uint `positional-arg-name:"month"` // Invoice Month
+		Year  uint `positional-arg-name:"year"`  // Invoice Year
+	} `positional-args:"true" optional:"true"`
+}
+
+// Execute executes the new invoice command.
+func (cmd *InvoiceExchangeRateCmd) Execute(args []string) error {
+	month := cmd.Args.Month
+	year := cmd.Args.Year
+
+	ier := &v1.InvoiceExchangeRate{
+		Month: uint(month),
+		Year:  uint(year),
+	}
+
+	// Print request details
+	err := printJSON(ier)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	ierr, err := client.InvoiceExchangeRate(ier)
+	if err != nil {
+		return err
+	}
+
+	// Print response details
+	return printJSON(ierr)
+}
+
+const newInvoiceExchangeRateMsg = `invoiceexchangerate [flags]" 
+
+Request an USD/DCR exchange rate for a given month.
+
+Arguments:
+1. month			 (string, required)   Month (MM, 01-12)
+2. year				 (string, required)   Year (YYYY)
+
+
+Result:
+{
+  "exchangerate": (float64) Calculated rate
+}`

--- a/politeiawww/cmd/politeiawwwcli/commands/invoiceexchangerate.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/invoiceexchangerate.go
@@ -22,8 +22,8 @@ func (cmd *InvoiceExchangeRateCmd) Execute(args []string) error {
 	year := cmd.Args.Year
 
 	ier := &v1.InvoiceExchangeRate{
-		Month: uint(month),
-		Year:  uint(year),
+		Month: month,
+		Year:  year,
 	}
 
 	// Print request details

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -400,7 +400,7 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleUserInvoices, permissionLogin)
 	p.addRoute(http.MethodGet, cms.RouteInvoiceComments,
 		p.handleInvoiceComments, permissionLogin)
-	p.addRoute(http.MethodPost, cms.RouteExchangeRate,
+	p.addRoute(http.MethodPost, cms.RouteInvoiceExchangeRate,
 		p.handleInvoiceExchangeRate, permissionLogin)
 
 	// Unauthenticated websocket

--- a/politeiawww/prices.go
+++ b/politeiawww/prices.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+const poloURL = "https://poloniex.com/public"
+const httpTimeout = time.Second * 3
+const pricePeriod = 900
+
+type poloChartData struct {
+	Date            uint64  `json:"date"`
+	WeightedAverage float64 `json:"weightedAverage"`
+}
+
+// GetMonthAverage returns the average USD/DCR price for a given month
+func (p *politeiawww) GetMonthAverage(month time.Month, year int) (float64, error) {
+	startTime := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	endTime := startTime.AddDate(0, 1, 0)
+
+	unixStart := startTime.Unix()
+	unixEnd := endTime.Unix()
+
+	// Download BTC/DCR and USDT/BTC prices from Poloniex
+	dcrPrices, err := getPrices("BTC_DCR", unixStart, unixEnd)
+	if err != nil {
+		return 0, err
+	}
+	btcPrices, err := getPrices("USDT_BTC", unixStart, unixEnd)
+	if err != nil {
+		return 0, err
+	}
+
+	// Create a map of unix timestamps => average price
+	usdtDcrPrices := make(map[uint64]float64)
+
+	// Select only timestamps which appear in both charts to
+	// populate the result set. Multiply BTC/DCR rate by
+	// USDT/BTC rate to get USDT/DCR rate.
+	for timestamp, dcr := range dcrPrices {
+		if btc, ok := btcPrices[timestamp]; ok {
+			usdtDcrPrices[timestamp] = dcr * btc
+		}
+	}
+
+	// Calculate and return the average of all USDT/DCR prices
+	var average float64
+	for _, price := range usdtDcrPrices {
+		average += price
+	}
+	average = average / float64(len(usdtDcrPrices))
+
+	// Polo doesn't like >6 requests per second
+	time.Sleep(300 * time.Millisecond)
+
+	return average, nil
+}
+
+// GetPrices contacts the Poloniex API to download
+// price data for a given CC pairing. Returns a map
+// of unix timestamp => average price
+func getPrices(pairing string, startDate int64, endDate int64) (map[uint64]float64, error) {
+	// Construct HTTP request and set parameters
+	req, err := http.NewRequest(http.MethodGet, poloURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Set("command", "returnChartData")
+	q.Set("currencyPair", pairing)
+	q.Set("start", strconv.FormatInt(startDate, 10))
+	q.Set("end", strconv.FormatInt(endDate, 10))
+	q.Set("period", strconv.Itoa(pricePeriod))
+	req.URL.RawQuery = q.Encode()
+
+	// Create HTTP client,
+	httpClient := http.Client{
+		Timeout: httpTimeout,
+	}
+
+	// Send HTTP request
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	// Read response and deserialise JSON
+	decoder := json.NewDecoder(resp.Body)
+	var chartData []poloChartData
+	err = decoder.Decode(&chartData)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a map of unix timestamps => average price
+	prices := make(map[uint64]float64, len(chartData))
+	for _, data := range chartData {
+		prices[data.Date] = data.WeightedAverage
+	}
+
+	return prices, nil
+}
+
+// GetMonthAverage returns the average USD/DCR price for a given month
+func (p *politeiawww) processInvoiceExchangeRate(ier cms.InvoiceExchangeRate) (cms.InvoiceExchangeRateReply, error) {
+	reply := cms.InvoiceExchangeRateReply{}
+
+	monthAvg, err := p.GetMonthAverage(time.Month(ier.Month), int(ier.Year))
+	if err != nil {
+		return reply, err
+	}
+	reply.ExchangeRate = monthAvg
+	return reply, nil
+}

--- a/politeiawww/prices.go
+++ b/politeiawww/prices.go
@@ -55,9 +55,6 @@ func (p *politeiawww) GetMonthAverage(month time.Month, year int) (float64, erro
 	}
 	average = average / float64(len(usdtDcrPrices))
 
-	// Polo doesn't like >6 requests per second
-	time.Sleep(300 * time.Millisecond)
-
 	return average, nil
 }
 


### PR DESCRIPTION
This is a first pass of implementing an exchange rate endpoint.
It calculates a monthly average exchange based on a provided month/year.

Currently, this is calculation is done each time.  Once this implementation
and calculation has been approved/merged, I will go about adding a caching system
in the cms database that will only request the prices and calculate when if there
is not an entry found in the database.