### PR TITLE
[util]: Remove Insight references in paywall

### DIFF
--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1966,11 +1966,6 @@ func (p *politeiawww) processVerifyUserPayment(u *user.User, vupt www.VerifyUser
 		u.NewUserPaywallAmount, u.NewUserPaywallTxNotBefore,
 		p.cfg.MinConfirmationsRequired)
 	if err != nil {
-		if err == util.ErrCannotVerifyPayment {
-			return nil, www.UserError{
-				ErrorCode: www.ErrorStatusCannotVerifyPayment,
-			}
-		}
 		return nil, err
 	}
 

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -331,14 +331,13 @@ func FetchTxWithBlockExplorers(address string, amount uint64, txnotbefore int64,
 	}
 	explorerURL := dcrdataURL + "/raw"
 
-	//Fetch transaction from dcrdata
+	// Fetch transaction from dcrdata
 	txID, amount, err := fetchTxWithBE(explorerURL, address, amount,
 		txnotbefore, minConfirmations)
 	if err != nil {
 		log.Printf("failed to fetch from dcrdata: %v", err)
-	} else {
-		return txID, amount, nil
 	}
+
 	return txID, amount, nil
 }
 
@@ -384,13 +383,12 @@ func convertBETransactionToTxDetails(address string, tx BETransaction) (*TxDetai
 // FetchTxsForAddress fetches the transactions that have been sent to the
 // provided wallet address from the dcrdata block explorer
 func FetchTxsForAddress(address string) ([]TxDetails, error) {
-	// Get block explorer URLs
+	// Get block explorer URL
 	addr, err := dcrutil.DecodeAddress(address)
 	if err != nil {
 		return nil, fmt.Errorf("invalid address %v: %v", addr, err)
 	}
-	dcrdataURL, err := blockExplorerURLForAddress(address,
-		addr.Net())
+	dcrdataURL, err := blockExplorerURLForAddress(address, addr.Net())
 	if err != nil {
 		return nil, err
 	}

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -38,14 +38,6 @@ type FaucetResponse struct {
 	Error string
 }
 
-// PaywallGatewayNewOrderResponse respresents the expected JSON response to a
-// PaywallGatewayNewOrder command.
-type PaywallGatewayNewOrderResponse struct {
-	Error         string
-	OrderID       string
-	PaywallAmount uint64
-}
-
 // BETransaction is an object representing a transaction; it's
 // part of the data returned from the URL for the block explorer
 // when fetching the transactions for an address.

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -60,7 +60,10 @@ type BETransactionScriptPubkey struct {
 	Addresses []string `json:"addresses"` // Array of transaction input addresses
 }
 
-// TxDetails is an object representing a transaction from dcrdata
+// TxDetails is an object representing a transaction.
+// XXX This was previously being used to standardize the different responses
+// from the dcrdata and insight APIs. Support for the insight API was removed
+// but parts of politeiawww still consume this struct so it has remained.
 type TxDetails struct {
 	Address       string // Transaction address
 	TxID          string // Transacion ID

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -78,11 +78,6 @@ type TxDetails struct {
 	Confirmations uint64 // Number of confirmations
 }
 
-var (
-	// ErrCannotVerifyPayment is emitted when a transaction cannot be verified by dcrdata
-	ErrCannotVerifyPayment = errors.New("cannot verify payment at this time")
-)
-
 func makeRequest(url string, timeout time.Duration) ([]byte, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -335,7 +330,7 @@ func FetchTxWithBlockExplorers(address string, amount uint64, txnotbefore int64,
 	txID, amount, err := fetchTxWithBE(explorerURL, address, amount,
 		txnotbefore, minConfirmations)
 	if err != nil {
-		log.Printf("failed to fetch from dcrdata: %v", err)
+		return "", 0, fmt.Errorf("failed to fetch from dcrdata: %v", err)
 	}
 
 	return txID, amount, nil
@@ -397,7 +392,7 @@ func FetchTxsForAddress(address string) ([]TxDetails, error) {
 	// Fetch using dcrdata block explorer
 	dcrdataTxs, err := fetchTxsWithBE(explorerURL)
 	if err != nil {
-		log.Printf("failed to fetch from dcrdata: %v", err)
+		return nil, fmt.Errorf("failed to fetch from dcrdata: %v", err)
 	}
 	txs := make([]TxDetails, 0, len(dcrdataTxs))
 	for _, tx := range dcrdataTxs {


### PR DESCRIPTION
Closes #747 

This commit removes all the direct references to the Insight API in `util/paywall.go`. However, this commit *does* leave in place much of the structure for utilizing a backup paywall URL, should we decide to move to a new one in the future.