### PR TITLE
multi: Add token inventory approved and rejected

### DIFF
--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -2537,3 +2537,14 @@ func (g *gitBackEnd) pluginInventory() (string, error) {
 
 	return string(payload), nil
 }
+
+// pluginLoadVoteSummaries is a pass through function. CmdLoadVoteSummaries
+// does not require any work to be performed in gitBackEnd.
+func (g *gitBackEnd) pluginLoadVoteSummaries() (string, error) {
+	r := decredplugin.LoadVoteSummariesReply{}
+	reply, err := decredplugin.EncodeLoadVoteSummariesReply(r)
+	if err != nil {
+		return "", err
+	}
+	return string(reply), nil
+}

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2382,6 +2382,9 @@ func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
 	case decredplugin.CmdInventory:
 		payload, err := g.pluginInventory()
 		return decredplugin.CmdInventory, payload, err
+	case decredplugin.CmdLoadVoteSummaries:
+		payload, err := g.pluginLoadVoteSummaries()
+		return decredplugin.CmdLoadVoteSummaries, payload, err
 	}
 	return "", "", fmt.Errorf("invalid payload command") // XXX this needs to become a type error
 }

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -179,3 +179,35 @@ type CastVote struct {
 func (CastVote) TableName() string {
 	return tableCastVotes
 }
+
+// VoteOptionResults records the vote result for a vote option. A
+// VoteOptionResult should only be created once the proposal vote has finished.
+//
+// This is a decred plugin model.
+type VoteOptionResult struct {
+	Key    string     `gorm:"primary_key"`      // Primary key (token+votebit)
+	Token  string     `gorm:"not null;size:64"` // Censorship token (VoteSummary foreign key)
+	Votes  uint64     `gorm:"not null"`         // Number of votes cast for this option
+	Option VoteOption `gorm:"not null"`         // Vote option
+}
+
+// TableName returns the name of the VoteOptionResult database table.
+func (VoteOptionResult) TableName() string {
+	return tableVoteOptionResults
+}
+
+// VoteSummary records the tallied vote results for a proposal and whether the
+// vote was approved/rejected.  A vote summary should only be created once the
+// voting period has ended.  The vote summaries table is lazy loaded.
+//
+// This is a decred plugin model.
+type VoteSummary struct {
+	Token    string             `gorm:"primary_key;size:64"` // Censorship token
+	Approved bool               `gorm:"not null"`            // Vote was approved
+	Results  []VoteOptionResult `gorm:"foreignkey:Token"`    // Results for the vote options
+}
+
+// TableName returns the name of the VoteSummary database table.
+func (VoteSummary) TableName() string {
+	return tableVoteSummaries
+}

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -1218,16 +1218,19 @@ type ProposalsStatsReply struct {
 }
 
 // TokenInventory retrieves the censorship record tokens of all proposals in
-// the inventory.  The token are categorized in a manner that resembles their
-// vote statuses, but that has been altered to be a more natural fit with how a
-// UI would display them.
+// the inventory, categorized by stage of the voting process.
 type TokenInventory struct{}
 
-// TokenInventoryReply is used to reply to the TokenInventory command.
+// TokenInventoryReply is used to reply to the TokenInventory command and
+// returns the tokens of all proposals in the inventory.  The tokens are
+// categorized by stage of the voting process.  Pre and abandoned tokens are
+// sorted by timestamp in decending order.  Active, approved, and rejected
+// tokens are sorted by voting period start block height in decending order.
 type TokenInventoryReply struct {
 	Pre       []string `json:"pre"`       // Tokens of all props that are pre-vote
 	Active    []string `json:"active"`    // Tokens of all props with an active voting period
-	Finished  []string `json:"finished"`  // Tokens of all props with a finished voting period
+	Approved  []string `json:"approved"`  // Tokens of all props that have been approved by a vote
+	Rejected  []string `json:"rejected"`  // Tokens of all props that have been rejected by a vote
 	Abandoned []string `json:"abandoned"` // Tokens of all props that have been abandoned
 }
 

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -487,7 +487,8 @@ func convertTokenInventoryReplyFromDecred(r decredplugin.TokenInventoryReply) ww
 	return www.TokenInventoryReply{
 		Pre:       r.Pre,
 		Active:    r.Active,
-		Finished:  r.Finished,
+		Approved:  r.Approved,
+		Rejected:  r.Rejected,
 		Abandoned: r.Abandoned,
 	}
 }


### PR DESCRIPTION
Closes #819.

This commit removes the 'finished' field from the token inventory reply
and replaces it with the fields 'approved' and 'rejected'. These fields
correspond to proposals with approved and rejected votes.

A cache table for vote summaries was added to enable proposal lookups by
whether their vote was approved or rejected. The vote summaries table is
lazy loaded. Loading vote summaries required the addition of a new
decred plugin command since only politeaid has write access to the
cache.