### PR TITLE
Correct the update of user identity 

### DIFF
--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1308,7 +1308,6 @@ func (p *politeiawww) processVerifyUpdateUserKey(u *user.User, vu www.VerifyUpda
 	for k, v := range u.Identities {
 		if v.Deactivated == 0 {
 			u.Identities[k].Deactivated = t
-			break
 		}
 	}
 	u.Identities[len(u.Identities)-1].Activated = t


### PR DESCRIPTION
This PR adds a simple fix to the process of updating the user identity. Some users may contain more than one identity activated which I believe is due to some errors while migrating the database or just some artifacts from old implementation. This PR removes the `break` statement in the for loop which makes sure all identities are deactivated before activating the last one. More information about the bug related to this PR can be found [here](https://github.com/decred/politeiagui/issues/1249#issuecomment-497927896)