### PR TITLE
www: Add TokenInventory route

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -20,6 +20,7 @@ const (
 	CmdCommentLikes          = "commentlikes"
 	CmdProposalCommentsLikes = "proposalcommentslikes"
 	CmdInventory             = "inventory"
+	CmdTokenInventory        = "tokeninventory"
 	MDStreamAuthorizeVote    = 13 // Vote authorization by proposal author
 	MDStreamVoteBits         = 14 // Vote bits and mask
 	MDStreamVoteSnapshot     = 15 // Vote tickets and start/end parameters
@@ -779,4 +780,54 @@ func DecodeInventoryReply(payload []byte) (*InventoryReply, error) {
 	}
 
 	return &ir, nil
+}
+
+// TokenInventory requests the tokens of all records in the inventory.
+type TokenInventory struct {
+	BestBlock uint64 `json:"bestblock"` // Best block
+}
+
+// EncodeTokenInventory encodes a TokenInventory into a JSON byte slice.
+func EncodeTokenInventory(i TokenInventory) ([]byte, error) {
+	return json.Marshal(i)
+}
+
+// DecodeTokenInventory decodes a JSON byte slice into a TokenInventory.
+func DecodeTokenInventory(payload []byte) (*TokenInventory, error) {
+	var i TokenInventory
+
+	err := json.Unmarshal(payload, &i)
+	if err != nil {
+		return nil, err
+	}
+
+	return &i, nil
+}
+
+// TokenInventoryReply is the response to the TokenInventory command and
+// returns the tokens of all records in the inventory, categorized by stage of
+// the voting process.
+type TokenInventoryReply struct {
+	Pre       []string `json:"pre"`       // Tokens of records that are pre-vote
+	Active    []string `json:"active"`    // Tokens of records with an active voting period
+	Finished  []string `json:"finished"`  // Tokens of records with a finished voting period
+	Abandoned []string `json:"abandoned"` // Tokens of records that have been abandoned
+}
+
+// EncodeTokenInventoryReply encodes a TokenInventoryReply into a JSON byte
+// slice.
+func EncodeTokenInventoryReply(itr TokenInventoryReply) ([]byte, error) {
+	return json.Marshal(itr)
+}
+
+// DecodeTokenInventoryReply decodes a JSON byte slice into a inventory.
+func DecodeTokenInventoryReply(payload []byte) (*TokenInventoryReply, error) {
+	var itr TokenInventoryReply
+
+	err := json.Unmarshal(payload, &itr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &itr, nil
 }

--- a/politeiad/cache/cache.go
+++ b/politeiad/cache/cache.go
@@ -35,10 +35,6 @@ var (
 	// ErrInvalidPluginCmd is emitted when an invalid plugin command
 	// is used.
 	ErrInvalidPluginCmd = errors.New("invalid plugin command")
-
-	// ErrWrongPluginVersion is emitted when the version of a cache
-	// plugin does not match the version of the plugin tables.
-	ErrWrongPluginVersion = errors.New("wrong plugin version")
 )
 
 const (

--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -5,6 +5,7 @@
 package cockroachdb
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -179,7 +180,7 @@ func convertAuthorizeVoteToDecred(av AuthorizeVote) decredplugin.AuthorizeVote {
 	}
 }
 
-func convertStartVoteFromDecred(sv decredplugin.StartVote, svr decredplugin.StartVoteReply) StartVote {
+func convertStartVoteFromDecred(sv decredplugin.StartVote, svr decredplugin.StartVoteReply, endHeight uint64) StartVote {
 	opts := make([]VoteOption, 0, len(sv.Vote.Options))
 	for _, v := range sv.Vote.Options {
 		opts = append(opts, VoteOption{
@@ -200,7 +201,7 @@ func convertStartVoteFromDecred(sv decredplugin.StartVote, svr decredplugin.Star
 		Signature:        sv.Signature,
 		StartBlockHeight: svr.StartBlockHeight,
 		StartBlockHash:   svr.StartBlockHash,
-		EndHeight:        svr.EndHeight,
+		EndHeight:        endHeight,
 		EligibleTickets:  strings.Join(svr.EligibleTickets, ","),
 	}
 }
@@ -235,7 +236,7 @@ func convertStartVoteToDecred(sv StartVote) (decredplugin.StartVote, decredplugi
 	dsvr := decredplugin.StartVoteReply{
 		StartBlockHeight: sv.StartBlockHeight,
 		StartBlockHash:   sv.StartBlockHash,
-		EndHeight:        sv.EndHeight,
+		EndHeight:        fmt.Sprint(sv.EndHeight),
 		EligibleTickets:  tix,
 	}
 

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -64,8 +64,10 @@ func (Record) TableName() string {
 	return tableRecords
 }
 
-// Comment is a decred plugin comment, including all of the server side
+// Comment represents a record comment, including all of the server side
 // metadata.
+//
+// This is a decred plugin model.
 type Comment struct {
 	Key       string `gorm:"primary_key"`       // Primary key (token+commentID)
 	Token     string `gorm:"not null;size:64"`  // Censorship token
@@ -84,8 +86,10 @@ func (Comment) TableName() string {
 	return tableComments
 }
 
-// LikeComment is a decred plugin comment upvote/downvote.  The server side
-// metadata is not included.
+// LikeComment describes a comment upvote/downvote.  The server side metadata
+// is not included.
+//
+// This is a decred plugin model.
 type LikeComment struct {
 	Key       uint   `gorm:"primary_key"`       // Primary key
 	Token     string `gorm:"not null;size:64"`  // Censorship token
@@ -100,9 +104,10 @@ func (LikeComment) TableName() string {
 	return tableCommentLikes
 }
 
-// AuthorizeVote is a decred plugin metadata stream that is created by a
-// proposal author and is used to indicate that the proposal has been finalized
-// and is ready to be voted on.
+// AuthorizeVote is used to indicate that a record has been finalized and is
+// ready to be voted on.
+//
+// This is a decred plugin model.
 type AuthorizeVote struct {
 	Key       string `gorm:"primary_key"`       // Primary key (token+version)
 	Token     string `gorm:"not null;size:64"`  // Censorship token
@@ -119,7 +124,9 @@ func (AuthorizeVote) TableName() string {
 	return tableAuthorizeVotes
 }
 
-// VoteOption is a decred plugin struct that describes a single vote option.
+// VoteOption describes a single vote option.
+//
+// This is a decred plugin model.
 type VoteOption struct {
 	Key         uint   `gorm:"primary_key"`      // Primary key
 	Token       string `gorm:"not null;size:64"` // StartVote foreign key
@@ -133,8 +140,9 @@ func (VoteOption) TableName() string {
 	return tableVoteOptions
 }
 
-// StartVote is a decred plugin struct that is used to record the details of
-// a proposal vote.
+// StartVote records the details of a proposal vote.
+//
+// This is a decred plugin model.
 type StartVote struct {
 	Token            string       `gorm:"primary_key;size:64"` // Censorship token
 	Version          uint64       `gorm:"not null"`            // Version of files
@@ -147,7 +155,7 @@ type StartVote struct {
 	Signature        string       `gorm:"not null;size:128"`   // Signature of Votehash
 	StartBlockHeight string       `gorm:"not null"`            // Block height
 	StartBlockHash   string       `gorm:"not null"`            // Block hash
-	EndHeight        string       `gorm:"not null"`            // Height of vote end
+	EndHeight        uint64       `gorm:"not null"`            // Height of vote end
 	EligibleTickets  string       `gorm:"not null"`            // Valid voting tickets
 }
 
@@ -156,7 +164,9 @@ func (StartVote) TableName() string {
 	return tableStartVotes
 }
 
-// CastVote is a decred plugin struct that is used to record a signed vote.
+// CastVote records a signed vote.
+//
+// This is a decred plugin model.
 type CastVote struct {
 	Key       uint   `gorm:"primary_key"`       // Primary key
 	Token     string `gorm:"not null;size:64"`  // Censorship token

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -60,6 +60,7 @@ const (
 	RouteAllVoteStatus            = "/proposals/votestatus"
 	RouteVoteStatus               = "/proposals/{token:[A-z0-9]{64}}/votestatus"
 	RoutePropsStats               = "/proposals/stats"
+	RouteTokenInventory           = "/proposals/tokeninventory"
 	RouteUnauthenticatedWebSocket = "/ws"
 	RouteAuthenticatedWebSocket   = "/aws"
 
@@ -1205,6 +1206,20 @@ type ProposalsStatsReply struct {
 	NumOfUnvettedChanges int `json:"numofunvettedchanges"` // Counting number of proposals with unvetted changes
 	NumOfPublic          int `json:"numofpublic"`          // Counting number of public proposals
 	NumOfAbandoned       int `json:"numofabandoned"`       // Counting number of abandoned proposals
+}
+
+// TokenInventory retrieves the censorship record tokens of all proposals in
+// the inventory.  The token are categorized in a manner that resembles their
+// vote statuses, but that has been altered to be a more natural fit with how a
+// UI would display them.
+type TokenInventory struct{}
+
+// TokenInventoryReply is used to reply to the TokenInventory command.
+type TokenInventoryReply struct {
+	Pre       []string `json:"pre"`       // Tokens of all props that are pre-vote
+	Active    []string `json:"active"`    // Tokens of all props with an active voting period
+	Finished  []string `json:"finished"`  // Tokens of all props with a finished voting period
+	Abandoned []string `json:"abandoned"` // Tokens of all props that have been abandoned
 }
 
 // Websocket commands

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -1533,6 +1533,30 @@ func (c *Client) SetInvoiceStatus(sis *cms.SetInvoiceStatus) (*cms.SetInvoiceSta
 	return &sisr, nil
 }
 
+// TokenInventory retrieves the censorship record tokens of all proposals in
+// the inventory.
+func (c *Client) TokenInventory() (*v1.TokenInventoryReply, error) {
+	responseBody, err := c.makeRequest("GET", v1.RouteTokenInventory, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var tir v1.TokenInventoryReply
+	err = json.Unmarshal(responseBody, &tir)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal TokenInventoryReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(tir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &tir, nil
+}
+
 // Close all client connections.
 func (c *Client) Close() {
 	if c.conn != nil {

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -99,6 +99,7 @@ type Cmds struct {
 	Subscribe          SubscribeCmd          `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`
 	Tally              TallyCmd              `command:"tally" description:"(public) get the vote tally for a proposal"`
 	TestRun            TestRunCmd            `command:"testrun" description:"         run a series of tests on the politeiawww routes (dev use only)"`
+	TokenInventory     TokenInventoryCmd     `command:"tokeninventory" description:"(public) get the censorship record tokens of all proposals"`
 	UpdateUserKey      UpdateUserKeyCmd      `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
 	UserDetails        UserDetailsCmd        `command:"userdetails" description:"(public) get the details of a user profile"`
 	UserLikeComments   UserLikeCommentsCmd   `command:"userlikecomments" description:"(user)   get the logged in user's comment upvotes/downvotes for a proposal"`

--- a/politeiawww/cmd/politeiawwwcli/commands/tokeninventory.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/tokeninventory.go
@@ -1,0 +1,14 @@
+package commands
+
+// TokenInventory retrieves the censorship record tokens of all proposals in
+// the inventory.
+type TokenInventoryCmd struct{}
+
+// Execute executes the token inventory command.
+func (cmd *TokenInventoryCmd) Execute(args []string) error {
+	reply, err := client.TokenInventory()
+	if err != nil {
+		return err
+	}
+	return printJSON(reply)
+}

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -475,6 +475,15 @@ func convertPluginFromPD(p pd.Plugin) Plugin {
 	}
 }
 
+func convertTokenInventoryReplyFromDecred(r decredplugin.TokenInventoryReply) www.TokenInventoryReply {
+	return www.TokenInventoryReply{
+		Pre:       r.Pre,
+		Active:    r.Active,
+		Finished:  r.Finished,
+		Abandoned: r.Abandoned,
+	}
+}
+
 func convertInvoiceFileFromWWW(f *www.File) []pd.File {
 	return []pd.File{{
 		Name:    "invoice.csv",

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -242,3 +242,33 @@ func (p *politeiawww) decredInventory() (*decredplugin.InventoryReply, error) {
 
 	return ir, nil
 }
+
+// decredTokenInventory sends the decred plugin tokeninventory command to the
+// cache.
+func (p *politeiawww) decredTokenInventory(bestBlock uint64) (*decredplugin.TokenInventoryReply, error) {
+	payload, err := decredplugin.EncodeTokenInventory(
+		decredplugin.TokenInventory{
+			BestBlock: bestBlock,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	pc := cache.PluginCommand{
+		ID:             decredplugin.ID,
+		Command:        decredplugin.CmdTokenInventory,
+		CommandPayload: string(payload),
+	}
+
+	reply, err := p.cache.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+
+	tir, err := decredplugin.DecodeTokenInventoryReply([]byte(reply.Payload))
+	if err != nil {
+		return nil, err
+	}
+
+	return tir, nil
+}

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -450,6 +450,17 @@ func (p *politeiawww) handleProposalsStats(w http.ResponseWriter, r *http.Reques
 	util.RespondWithJSON(w, http.StatusOK, psr)
 }
 
+// handleTokenInventory returns the tokens of all proposals in the inventory.
+func (p *politeiawww) handleTokenInventory(w http.ResponseWriter, r *http.Request) {
+	reply, err := p.processTokenInventory()
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleTokenInventory: processTokenInventory: %v", err)
+		return
+	}
+	util.RespondWithJSON(w, http.StatusOK, reply)
+}
+
 // handleProposalPaywallDetails returns paywall details that allows the user to
 // purchase proposal credits.
 func (p *politeiawww) handleProposalPaywallDetails(w http.ResponseWriter, r *http.Request) {
@@ -1058,6 +1069,8 @@ func (p *politeiawww) setPoliteiaWWWRoutes() {
 		p.handleVoteStatus, permissionPublic)
 	p.addRoute(http.MethodGet, www.RoutePropsStats,
 		p.handleProposalsStats, permissionPublic)
+	p.addRoute(http.MethodGet, www.RouteTokenInventory,
+		p.handleTokenInventory, permissionPublic)
 
 	// Routes that require being logged in.
 	p.addRoute(http.MethodGet, www.RouteProposalPaywallDetails,

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1928,3 +1928,20 @@ func (p *politeiawww) processStartVote(sv www.StartVote, u *user.User) (*www.Sta
 	rv := convertStartVoteReplyFromDecred(*vr)
 	return &rv, nil
 }
+
+// processTokenInventory returns the tokens of all proposals in the inventory,
+// categorized by stage of the voting process.
+func (p *politeiawww) processTokenInventory() (*www.TokenInventoryReply, error) {
+	bb, err := p.getBestBlock()
+	if err != nil {
+		return nil, err
+	}
+
+	reply, err := p.decredTokenInventory(bb)
+	if err != nil {
+		return nil, err
+	}
+
+	itr := convertTokenInventoryReplyFromDecred(*reply)
+	return &itr, err
+}


### PR DESCRIPTION
Closes #795.

This diff adds a TokenInventory route to politeiawww.  The TokenInventory route retrieves the censorship record tokens of all proposals in the inventory.  The returned tokens are categorized in a manner that resembles their vote statuses, but that has been altered to be a more natural fit with how a UI would display them.  The categories are pre, active, finished, and abandoned. 

The 'finished' category was not broken up into 'approved' and 'rejected' because politeia is designed to be able to handle proposal votes with multiple voting options.  Categorizing the finished proposal votes into 'approved' and 'rejected' only makes sense for simple yes/no proposal votes.

The cache StartVote model was also updated.  The type of the EndHeight field was changed from a string to a uint64 so that, given the best block, a query can categorize the results into 'active' and 'finished' voting periods.

Query performance on my local machine when testing against the mainnet pi production data was as follows:

```
pre query           : 98ms
active query        : 97ms
finished query      : 102ms
abandoned query     : 4ms
```
Keep in mind that my local machine performance is significantly slower than the production pi performance.
