### PR TITLE
Create scripts directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,18 +158,14 @@ Install CockroachDB using the instructions found in the [CockroachDB
 Documentation](https://www.cockroachlabs.com/docs/stable/install-cockroachdb-mac.html).
 
 Run the following commands to create the CockroachDB certificates required for
-running CockroachDB with Politeia.  It's ok if the directory `~/.cockroachdb`
-does not exist yet.  The script will create it.  **The directory that you pass
-into the script must be the same cockroachdb directory that you use in the
-politeiad and politeiawww config files when specifying the cache
-certificates.**
+running CockroachDB with Politeia.
 
     cd $GOPATH/src/github.com/decred/politeia
-    ./cockroachcerts.sh ~/.cockroachdb
+    ./scripts/cockroachcerts.sh
 
-The script will create the following certificates and directories:
+The script creates following certificates and directories.
 
-    .cockroachdb
+    ~/.cockroachdb
     ├── ca.key
     └── certs
         ├── ca.crt
@@ -215,7 +211,7 @@ Once CockroachDB is running, you can setup the cache databases using the
 commands below.
 
     cd $GOPATH/src/github.com/decred/politeia
-    ./cachesetup.sh ~/.cockroachdb
+    ./scripts/cachesetup.sh
 
 The database setup is now complete.  If you want to run database commands
 manually you can do so by opening a sql shell.
@@ -232,7 +228,7 @@ using the script below.  CockroachDB must be running when you execute this
 script.
 
     cd $GOPATH/src/github.com/decred/politeia
-    ./cmssetup.sh ~/.cockroachdb
+    ./scripts/cmssetup.sh
     
 
 #### 5. Build the programs:

--- a/scripts/cachesetup.sh
+++ b/scripts/cachesetup.sh
@@ -6,27 +6,25 @@
 
 set -ex
 
-# COCKROACHDB_DIR must be the same directory that was passed into the
+# COCKROACHDB_DIR must be the same directory that was used with the
 # cockroachcerts.sh script.
-readonly COCKROACHDB_DIR=$1
-
+COCKROACHDB_DIR=$1
 if [ "${COCKROACHDB_DIR}" == "" ]; then
-    >&2 echo "error: missing argument CockroachDB directory"
-    exit
+  COCKROACHDB_DIR="${HOME}/.cockroachdb"
 fi
 
 # ROOT_CERTS_DIR must contain client.root.crt, client.root.key, and ca.crt.
 readonly ROOT_CERTS_DIR="${COCKROACHDB_DIR}/certs/clients/root"
 
 if [ ! -f "${ROOT_CERTS_DIR}/client.root.crt" ]; then
-    >&2 echo "error: file not found ${ROOT_CERTS_DIR}/client.root.crt"
-    exit
+  >&2 echo "error: file not found ${ROOT_CERTS_DIR}/client.root.crt"
+  exit
 elif [ ! -f "${ROOT_CERTS_DIR}/client.root.key" ]; then
-    >&2 echo "error: file not found ${ROOT_CERTS_DIR}/client.root.key"
-    exit
+  >&2 echo "error: file not found ${ROOT_CERTS_DIR}/client.root.key"
+  exit
 elif [ ! -f "${ROOT_CERTS_DIR}/ca.crt" ]; then
-    >&2 echo "error: file not found ${ROOT_CERTS_DIR}/ca.crt"
-    exit
+  >&2 echo "error: file not found ${ROOT_CERTS_DIR}/ca.crt"
+  exit
 fi
 
 # Database names.

--- a/scripts/cmssetup.sh
+++ b/scripts/cmssetup.sh
@@ -6,27 +6,25 @@
 
 set -ex
 
-# COCKROACHDB_DIR must be the same directory that was passed into the
+# COCKROACHDB_DIR must be the same directory that was used with the
 # cockroachcerts.sh script.
-readonly COCKROACHDB_DIR=$1
-
+COCKROACHDB_DIR=$1
 if [ "${COCKROACHDB_DIR}" == "" ]; then
-    >&2 echo "error: missing argument CockroachDB directory"
-    exit
+  COCKROACHDB_DIR="${HOME}/.cockroachdb"
 fi
 
 # ROOT_CERTS_DIR must contain client.root.crt, client.root.key, and ca.crt.
 readonly ROOT_CERTS_DIR="${COCKROACHDB_DIR}/certs/clients/root"
 
 if [ ! -f "${ROOT_CERTS_DIR}/client.root.crt" ]; then
-    >&2 echo "error: file not found ${ROOT_CERTS_DIR}/client.root.crt"
-    exit
+  >&2 echo "error: file not found ${ROOT_CERTS_DIR}/client.root.crt"
+  exit
 elif [ ! -f "${ROOT_CERTS_DIR}/client.root.key" ]; then
-    >&2 echo "error: file not found ${ROOT_CERTS_DIR}/client.root.key"
-    exit
+  >&2 echo "error: file not found ${ROOT_CERTS_DIR}/client.root.key"
+  exit
 elif [ ! -f "${ROOT_CERTS_DIR}/ca.crt" ]; then
-    >&2 echo "error: file not found ${ROOT_CERTS_DIR}/ca.crt"
-    exit
+  >&2 echo "error: file not found ${ROOT_CERTS_DIR}/ca.crt"
+  exit
 fi
 
 # Database names.

--- a/scripts/cockroachcerts.sh
+++ b/scripts/cockroachcerts.sh
@@ -14,11 +14,9 @@ readonly USER_POLITEIAD="politeiad"
 readonly USER_POLITEIAWWW="politeiawww"
 
 # COCKROACHDB_DIR is where all of the certificates will be created.
-readonly COCKROACHDB_DIR=$1
-
+COCKROACHDB_DIR=$1
 if [ "${COCKROACHDB_DIR}" == "" ]; then
-    >&2 echo "error: missing argument CockroachDB directory"
-    exit
+  COCKROACHDB_DIR="${HOME}/.cockroachdb"
 fi
 
 # Create cockroachdb directories.


### PR DESCRIPTION
This commit moves the cockroachdb setup scripts into a `/scripts` directory.  I'm adding another setup script for the userdb in #820 and it felt like they should be organized into a separate directory.

This also updates the setup scripts to default to `~/.cockroachdb` instead of requiring `~/.cockroachdb` be passed in as an argument.  They still take an optional argument if you want to put the cockroachdb directory somewhere else.