### PR TITLE
[cms] Add month/year validation to invoice input

### DIFF
--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -134,6 +134,7 @@ notifications.  It does not render HTML.
 - [`ErrorStatusMalformedDescription`](#ErrorStatusMalformedDescription) 
 - [`ErrorStatusWrongInvoiceStatus`](#ErrorStatusWrongInvoiceStatus) 
 - [`ErrorStatusInvoiceRequireLineItems`](#ErrorStatusInvoiceRequireLineItems)
+- [`ErrorStatusInvalidInvoiceMonthYear`](#ErrorStatusInvalidInvoiceMonthYear)
 - [`ErrorStatusMultipleInvoiceMonthYear`](#ErrorStatusMultipleInvoiceMonthYear)
 
 **Proposal status codes**
@@ -2549,6 +2550,7 @@ Reply:
 | <a name="ErrorStatusWrongInvoiceStatus">ErrorStatusWrongInvoiceStatus</a> | 80 | Wrong status for an invoice to be editted (approved, rejected, paid). |
 | <a name="ErrorStatusInvoiceRequireLineItems">ErrorStatusInvoiceRequireLineItems</a> | 81 | Invoices require at least 1 line item to be included. |
 | <a name="ErrorStatusMultipleInvoiceMonthYear">ErrorStatusMultipleInvoiceMonthYear</a> | 82 | Users are only allowed to submit 1 invoice per month/year. |
+| <a name="ErrorStatusInvalidInvoiceMonthYear">ErrorStatusInvalidInvoiceMonthYear</a> | 83 | An invalid month/year was detected in an invoice. |
 
 
 ### Proposal status codes

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -228,6 +228,7 @@ const (
 	ErrorStatusWrongInvoiceStatus             ErrorStatusT = 80
 	ErrorStatusInvoiceRequireLineItems        ErrorStatusT = 81
 	ErrorStatusMultipleInvoiceMonthYear       ErrorStatusT = 82
+	ErrorStatusInvalidInvoiceMonthYear        ErrorStatusT = 83
 
 	// Proposal state codes
 	//
@@ -405,6 +406,7 @@ var (
 		ErrorStatusWrongInvoiceStatus:             "invoice is an wrong status to be editted (approved, rejected or paid)",
 		ErrorStatusInvoiceRequireLineItems:        "invoices require at least 1 line item",
 		ErrorStatusMultipleInvoiceMonthYear:       "only one invoice per month/year is allowed to be submitted",
+		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -459,7 +459,8 @@ func validateInvoice(ni cms.NewInvoice, u *user.User) error {
 			// month is after the current date.  For example, if a user submits
 			// an invoice for 03/2019, the first time that they could submit an
 			// invoice would be approx. 12:01 AM 04/01/2019
-			startOfFollowingMonth := time.Date(int(invInput.Year), time.Month(invInput.Month+1), 0, 0, 0, 0, 0, time.UTC)
+			startOfFollowingMonth := time.Date(int(invInput.Year),
+				time.Month(invInput.Month+1), 0, 0, 0, 0, 0, time.UTC)
 			if startOfFollowingMonth.After(time.Now()) {
 				return www.UserError{
 					ErrorCode: www.ErrorStatusInvalidInvoiceMonthYear,


### PR DESCRIPTION
This adds basic validation that the current date is not before the end of the 
invoice's billing cycle.