### PR TITLE
Fix panic on resend verification in CMS

### DIFF
--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1064,8 +1064,10 @@ func (p *politeiawww) processResendVerification(rv *www.ResendVerification) (*ww
 	}
 
 	// Remove the original pubkey from the cache.
-	existingPublicKey := hex.EncodeToString(u.Identities[0].Key[:])
-	p.removeUserPubkeyAssociaton(u, existingPublicKey)
+	if len(u.Identities) > 0 {
+		existingPublicKey := hex.EncodeToString(u.Identities[0].Key[:])
+		p.removeUserPubkeyAssociaton(u, existingPublicKey)
+	}
 
 	// Set a new verificaton token and identity.
 	setNewUserVerificationAndIdentity(u, token, expiry, true, pk)


### PR DESCRIPTION
Fixes #808 

While this will fix the panic, this isn't really a valid endpoint for CMS.  We need to think about how to reroute these and some others in userwww.