### PR TITLE
www: Fix inconsistencies in paywall polling logic

### DIFF
--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -83,6 +83,12 @@ func (p *politeiawww) checkForProposalPayments(pool map[uuid.UUID]paywallPoolMem
 		log.Tracef("Checking proposal paywall address for user %v...", u.Email)
 
 		paywall := p.mostRecentProposalPaywall(u)
+
+		// Sanity check
+		if paywall == nil {
+			continue
+		}
+
 		if paywallHasExpired(paywall.PollExpiry) {
 			userIDsToRemove = append(userIDsToRemove, userID)
 			log.Tracef("  removing from polling, poll has expired")
@@ -107,6 +113,7 @@ func (p *politeiawww) checkForProposalPayments(pool map[uuid.UUID]paywallPoolMem
 			log.Tracef("  removing from polling, user just paid")
 		} else if tx != nil {
 			log.Tracef("  updating pool member with id: %v", userID)
+
 			// Update pool member if payment tx was found but
 			// does not have enough confimrations.
 			poolMember.txID = tx.TxID

--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -106,6 +106,7 @@ func (p *politeiawww) checkForProposalPayments(pool map[uuid.UUID]paywallPoolMem
 			userIDsToRemove = append(userIDsToRemove, userID)
 			log.Tracef("  removing from polling, user just paid")
 		} else if tx != nil {
+			log.Tracef("  updating pool member with id: %v", userID)
 			// Update pool member if payment tx was found but
 			// does not have enough confimrations.
 			poolMember.txID = tx.TxID
@@ -127,7 +128,6 @@ func (p *politeiawww) checkForPayments() {
 	for {
 		// Removing pool members from the pool while in the middle of
 		// polling can cause a race to occur in checkForProposalPayments.
-
 		userPaywallsToCheck := p.createUserPaywallPoolCopy()
 
 		// Check new user payments.
@@ -135,14 +135,14 @@ func (p *politeiawww) checkForPayments() {
 		if !shouldContinue {
 			return
 		}
-		p.removeUsersFromPool(userIDsToRemove)
+		p.removeUsersFromPool(userIDsToRemove, paywallTypeUser)
 
 		// Check proposal payments.
 		shouldContinue, userIDsToRemove = p.checkForProposalPayments(userPaywallsToCheck)
 		if !shouldContinue {
 			return
 		}
-		p.removeUsersFromPool(userIDsToRemove)
+		p.removeUsersFromPool(userIDsToRemove, paywallTypeProposal)
 
 		time.Sleep(paywallCheckGap)
 	}

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1988,15 +1988,16 @@ func (p *politeiawww) processVerifyUserPayment(u *user.User, vupt www.VerifyUser
 	return &reply, nil
 }
 
-// removeUsersFromPool removes provided user IDs from the the poll pool.
-// Currently, updating user db and removal from pool isn't an atomic
-// operation. This can lead to a scenario where user has been marked as
-// paid in db, but has not yet been removed from the pool. If a user
-// issues a proposal paywall during this time, the proposal paywall will
-// replace the user paywall in the pool. When the pool proceeds to remove
-// the user paywall, it will mistakenly remove the proposal paywall instead.
+// removeUsersFromPool removes the provided user IDs from the the poll pool.
+//
+// Currently, updating the user db and removing the user from pool isn't an
+// atomic operation.  This can lead to a scenario where the user has been
+// marked as paid in the db, but has not yet been removed from the pool. If a
+// user issues a proposal paywall during this time, the proposal paywall will
+// replace the user paywall in the pool. When the pool proceeds to remove the
+// user paywall, it will mistakenly remove the proposal paywall instead.
 // Proposal credits will not be added to the user's account. The workaround
-// until this code gets replaced with websockets is to pass the paywallType
+// until this code gets replaced with websockets is to pass in the paywallType
 // when removing a pool member.
 //
 // This function must be called WITHOUT the mutex held.

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1625,8 +1625,7 @@ func (p *politeiawww) processManageUser(mu *www.ManageUser, adminUser *user.User
 	case www.UserManageExpireResetPasswordVerification:
 		user.ResetPasswordVerificationExpiry = expiredTime
 	case www.UserManageClearUserPaywall:
-		p.removeUsersFromPool([]uuid.UUID{user.ID})
-
+		p.removeUsersFromPool([]uuid.UUID{user.ID}, paywallTypeUser)
 		user.NewUserPaywallAmount = 0
 		user.NewUserPaywallTx = "cleared_by_admin"
 		user.NewUserPaywallPollExpiry = 0
@@ -1990,14 +1989,25 @@ func (p *politeiawww) processVerifyUserPayment(u *user.User, vupt www.VerifyUser
 }
 
 // removeUsersFromPool removes provided user IDs from the the poll pool.
+// Currently, updating user db and removal from pool isn't an atomic
+// operation. This can lead to a scenario where user has been marked as
+// paid in db, but has not yet been removed from the pool. If a user
+// issues a proposal paywall during this time, the proposal paywall will
+// replace the user paywall in the pool. When the pool proceeds to remove
+// the user paywall, it will mistakenly remove the proposal paywall instead.
+// Proposal credits will not be added to the user's account. The workaround
+// until this code gets replaced with websockets is to pass the paywallType
+// when removing a pool member.
 //
 // This function must be called WITHOUT the mutex held.
-func (p *politeiawww) removeUsersFromPool(userIDsToRemove []uuid.UUID) {
+func (p *politeiawww) removeUsersFromPool(userIDsToRemove []uuid.UUID, paywallType string) {
 	p.Lock()
 	defer p.Unlock()
 
 	for _, userID := range userIDsToRemove {
-		delete(p.userPaywallPool, userID)
+		if p.userPaywallPool[userID].paywallType == paywallType {
+			delete(p.userPaywallPool, userID)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR solves a inconsistency when removing users from the paywall polling pool. A detailed comment about the bug is written on top of `removeUsersFromPool` function.