### PR TITLE
www: Remove pubkey memory cache

### DIFF
--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -113,8 +113,6 @@ type politeiawww struct {
 	test bool
 
 	// Following entries require locks
-	// XXX userPubkeys can be removed now that the userdb is queryable
-	userPubkeys     map[string]string               // [pubkey][userid]
 	userPaywallPool map[uuid.UUID]paywallPoolMember // [userid][paywallPoolMember]
 	commentScores   map[string]int64                // [token+commentID]resultVotes
 

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -151,17 +151,14 @@ func newUser(t *testing.T, p *politeiawww, isVerified, isAdmin bool) (*user.User
 		t.Fatalf("%v", err)
 	}
 
-	// Add the user to the politeiawww in-memory [pubkey]userID
-	// and [email]userID caches. Since the userID is generated
-	// in the database layer we need to lookup the user in order
-	// to get the userID.
+	// Add the user to the politeiawww in-memory [email]userID
+	// cache. Since the userID is generated in the database layer
+	// we need to lookup the user in order to get the userID.
 	usr, err := p.db.UserGetByUsername(u.Username)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-
-	p.setUserPubkeyAssociaton(usr, pubkey)
-	p.setUserEmails(usr.Email, usr.ID)
+	p.setUserEmailsCache(usr.Email, usr.ID)
 
 	// Add paywall info to the user record
 	err = p.GenerateNewUserPaywall(usr)
@@ -245,7 +242,6 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 		store:           store,
 		smtp:            smtp,
 		test:            true,
-		userPubkeys:     make(map[string]string),
 		userEmails:      make(map[string]uuid.UUID),
 		userPaywallPool: make(map[uuid.UUID]paywallPoolMember),
 		commentScores:   make(map[string]int64),

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -213,13 +213,10 @@ func (u *User) InactiveIdentity() *Identity {
 	return nil
 }
 
-// PublicKey returns a hex encoded string of the user's identity.
+// PublicKey returns a hex encoded string of the user's active identity.
 func (u *User) PublicKey() string {
 	if u.ActiveIdentity() != nil {
 		return u.ActiveIdentity().String()
-	}
-	if u.InactiveIdentity() != nil {
-		return u.InactiveIdentity().String()
 	}
 	return ""
 }
@@ -327,6 +324,7 @@ type Database interface {
 	// User functions
 	UserGetByUsername(string) (*User, error) // Return user record given the username
 	UserGetById(uuid.UUID) (*User, error)    // Return user record given its id
+	UserGetByPubKey(string) (*User, error)   // Return user record given a public key
 	UserNew(User) error                      // Add new user
 	UserUpdate(User) error                   // Update existing user
 	AllUsers(callbackFn func(u *User)) error // Iterate all users

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -323,7 +323,6 @@ func _main() error {
 		templates: make(map[string]*template.Template),
 
 		// XXX reevaluate where this goes
-		userPubkeys:     make(map[string]string),
 		userEmails:      make(map[string]uuid.UUID),
 		userPaywallPool: make(map[uuid.UUID]paywallPoolMember),
 		commentScores:   make(map[string]int64),
@@ -432,14 +431,8 @@ func _main() error {
 		log.Infof("Registered cache plugin: %v", v.ID)
 	}
 
-	// Setup pubkey-userid map
-	err = p.initUserPubkeys()
-	if err != nil {
-		return err
-	}
-
 	// Setup email-userID map
-	err = p.initUserEmails()
+	err = p.initUserEmailsCache()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #861.

This diff removes the public key memory cache from politeiawww. A
UserGetByPubKey function is added to the user database interface. All
user lookups by public key now query the user database instead of
relying on a memory cache.