### PR TITLE
[www]: Validate changes for proposal edits

### DIFF
--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -112,7 +112,6 @@ notifications.  It does not render HTML.
 - [`ErrorStatusInvalidUUID`](#ErrorStatusInvalidUUID)
 - [`ErrorStatusInvalidLikeCommentAction`](#ErrorStatusInvalidLikeCommentAction)
 - [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
-- [`ErrorStatusNoProposalChanges`](#ErrorStatusNoProposalChanges)
 - [`ErrorStatusMalformedName`](#ErrorStatusMalformedName)
 - [`ErrorStatusMalformedLocation`](#ErrorStatusMalformedLocation)
 - [`ErrorStatusInvoiceNotFound`](#ErrorStatusInvoiceNotFound)
@@ -138,7 +137,8 @@ notifications.  It does not render HTML.
 - [`ErrorStatusInvalidInvoiceMonthYear`](#ErrorStatusInvalidInvoiceMonthYear)
 - [`ErrorStatusMultipleInvoiceMonthYear`](#ErrorStatusMultipleInvoiceMonthYear)
 - [`ErrorStatusInvalidLineItemType`](#ErrorStatusInvalidLineItemType) 
-- [`ErrorStatusInvalidLaborExpense`](#ErrorStatusInvalidLaborExpense) 
+- [`ErrorStatusInvalidLaborExpense`](#ErrorStatusInvalidLaborExpense)
+- [`ErrorStatusNoProposalChanges`](#ErrorStatusNoProposalChanges)
 
 **Proposal status codes**
 
@@ -2529,7 +2529,6 @@ Reply:
 | <a name="ErrorStatusInvalidUUID">ErrorStatusInvalidUUID</a> | 56 | Invalid user UUID. |
 | <a name="ErrorStatusInvalidLikeCommentAction">ErrorStatusInvalidLikeCommentAction</a> | 57 | Invalid like comment action. |
 | <a name="ErrorStatusInvalidCensorshipToken">ErrorStatusInvalidCensorshipToken</a> | 58 | Invalid proposal censorship token. |
-| <a name="ErrorStatusNoProposalChanges">ErrorStatusNoProposalChanges</a> | 85 | No changes found in proposal. |
 | <a name="ErrorStatusMalformedName">ErrorStatusMalformedName</a> | 60 | Invalid name entered for CMS registration. |
 | <a name="ErrorStatusMalformedLocation">ErrorStatusMalformedLocation</a> | 61 | Invalid location entered for CMS registration. |
 | <a name="ErrorStatusInvoiceNotFound">ErrorStatusInvoiceNotFound</a> | 62 | Request invoice not found. |
@@ -2558,6 +2557,7 @@ Reply:
 | <a name="ErrorStatusInvalidPassword">ErrorStatusInvalidPassword</a> | 85 | User password was invalid |
 | <a name="ErrorStatusInvalidLineItemType">ErrorStatusInvalidLineItemType</a> | 86 | An invalid line item type was attempted. |
 | <a name="ErrorStatusInvalidLaborExpense">ErrorStatusInvalidLaborExpense</a> | 87 | An invalid value was entered into labor or expenses. |
+| <a name="ErrorStatusNoProposalChanges">ErrorStatusNoProposalChanges</a> | 88 | No changes found in proposal. |
 
 
 ### Proposal status codes
@@ -2654,7 +2654,7 @@ This is a shortened representation of a user, used for lists.
 | censorshiprecord | [`censorshiprecord`](#censorship-record) | The censorship record that was created when the proposal was submitted. |
 | files | array of [`File`](#file)s | This property will only be populated for the [`Proposal details`](#proposal-details) call. |
 | numcomments | number | The number of comments on the proposal. This should be ignored for proposals which are not public. |
-| statatuschangemessage | Message associated to the status change. |
+| statatuschangemessage | Message associated to the status change. |
 | pubishedat | The timestamp of when the proposal has been published. If the proposals has not been pubished, this field will not be present. |
 | censoredat | The timestamp of when the proposal has been censored. If the proposals has not been censored, this field will not be present. |
 | abandonedat | The timestamp of when the proposal has been abandoned. If the proposals has not been abandoned, this field will not be present. |

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -112,6 +112,7 @@ notifications.  It does not render HTML.
 - [`ErrorStatusInvalidUUID`](#ErrorStatusInvalidUUID)
 - [`ErrorStatusInvalidLikeCommentAction`](#ErrorStatusInvalidLikeCommentAction)
 - [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
+- [`ErrorStatusNoProposalChanges`](#ErrorStatusNoProposalChanges)
 - [`ErrorStatusMalformedName`](#ErrorStatusMalformedName)
 - [`ErrorStatusMalformedLocation`](#ErrorStatusMalformedLocation)
 - [`ErrorStatusInvoiceNotFound`](#ErrorStatusInvoiceNotFound)
@@ -2528,6 +2529,7 @@ Reply:
 | <a name="ErrorStatusInvalidUUID">ErrorStatusInvalidUUID</a> | 56 | Invalid user UUID. |
 | <a name="ErrorStatusInvalidLikeCommentAction">ErrorStatusInvalidLikeCommentAction</a> | 57 | Invalid like comment action. |
 | <a name="ErrorStatusInvalidCensorshipToken">ErrorStatusInvalidCensorshipToken</a> | 58 | Invalid proposal censorship token. |
+| <a name="ErrorStatusNoProposalChanges">ErrorStatusNoProposalChanges</a> | 85 | No changes found in proposal. |
 | <a name="ErrorStatusMalformedName">ErrorStatusMalformedName</a> | 60 | Invalid name entered for CMS registration. |
 | <a name="ErrorStatusMalformedLocation">ErrorStatusMalformedLocation</a> | 61 | Invalid location entered for CMS registration. |
 | <a name="ErrorStatusInvoiceNotFound">ErrorStatusInvoiceNotFound</a> | 62 | Request invoice not found. |

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -177,7 +177,7 @@ const (
 	ErrorStatusInvalidCensorshipToken      ErrorStatusT = 58
 	ErrorStatusEmailAlreadyVerified        ErrorStatusT = 59
 	ErrorStatusInvalidPassword             ErrorStatusT = 85
-	ErrorStatusNoProposalChanges           ErrorStatusT = 86
+	ErrorStatusNoProposalChanges           ErrorStatusT = 88
 
 	// CMS Errors
 	ErrorStatusMalformedName                  ErrorStatusT = 60

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -177,6 +177,7 @@ const (
 	ErrorStatusInvalidCensorshipToken      ErrorStatusT = 58
 	ErrorStatusEmailAlreadyVerified        ErrorStatusT = 59
 	ErrorStatusInvalidPassword             ErrorStatusT = 85
+	ErrorStatusNoProposalChanges           ErrorStatusT = 86
 
 	// CMS Errors
 	ErrorStatusMalformedName                  ErrorStatusT = 60
@@ -374,6 +375,7 @@ var (
 		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
 		ErrorStatusInvalidExchangeRate:            "exchange rate was invalid or didn't match expected result",
 		ErrorStatusInvalidPassword:                "invalid password",
+		ErrorStatusNoProposalChanges:              "no changes found in proposal",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1167,23 +1167,26 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		}
 	}
 
-	oldName, err := getProposalName(cachedProp.Files)
-	if err != nil {
-		return nil, err
+	//Check for changes between index.md
+	var mdchanges bool
+	for _, c := range cachedProp.Files {
+		if c.Name == indexFile {
+			for _, v := range ep.Files {
+				if v.Name == indexFile {
+					mdchanges = c.Payload != v.Payload
+				}
+			}
+		}
 	}
 
+	//Check for deleted files, added files, and markdown changes
 	if len(delFiles) == 0 &&
 		len(convertPropFilesFromWWW(cachedProp.Files)) ==
-			len(convertPropFilesFromWWW(ep.Files)) {
+			len(convertPropFilesFromWWW(ep.Files)) && !mdchanges {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusNoProposalChanges,
 		}
 	}
-
-	fmt.Println("New name equal to old name:", name == oldName)
-	fmt.Println("deletedFiles", len(delFiles))
-	fmt.Println("cachedprop added files", len(convertPropFilesFromWWW(cachedProp.Files)))
-	fmt.Println("added files", len(convertPropFilesFromWWW(ep.Files)))
 
 	// Setup politeiad request
 	challenge, err := util.Random(pd.ChallengeSize)

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1167,6 +1167,24 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		}
 	}
 
+	oldName, err := getProposalName(cachedProp.Files)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(delFiles) == 0 &&
+		len(convertPropFilesFromWWW(cachedProp.Files)) ==
+			len(convertPropFilesFromWWW(ep.Files)) {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusNoProposalChanges,
+		}
+	}
+
+	fmt.Println("New name equal to old name:", name == oldName)
+	fmt.Println("deletedFiles", len(delFiles))
+	fmt.Println("cachedprop added files", len(convertPropFilesFromWWW(cachedProp.Files)))
+	fmt.Println("added files", len(convertPropFilesFromWWW(ep.Files)))
+
 	// Setup politeiad request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1167,22 +1167,26 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		}
 	}
 
-	//Check for changes between index.md
-	var mdchanges bool
-	for _, c := range cachedProp.Files {
-		if c.Name == indexFile {
-			for _, v := range ep.Files {
-				if v.Name == indexFile {
-					mdchanges = c.Payload != v.Payload
-				}
-			}
+	// Check for changes in the index.md file
+	var newMDFile www.File
+	for _, v := range ep.Files {
+		if v.Name == indexFile {
+			newMDFile = v
 		}
 	}
 
-	//Check for deleted files, added files, and markdown changes
-	if len(delFiles) == 0 &&
-		len(convertPropFilesFromWWW(cachedProp.Files)) ==
-			len(convertPropFilesFromWWW(ep.Files)) && !mdchanges {
+	var oldMDFile www.File
+	for _, v := range cachedProp.Files {
+		if v.Name == indexFile {
+			oldMDFile = v
+		}
+	}
+
+	mdChanges := newMDFile.Payload != oldMDFile.Payload
+
+	// Check that the proposal has been changed
+	if !mdChanges && len(delFiles) == 0 &&
+		len(cachedProp.Files) == len(ep.Files) {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusNoProposalChanges,
 		}


### PR DESCRIPTION
Closes #761 

This commit adds validation into politeiawww which prevents submission of an edited proposal unless it actually contains changes. If there are no changes, this validation returns `ErrorStatusNoProposalChanges`