### PR TITLE
cache: Order vote inv by end height

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -875,7 +875,7 @@ func DecodeTokenInventory(payload []byte) (*TokenInventory, error) {
 // returns the tokens of all records in the inventory.  The tokens are
 // categorized by stage of the voting process.  Pre and abandoned tokens are
 // sorted by timestamp in decending order.  Active, approved, and rejected
-// tokens are sorted by voting period start block height in decending order.
+// tokens are sorted by voting period end block height in decending order.
 type TokenInventoryReply struct {
 	Pre       []string `json:"pre"`       // Tokens of records that are pre-vote
 	Active    []string `json:"active"`    // Tokens of records with an active voting period

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -771,7 +771,7 @@ func (d *decred) cmdTokenInventory(payload string) (string, error) {
        INNER JOIN start_votes
          ON vote_results.token = start_votes.token
          WHERE vote_results.approved = true
-       ORDER BY start_votes.start_block_height DESC`
+       ORDER BY start_votes.end_height DESC`
 	rows, err = d.recordsdb.Raw(q).Rows()
 	if err != nil {
 		return "", fmt.Errorf("approved: %v", err)
@@ -790,7 +790,7 @@ func (d *decred) cmdTokenInventory(payload string) (string, error) {
        INNER JOIN start_votes
          ON vote_results.token = start_votes.token
          WHERE vote_results.approved = false
-       ORDER BY start_votes.start_block_height DESC`
+       ORDER BY start_votes.end_height DESC`
 	rows, err = d.recordsdb.Raw(q).Rows()
 	if err != nil {
 		return "", fmt.Errorf("rejected: %v", err)

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -1183,7 +1183,7 @@ type TokenInventory struct{}
 // returns the tokens of all proposals in the inventory.  The tokens are
 // categorized by stage of the voting process.  Pre and abandoned tokens are
 // sorted by timestamp in decending order.  Active, approved, and rejected
-// tokens are sorted by voting period start block height in decending order.
+// tokens are sorted by voting period end block height in decending order.
 type TokenInventoryReply struct {
 	Pre       []string `json:"pre"`       // Tokens of all props that are pre-vote
 	Active    []string `json:"active"`    // Tokens of all props with an active voting period


### PR DESCRIPTION
This commit fixes a bug in some of the the sql queries from the token
inventory command.  The queries were ordering results by start block
height, which is a string.  They should have been ording results by end
height, which is a uint64.