### PR TITLE
[cms] Fix address watching for invoices

### DIFF
--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -217,7 +217,6 @@ func (p *politeiawww) checkHistoricalPayments(payment *database.Payments) bool {
 // It will return TRUE if paid, otherwise false.  It utilizes the util
 // FetchTxs which looks for transaction at a given address.
 func (p *politeiawww) checkPayments(payment *database.Payments, watchedAddr, notifiedTx string) bool {
-	// Get all txs since start time of watcher
 	txs, err := util.FetchTx(watchedAddr, notifiedTx)
 	if err != nil {
 		// XXX Some sort of 'recheck' or notice that it should do it again?

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -105,7 +105,11 @@ func (c *cockroachdb) InvoiceByToken(token string) (*database.Invoice, error) {
 	invoice := Invoice{
 		Token: token,
 	}
-	err := c.recordsdb.Find(&invoice).Error
+	err := c.recordsdb.
+		Preload("LineItems").
+		Preload("Changes").
+		Preload("Payments").
+		Find(&invoice).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			err = database.ErrInvoiceNotFound
@@ -524,10 +528,10 @@ func (c *cockroachdb) UpdatePayments(dbPayments *database.Payments) error {
 func (c *cockroachdb) PaymentsByAddress(address string) (*database.Payments, error) {
 	log.Debugf("PaymentsByAddress: %v", address)
 
-	payments := Payments{
-		Address: address,
-	}
-	err := c.recordsdb.Find(&payments).Error
+	payments := Payments{}
+	err := c.recordsdb.
+		Where("address = ?", address).
+		Find(&payments).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			err = database.ErrInvoiceNotFound

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -470,7 +470,8 @@ func FetchTxsForAddressNotBefore(address string, notBefore int64) ([]TxDetails, 
 		if err != nil {
 			return nil, fmt.Errorf("fetchDcrdataAddress: %v", err)
 		}
-
+		log.Printf("fetching txs for address %s not before %s from primary %s\n",
+			address, time.Unix(notBefore, 0), url)
 		// Convert transactions to TxDetails
 		txs := make([]TxDetails, len(dcrdataTxs))
 		for _, tx := range dcrdataTxs {
@@ -481,7 +482,10 @@ func FetchTxsForAddressNotBefore(address string, notBefore int64) ([]TxDetails, 
 			}
 			txs = append(txs, *txDetails)
 		}
-
+		if len(txs) == 0 {
+			done = true
+			continue
+		}
 		// Sanity check. Txs should already be sorted
 		// in reverse chronological order.
 		sort.SliceStable(txs, func(i, j int) bool {

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -470,8 +470,6 @@ func FetchTxsForAddressNotBefore(address string, notBefore int64) ([]TxDetails, 
 		if err != nil {
 			return nil, fmt.Errorf("fetchDcrdataAddress: %v", err)
 		}
-		log.Printf("fetching txs for address %s not before %s from primary %s\n",
-			address, time.Unix(notBefore, 0), url)
 		// Convert transactions to TxDetails
 		txs := make([]TxDetails, len(dcrdataTxs))
 		for _, tx := range dcrdataTxs {


### PR DESCRIPTION
This fixes some outstanding issues with payment checking and
address watching.  

Now upon address subscription notification, the included txid
and the address will be used to query dcrdata for the
full transaction information via util.FetchTx.  

For restart, it will now use checkHistoricalPayments which
still uses util.FetchTxsForAddressNotBefore to pull all transactions
for a given address before a given time.