### PR TITLE
cache: Remove duplicate vote lookup

### DIFF
--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -2171,7 +2171,6 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 				t)
 			continue
 		}
-		br.Receipts[k].ClientSignature = v.Signature
 
 		// Ensure journal directory exists
 		dir := pijoin(g.journals, v.Token)
@@ -2185,7 +2184,6 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 		// Sign signature
 		r := fi.SignMessage([]byte(v.Signature))
 		receipt := hex.EncodeToString(r[:])
-		br.Receipts[k].Signature = receipt
 
 		// Write vote to journal
 		err = g.writeVote(v, receipt, bfilename)
@@ -2194,8 +2192,13 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 				br.Receipts[k].Error = "duplicate vote: " + v.Token
 				continue
 			}
-			return "", err
+			// Should not fail, so return failure to alert people
+			return "", fmt.Errorf("write vote: %v", err)
 		}
+
+		// Update reply
+		br.Receipts[k].ClientSignature = v.Signature
+		br.Receipts[k].Signature = receipt
 
 		// Mark comment journal dirty
 		flushFilename := pijoin(g.journals, v.Token,


### PR DESCRIPTION
This commit updates how votes are inserted into the cache. It removes
the vote lookup that was checking for duplicate votes. This lookup query
was too expensive and is not needed. It was causing cache build times to
be unreasonable (~3 hours) and would also cause extremely long response
times if someone were to cast a large block of votes all at once, which
does occasionally happen.

Removing this query does not effect whether duplicate votes will be
added to cache once they have been rejected by gitbe. Any vote that does
not have a valid vote receipt is not added to cache. Duplicate votes
that are rejected by gitbe do not contain a valid vote receipt.

Removing this query does mean that the 15 duplicate votes that made it
into the "Decentralize Treasury Spending" proposal vote journal will be
added to the cache and reflected in the vote total. I don't consider
this to be a huge issue since the proposal passed with a 97.49% approval
rating. Documenting the 15 duplicate votes in the Politeia Digest and
Decred Journal should be sufficient.