### PR TITLE
[cms] Add new route register func for cms mode 

### DIFF
--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -35,31 +35,6 @@ func (p *politeiawww) handleInviteNewUser(w http.ResponseWriter, r *http.Request
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
 
-// handleInviteNewUser handles the invitation of a new contractor by an
-// administrator for the Contractor Management System.
-func (p *politeiawww) handleRegisterUser(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("handleRegister")
-
-	// Get the new user command.
-	var u cms.RegisterUser
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&u); err != nil {
-		RespondWithError(w, r, 0, "handleRegisterUser: unmarshal", www.UserError{
-			ErrorCode: www.ErrorStatusInvalidInput,
-		})
-		return
-	}
-
-	reply, err := p.processRegisterUser(u)
-	if err != nil {
-		RespondWithError(w, r, 0, "handleRegisterUser: ProcessRegisterUser %v", err)
-		return
-	}
-
-	// Reply with the verification token.
-	util.RespondWithJSON(w, http.StatusOK, reply)
-}
-
 // handleNewInvoice handles the incoming new invoice command.
 func (p *politeiawww) handleNewInvoice(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleNewInvoice")
@@ -391,12 +366,4 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleSetInvoiceStatus, permissionAdmin)
 	p.addRoute(http.MethodPost, cms.RouteGeneratePayouts,
 		p.handleGeneratePayouts, permissionAdmin)
-
-	// Routes for Contractor Management System
-
-	// Publicish routes
-	p.addRoute(http.MethodPost, cms.RouteRegisterUser, p.handleRegisterUser,
-		permissionPublic)
-
-	// Admin Routes
 }

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -753,3 +753,37 @@ func (p *politeiawww) setUserWWWRoutes() {
 	p.addRoute(http.MethodPost, www.RouteManageUser,
 		p.handleManageUser, permissionAdmin)
 }
+
+// setCMSUserWWWRoutes setsup the user routes for cms mode
+func (p *politeiawww) setCMSUserWWWRoutes() {
+	// Public routes
+	p.addRoute(http.MethodPost, www.RouteLogin, p.handleLogin,
+		permissionPublic)
+	p.addRoute(http.MethodPost, www.RouteLogout, p.handleLogout,
+		permissionPublic)
+	p.addRoute(http.MethodPost, www.RouteResetPassword,
+		p.handleResetPassword, permissionPublic)
+	p.addRoute(http.MethodGet, www.RouteUserDetails,
+		p.handleUserDetails, permissionPublic)
+
+	// Routes that require being logged in.
+	p.addRoute(http.MethodPost, www.RouteSecret, p.handleSecret,
+		permissionLogin)
+	p.addRoute(http.MethodGet, www.RouteUserMe, p.handleMe, permissionLogin)
+	p.addRoute(http.MethodPost, www.RouteUpdateUserKey,
+		p.handleUpdateUserKey, permissionLogin)
+	p.addRoute(http.MethodPost, www.RouteVerifyUpdateUserKey,
+		p.handleVerifyUpdateUserKey, permissionLogin)
+	p.addRoute(http.MethodPost, www.RouteChangeUsername,
+		p.handleChangeUsername, permissionLogin)
+	p.addRoute(http.MethodPost, www.RouteChangePassword,
+		p.handleChangePassword, permissionLogin)
+	p.addRoute(http.MethodPost, www.RouteEditUser,
+		p.handleEditUser, permissionLogin)
+
+	// Routes that require being logged in as an admin user.
+	p.addRoute(http.MethodGet, www.RouteUsers,
+		p.handleUsers, permissionAdmin)
+	p.addRoute(http.MethodPost, www.RouteManageUser,
+		p.handleManageUser, permissionAdmin)
+}

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -450,8 +450,12 @@ func _main() error {
 	switch p.cfg.Mode {
 	case politeiaWWWMode:
 		p.setPoliteiaWWWRoutes()
+		// XXX setup user routes
+		p.setUserWWWRoutes()
 	case cmsWWWMode:
 		p.setCMSWWWRoutes()
+		// XXX setup user routes
+		p.setCMSUserWWWRoutes()
 		cmsdb.UseLogger(cockroachdbLog)
 		net := filepath.Base(p.cfg.DataDir)
 		p.cmsDB, err = cmsdb.New(p.cfg.DBHost, net, p.cfg.DBRootCert,
@@ -466,9 +470,6 @@ func _main() error {
 	default:
 		return fmt.Errorf("unknown mode %v:", p.cfg.Mode)
 	}
-
-	// XXX setup user routes
-	p.setUserWWWRoutes()
 
 	// Persist session cookies.
 	var cookieKey []byte


### PR DESCRIPTION
Close #808 

This adds a new route registering function while using CMS mode.

This will hopefully remove the need for any mode checks downstream.
If CMS (or any other mode) need a slightly different implementation of
a shared route, they may change the route in `setCMSUserWWWRoutes()`
to a newly added handler defined in `userwww.go`
