### PR TITLE
cache: Fix VoteOptionResult bug

### DIFF
--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -899,6 +899,7 @@ func (d *decred) cmdVoteSummary(payload string) (string, error) {
 	err = d.recordsdb.
 		Where("token = ?", vs.Token).
 		Preload("Results").
+		Preload("Results.Option").
 		Find(&vr).
 		Error
 	if err == gorm.ErrRecordNotFound {

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -190,10 +190,11 @@ func (CastVote) TableName() string {
 //
 // This is a decred plugin model.
 type VoteOptionResult struct {
-	Key    string     `gorm:"primary_key"`      // Primary key (token+votebit)
-	Token  string     `gorm:"not null;size:64"` // Censorship token (VoteResults foreign key)
-	Votes  uint64     `gorm:"not null"`         // Number of votes cast for this option
-	Option VoteOption `gorm:"not null"`         // Vote option
+	Key       string     `gorm:"primary_key"`      // Primary key (token+votebit)
+	Token     string     `gorm:"not null;size:64"` // Censorship token (VoteResults foreign key)
+	Votes     uint64     `gorm:"not null"`         // Number of votes cast for this option
+	Option    VoteOption `gorm:"not null"`         // Vote option
+	OptionKey uint       `gorm:"not null"`         // VoteOption foreign key
 }
 
 // TableName returns the name of the VoteOptionResult database table.


### PR DESCRIPTION
This commit fixes a bug that was causing the vote option details to not be returned in the vote results query.