### PR TITLE
[cms] Bump line item column length to 500

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -94,7 +94,7 @@ const (
 
 	// PolicyMaxLineItemColLength is the maximum length for the strings in
 	// each column field of the lineItem structure.
-	PolicyMaxLineItemColLength = 200
+	PolicyMaxLineItemColLength = 500
 )
 
 var (


### PR DESCRIPTION
There were some users that were going above the 200 char limit.  