### PR TITLE
[cms] Add ExchangeRate to invoice json

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"github.com/decred/dcrd/dcrutil"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 )
 
@@ -127,6 +128,7 @@ type InvoiceInput struct {
 	Version            uint             `json:"version"`            // Version of the invoice input
 	Month              uint             `json:"month"`              // Month of Invoice
 	Year               uint             `json:"year"`               // Year of Invoice
+	ExchangeRate       uint             `json:"exchangerate"`       // Exchange rate of a given month/year
 	ContractorName     string           `json:"contractorname"`     // IRL name of contractor
 	ContractorLocation string           `json:"contractorlocation"` // IRL location of contractor
 	ContractorContact  string           `json:"contractorcontact"`  // Contractor email or other contact
@@ -193,15 +195,18 @@ type GeneratePayoutsReply struct {
 
 // Payout contains an address and an amount to be paid
 type Payout struct {
-	ContractorName string `json:"contractorname"`
-	ContractorRate uint   `json:"contractorrate"`
-	Username       string `json:"username"`
-	Month          uint   `json:"month"`
-	Year           uint   `json:"year"`
-	Token          string `json:"token"`
-	Address        string `json:"address"`
-	LaborTotal     uint   `json:"labortotal"`
-	ExpenseTotal   uint   `json:"expensetotal"`
+	ContractorName string         `json:"contractorname"`
+	ContractorRate uint           `json:"contractorrate"`
+	Username       string         `json:"username"`
+	Month          uint           `json:"month"`
+	Year           uint           `json:"year"`
+	Token          string         `json:"token"`
+	Address        string         `json:"address"`
+	LaborTotal     uint           `json:"labortotal"`
+	ExpenseTotal   uint           `json:"expensetotal"`
+	Total          uint           `json:"total"`
+	DCRTotal       dcrutil.Amount `json:"dcrtotal"`
+	ExchangeRate   uint           `json:"exchangerate"`
 }
 
 // InvoiceExchangeRate contains the request to receive a monthly exchange rate
@@ -212,5 +217,5 @@ type InvoiceExchangeRate struct {
 
 // InvoiceExchangeRateReply returns the calculated monthly exchange rate
 type InvoiceExchangeRateReply struct {
-	ExchangeRate float64 `json:"exchangerate"`
+	ExchangeRate uint `json:"exchangerate"`
 }

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -128,7 +128,7 @@ type InvoiceInput struct {
 	Version            uint             `json:"version"`            // Version of the invoice input
 	Month              uint             `json:"month"`              // Month of Invoice
 	Year               uint             `json:"year"`               // Year of Invoice
-	ExchangeRate       uint             `json:"exchangerate"`       // Exchange rate of a given month/year
+	ExchangeRate       uint             `json:"exchangerate"`       // Exchange rate of a given month/year in USD cents
 	ContractorName     string           `json:"contractorname"`     // IRL name of contractor
 	ContractorLocation string           `json:"contractorlocation"` // IRL location of contractor
 	ContractorContact  string           `json:"contractorcontact"`  // Contractor email or other contact
@@ -196,17 +196,17 @@ type GeneratePayoutsReply struct {
 // Payout contains an address and an amount to be paid
 type Payout struct {
 	ContractorName string         `json:"contractorname"`
-	ContractorRate uint           `json:"contractorrate"`
+	ContractorRate uint           `json:"contractorrate"` // in USD cents
 	Username       string         `json:"username"`
-	Month          uint           `json:"month"`
-	Year           uint           `json:"year"`
-	Token          string         `json:"token"`
-	Address        string         `json:"address"`
-	LaborTotal     uint           `json:"labortotal"`
-	ExpenseTotal   uint           `json:"expensetotal"`
-	Total          uint           `json:"total"`
-	DCRTotal       dcrutil.Amount `json:"dcrtotal"`
-	ExchangeRate   uint           `json:"exchangerate"`
+	Month          uint           `json:"month"`        // Invoice month
+	Year           uint           `json:"year"`         // Invoice year
+	Token          string         `json:"token"`        // Invoice token
+	Address        string         `json:"address"`      // User provided payment address
+	LaborTotal     uint           `json:"labortotal"`   // in USD cents
+	ExpenseTotal   uint           `json:"expensetotal"` // in USD cents
+	Total          uint           `json:"total"`        // in USD cents
+	DCRTotal       dcrutil.Amount `json:"dcrtotal"`     // in DCR atoms
+	ExchangeRate   uint           `json:"exchangerate"` // in USD cents
 }
 
 // InvoiceExchangeRate contains the request to receive a monthly exchange rate
@@ -217,5 +217,5 @@ type InvoiceExchangeRate struct {
 
 // InvoiceExchangeRateReply returns the calculated monthly exchange rate
 type InvoiceExchangeRateReply struct {
-	ExchangeRate uint `json:"exchangerate"`
+	ExchangeRate uint `json:"exchangerate"` // in USD cents
 }

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -229,6 +229,7 @@ const (
 	ErrorStatusInvoiceRequireLineItems        ErrorStatusT = 81
 	ErrorStatusMultipleInvoiceMonthYear       ErrorStatusT = 82
 	ErrorStatusInvalidInvoiceMonthYear        ErrorStatusT = 83
+	ErrorStatusInvalidExchangeRate            ErrorStatusT = 84
 
 	// Proposal state codes
 	//
@@ -407,6 +408,7 @@ var (
 		ErrorStatusInvoiceRequireLineItems:        "invoices require at least 1 line item",
 		ErrorStatusMultipleInvoiceMonthYear:       "only one invoice per month/year is allowed to be submitted",
 		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
+		ErrorStatusInvalidExchangeRate:            "exchange rate was invalid or didn't match expected result",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/cmd/politeiawwwcli/commands/newinvoice.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newinvoice.go
@@ -104,8 +104,20 @@ func (cmd *NewInvoiceCmd) Execute(args []string) error {
 		return fmt.Errorf("Parsing CSV failed: %v", err)
 	}
 
+	ier := &v1.InvoiceExchangeRate{
+		Month: month,
+		Year:  year,
+	}
+
+	// Send request
+	ierr, err := client.InvoiceExchangeRate(ier)
+	if err != nil {
+		return err
+	}
+
 	invInput.Month = month
 	invInput.Year = year
+	invInput.ExchangeRate = ierr.ExchangeRate
 	invInput.ContractorName = strings.TrimSpace(cmd.Name)
 	invInput.ContractorLocation = strings.TrimSpace(cmd.Location)
 	invInput.ContractorContact = strings.TrimSpace(cmd.Contact)
@@ -118,6 +130,11 @@ func (cmd *NewInvoiceCmd) Execute(args []string) error {
 	}
 	invInput.ContractorRate = uint(rate * 100)
 
+	// Print request details
+	err = printJSON(invInput)
+	if err != nil {
+		return err
+	}
 	b, err := json.Marshal(invInput)
 	if err != nil {
 		return fmt.Errorf("Marshal: %v", err)

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -22,6 +22,7 @@ func EncodeInvoice(dbInvoice *database.Invoice) *Invoice {
 	invoice.UserID = dbInvoice.UserID
 	invoice.Month = dbInvoice.Month
 	invoice.Year = dbInvoice.Year
+	invoice.ExchangeRate = dbInvoice.ExchangeRate
 	invoice.Status = uint(dbInvoice.Status)
 	invoice.StatusChangeReason = dbInvoice.StatusChangeReason
 	invoice.Timestamp = time.Unix(dbInvoice.Timestamp, 0)
@@ -67,6 +68,7 @@ func DecodeInvoice(invoice *Invoice) (*database.Invoice, error) {
 	dbInvoice.Username = invoice.Username
 	dbInvoice.Month = invoice.Month
 	dbInvoice.Year = invoice.Year
+	dbInvoice.ExchangeRate = invoice.ExchangeRate
 	dbInvoice.Status = cms.InvoiceStatusT(invoice.Status)
 	dbInvoice.StatusChangeReason = invoice.StatusChangeReason
 	dbInvoice.Timestamp = invoice.Timestamp.Unix()

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -17,6 +17,7 @@ type Invoice struct {
 	Username           string    `gorm:"-"` // Only populated when reading from the database
 	Month              uint      `gorm:"not null"`
 	Year               uint      `gorm:"not null"`
+	ExchangeRate       uint      `gorm:"not null"`
 	Timestamp          time.Time `gorm:"not null"`
 	Status             uint      `gorm:"not null"`
 	StatusChangeReason string    `gorm:"not null"`

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -53,6 +53,7 @@ type Invoice struct {
 	Username           string // Only populated when reading from the database
 	Month              uint
 	Year               uint
+	ExchangeRate       uint
 	Timestamp          int64
 	Status             cms.InvoiceStatusT
 	StatusChangeReason string

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -550,6 +550,7 @@ func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) *cms.I
 		PaymentAddress:     dbInvoice.PaymentAddress,
 		Month:              dbInvoice.Month,
 		Year:               dbInvoice.Year,
+		ExchangeRate:       dbInvoice.ExchangeRate,
 	}
 	invInputLineItems := make([]cms.LineItemsInput, 0, len(dbInvoice.LineItems))
 	for _, dbLineItem := range dbInvoice.LineItems {
@@ -611,6 +612,7 @@ func convertRecordToDatabaseInvoice(p pd.Record) (*cmsdatabase.Invoice, error) {
 
 			dbInvoice.Month = ii.Month
 			dbInvoice.Year = ii.Year
+			dbInvoice.ExchangeRate = ii.ExchangeRate
 			dbInvoice.LineItems = convertLineItemsToDatabase(dbInvoice.Token,
 				ii.LineItems)
 			dbInvoice.ContractorContact = ii.ContractorContact

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -482,7 +482,8 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.User) error {
 
 			// Verify that the submitted monthly average matches the value
 			// was calculated server side.
-			monthAvg, err := p.GetMonthAverage(time.Month(invInput.Month), int(invInput.Year))
+			monthAvg, err := p.GetMonthAverage(time.Month(invInput.Month),
+				int(invInput.Year))
 			if err != nil {
 				return www.UserError{
 					ErrorCode: www.ErrorStatusInvalidExchangeRate,
@@ -1071,10 +1072,9 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 			}
 		}
 
-		// Divide by 100 to get amounts in USD
-		payout.LaborTotal = totalLaborMinutes * inv.ContractorRate / (60 * 100)
+		payout.LaborTotal = totalLaborMinutes * inv.ContractorRate / 60
 		payout.ContractorRate = inv.ContractorRate
-		payout.ExpenseTotal = totalExpenses / 100
+		payout.ExpenseTotal = totalExpenses
 
 		payout.Address = inv.PaymentAddress
 		payout.Token = inv.Token
@@ -1085,7 +1085,8 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 		payout.Year = inv.Year
 		payout.Total = payout.LaborTotal + payout.ExpenseTotal
 		if inv.ExchangeRate > 0 {
-			payout.DCRTotal, err = dcrutil.NewAmount(float64(payout.Total*100) / float64(inv.ExchangeRate))
+			payout.DCRTotal, err = dcrutil.NewAmount(float64(payout.Total) /
+				float64(inv.ExchangeRate))
 		}
 		payout.ExchangeRate = inv.ExchangeRate
 

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -192,7 +192,7 @@ func validateLocation(location string) error {
 func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.NewInvoiceReply, error) {
 	log.Tracef("processNewInvoice")
 
-	err := validateInvoice(ni, u)
+	err := p.validateInvoice(ni, u)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.N
 	}, nil
 }
 
-func validateInvoice(ni cms.NewInvoice, u *user.User) error {
+func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.User) error {
 	log.Tracef("validateInvoice")
 
 	// Obtain signature
@@ -477,6 +477,20 @@ func validateInvoice(ni cms.NewInvoice, u *user.User) error {
 			if !addr.IsForNet(activeNetParams.Params) {
 				return www.UserError{
 					ErrorCode: www.ErrorStatusInvalidPaymentAddress,
+				}
+			}
+
+			// Verify that the submitted monthly average matches the value
+			// was calculated server side.
+			monthAvg, err := p.GetMonthAverage(time.Month(invInput.Month), int(invInput.Year))
+			if err != nil {
+				return www.UserError{
+					ErrorCode: www.ErrorStatusInvalidExchangeRate,
+				}
+			}
+			if monthAvg != invInput.ExchangeRate {
+				return www.UserError{
+					ErrorCode: www.ErrorStatusInvalidExchangeRate,
 				}
 			}
 
@@ -877,7 +891,7 @@ func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms
 		PublicKey: ei.PublicKey,
 		Signature: ei.Signature,
 	}
-	err = validateInvoice(ni, u)
+	err = p.validateInvoice(ni, u)
 	if err != nil {
 		return nil, err
 	}
@@ -1059,7 +1073,7 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 
 		// Divide by 100 to get amounts in USD
 		payout.LaborTotal = totalLaborMinutes * inv.ContractorRate / (60 * 100)
-		payout.ContractorRate = inv.ContractorRate / 100
+		payout.ContractorRate = inv.ContractorRate
 		payout.ExpenseTotal = totalExpenses / 100
 
 		payout.Address = inv.PaymentAddress
@@ -1069,6 +1083,11 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 		payout.Username = p.getUsernameById(inv.UserID)
 		payout.Month = inv.Month
 		payout.Year = inv.Year
+		payout.Total = payout.LaborTotal + payout.ExpenseTotal
+		if inv.ExchangeRate > 0 {
+			payout.DCRTotal, err = dcrutil.NewAmount(float64(payout.Total*100) / float64(inv.ExchangeRate))
+		}
+		payout.ExchangeRate = inv.ExchangeRate
 
 		payouts = append(payouts, payout)
 	}

--- a/politeiawww/prices.go
+++ b/politeiawww/prices.go
@@ -56,8 +56,7 @@ func (p *politeiawww) GetMonthAverage(month time.Month, year int) (uint, error) 
 	}
 	average = average / float64(len(usdtDcrPrices))
 
-	averageInt := uint(math.Round(average * 100))
-	return averageInt, nil
+	return uint(math.Round(average * 100)), nil
 }
 
 // GetPrices contacts the Poloniex API to download

--- a/politeiawww/prices.go
+++ b/politeiawww/prices.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -19,7 +20,7 @@ type poloChartData struct {
 }
 
 // GetMonthAverage returns the average USD/DCR price for a given month
-func (p *politeiawww) GetMonthAverage(month time.Month, year int) (float64, error) {
+func (p *politeiawww) GetMonthAverage(month time.Month, year int) (uint, error) {
 	startTime := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
 	endTime := startTime.AddDate(0, 1, 0)
 
@@ -55,7 +56,8 @@ func (p *politeiawww) GetMonthAverage(month time.Month, year int) (float64, erro
 	}
 	average = average / float64(len(usdtDcrPrices))
 
-	return average, nil
+	averageInt := uint(math.Round(average * 100))
+	return averageInt, nil
 }
 
 // GetPrices contacts the Poloniex API to download


### PR DESCRIPTION
This adds an ExchangeRate field to the InvoiceInput struct.

With this change it requires newly submitted invoices to have
the corresponding month's exchange rate included in the invoice
payload.  In doing so, it requires the cli request for newinvoice to
first request the exchange rate from the server to use.  A similar
process will be required when using the GUI.  

This also adds additional fields to the generated payouts for admins.
Exchange rate and the total DCR to be paid out by the invoice.