### PR TITLE
[cms] Cache exchange rate

### DIFF
--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -24,6 +24,7 @@ const (
 	tableNameInvoice       = "invoices"
 	tableNameLineItem      = "line_items"
 	tableNameInvoiceChange = "invoice_change"
+	tableNameExchangeRate  = "exchange_rate"
 
 	userPoliteiawww = "politeiawww" // cmsdb user (read/write access)
 )
@@ -261,6 +262,32 @@ func (c *cockroachdb) InvoicesAll() ([]database.Invoice, error) {
 		dbInvoices = append(dbInvoices, *dbInvoice)
 	}
 	return dbInvoices, nil
+}
+
+// Create new exchange rate.
+//
+// NewExchangeRate satisfies the backend interface.
+func (c *cockroachdb) NewExchangeRate(dbExchangeRate *database.ExchangeRate) error {
+	exchRate := encodeExchangeRate(dbExchangeRate)
+
+	log.Debugf("NewExchangeRate: %v %v", exchRate.Month, exchRate.Year)
+	return c.recordsdb.Create(exchRate).Error
+}
+
+// Return exchange rate by month/year
+func (c *cockroachdb) ExchangeRate(month, year uint) (*database.ExchangeRate, error) {
+	log.Tracef("ExchangeRate")
+
+	exchangeRate := ExchangeRate{}
+	err := c.recordsdb.
+		Where("month = ? AND year = ?", month, year).
+		Find(&exchangeRate).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeExchangeRate(exchangeRate), nil
 }
 
 // Close satisfies the backend interface.

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -23,8 +23,8 @@ const (
 	// Database table names
 	tableNameInvoice       = "invoices"
 	tableNameLineItem      = "line_items"
-	tableNameInvoiceChange = "invoice_change"
-	tableNameExchangeRate  = "exchange_rate"
+	tableNameInvoiceChange = "invoice_changes"
+	tableNameExchangeRate  = "exchange_rates"
 
 	userPoliteiawww = "politeiawww" // cmsdb user (read/write access)
 )
@@ -38,7 +38,7 @@ type cockroachdb struct {
 
 // Create new invoice.
 //
-// CreateInvoice satisfies the backend interface.
+// CreateInvoice satisfies the database interface.
 func (c *cockroachdb) NewInvoice(dbInvoice *database.Invoice) error {
 	invoice := EncodeInvoice(dbInvoice)
 
@@ -48,7 +48,7 @@ func (c *cockroachdb) NewInvoice(dbInvoice *database.Invoice) error {
 
 // Update existing invoice.
 //
-// CreateInvoice satisfies the backend interface.
+// UpdateInvoice satisfies the database interface.
 func (c *cockroachdb) UpdateInvoice(dbInvoice *database.Invoice) error {
 	invoice := EncodeInvoice(dbInvoice)
 
@@ -95,7 +95,7 @@ func (c *cockroachdb) InvoicesByUserID(userid string) ([]database.Invoice, error
 	return dbInvoices, nil
 }
 
-// Return invoice by its token.
+// InvoiceByToken Return invoice by its token.
 func (c *cockroachdb) InvoiceByToken(token string) (*database.Invoice, error) {
 	log.Debugf("InvoiceByToken: %v", token)
 
@@ -113,7 +113,7 @@ func (c *cockroachdb) InvoiceByToken(token string) (*database.Invoice, error) {
 	return DecodeInvoice(&invoice)
 }
 
-// Return all invoices by month year and status
+// InvoicesByMonthYearStatus returns all invoices by month year and status
 func (c *cockroachdb) InvoicesByMonthYearStatus(month, year uint16, status int) ([]database.Invoice, error) {
 	log.Tracef("InvoicesByMonthYearStatus")
 
@@ -151,7 +151,7 @@ func (c *cockroachdb) InvoicesByMonthYearStatus(month, year uint16, status int) 
 	return dbInvoices, nil
 }
 
-// Return all invoices by month/year
+// InvoicesByMonthYear returns all invoices by month/year
 func (c *cockroachdb) InvoicesByMonthYear(month, year uint16) ([]database.Invoice, error) {
 	log.Tracef("InvoicesByMonthYear")
 
@@ -189,7 +189,7 @@ func (c *cockroachdb) InvoicesByMonthYear(month, year uint16) ([]database.Invoic
 	return dbInvoices, nil
 }
 
-// Return all invoices by status
+// InvoicesByStatus returns all invoices by status
 func (c *cockroachdb) InvoicesByStatus(status int) ([]database.Invoice, error) {
 	log.Tracef("InvoicesByStatus")
 
@@ -227,7 +227,7 @@ func (c *cockroachdb) InvoicesByStatus(status int) ([]database.Invoice, error) {
 	return dbInvoices, nil
 }
 
-// Return all invoices
+// InvoicesAll returns all invoices
 func (c *cockroachdb) InvoicesAll() ([]database.Invoice, error) {
 	log.Tracef("InvoicesAll")
 
@@ -266,7 +266,7 @@ func (c *cockroachdb) InvoicesAll() ([]database.Invoice, error) {
 
 // Create new exchange rate.
 //
-// NewExchangeRate satisfies the backend interface.
+// NewExchangeRate satisfies the database interface.
 func (c *cockroachdb) NewExchangeRate(dbExchangeRate *database.ExchangeRate) error {
 	exchRate := encodeExchangeRate(dbExchangeRate)
 
@@ -274,7 +274,7 @@ func (c *cockroachdb) NewExchangeRate(dbExchangeRate *database.ExchangeRate) err
 	return c.recordsdb.Create(exchRate).Error
 }
 
-// Return exchange rate by month/year
+// ExchangeRate returns exchange rate by month/year
 func (c *cockroachdb) ExchangeRate(month, year int) (*database.ExchangeRate, error) {
 	log.Tracef("ExchangeRate")
 
@@ -293,7 +293,7 @@ func (c *cockroachdb) ExchangeRate(month, year int) (*database.ExchangeRate, err
 	return decodeExchangeRate(exchangeRate), nil
 }
 
-// Close satisfies the backend interface.
+// Close satisfies the database interface.
 func (c *cockroachdb) Close() error {
 	return c.recordsdb.Close()
 }

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -275,7 +275,7 @@ func (c *cockroachdb) NewExchangeRate(dbExchangeRate *database.ExchangeRate) err
 }
 
 // Return exchange rate by month/year
-func (c *cockroachdb) ExchangeRate(month, year uint) (*database.ExchangeRate, error) {
+func (c *cockroachdb) ExchangeRate(month, year int) (*database.ExchangeRate, error) {
 	log.Tracef("ExchangeRate")
 
 	exchangeRate := ExchangeRate{}
@@ -284,6 +284,9 @@ func (c *cockroachdb) ExchangeRate(month, year uint) (*database.ExchangeRate, er
 		Find(&exchangeRate).
 		Error
 	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			err = database.ErrExchangeRateNotFound
+		}
 		return nil, err
 	}
 
@@ -314,6 +317,12 @@ func createCmsTables(tx *gorm.DB) error {
 	}
 	if !tx.HasTable(tableNameInvoiceChange) {
 		err := tx.CreateTable(&InvoiceChange{}).Error
+		if err != nil {
+			return err
+		}
+	}
+	if !tx.HasTable(tableNameExchangeRate) {
+		err := tx.CreateTable(&ExchangeRate{}).Error
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -157,3 +157,19 @@ func DecodeInvoices(invoices []Invoice) ([]database.Invoice, error) {
 
 	return dbInvoices, nil
 }
+
+func encodeExchangeRate(dbExchangeRate *database.ExchangeRate) ExchangeRate {
+	exchangeRate := ExchangeRate{}
+	exchangeRate.Month = dbExchangeRate.Month
+	exchangeRate.Year = dbExchangeRate.Year
+	exchangeRate.ExchangeRate = dbExchangeRate.ExchangeRate
+	return exchangeRate
+}
+
+func decodeExchangeRate(exchangeRate ExchangeRate) *database.ExchangeRate {
+	dbExchangeRate := &database.ExchangeRate{}
+	dbExchangeRate.Month = exchangeRate.Month
+	dbExchangeRate.Year = exchangeRate.Year
+	dbExchangeRate.ExchangeRate = exchangeRate.ExchangeRate
+	return dbExchangeRate
+}

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -72,3 +72,15 @@ type InvoiceChange struct {
 func (InvoiceChange) TableName() string {
 	return tableNameInvoiceChange
 }
+
+// ExchangeRate contains cached calculated rates for a given month/year
+type ExchangeRate struct {
+	Month        uint `gorm:"not null"`
+	Year         uint `gorm:"not null"`
+	ExchangeRate uint `gorm:"not null"`
+}
+
+// TableName returns the table name of the line items table.
+func (ExchangeRate) TableName() string {
+	return tableNameExchangeRate
+}

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -19,6 +19,9 @@ var (
 	// ErrInvoiceNotFound indicates that the invoice was not found in the
 	// database.
 	ErrInvoiceNotFound = errors.New("invoice not found")
+
+	// ErrExchangeRateNotFound indicates that an exchange rate for a given month/year was not found
+	ErrExchangeRateNotFound = errors.New("exchange rate not found")
 )
 
 // Database interface that is required by the web server.
@@ -38,7 +41,7 @@ type Database interface {
 	// ExchangeRate functions
 	NewExchangeRate(*ExchangeRate) error // Create new exchange rate
 
-	ExchangeRate(uint16, uint16) (*ExchangeRate, error) // Return an exchange rate based on month and year
+	ExchangeRate(int, int) (*ExchangeRate, error) // Return an exchange rate based on month and year
 	// Setup the invoice tables
 	Setup() error
 

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -35,6 +35,10 @@ type Database interface {
 	InvoicesByStatus(int) ([]Invoice, error)                          // Returns all invoices by status
 	InvoicesAll() ([]Invoice, error)                                  // Returns all invoices
 
+	// ExchangeRate functions
+	NewExchangeRate(*ExchangeRate) error // Create new exchange rate
+
+	ExchangeRate(uint16, uint16) (*ExchangeRate, error) // Return an exchange rate based on month and year
 	// Setup the invoice tables
 	Setup() error
 
@@ -93,4 +97,11 @@ type InvoiceChange struct {
 	NewStatus      cms.InvoiceStatusT
 	Reason         string
 	Timestamp      int64
+}
+
+// ExchangeRate contains cached calculated rates for a given month/year
+type ExchangeRate struct {
+	Month        uint
+	Year         uint
+	ExchangeRate uint
 }

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -482,14 +482,12 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.User) error {
 
 			// Verify that the submitted monthly average matches the value
 			// was calculated server side.
-			monthAvg, err := p.GetMonthAverage(time.Month(invInput.Month),
+			monthAvg, err := p.cmsDB.ExchangeRate(int(invInput.Month),
 				int(invInput.Year))
 			if err != nil {
-				return www.UserError{
-					ErrorCode: www.ErrorStatusInvalidExchangeRate,
-				}
+				return err
 			}
-			if monthAvg != invInput.ExchangeRate {
+			if monthAvg.ExchangeRate != invInput.ExchangeRate {
 				return www.UserError{
 					ErrorCode: www.ErrorStatusInvalidExchangeRate,
 				}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -485,7 +485,9 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.User) error {
 			monthAvg, err := p.cmsDB.ExchangeRate(int(invInput.Month),
 				int(invInput.Year))
 			if err != nil {
-				return err
+				return www.UserError{
+					ErrorCode: www.ErrorStatusInvalidExchangeRate,
+				}
 			}
 			if monthAvg.ExchangeRate != invInput.ExchangeRate {
 				return www.UserError{


### PR DESCRIPTION
Requires #821 

This adds a new table into the cmsdatabase that caches
calculated monthly averages for a given month/year.

The first time a month/year is requested, the results are
stored and retrieved for any subsequent requests.