### PR TITLE
www: Validate Before and After tokens

### DIFF
--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -162,13 +162,12 @@ func validateComment(c www.NewComment) error {
 		}
 	}
 	// validate token
-	_, err := util.ConvertStringToken(c.Token)
-	if err != nil && err.Error() == "invalid censorship token size" {
-		err = www.UserError{
+	if !tokenIsValid(c.Token) {
+		return www.UserError{
 			ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 		}
 	}
-	return err
+	return nil
 }
 
 // processNewComment sends a new comment decred plugin command to politeaid

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -1107,3 +1107,193 @@ func TestProcessSetProposalStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessAllVetted(t *testing.T) {
+	// Setup test environment
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
+
+	// Create test data
+	tokenValid := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351b5d"
+	tokenNotHex := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351zzz"
+	tokenShort := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351b5"
+	tokenLong := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351b5dd"
+
+	// Setup tests
+	var tests = []struct {
+		name string
+		av   www.GetAllVetted
+		want error
+	}{
+		{"before token not hex",
+			www.GetAllVetted{
+				Before: tokenNotHex,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"before token invalid length short",
+			www.GetAllVetted{
+				Before: tokenShort,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"before token invalid length long",
+			www.GetAllVetted{
+				Before: tokenLong,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"after token not hex",
+			www.GetAllVetted{
+				After: tokenNotHex,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"after token invalid length short",
+			www.GetAllVetted{
+				After: tokenShort,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"after token invalid length long",
+			www.GetAllVetted{
+				After: tokenLong,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"valid before token",
+			www.GetAllVetted{
+				Before: tokenValid,
+			},
+			nil,
+		},
+		{"valid after token",
+			www.GetAllVetted{
+				After: tokenValid,
+			},
+			nil,
+		},
+
+		// XXX only partial test coverage has been added to this route
+	}
+
+	// Run tests
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			_, err := p.processAllVetted(v.av)
+			got := errToStr(err)
+			want := errToStr(v.want)
+			if got != want {
+				t.Errorf("got error %v, want %v",
+					got, want)
+			}
+		})
+	}
+}
+
+func TestProcessAllUnvetted(t *testing.T) {
+	// Setup test environment
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
+
+	// Create test data
+	tokenValid := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351b5d"
+	tokenNotHex := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351zzz"
+	tokenShort := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351b5"
+	tokenLong := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351b5dd"
+
+	// Setup tests
+	var tests = []struct {
+		name string
+		au   www.GetAllUnvetted
+		want error
+	}{
+		{"before token not hex",
+			www.GetAllUnvetted{
+				Before: tokenNotHex,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"before token invalid length short",
+			www.GetAllUnvetted{
+				Before: tokenShort,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"before token invalid length long",
+			www.GetAllUnvetted{
+				Before: tokenLong,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"after token not hex",
+			www.GetAllUnvetted{
+				After: tokenNotHex,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"after token invalid length short",
+			www.GetAllUnvetted{
+				After: tokenShort,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"after token invalid length long",
+			www.GetAllUnvetted{
+				After: tokenLong,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
+			},
+		},
+		{"valid before token",
+			www.GetAllUnvetted{
+				Before: tokenValid,
+			},
+			nil,
+		},
+		{"valid after token",
+			www.GetAllUnvetted{
+				After: tokenValid,
+			},
+			nil,
+		},
+
+		// XXX only partial test coverage has been added to this route
+	}
+
+	// Run tests
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			_, err := p.processAllUnvetted(v.au)
+			got := errToStr(err)
+			want := errToStr(v.want)
+			if got != want {
+				t.Errorf("got error %v, want %v",
+					got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds validation to the GetAllVetted and GetAllUnvetted
routes to ensure that the tokens being passed up in the Before and After
params are valid censorship tokens. Unit tests are also added.