### PR TITLE
[www]: Invalid password Error Status

### DIFF
--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -2551,6 +2551,8 @@ Reply:
 | <a name="ErrorStatusInvoiceRequireLineItems">ErrorStatusInvoiceRequireLineItems</a> | 81 | Invoices require at least 1 line item to be included. |
 | <a name="ErrorStatusMultipleInvoiceMonthYear">ErrorStatusMultipleInvoiceMonthYear</a> | 82 | Users are only allowed to submit 1 invoice per month/year. |
 | <a name="ErrorStatusInvalidInvoiceMonthYear">ErrorStatusInvalidInvoiceMonthYear</a> | 83 | An invalid month/year was detected in an invoice. |
+| <a name="ErrorStatusInvalidExchangeRate">ErrorStatusInvalidExchangeRate</a> | 84 | Invalid Exchange Rate |
+| <a name="ErrorStatusInvalidPassword">ErrorStatusInvalidPassword</a> | 85 | User password was invalid |
 
 
 ### Proposal status codes

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -176,6 +176,7 @@ const (
 	ErrorStatusInvalidLikeCommentAction    ErrorStatusT = 57
 	ErrorStatusInvalidCensorshipToken      ErrorStatusT = 58
 	ErrorStatusEmailAlreadyVerified        ErrorStatusT = 59
+	ErrorStatusInvalidPassword             ErrorStatusT = 85
 
 	// CMS Errors
 	ErrorStatusMalformedName                  ErrorStatusT = 60
@@ -370,6 +371,7 @@ var (
 		ErrorStatusMultipleInvoiceMonthYear:       "only one invoice per month/year is allowed to be submitted",
 		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
 		ErrorStatusInvalidExchangeRate:            "exchange rate was invalid or didn't match expected result",
+		ErrorStatusInvalidPassword:                "invalid password",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1289,7 +1289,7 @@ func (p *politeiawww) processChangeUsername(email string, cu www.ChangeUsername)
 		[]byte(cu.Password))
 	if err != nil {
 		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusInvalidEmailOrPassword,
+			ErrorCode: www.ErrorStatusInvalidPassword,
 		}
 	}
 

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -982,7 +982,7 @@ func TestProcessChangeUsername(t *testing.T) {
 				Password: "wrong",
 			},
 			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidEmailOrPassword,
+				ErrorCode: www.ErrorStatusInvalidPassword,
 			}},
 
 		{"invalid username", u.Email,

--- a/politeiawww/userwww_test.go
+++ b/politeiawww/userwww_test.go
@@ -630,7 +630,7 @@ func TestHandleChangeUsername(t *testing.T) {
 		{"processChangeUsername error", www.ChangeUsername{},
 			http.StatusBadRequest,
 			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidEmailOrPassword,
+				ErrorCode: www.ErrorStatusInvalidPassword,
 			}},
 
 		{"success",


### PR DESCRIPTION
This commit adds an `ErrorStatusInvalidPassword`, which is triggered by `processChangeUsername` when attempting to change the username with an invalid password.

Fixes #831 