### PR TITLE
[cms] Remove confusing policy field

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -87,11 +87,7 @@ const (
 
 	// PolicyMaxLineItemColLength is the maximum length for the strings in
 	// each column field of the lineItem structure.
-	PolicyMaxLineItemColLength = 50
-
-	// PolicyyMaxInvoiceFieldLength is the maximum number of characters
-	// accepted for invoice fields within invoice.json
-	PolicyMaxInvoiceFieldLength = 200
+	PolicyMaxLineItemColLength = 200
 )
 
 var (

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -86,7 +86,8 @@ func validateInvoiceField(field string) bool {
 			field, formatInvoiceField(field))
 		return false
 	}
-	if len(field) > cms.PolicyMaxInvoiceFieldLength {
+	if len(field) > cms.PolicyMaxLineItemColLength ||
+		len(field) < cms.PolicyMinLineItemColLength {
 		log.Tracef("validateInvoiceField: not within bounds: %s",
 			field)
 		return false
@@ -113,7 +114,8 @@ func createInvoiceFieldRegex() string {
 		}
 	}
 	buf.WriteString("]{0,")
-	buf.WriteString(strconv.Itoa(cms.PolicyMaxInvoiceFieldLength) + "}$")
+	buf.WriteString(strconv.Itoa(cms.PolicyMinLineItemColLength) + ",")
+	buf.WriteString(strconv.Itoa(cms.PolicyMaxLineItemColLength) + "}$")
 
 	return buf.String()
 }


### PR DESCRIPTION
There were 2 Max length policy's available for line item field length.  I've opted to remove one and update the old to the proper value of 200.  Verified that the policy is properly given to the GUI for validation.