### PR TITLE
www: Add doco for proposal filtering params

### DIFF
--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -1230,7 +1230,9 @@ Reply:
 
 ### `Unvetted`
 
-Retrieve a page of unvetted proposals; the number of proposals returned in the page is limited by the `proposallistpagesize` property, which is provided via [`Policy`](#policy).  This call requires admin privileges.
+Retrieve a page of unvetted proposals; the number of proposals returned in the
+page is limited by the `ProposalListPageSize` property, which is provided via
+[`Policy`](#policy).  This call requires admin privileges.
 
 **Route:** `GET /v1/proposals/unvetted`
 
@@ -1238,8 +1240,8 @@ Retrieve a page of unvetted proposals; the number of proposals returned in the p
 
 | Parameter | Type | Description | Required |
 |-|-|-|-|
-| before | String | A proposal censorship token; if provided, the page of proposals returned will end right before the proposal whose token is provided. This parameter should not be specified if `after` is set. | |
-| after | String | A proposal censorship token; if provided, the page of proposals returned will begin right after the proposal whose token is provided. This parameter should not be specified if `before` is set. | |
+| before | String | A proposal censorship token; if provided, the page of proposals returned will end right before the proposal whose token is provided, when sorted in reverse chronological order. This parameter should not be specified if `after` is set. | |
+| after | String | A proposal censorship token; if provided, the page of proposals returned will begin right after the proposal whose token is provided, when sorted in reverse chronological order. This parameter should not be specified if `before` is set. | |
 
 **Results:**
 
@@ -1282,7 +1284,9 @@ Reply:
 
 ### `Vetted`
 
-Retrieve a page of vetted proposals; the number of proposals returned in the page is limited by the `proposallistpagesize` property, which is provided via [`Policy`](#policy).
+Retrieve a page of vetted proposals; the number of proposals returned in the
+page is limited by the `ProposalListPageSize` property, which is provided via
+[`Policy`](#policy).
 
 **Route:** `GET /v1/proposals/vetted`
 
@@ -1290,8 +1294,8 @@ Retrieve a page of vetted proposals; the number of proposals returned in the pag
 
 | Parameter | Type | Description | Required |
 |-|-|-|-|
-| before | String | A proposal censorship token; if provided, the page of proposals returned will end right before the proposal whose token is provided. This parameter should not be specified if `after` is set. | |
-| after | String | A proposal censorship token; if provided, the page of proposals returned will begin right after the proposal whose token is provided. This parameter should not be specified if `before` is set. | |
+| before | String | A proposal censorship token; if provided, the page of proposals returned will end right before the proposal whose token is provided, when sorted in reverse chronological order. This parameter should not be specified if `after` is set. | |
+| after | String | A proposal censorship token; if provided, the page of proposals returned will begin right after the proposal whose token is provided, when sorted in reverse chronological order. This parameter should not be specified if `before` is set. | |
 
 **Results:**
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -798,11 +798,19 @@ type SetProposalStatusReply struct {
 }
 
 // GetAllUnvetted retrieves all unvetted proposals; the maximum number returned
-// is dictated by ProposalListPageSize. This command optionally takes either
-// a Before or After parameter, which specify a proposal's censorship token.
-// If After is specified, the "page" returned starts after the proposal whose
-// censorship token is provided. If Before is specified, the "page" returned
-// starts before the proposal whose censorship token is provided.
+// is dictated by ProposalListPageSize.
+//
+// This command optionally takes either a Before or After parameter, which
+// specify a proposal's censorship token. If After is specified, the "page"
+// returned starts after the provided censorship token, when sorted in reverse
+// chronological order. A simplified example is shown below.
+//
+// input: [5,4,3,2,1]
+// after=3
+// output: [2,1]
+//
+// If Before is specified, the "page" returned starts before the provided
+// proposal censorship token, when sorted in reverse chronological order.
 //
 // Note: This call requires admin privileges.
 type GetAllUnvetted struct {
@@ -815,12 +823,20 @@ type GetAllUnvettedReply struct {
 	Proposals []ProposalRecord `json:"proposals"`
 }
 
-// GetAllVetted retrieves vetted proposals; the maximum number returned is dictated
-// by ProposalListPageSize. This command optionally takes either a Before or After
-// parameter, which specify a proposal's censorship token. If After is specified,
-// the "page" returned starts after the proposal whose censorship token is provided.
-// If Before is specified, the "page" returned starts before the proposal whose
-// censorship token is provided.
+// GetAllVetted retrieves vetted proposals; the maximum number returned is
+// dictated by ProposalListPageSize.
+//
+// This command optionally takes either a Before or After parameter, which
+// specify a proposal's censorship token. If After is specified, the "page"
+// returned starts after the provided censorship token, when sorted in reverse
+// chronological order. A simplified example is shown below.
+//
+// input: [5,4,3,2,1]
+// after=3
+// output: [2,1]
+//
+// If Before is specified, the "page" returned starts before the provided
+// proposal censorship token, when sorted in reverse chronological order.
 type GetAllVetted struct {
 	Before string `schema:"before"`
 	After  string `schema:"after"`


### PR DESCRIPTION
The `/proposals/vetted` and `/proposals/unvetted` have the optional
query params "before" and "after".  These query params filter the
proposals after they've been sorted into reverse chronological order.
This is not what you would typically expect, so I added additional
documentation to make this clear.