### PR TITLE
[cms] Remove check for multiple invoices per month

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -723,7 +723,6 @@ Reply:
 | <a name="ErrorStatusMalformedDescription">ErrorStatusMalformedDescription</a> | 1020 | Malformed description for a line item. |
 | <a name="ErrorStatusWrongInvoiceStatus">ErrorStatusWrongInvoiceStatus</a> | 1021 | Wrong status for an invoice to be editted (approved, rejected, paid). |
 | <a name="ErrorStatusInvoiceRequireLineItems">ErrorStatusInvoiceRequireLineItems</a> | 1022 | Invoices require at least 1 line item to be included. |
-| <a name="ErrorStatusMultipleInvoiceMonthYear">ErrorStatusMultipleInvoiceMonthYear</a> | 1023 | Users are only allowed to submit 1 invoice per month/year. |
 | <a name="ErrorStatusInvalidInvoiceMonthYear">ErrorStatusInvalidInvoiceMonthYear</a> | 1024 | An invalid month/year was detected in an invoice. |
 | <a name="ErrorStatusInvalidExchangeRate">ErrorStatusInvalidExchangeRate</a> | 1025 | Invalid Exchange Rate |
 | <a name="ErrorStatusInvalidLineItemType">ErrorStatusInvalidLineItemType</a> | 1026 | An invalid line item type was attempted. |

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -124,7 +124,6 @@ const (
 	ErrorStatusMalformedDescription           www.ErrorStatusT = 1020
 	ErrorStatusWrongInvoiceStatus             www.ErrorStatusT = 1021
 	ErrorStatusInvoiceRequireLineItems        www.ErrorStatusT = 1022
-	ErrorStatusMultipleInvoiceMonthYear       www.ErrorStatusT = 1023
 	ErrorStatusInvalidInvoiceMonthYear        www.ErrorStatusT = 1024
 	ErrorStatusInvalidExchangeRate            www.ErrorStatusT = 1025
 	ErrorStatusInvalidLineItemType            www.ErrorStatusT = 1026
@@ -181,7 +180,6 @@ var (
 		ErrorStatusMalformedDescription:           "line item has malformed description",
 		ErrorStatusWrongInvoiceStatus:             "invoice is an wrong status to be editted (approved, rejected or paid)",
 		ErrorStatusInvoiceRequireLineItems:        "invoices require at least 1 line item",
-		ErrorStatusMultipleInvoiceMonthYear:       "only one invoice per month/year is allowed to be submitted",
 		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
 		ErrorStatusInvalidExchangeRate:            "exchange rate was invalid or didn't match expected result",
 		ErrorStatusDuplicatePaymentAddress:        "a duplicate payment address was used",

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -265,19 +265,6 @@ func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.N
 	if err != nil {
 		return nil, err
 	}
-	// Check to make sure user has not yet submitted an invoice for the month/year
-	dbInvs, err := p.cmsDB.InvoicesByUserID(u.ID.String())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, dbInv := range dbInvs {
-		if dbInv.Month == ni.Month && dbInv.Year == ni.Year {
-			return nil, www.UserError{
-				ErrorCode: cms.ErrorStatusMultipleInvoiceMonthYear,
-			}
-		}
-	}
 
 	m := backendInvoiceMetadata{
 		Version:   backendInvoiceMetadataVersion,


### PR DESCRIPTION
Close #849
After consideration, the administrators felt like there could be valid situations where a contractor may need to submit multiple invoices for a given month.