### PR TITLE
 [cms] Add line item payout summary commands 

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -694,6 +694,7 @@ Reply:
       "expenses": 5000
     }
   ]
+}
 ```
 
 ### Error codes

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -19,6 +19,7 @@ server side notifications.  It does not render HTML.
 - [`Invoice comments`](#invoice-comments)
 - [`Invoice exchange rate`](#invoice-exchange-rate)
 - [`Pay invoices`](#pay-invoices)
+- [`Line item payouts`](#line-item-payouts)
 
 **Invoice status codes**
 
@@ -638,6 +639,63 @@ Reply:
 {}
 ```
 
+### `Line Item Payouts`
+
+This command would provide a list of line items that were paid out in a given
+date range.  
+
+Note: This call requires admin privileges.
+
+**Route:** `GET /v1/admin/lineitempayouts`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| starttime | int64 | Start time for the line item range (in Unix seconds) | Yes |
+| endtime | int64 | End time for the line item range (in Unix seconds) | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+
+**Example**
+
+Request:
+
+```json
+{
+  "starttime": "1559460156",
+  "endtime": "1560460156"
+}
+```
+
+Reply:
+
+```json
+{
+  "lineitems": [{  
+      "type": 1,
+      "domain": "Design",
+      "subdomain": "dcrweb",
+      "description": "Creating mock ups of the current site.",
+      "proposaltoken": "",
+      "labor": 7380,
+      "expenses": 0
+    },
+    {
+      "type": 2,
+      "domain": "Design",
+      "subdomain": "dcrweb",
+      "description": "Buying stickers.  Lots of stickers.",
+      "proposaltoken": "",
+      "labor": 0,
+      "expenses": 5000
+    }
+  ]
+```
+
 ### Error codes
 
 | Status | Value | Description |
@@ -670,6 +728,7 @@ Reply:
 | <a name="ErrorStatusInvalidLineItemType">ErrorStatusInvalidLineItemType</a> | 1026 | An invalid line item type was attempted. |
 | <a name="ErrorStatusInvalidLaborExpense">ErrorStatusInvalidLaborExpense</a> | 1027 | An invalid value was entered into labor or expenses. |
 | <a name="ErrorStatusDuplicatePaymentAddress">ErrorStatusDuplicatePaymentAddress</a> | 1028 | An duplicate payment address was entered. |
+| <a name="ErrorStatusInvalidDatesRequested"></a> | 1029 | Invalid dates were submitted for a request. |
 
 ### Invoice status codes
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -21,6 +21,7 @@ const (
 	RouteUserInvoices        = "/user/invoices"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteGeneratePayouts     = "/admin/generatepayouts"
+	RouteLineItemPayouts     = "/admin/lineitempayouts"
 	RoutePayInvoices         = "/admin/payinvoices"
 	RouteInvoiceComments     = "/invoices/{token:[A-z0-9]{64}}/comments"
 	RouteInvoiceExchangeRate = "/invoices/exchangerate"
@@ -125,6 +126,7 @@ const (
 	ErrorStatusInvalidLineItemType            www.ErrorStatusT = 1026
 	ErrorStatusInvalidLaborExpense            www.ErrorStatusT = 1027
 	ErrorStatusDuplicatePaymentAddress        www.ErrorStatusT = 1028
+	ErrorStatusInvalidDatesRequested          www.ErrorStatusT = 1029
 )
 
 var (
@@ -178,6 +180,7 @@ var (
 		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
 		ErrorStatusInvalidExchangeRate:            "exchange rate was invalid or didn't match expected result",
 		ErrorStatusDuplicatePaymentAddress:        "a duplicate payment address was used",
+		ErrorStatusInvalidDatesRequested:          "invalid dates were requested",
 	}
 )
 
@@ -391,3 +394,16 @@ type PayInvoices struct{}
 
 // PayInvoicesReply will be empty if no errors have occurred.
 type PayInvoicesReply struct{}
+
+// LineItemPayouts contains the request to receive line items from payouts
+// within a start and end date.
+type LineItemPayouts struct {
+	StartTime int64 `json:"starttime"` // Start time for range (in unix seconds)
+	EndTime   int64 `json:"endtime"`   // End time for rang (in unix seconds)
+}
+
+// LineItemPayoutsReply returns an array of line items within the requested
+// date range.
+type LineItemPayoutsReply struct {
+	LineItems []LineItemsInput `json:"lineitems"` // Line items within the requested date range.
+}

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -1634,6 +1634,30 @@ func (c *Client) InvoiceExchangeRate(ier *cms.InvoiceExchangeRate) (*cms.Invoice
 	return &ierr, nil
 }
 
+// LineItemPayouts retrieves invoices base on possible field set in the request
+// month/year and/or status
+func (c *Client) LineItemPayouts(lip *cms.LineItemPayouts) (*cms.LineItemPayoutsReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteLineItemPayouts, lip)
+	if err != nil {
+		return nil, err
+	}
+
+	var lipr cms.LineItemPayoutsReply
+	err = json.Unmarshal(responseBody, &lipr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal LineItemPayouts: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(lipr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &lipr, nil
+}
+
 // Close all client connections.
 func (c *Client) Close() {
 	if c.conn != nil {

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -74,6 +74,7 @@ type Cmds struct {
 	InviteNewUser       InviteNewUserCmd       `command:"invite" description:"(admin)  invite a new user"`
 	InvoiceDetails      InvoiceDetailsCmd      `command:"invoicedetails" description:"(public) get the details of a proposal"`
 	LikeComment         LikeCommentCmd         `command:"likecomment" description:"(user)   upvote/downvote a comment"`
+	LineItemPayouts     LineItemPayoutsCmd     `command:"lineitempayouts" description:"(admin) generate line item list for a given date range"`
 	Login               LoginCmd               `command:"login" description:"(public) login to Politeia"`
 	Logout              LogoutCmd              `command:"logout" description:"(public) logout of Politeia"`
 	Me                  MeCmd                  `command:"me" description:"(user)   get user details for the logged in user"`

--- a/politeiawww/cmd/politeiawwwcli/commands/lineitempayouts.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/lineitempayouts.go
@@ -32,8 +32,10 @@ func (cmd *LineItemPayoutsCmd) Execute(args []string) error {
 		return fmt.Errorf("month and year are both required to determine line item date range")
 	}
 
-	startDate := time.Date(int(cmd.Args.Year), time.Month(int(cmd.Args.Month)), 0, 0, 0, 0, 0, time.UTC)
-	endDate := time.Date(int(cmd.Args.Year), time.Month(int(cmd.Args.Month+1)), 0, 0, 0, 0, 0, time.UTC)
+	startDate := time.Date(int(cmd.Args.Year), time.Month(int(cmd.Args.Month)),
+		0, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(int(cmd.Args.Year), time.Month(int(cmd.Args.Month+1)),
+		0, 0, 0, 0, 0, time.UTC)
 
 	lip := v1.LineItemPayouts{
 		StartTime: startDate.Unix(),

--- a/politeiawww/cmd/politeiawwwcli/commands/lineitempayouts.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/lineitempayouts.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+	"time"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// LineItemPayoutsCmd request the line items that were paid out in the specified
+// month/year.
+type LineItemPayoutsCmd struct {
+	Args struct {
+		Month uint `positional-arg-name:"month"`
+		Year  uint `positional-arg-name:"year"`
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the line item payouts command
+func (cmd *LineItemPayoutsCmd) Execute(args []string) error {
+	// Fetch CSRF tokens
+	_, err := client.Version()
+	if err != nil {
+		return fmt.Errorf("Version: %v", err)
+	}
+
+	if cmd.Args.Month == 0 || cmd.Args.Year == 0 {
+		return fmt.Errorf("month and year are both required to determine line item date range")
+	}
+
+	startDate := time.Date(int(cmd.Args.Year), time.Month(int(cmd.Args.Month)), 0, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(int(cmd.Args.Year), time.Month(int(cmd.Args.Month+1)), 0, 0, 0, 0, 0, time.UTC)
+
+	lip := v1.LineItemPayouts{
+		StartTime: startDate.Unix(),
+		EndTime:   endDate.Unix(),
+	}
+	// Send request
+	lipr, err := client.LineItemPayouts(&lip)
+	if err != nil {
+		return fmt.Errorf("error LineItemPayouts: %v", err)
+	}
+
+	// Print response details
+	return printJSON(lipr)
+}

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/decred/politeia/decredplugin"
 	database "github.com/decred/politeia/politeiawww/cmsdatabase"
@@ -316,6 +317,42 @@ func (c *cockroachdb) ExchangeRate(month, year int) (*database.ExchangeRate, err
 	}
 
 	return decodeExchangeRate(exchangeRate), nil
+}
+
+// LineItemsByDateRange takes a start and end time (in Unix seconds) and returns
+// all line items that have been paid in that range.  This uses the invoice_changes
+// table to discover the token to look up the correct line items.
+func (c *cockroachdb) LineItemsByDateRange(start, end int64) ([]database.LineItem, error) {
+	log.Debugf("LineItemsByDateRange: %v %v", time.Unix(start, 0), time.Unix(end, 0))
+	// Get all invoice changes of PAID status within date range.
+	invoiceChanges := make([]InvoiceChange, 0, 1024) // PNOOMA
+	err := c.recordsdb.
+		Where("timestamp BETWEEN ? AND ?", time.Unix(start, 0), time.Unix(end, 0)).
+		Find(&invoiceChanges).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	// Using all invoice tokens from the results of the query above, ask for all
+	// line items that match those tokens.
+	dbLineItems := make([]database.LineItem, 0, 1024)
+	for _, v := range invoiceChanges {
+		lineItems := make([]LineItem, 0, 1024)
+		err = c.recordsdb.
+			Where("invoice_token = ?", v.InvoiceToken).
+			Find(&lineItems).
+			Error
+		if err != nil {
+			return nil, err
+		}
+		for _, vv := range lineItems {
+			dbLineItem := DecodeInvoiceLineItem(&vv)
+			dbLineItems = append(dbLineItems, *dbLineItem)
+		}
+	}
+
+	return dbLineItems, nil
 }
 
 // Close satisfies the database interface.

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -320,14 +320,17 @@ func (c *cockroachdb) ExchangeRate(month, year int) (*database.ExchangeRate, err
 }
 
 // LineItemsByDateRange takes a start and end time (in Unix seconds) and returns
-// all line items that have been paid in that range.  This uses the invoice_changes
-// table to discover the token to look up the correct line items.
+// all line items that have been paid in that range.  This uses the
+// invoice_changes table to discover the token to look up the correct line items.
 func (c *cockroachdb) LineItemsByDateRange(start, end int64) ([]database.LineItem, error) {
-	log.Debugf("LineItemsByDateRange: %v %v", time.Unix(start, 0), time.Unix(end, 0))
+	log.Debugf("LineItemsByDateRange: %v %v", time.Unix(start, 0),
+		time.Unix(end, 0))
 	// Get all invoice changes of PAID status within date range.
 	invoiceChanges := make([]InvoiceChange, 0, 1024) // PNOOMA
 	err := c.recordsdb.
-		Where("timestamp BETWEEN ? AND ?", time.Unix(start, 0), time.Unix(end, 0)).
+		Where("timestamp BETWEEN ? AND ?",
+			time.Unix(start, 0),
+			time.Unix(end, 0)).
 		Find(&invoiceChanges).
 		Error
 	if err != nil {

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -38,6 +38,7 @@ type Database interface {
 	InvoicesByMonthYear(uint16, uint16) ([]Invoice, error)            // Returns all invoice by month, year
 	InvoicesByStatus(int) ([]Invoice, error)                          // Returns all invoices by status
 	InvoicesAll() ([]Invoice, error)                                  // Returns all invoices
+	LineItemsByDateRange(int64, int64) ([]LineItem, error)            // Returns all paid invoice line items from range provided
 
 	// ExchangeRate functions
 	NewExchangeRate(*ExchangeRate) error // Create new exchange rate

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -394,7 +394,8 @@ func (p *politeiawww) handlePayInvoices(w http.ResponseWriter, r *http.Request) 
 
 	reply, err := p.processPayInvoices(user)
 	if err != nil {
-		RespondWithError(w, r, 0, "handlePayInvoices: processAdminInvoices %v", err)
+		RespondWithError(w, r, 0, "handlePayInvoices: processAdminInvoices %v",
+			err)
 		return
 	}
 

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -401,6 +401,30 @@ func (p *politeiawww) handlePayInvoices(w http.ResponseWriter, r *http.Request) 
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
 
+// handleLineItemPayouts handles incoming requests for line item payout information
+func (p *politeiawww) handleLineItemPayouts(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleLineItemPayouts")
+
+	var lip cms.LineItemPayouts
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&lip); err != nil {
+		RespondWithError(w, r, 0, "handleLineItemPayouts: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	lipr, err := p.processLineItemPayouts(lip)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleLineItemPayouts: processLineItemPayouts: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, lipr)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -458,4 +482,6 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleGeneratePayouts, permissionAdmin)
 	p.addRoute(http.MethodGet, cms.RoutePayInvoices,
 		p.handlePayInvoices, permissionAdmin)
+	p.addRoute(http.MethodPost, cms.RouteLineItemPayouts,
+		p.handleLineItemPayouts, permissionAdmin)
 }

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -601,6 +601,22 @@ func convertLineItemsToDatabase(token string, l []cms.LineItemsInput) []cmsdatab
 	return dl
 }
 
+func convertDatabaseToLineItems(dl []cmsdatabase.LineItem) []cms.LineItemsInput {
+	l := make([]cms.LineItemsInput, 0, len(dl))
+	for _, v := range dl {
+		l = append(l, cms.LineItemsInput{
+			Type:          v.Type,
+			Domain:        v.Domain,
+			Subdomain:     v.Subdomain,
+			Description:   v.Description,
+			ProposalToken: v.ProposalURL,
+			Labor:         v.Labor,
+			Expenses:      v.Expenses,
+		})
+	}
+	return l
+}
+
 func convertRecordToDatabaseInvoice(p pd.Record) (*cmsdatabase.Invoice, error) {
 	dbInvoice := cmsdatabase.Invoice{
 		Files:           convertRecordFilesToWWW(p.Files),

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1556,3 +1556,22 @@ func decodeBackendInvoiceStatusChanges(payload []byte) ([]backendInvoiceStatusCh
 
 	return md, nil
 }
+
+// processLineItemPayouts looks for all line items within the given start and end dates.
+func (p *politeiawww) processLineItemPayouts(lip cms.LineItemPayouts) (*cms.LineItemPayoutsReply, error) {
+	reply := &cms.LineItemPayoutsReply{}
+
+	// check for valid dates
+	if lip.StartTime > lip.EndTime {
+		return nil, www.UserError{
+			ErrorCode: cms.ErrorStatusInvalidDatesRequested,
+		}
+	}
+	dbLineItems, err := p.cmsDB.LineItemsByDateRange(lip.StartTime, lip.EndTime)
+	if err != nil {
+		return nil, err
+	}
+	lineItems := convertDatabaseToLineItems(dbLineItems)
+	reply.LineItems = lineItems
+	return reply, nil
+}


### PR DESCRIPTION
This command allows administrators to query the cms database for
all paid out line items within a given period of time.  This will be
used to create public summaries of expenditures by domain for any
given month.