### PR TITLE
[cms] Add PayInvoices command

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -18,6 +18,7 @@ server side notifications.  It does not render HTML.
 - [`Generate payouts`](#generate-payouts)
 - [`Invoice comments`](#invoice-comments)
 - [`Invoice exchange rate`](#invoice-exchange-rate)
+- [`Pay invoices`](#pay-invoices)
 
 **Invoice status codes**
 
@@ -604,6 +605,39 @@ Reply:
 }
 ```
 
+### `Pay invoices`
+
+Temporary command that allows administrators to set all approved invoices to paid.
+This command will be removed once the address watcher for approved invoices 
+is complete and properly functioning.
+
+Note: This call requires admin privileges.
+
+**Route:** `GET /v1/admin/payinvoices`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+
+**Example**
+
+Request:
+
+```json
+{}
+```
+
+Reply:
+
+```json
+{}
+```
 
 ### Invoice status codes
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -318,5 +318,5 @@ type InvoiceExchangeRateReply struct {
 // to paid status.
 type PayInvoices struct{}
 
-// PayInvoicesReply will be empty if no errors have occured.
+// PayInvoicesReply will be empty if no errors have occurred.
 type PayInvoicesReply struct{}

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -20,6 +20,7 @@ const (
 	RouteUserInvoices        = "/user/invoices"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteGeneratePayouts     = "/admin/generatepayouts"
+	RoutePayInvoices         = "/admin/payinvoices"
 	RouteInvoiceComments     = "/invoices/{token:[A-z0-9]{64}}/comments"
 	RouteInvoiceExchangeRate = "/invoices/exchangerate"
 
@@ -312,3 +313,10 @@ type InvoiceExchangeRate struct {
 type InvoiceExchangeRateReply struct {
 	ExchangeRate uint `json:"exchangerate"` // in USD cents
 }
+
+// PayInvoices temporarily allows the administrator to set all approved invoices
+// to paid status.
+type PayInvoices struct{}
+
+// PayInvoicesReply will be empty if no errors have occured.
+type PayInvoicesReply struct{}

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/decred/dcrwallet/rpc/walletrpc"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
 	"github.com/gorilla/schema"
 	"golang.org/x/net/publicsuffix"
@@ -823,6 +823,24 @@ func (c *Client) GeneratePayouts(gp *cms.GeneratePayouts) (*cms.GeneratePayoutsR
 	}
 
 	return &gpr, nil
+}
+
+// PayInvoices is a temporary command that allows an administrator to set all
+// approved invoices to the paid status. This will be removed once the
+// address watching for payment is complete and working.
+func (c *Client) PayInvoices(pi *cms.PayInvoices) (*cms.PayInvoicesReply, error) {
+	responseBody, err := c.makeRequest("GET", cms.RoutePayInvoices, pi)
+	if err != nil {
+		return nil, err
+	}
+
+	var pir cms.PayInvoicesReply
+	err = json.Unmarshal(responseBody, &pir)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal PayInvoiceReply: %v", err)
+	}
+
+	return &pir, nil
 }
 
 // SetProposalStatus changes the status of the specified proposal.

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -20,7 +20,7 @@ import (
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiad/api/v1/mime"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	wwwclient "github.com/decred/politeia/politeiawww/cmd/politeiawwwcli/client"
 	"github.com/decred/politeia/politeiawww/cmd/politeiawwwcli/config"
 	"github.com/decred/politeia/util"
@@ -81,6 +81,7 @@ type Cmds struct {
 	NewProposal         NewProposalCmd         `command:"newproposal" description:"(user)   create a new proposal"`
 	NewComment          NewCommentCmd          `command:"newcomment" description:"(user)   create a new proposal comment"`
 	NewUser             NewUserCmd             `command:"newuser" description:"(public) create a new user"`
+	PayInvoices         PayInvoicesCmd         `command:"payinvoices" description:"(admin) set all approved invoices to paid"`
 	Policy              PolicyCmd              `command:"policy" description:"(public) get the server policy"`
 	ProposalComments    ProposalCommentsCmd    `command:"proposalcomments" description:"(public) get the comments for a proposal"`
 	ProposalDetails     ProposalDetailsCmd     `command:"proposaldetails" description:"(public) get the details of a proposal"`

--- a/politeiawww/cmd/politeiawwwcli/commands/payinvoices.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/payinvoices.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// PayInvoicesCmd
+type PayInvoicesCmd struct {
+}
+
+// Execute executes the generate payouts command.
+func (cmd *PayInvoicesCmd) Execute(args []string) error {
+
+	// Pay invoices
+	pir, err := client.PayInvoices(
+		&v1.PayInvoices{})
+	if err != nil {
+		return err
+	}
+
+	// Print user invoices
+	return printJSON(pir)
+}

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -372,17 +372,6 @@ func (p *politeiawww) handleCMSPolicy(w http.ResponseWriter, r *http.Request) {
 func (p *politeiawww) handlePayInvoices(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handlePayInvoices")
 
-	// Get pay invoices command
-	var pi cms.PayInvoices
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&pi); err != nil {
-		RespondWithError(w, r, 0, "handlePayInvoices: unmarshal",
-			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidInput,
-			})
-		return
-	}
-
 	user, err := p.getSessionUser(w, r)
 	if err != nil {
 		RespondWithError(w, r, 0,

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -454,6 +454,6 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleSetInvoiceStatus, permissionAdmin)
 	p.addRoute(http.MethodPost, cms.RouteGeneratePayouts,
 		p.handleGeneratePayouts, permissionAdmin)
-	p.addRoute(http.MethodPost, cms.RoutePayInvoices,
+	p.addRoute(http.MethodGet, cms.RoutePayInvoices,
 		p.handlePayInvoices, permissionAdmin)
 }

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1305,7 +1305,8 @@ func (p *politeiawww) getInvoiceComments(token string) ([]www.Comment, error) {
 	return comments, nil
 }
 
-// processPayInvoices
+// processPayInvoices looks for all approved invoices and then goes about
+// changing their statuses' to paid.
 func (p *politeiawww) processPayInvoices(u *user.User) (*cms.PayInvoicesReply, error) {
 	log.Tracef("processPayInvoices")
 
@@ -1345,7 +1346,8 @@ func (p *politeiawww) processPayInvoices(u *user.User) (*cms.PayInvoicesReply, e
 			},
 		}
 
-		responseBody, err := p.makeRequest(http.MethodPost, pd.UpdateVettedMetadataRoute, pdCommand)
+		responseBody, err := p.makeRequest(http.MethodPost,
+			pd.UpdateVettedMetadataRoute, pdCommand)
 		if err != nil {
 			return nil, err
 		}
@@ -1353,8 +1355,9 @@ func (p *politeiawww) processPayInvoices(u *user.User) (*cms.PayInvoicesReply, e
 		var pdReply pd.UpdateVettedMetadataReply
 		err = json.Unmarshal(responseBody, &pdReply)
 		if err != nil {
-			return nil, fmt.Errorf("Could not unmarshal UpdateVettedMetadataReply: %v",
-				err)
+			return nil,
+				fmt.Errorf("Could not unmarshal UpdateVettedMetadataReply: %v",
+					err)
 		}
 
 		// Verify the UpdateVettedMetadata challenge.

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1305,6 +1305,82 @@ func (p *politeiawww) getInvoiceComments(token string) ([]www.Comment, error) {
 	return comments, nil
 }
 
+// processPayInvoices
+func (p *politeiawww) processPayInvoices(u *user.User) (*cms.PayInvoicesReply, error) {
+	log.Tracef("processPayInvoices")
+
+	dbInvs, err := p.cmsDB.InvoicesByStatus(int(cms.InvoiceStatusApproved))
+	if err != nil {
+		return nil, err
+	}
+
+	reply := &cms.PayInvoicesReply{}
+	for _, inv := range dbInvs {
+
+		// Create the change record.
+		c := backendInvoiceStatusChange{
+			Version:        backendInvoiceStatusChangeVersion,
+			AdminPublicKey: u.PublicKey(),
+			Timestamp:      time.Now().Unix(),
+			NewStatus:      cms.InvoiceStatusPaid,
+		}
+		blob, err := encodeBackendInvoiceStatusChange(c)
+		if err != nil {
+			return nil, err
+		}
+
+		challenge, err := util.Random(pd.ChallengeSize)
+		if err != nil {
+			return nil, err
+		}
+
+		pdCommand := pd.UpdateVettedMetadata{
+			Challenge: hex.EncodeToString(challenge),
+			Token:     inv.Token,
+			MDAppend: []pd.MetadataStream{
+				{
+					ID:      mdStreamInvoiceStatusChanges,
+					Payload: string(blob),
+				},
+			},
+		}
+
+		responseBody, err := p.makeRequest(http.MethodPost, pd.UpdateVettedMetadataRoute, pdCommand)
+		if err != nil {
+			return nil, err
+		}
+
+		var pdReply pd.UpdateVettedMetadataReply
+		err = json.Unmarshal(responseBody, &pdReply)
+		if err != nil {
+			return nil, fmt.Errorf("Could not unmarshal UpdateVettedMetadataReply: %v",
+				err)
+		}
+
+		// Verify the UpdateVettedMetadata challenge.
+		err = util.VerifyChallenge(p.cfg.Identity, challenge, pdReply.Response)
+		if err != nil {
+			return nil, err
+		}
+
+		// Update the database with the metadata changes.
+		inv.Changes = append(inv.Changes, database.InvoiceChange{
+			Timestamp:      c.Timestamp,
+			AdminPublicKey: c.AdminPublicKey,
+			NewStatus:      c.NewStatus,
+			Reason:         c.Reason,
+		})
+		inv.StatusChangeReason = c.Reason
+		inv.Status = c.NewStatus
+
+		err = p.cmsDB.UpdateInvoice(&inv)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return reply, err
+}
+
 // backendInvoiceMetadata represents the general metadata for an invoice and is
 // stored in the metadata stream mdStreamInvoiceGeneral in politeiad.
 type backendInvoiceMetadata struct {


### PR DESCRIPTION
This is a temporary command that allows for administrators
to set all approved invoices to paid.  

This command will be either be wholly removed or changed
significantly when the address watcher for paid invoices
has been added.  

We may keep this command in some fashion to allow for
administrators to update to the paid status in case of issues
or problems with the watcher.