### PR TITLE
Increases max number of invoice png attachments

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -44,7 +44,7 @@ const (
 
 	// PolicyMaxImages is the maximum number of images accepted
 	// when creating a new invoice
-	PolicyMaxImages = 5
+	PolicyMaxImages = 20
 
 	// PolicyMaxImageSize is the maximum image file size (in bytes)
 	// accepted when creating a new invoice


### PR DESCRIPTION
As per discussed in contractor riot chat, the maximum number of png attachments accepted by an invoice should increase significantly. @alexlyp and I agreed that 20 would be a reasonable upper limit.