### PR TITLE
decredplugin: Add VoteSummary command

### DIFF
--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -2538,11 +2538,11 @@ func (g *gitBackEnd) pluginInventory() (string, error) {
 	return string(payload), nil
 }
 
-// pluginLoadVoteSummaries is a pass through function. CmdLoadVoteSummaries
-// does not require any work to be performed in gitBackEnd.
-func (g *gitBackEnd) pluginLoadVoteSummaries() (string, error) {
-	r := decredplugin.LoadVoteSummariesReply{}
-	reply, err := decredplugin.EncodeLoadVoteSummariesReply(r)
+// pluginLoadVoteResults is a pass through function. CmdLoadVoteResults does
+// not require any work to be performed in gitBackEnd.
+func (g *gitBackEnd) pluginLoadVoteResults() (string, error) {
+	r := decredplugin.LoadVoteResultsReply{}
+	reply, err := decredplugin.EncodeLoadVoteResultsReply(r)
 	if err != nil {
 		return "", err
 	}

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2382,9 +2382,9 @@ func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
 	case decredplugin.CmdInventory:
 		payload, err := g.pluginInventory()
 		return decredplugin.CmdInventory, payload, err
-	case decredplugin.CmdLoadVoteSummaries:
-		payload, err := g.pluginLoadVoteSummaries()
-		return decredplugin.CmdLoadVoteSummaries, payload, err
+	case decredplugin.CmdLoadVoteResults:
+		payload, err := g.pluginLoadVoteResults()
+		return decredplugin.CmdLoadVoteResults, payload, err
 	}
 	return "", "", fmt.Errorf("invalid payload command") // XXX this needs to become a type error
 }

--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -191,18 +191,19 @@ func convertStartVoteFromDecred(sv decredplugin.StartVote, svr decredplugin.Star
 		})
 	}
 	return StartVote{
-		Token:            sv.Vote.Token,
-		Mask:             sv.Vote.Mask,
-		Duration:         sv.Vote.Duration,
-		QuorumPercentage: sv.Vote.QuorumPercentage,
-		PassPercentage:   sv.Vote.PassPercentage,
-		Options:          opts,
-		PublicKey:        sv.PublicKey,
-		Signature:        sv.Signature,
-		StartBlockHeight: svr.StartBlockHeight,
-		StartBlockHash:   svr.StartBlockHash,
-		EndHeight:        endHeight,
-		EligibleTickets:  strings.Join(svr.EligibleTickets, ","),
+		Token:               sv.Vote.Token,
+		Mask:                sv.Vote.Mask,
+		Duration:            sv.Vote.Duration,
+		QuorumPercentage:    sv.Vote.QuorumPercentage,
+		PassPercentage:      sv.Vote.PassPercentage,
+		Options:             opts,
+		PublicKey:           sv.PublicKey,
+		Signature:           sv.Signature,
+		StartBlockHeight:    svr.StartBlockHeight,
+		StartBlockHash:      svr.StartBlockHash,
+		EndHeight:           endHeight,
+		EligibleTickets:     strings.Join(svr.EligibleTickets, ","),
+		EligibleTicketCount: len(svr.EligibleTickets),
 	}
 }
 
@@ -245,10 +246,11 @@ func convertStartVoteToDecred(sv StartVote) (decredplugin.StartVote, decredplugi
 
 func convertCastVoteFromDecred(cv decredplugin.CastVote) CastVote {
 	return CastVote{
-		Token:     cv.Token,
-		Ticket:    cv.Ticket,
-		VoteBit:   cv.VoteBit,
-		Signature: cv.Signature,
+		Token:        cv.Token,
+		Ticket:       cv.Ticket,
+		VoteBit:      cv.VoteBit,
+		Signature:    cv.Signature,
+		TokenVoteBit: cv.Token + cv.VoteBit,
 	}
 }
 
@@ -259,4 +261,21 @@ func convertCastVoteToDecred(cv CastVote) decredplugin.CastVote {
 		VoteBit:   cv.VoteBit,
 		Signature: cv.Signature,
 	}
+}
+
+func convertVoteOptionResultToDecred(r VoteOptionResult) decredplugin.VoteOptionResult {
+	return decredplugin.VoteOptionResult{
+		ID:          r.Option.ID,
+		Description: r.Option.Description,
+		Bits:        r.Option.Bits,
+		Votes:       r.Votes,
+	}
+}
+
+func convertVoteOptionResultsToDecred(r []VoteOptionResult) []decredplugin.VoteOptionResult {
+	results := make([]decredplugin.VoteOptionResult, 0, len(r))
+	for _, v := range r {
+		results = append(results, convertVoteOptionResultToDecred(v))
+	}
+	return results
 }

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -144,19 +144,20 @@ func (VoteOption) TableName() string {
 //
 // This is a decred plugin model.
 type StartVote struct {
-	Token            string       `gorm:"primary_key;size:64"` // Censorship token
-	Version          uint64       `gorm:"not null"`            // Version of files
-	Mask             uint64       `gorm:"not null"`            // Valid votebits
-	Duration         uint32       `gorm:"not null"`            // Duration in blocks
-	QuorumPercentage uint32       `gorm:"not null"`            // Percent of eligible votes required for quorum
-	PassPercentage   uint32       `gorm:"not null"`            // Percent of total votes required to pass
-	Options          []VoteOption `gorm:"foreignkey:Token"`    // Vote option
-	PublicKey        string       `gorm:"not null;size:64"`    // Key used for signature
-	Signature        string       `gorm:"not null;size:128"`   // Signature of Votehash
-	StartBlockHeight string       `gorm:"not null"`            // Block height
-	StartBlockHash   string       `gorm:"not null"`            // Block hash
-	EndHeight        uint64       `gorm:"not null"`            // Height of vote end
-	EligibleTickets  string       `gorm:"not null"`            // Valid voting tickets
+	Token               string       `gorm:"primary_key;size:64"` // Censorship token
+	Version             uint64       `gorm:"not null"`            // Version of files
+	Mask                uint64       `gorm:"not null"`            // Valid votebits
+	Duration            uint32       `gorm:"not null"`            // Duration in blocks
+	QuorumPercentage    uint32       `gorm:"not null"`            // Percent of eligible votes required for quorum
+	PassPercentage      uint32       `gorm:"not null"`            // Percent of total votes required to pass
+	Options             []VoteOption `gorm:"foreignkey:Token"`    // Vote option
+	PublicKey           string       `gorm:"not null;size:64"`    // Key used for signature
+	Signature           string       `gorm:"not null;size:128"`   // Signature of Votehash
+	StartBlockHeight    string       `gorm:"not null"`            // Block height
+	StartBlockHash      string       `gorm:"not null"`            // Block hash
+	EndHeight           uint64       `gorm:"not null"`            // Height of vote end
+	EligibleTickets     string       `gorm:"not null"`            // Valid voting tickets
+	EligibleTicketCount int          `gorm:"not null"`            // Number of eligible tickets
 }
 
 // TableName returns the name of the StartVote database table.
@@ -168,11 +169,15 @@ func (StartVote) TableName() string {
 //
 // This is a decred plugin model.
 type CastVote struct {
-	Key       uint   `gorm:"primary_key"`            // Primary key
-	Token     string `gorm:"not null;size:64;index"` // Censorship token
-	Ticket    string `gorm:"not null"`               // Ticket ID
-	VoteBit   string `gorm:"not null"`               // Hex encoded vote bit that was selected
-	Signature string `gorm:"not null;size:130"`      // Signature of Token+Ticket+VoteBit
+	Key       uint   `gorm:"primary_key"`       // Primary key
+	Token     string `gorm:"not null;size:64"`  // Censorship token
+	Ticket    string `gorm:"not null"`          // Ticket ID
+	VoteBit   string `gorm:"not null"`          // Hex encoded vote bit that was selected
+	Signature string `gorm:"not null;size:130"` // Signature of Token+Ticket+VoteBit
+
+	// TokenVoteBit is the Token+VoteBit. Indexing TokenVoteBit allows
+	// for quick lookups of the number of votes cast for each vote bit.
+	TokenVoteBit string `gorm:"no null;index"`
 }
 
 // TableName returns the name of the CastVote database table.
@@ -186,7 +191,7 @@ func (CastVote) TableName() string {
 // This is a decred plugin model.
 type VoteOptionResult struct {
 	Key    string     `gorm:"primary_key"`      // Primary key (token+votebit)
-	Token  string     `gorm:"not null;size:64"` // Censorship token (VoteSummary foreign key)
+	Token  string     `gorm:"not null;size:64"` // Censorship token (VoteResults foreign key)
 	Votes  uint64     `gorm:"not null"`         // Number of votes cast for this option
 	Option VoteOption `gorm:"not null"`         // Vote option
 }
@@ -196,18 +201,18 @@ func (VoteOptionResult) TableName() string {
 	return tableVoteOptionResults
 }
 
-// VoteSummary records the tallied vote results for a proposal and whether the
-// vote was approved/rejected.  A vote summary should only be created once the
-// voting period has ended.  The vote summaries table is lazy loaded.
+// VoteResults records the tallied vote results for a proposal and whether the
+// vote was approved/rejected.  A vote result entry should only be created once
+// the voting period has ended.  The vote results table is lazy loaded.
 //
 // This is a decred plugin model.
-type VoteSummary struct {
+type VoteResults struct {
 	Token    string             `gorm:"primary_key;size:64"` // Censorship token
 	Approved bool               `gorm:"not null"`            // Vote was approved
 	Results  []VoteOptionResult `gorm:"foreignkey:Token"`    // Results for the vote options
 }
 
-// TableName returns the name of the VoteSummary database table.
-func (VoteSummary) TableName() string {
-	return tableVoteSummaries
+// TableName returns the name of the VoteResults database table.
+func (VoteResults) TableName() string {
+	return tableVoteResults
 }

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -482,6 +482,20 @@ func convertPluginFromPD(p pd.Plugin) Plugin {
 		Settings: ps,
 	}
 }
+func convertVoteOptionResultsFromDecred(vor []decredplugin.VoteOptionResult) []www.VoteOptionResult {
+	r := make([]www.VoteOptionResult, 0, len(vor))
+	for _, v := range vor {
+		r = append(r, www.VoteOptionResult{
+			Option: www.VoteOption{
+				Id:          v.ID,
+				Description: v.Description,
+				Bits:        v.Bits,
+			},
+			VotesReceived: v.Votes,
+		})
+	}
+	return r
+}
 
 func convertTokenInventoryReplyFromDecred(r decredplugin.TokenInventoryReply) www.TokenInventoryReply {
 	return www.TokenInventoryReply{

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -434,7 +434,7 @@ func (p *politeiawww) handleVoteStatus(w http.ResponseWriter, r *http.Request) {
 	vsr, err := p.processVoteStatus(pathParams["token"])
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleCommentsGet: ProcessCommentGet %v", err)
+			"handleVoteStatus: ProcessVoteStatus: %v", err)
 		return
 	}
 	util.RespondWithJSON(w, http.StatusOK, vsr)


### PR DESCRIPTION
Closes #796.

This commit does two things:

1. Creates a light weight VoteSummary decred plugin command that returns
a summary of the vote params and results. Without this command, the only
way to get a summary of the vote results was to fetch all of the cast votes
and tally them manually.

2. Renames the VoteSummary table to VoteResults, which is a more
accurate name.