### PR TITLE
[cms] Add 0-9 to acceptable Name/Location regex

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -143,7 +143,7 @@ var (
 	// PolicyCMSNameLocationSupportedChars is the regular expression of a valid
 	// name or location for registering users on cms.
 	PolicyCMSNameLocationSupportedChars = []string{
-		"A-z", ".", "-", " ", ","}
+		"A-z", "0-9", ".", "-", " ", ","}
 
 	// PolicyCMSContactSupportedChars is the regular expression of a valid
 	// contact for registering users on cms.


### PR DESCRIPTION
Possibility that some companies or location would contain a numeral.