### PR TITLE
www: Remove email lookups from reset password.

### DIFF
--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -32,6 +32,7 @@ const (
 	RouteChangeUsername           = "/user/username/change"
 	RouteChangePassword           = "/user/password/change"
 	RouteResetPassword            = "/user/password/reset"
+	RouteVerifyResetPassword      = "/user/password/reset/verify"
 	RouteUserProposals            = "/user/proposals"
 	RouteUserProposalCredits      = "/user/proposals/credits"
 	RouteUserCommentsLikes        = "/user/proposals/{token:[A-z0-9]{64}}/commentslikes"
@@ -544,19 +545,33 @@ type ChangePassword struct {
 // is logged in.
 type ChangePasswordReply struct{}
 
-// ResetPassword is used to perform a password change when the
-// user is not logged in.
+// ResetPassword is used to perform a password change when the user is not
+// logged in. If the username and email address match the user record in the
+// database then a reset password verification token will be email to the user.
 type ResetPassword struct {
-	Email             string `json:"email"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}
+
+// ResetPasswordReply is used to reply to the ResetPassword command. The
+// verification token will only be present if the email server has been
+// disabled.
+type ResetPasswordReply struct {
+	VerificationToken string `json:"verificationtoken"`
+}
+
+// VerifyResetPassword is used to verify the verification token sent to a user
+// in the ResestPassword command and will update the user's password with the
+// provided NewPassword if everything matches.
+type VerifyResetPassword struct {
+	Username          string `json:"username"`
 	VerificationToken string `json:"verificationtoken"`
 	NewPassword       string `json:"newpassword"`
 }
 
-// ResetPasswordReply is used to reply to the ResetPassword command
-// with an error if the command is unsuccessful.
-type ResetPasswordReply struct {
-	VerificationToken string `json:"verificationtoken"`
-}
+// VerifyResetPasswordReply is used to reply to the VerifyResetPassword
+// command.
+type VerifyResetPasswordReply struct{}
 
 // UserProposalCredits is used to request a list of all the user's unspent
 // proposal credits and a list of all of the user's spent proposal credits.

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -624,6 +624,29 @@ func (c *Client) ResetPassword(rp *v1.ResetPassword) (*v1.ResetPasswordReply, er
 	return &rpr, nil
 }
 
+// VerifyResetPassword sends the VerifyResetPassword command to politeiawww.
+func (c *Client) VerifyResetPassword(vrp v1.VerifyResetPassword) (*v1.VerifyResetPasswordReply, error) {
+	respBody, err := c.makeRequest("POST", v1.RouteVerifyResetPassword, vrp)
+	if err != nil {
+		return nil, err
+	}
+
+	var reply v1.VerifyResetPasswordReply
+	err = json.Unmarshal(respBody, &reply)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal VerifyResetPasswordReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(reply)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &reply, nil
+}
+
 // ProposalPaywallDetails retrieves proposal credit paywall information for the
 // logged in user.
 func (c *Client) ProposalPaywallDetails() (*v1.ProposalPaywallDetailsReply, error) {

--- a/politeiawww/userwww_test.go
+++ b/politeiawww/userwww_test.go
@@ -525,53 +525,51 @@ func TestHandleResetPassword(t *testing.T) {
 	p, cleanup := newTestPoliteiawww(t)
 	defer cleanup()
 
-	// Create a user that has already been assigned a reset
-	// password verification token.
+	// Create a test user
 	usr, _ := newUser(t, p, true, false)
-	newPass := usr.Username + "aaa"
-	token, expiry, err := newVerificationTokenAndExpiry()
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	usr.ResetPasswordVerificationToken = token
-	usr.ResetPasswordVerificationExpiry = expiry
-	err = p.db.UserUpdate(*usr)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
+
+	// Remove the min wait time requirement so that the tests
+	// aren't slow.
+	wt := resetPasswordMinWaitTime
+	resetPasswordMinWaitTime = 0 * time.Millisecond
+	defer func() {
+		resetPasswordMinWaitTime = wt
+	}()
 
 	// Setup tests
 	var tests = []struct {
 		name       string
 		reqBody    interface{}
-		wantStatus int
+		wantStatus int // HTTP status code
 		wantError  error
 	}{
-		{"invalid request body", "", http.StatusBadRequest,
+		{
+			"invalid request body",
+			"",
+			http.StatusBadRequest,
 			www.UserError{
 				ErrorCode: www.ErrorStatusInvalidInput,
-			}},
-
-		{"user not found", www.ResetPassword{}, http.StatusOK, nil},
-
-		{"processResetPassword error",
+			},
+		},
+		{
+			"processResetPassword error",
 			www.ResetPassword{
-				Email:             usr.Email,
-				VerificationToken: hex.EncodeToString(token),
-				NewPassword:       "x",
+				Username: "wrongusername",
 			},
 			http.StatusBadRequest,
 			www.UserError{
-				ErrorCode: www.ErrorStatusMalformedPassword,
-			}},
-
-		{"success",
-			www.ResetPassword{
-				Email:             usr.Email,
-				VerificationToken: hex.EncodeToString(token),
-				NewPassword:       newPass,
+				ErrorCode: www.ErrorStatusUserNotFound,
 			},
-			http.StatusOK, nil},
+		},
+		{
+			"success",
+			www.ResetPassword{
+				Username: usr.Username,
+				Email:    usr.Email,
+			},
+			http.StatusOK,
+			nil,
+		},
 	}
 
 	// Run tests
@@ -608,6 +606,99 @@ func TestHandleResetPassword(t *testing.T) {
 			if got != want {
 				t.Errorf("got error %v, want %v",
 					got, want)
+			}
+		})
+	}
+}
+
+func TestHandleVerifyResetPassword(t *testing.T) {
+	p, cleanup := newTestPoliteiawww(t)
+	defer cleanup()
+
+	// Create a user that has already been assigned a reset
+	// password verification token.
+	usr, _ := newUser(t, p, true, false)
+	token, expiry, err := newVerificationTokenAndExpiry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	usr.ResetPasswordVerificationToken = token
+	usr.ResetPasswordVerificationExpiry = expiry
+	err = p.db.UserUpdate(*usr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verificationToken := hex.EncodeToString(token)
+
+	// Setup tests
+	var tests = []struct {
+		name       string
+		reqBody    interface{}
+		wantStatus int // HTTP status code
+		wantErr    error
+	}{
+		{
+			"invalid request body",
+			"",
+			http.StatusBadRequest,
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			},
+		},
+		{
+			"processVerifyResetPassword error",
+			www.VerifyResetPassword{
+				Username: "wrongusername",
+			},
+			http.StatusBadRequest,
+			www.UserError{
+				ErrorCode: www.ErrorStatusUserNotFound,
+			},
+		},
+		{
+			"success",
+			www.VerifyResetPassword{
+				Username:          usr.Username,
+				VerificationToken: verificationToken,
+				NewPassword:       "helloworld",
+			},
+			http.StatusOK,
+			nil,
+		},
+	}
+
+	// Run tests
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			// Setup request
+			r := newPostReq(t, www.RouteVerifyResetPassword, v.reqBody)
+			w := httptest.NewRecorder()
+
+			// Run test case
+			p.handleVerifyResetPassword(w, r)
+			res := w.Result()
+			body, _ := ioutil.ReadAll(res.Body)
+
+			// Check status code
+			if res.StatusCode != v.wantStatus {
+				t.Errorf("got status code %v, want %v",
+					res.StatusCode, v.wantStatus)
+			}
+			if res.StatusCode == http.StatusOK {
+				// Test case passes; next case
+				return
+			}
+
+			// Check user error
+			var ue www.UserError
+			err := json.Unmarshal(body, &ue)
+			if err != nil {
+				t.Errorf("unmarshal UserError: %v", err)
+			}
+			got := errToStr(ue)
+			want := errToStr(v.wantErr)
+			if got != want {
+				t.Errorf("got error %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
This is required for #860.

This diff removes the user lookups by email address from the reset
password route and splits the ResetPassword route into two separate
routes.

ResetPassword
VerifyResetPassword

This is consistent with the pattern that is used for VerifyNewUser and
VerifyUpdateUserKey.

Since the ResetPassword command now contains the username and email
address, it was necessary to add a minimum wait time to the route in
order to prevent an attacker from being able to execute a timing attack
to determine if the provided email address is the user's valid email
address.

politeiagui changes will need to be completed before this can be merged.