### PR TITLE
www: Enforce unique usernames in pi and cms

### DIFF
--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -288,18 +288,26 @@ func TestProcessNewUser(t *testing.T) {
 				ErrorCode: www.ErrorStatusMalformedPassword,
 			}},
 
-		// usrExpired gets successfully created during the test
-		// "unverified user expired token" so usrExpiredPublicKey
-		// should now be a duplicate.
 		{"duplicate pubkey",
 			www.NewUser{
 				Email:     validEmail,
 				Password:  validPassword,
-				PublicKey: usrExpiredPublicKey,
+				PublicKey: usrVerified.PublicKey(),
 				Username:  validUsername,
 			},
 			www.UserError{
 				ErrorCode: www.ErrorStatusDuplicatePublicKey,
+			}},
+
+		{"duplicate username",
+			www.NewUser{
+				Email:     validEmail,
+				Password:  validPassword,
+				PublicKey: validPublicKey,
+				Username:  usrVerified.Username,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusDuplicateUsername,
 			}},
 
 		{"invalid email",


### PR DESCRIPTION
A bug was introduced in commit 00994d0 that allowed users with duplicate
usernames to be created for both pi and cms. This commit fixes that bug.