### PR TITLE
[cms] Trim spaces for Address for payouts

### DIFF
--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1184,9 +1184,9 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 		payout.ContractorRate = inv.ContractorRate
 		payout.ExpenseTotal = totalExpenses
 
-		payout.Address = inv.PaymentAddress
+		payout.Address = strings.TrimSpace(inv.PaymentAddress)
 		payout.Token = inv.Token
-		payout.ContractorName = inv.ContractorName
+		payout.ContractorName = strings.TrimSpace(inv.ContractorName)
 
 		payout.Username = username
 		payout.Month = inv.Month


### PR DESCRIPTION
This should fix the following issue:
Admin reported that an address had an extra space within the exported payout CSV.  This caused problems when attempting to process the payouts and had to fixed manually.