### PR TITLE
www: Switch login to use username.

### DIFF
--- a/politeiavoter/politeiavoter.go
+++ b/politeiavoter/politeiavoter.go
@@ -912,9 +912,9 @@ func (c *ctx) tally(args []string) error {
 	return nil
 }
 
-func (c *ctx) login(email, password string) (*v1.LoginReply, error) {
+func (c *ctx) login(username, password string) (*v1.LoginReply, error) {
 	l := v1.Login{
-		Email:    email,
+		Username: username,
 		Password: password,
 	}
 
@@ -952,7 +952,7 @@ func (c *ctx) _startVote(sv *v1.StartVote) (*v1.StartVoteReply, error) {
 func (c *ctx) startVote(args []string) error {
 	if len(args) != 4 {
 		return fmt.Errorf("startvote: not enough arguments, expected:" +
-			"identityfile email password token")
+			"identityfile username password token")
 	}
 
 	// startvote identityfile email password token

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -55,7 +55,7 @@ notifications.  It does not render HTML.
 **Error status codes**
 
 - [`ErrorStatusInvalid`](#ErrorStatusInvalid)
-- [`ErrorStatusInvalidEmailOrPassword`](#ErrorStatusInvalidEmailOrPassword)
+- [`ErrorStatusInvalidPassword`](#ErrorStatusInvalidPassword)
 - [`ErrorStatusMalformedEmail`](#ErrorStatusMalformedEmail)
 - [`ErrorStatusVerificationTokenInvalid`](#ErrorStatusVerificationTokenInvalid)
 - [`ErrorStatusVerificationTokenExpired`](#ErrorStatusVerificationTokenExpired)
@@ -306,10 +306,6 @@ Return pertinent user information of the current logged in user.
 
 **Results**: See the [`Login reply`](#login-reply).
 
-On failure the call shall return `403 Forbidden` and one of the following
-error codes:
-- [`ErrorStatusInvalidEmailOrPassword`](#ErrorStatusInvalidEmailOrPassword)
-
 **Example**
 
 Request:
@@ -506,7 +502,7 @@ the user database.  Note that Login reply is identical to Me reply.
 
 On failure the call shall return `401 Unauthorized` and one of the following
 error codes:
-- [`ErrorStatusInvalidEmailOrPassword`](#ErrorStatusInvalidEmailOrPassword)
+- [`ErrorStatusInvalidPassword`](#ErrorStatusInvalidPassword)
 - [`ErrorStatusUserLocked`](#ErrorStatusUserLocked)
 - [`ErrorStatusUserDeactivated`](#ErrorStatusUserDeactivated)
 - [`ErrorStatusEmailNotVerified`](#ErrorStatusEmailNotVerified)
@@ -859,7 +855,7 @@ Changes the username for the currently logged in user.
 
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
-- [`ErrorStatusInvalidEmailOrPassword`](#ErrorStatusInvalidEmailOrPassword)
+- [`ErrorStatusInvalidPassword`](#ErrorStatusInvalidPassword)
 - [`ErrorStatusMalformedUsername`](#ErrorStatusMalformedUsername)
 - [`ErrorStatusDuplicateUsername`](#ErrorStatusDuplicateUsername)
 
@@ -897,7 +893,7 @@ Changes the password for the currently logged in user.
 
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
-- [`ErrorStatusInvalidEmailOrPassword`](#ErrorStatusInvalidEmailOrPassword)
+- [`ErrorStatusInvalidPassword`](#ErrorStatusInvalidPassword)
 - [`ErrorStatusMalformedPassword`](#ErrorStatusMalformedPassword)
 
 **Example**
@@ -2481,7 +2477,7 @@ Reply:
 | Status | Value | Description |
 |-|-|-|
 | <a name="ErrorStatusInvalid">ErrorStatusInvalid</a> | 0 | The operation returned an invalid status. This shall be considered a bug. |
-| <a name="ErrorStatusInvalidEmailOrPassword">ErrorStatusInvalidEmailOrPassword</a> | 1 | Either the user name or password was invalid. |
+| <a name="ErrorStatusInvalidPassword">ErrorStatusInvalidPassword</a> | 1 | The password is invalid. |
 | <a name="ErrorStatusMalformedEmail">ErrorStatusMalformedEmail</a> | 2 | The provided email address was malformed. |
 | <a name="ErrorStatusVerificationTokenInvalid">ErrorStatusVerificationTokenInvalid</a> | 3 | The provided user activation token is invalid. |
 | <a name="ErrorStatusVerificationTokenExpired">ErrorStatusVerificationTokenExpired</a> | 4 | The provided user activation token is expired. |
@@ -2539,7 +2535,6 @@ Reply:
 | <a name="ErrorStatusInvalidUUID">ErrorStatusInvalidUUID</a> | 56 | Invalid user UUID. |
 | <a name="ErrorStatusInvalidLikeCommentAction">ErrorStatusInvalidLikeCommentAction</a> | 57 | Invalid like comment action. |
 | <a name="ErrorStatusInvalidCensorshipToken">ErrorStatusInvalidCensorshipToken</a> | 58 | Invalid proposal censorship token. |
-| <a name="ErrorStatusInvalidPassword">ErrorStatusInvalidPassword</a> | 85 | User password was invalid |
 | <a name="ErrorStatusNoProposalChanges">ErrorStatusNoProposalChanges</a> | 88 | No changes found in proposal. |
 
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -117,7 +117,7 @@ const (
 
 	// Error status codes
 	ErrorStatusInvalid                     ErrorStatusT = 0
-	ErrorStatusInvalidEmailOrPassword      ErrorStatusT = 1
+	ErrorStatusInvalidPassword             ErrorStatusT = 1
 	ErrorStatusMalformedEmail              ErrorStatusT = 2
 	ErrorStatusVerificationTokenInvalid    ErrorStatusT = 3
 	ErrorStatusVerificationTokenExpired    ErrorStatusT = 4
@@ -176,7 +176,6 @@ const (
 	ErrorStatusInvalidLikeCommentAction    ErrorStatusT = 57
 	ErrorStatusInvalidCensorshipToken      ErrorStatusT = 58
 	ErrorStatusEmailAlreadyVerified        ErrorStatusT = 59
-	ErrorStatusInvalidPassword             ErrorStatusT = 85
 	ErrorStatusNoProposalChanges           ErrorStatusT = 88
 
 	// Proposal state codes
@@ -256,7 +255,7 @@ var (
 	// ErrorStatus converts error status codes to human readable text.
 	ErrorStatus = map[ErrorStatusT]string{
 		ErrorStatusInvalid:                     "invalid error status",
-		ErrorStatusInvalidEmailOrPassword:      "invalid email or password",
+		ErrorStatusInvalidPassword:             "invalid password",
 		ErrorStatusMalformedEmail:              "malformed email",
 		ErrorStatusVerificationTokenInvalid:    "invalid verification token",
 		ErrorStatusVerificationTokenExpired:    "expired verification token",
@@ -315,7 +314,6 @@ var (
 		ErrorStatusInvalidLikeCommentAction:    "invalid like comment action",
 		ErrorStatusInvalidCensorshipToken:      "invalid proposal censorship token",
 		ErrorStatusEmailAlreadyVerified:        "email address is already verified",
-		ErrorStatusInvalidPassword:             "invalid password",
 		ErrorStatusNoProposalChanges:           "no changes found in proposal",
 	}
 
@@ -643,7 +641,7 @@ type AbridgedUser struct {
 // Login attempts to login the user.  Note that by necessity the password
 // travels in the clear.
 type Login struct {
-	Email    string `json:"email"`
+	Username string `json:"username"`
 	Password string `json:"password"`
 }
 

--- a/politeiawww/cmd/politeiawwwcli/commands/login.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/login.go
@@ -13,30 +13,21 @@ import (
 // LoginCmd logs into Politeia using the specified credentials.
 type LoginCmd struct {
 	Args struct {
-		Email    string `positional-arg-name:"email"`    // User email address
-		Password string `positional-arg-name:"password"` // User password
+		Username string `positional-arg-name:"username"`
+		Password string `positional-arg-name:"password"`
 	} `positional-args:"true" required:"true"`
 }
 
 // Execute executes the login command.
 func (cmd *LoginCmd) Execute(args []string) error {
-	email := cmd.Args.Email
-	password := cmd.Args.Password
-
-	// Fetch CSRF tokens
-	_, err := client.Version()
-	if err != nil {
-		return err
-	}
-
 	// Setup login request
 	l := &v1.Login{
-		Email:    email,
-		Password: digestSHA3(password),
+		Username: cmd.Args.Username,
+		Password: digestSHA3(cmd.Args.Password),
 	}
 
 	// Print request details
-	err = printJSON(l)
+	err := printJSON(l)
 	if err != nil {
 		return err
 	}
@@ -58,13 +49,13 @@ func (cmd *LoginCmd) Execute(args []string) error {
 }
 
 // loginHelpMsg is the output for the help command when 'login' is specified.
-const loginHelpMsg = `login "email" "password"
+const loginHelpMsg = `login "username" "password"
 
 Login as a user or admin.
 
 Arguments:
-1. email      (string, required)   Email address of user
-2. password   (string, required)   Accompanying password for provided email
+1. username   (string, required)   Username
+2. password   (string, required)   Password
 
 Result:
 {

--- a/politeiawww/cmd/politeiawwwcli/commands/newuser.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newuser.go
@@ -122,7 +122,7 @@ func (cmd *NewUserCmd) Execute(args []string) error {
 
 	// Login to politeia
 	l := &v1.Login{
-		Email:    email,
+		Username: username,
 		Password: digestSHA3(password),
 	}
 

--- a/politeiawww/cmd/politeiawwwcli/commands/register.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/register.go
@@ -143,7 +143,7 @@ func (cmd *RegisterUserCmd) Execute(args []string) error {
 
 	// Login to cms
 	l := &www.Login{
-		Email:    email,
+		Username: cmd.Username,
 		Password: digestSHA3(cmd.Password),
 	}
 

--- a/politeiawww/cmd/politeiawwwcli/commands/testrun.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/testrun.go
@@ -17,8 +17,8 @@ import (
 // TestRunCmd performs a test run of all the politeiawww routes.
 type TestRunCmd struct {
 	Args struct {
-		AdminEmail    string `positional-arg-name:"adminemail"`    // Admin email
-		AdminPassword string `positional-arg-name:"adminpassword"` // Admin password
+		AdminUsername string `positional-arg-name:"adminusername"`
+		AdminPassword string `positional-arg-name:"adminpassword"`
 	} `positional-args:"true" required:"true"`
 }
 
@@ -32,9 +32,9 @@ type testUser struct {
 }
 
 // login logs in the specified user.
-func login(email, password string) error {
+func login(username, password string) error {
 	lc := LoginCmd{}
-	lc.Args.Email = email
+	lc.Args.Username = username
 	lc.Args.Password = password
 	return lc.Execute(nil)
 }
@@ -107,9 +107,9 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	// Ensure admin credentials are valid and that the admin has
 	// paid their user registration fee.
 	fmt.Printf("Validating admin credentials\n")
-	admin.email = cmd.Args.AdminEmail
+	admin.username = cmd.Args.AdminUsername
 	admin.password = cmd.Args.AdminPassword
-	err = login(admin.email, admin.password)
+	err = login(admin.username, admin.password)
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	fmt.Printf("Login user\n")
 	lr, err := client.Login(
 		&v1.Login{
-			Email:    email,
+			Username: username,
 			Password: digestSHA3(password),
 		})
 	if err != nil {
@@ -386,7 +386,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Login with admin and make the proposal public
 	fmt.Printf("  Login admin\n")
-	err = login(admin.email, admin.password)
+	err = login(admin.username, admin.password)
 	if err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Log back in with user
 	fmt.Printf("  Login user\n")
-	err = login(user.email, user.password)
+	err = login(user.username, user.password)
 	if err != nil {
 		return err
 	}
@@ -601,7 +601,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Login
 	fmt.Printf("  Login admin\n")
-	err = login(admin.email, admin.password)
+	err = login(admin.username, admin.password)
 	if err != nil {
 		return err
 	}
@@ -664,7 +664,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	// Login with user in order to submit proposals that we can
 	// use to test the set proposal status route.
 	fmt.Printf("  Login user\n")
-	err = login(user.email, user.password)
+	err = login(user.username, user.password)
 	if err != nil {
 		return err
 	}
@@ -756,7 +756,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Log back in with admin
 	fmt.Printf("  Login admin\n")
-	err = login(admin.email, admin.password)
+	err = login(admin.username, admin.password)
 	if err != nil {
 		return err
 	}
@@ -931,7 +931,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Login with user
 	fmt.Printf("  Login user\n")
-	err = login(user.email, user.password)
+	err = login(user.username, user.password)
 	if err != nil {
 		return err
 	}
@@ -951,7 +951,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Log back in with admin
 	fmt.Printf("  Login admin\n")
-	err = login(admin.email, admin.password)
+	err = login(admin.username, admin.password)
 	if err != nil {
 		return err
 	}
@@ -1394,7 +1394,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Login with user
 	fmt.Printf("  Login user\n")
-	err = login(user.email, user.password)
+	err = login(user.username, user.password)
 	if err != nil {
 		return err
 	}
@@ -1418,7 +1418,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	return nil
 }
 
-const testRunHelpMsg = `testrun "adminemail" "adminpassword"
+const testRunHelpMsg = `testrun "adminusername" "adminpassword"
 
 Run a series of tests on the politeiawww routes.  This command can only be run
 on testnet.
@@ -1435,6 +1435,6 @@ not being run locally or if the wallet does not contain any eligible tickets
 a warning will be logged and voting will be skipped.
 
 Arguments:
-1. adminemail      (string, required)   Admin email
+1. adminusername   (string, required)   Admin username
 2. adminpassword   (string, required)   Admin password
 `

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1150,8 +1150,8 @@ func (p *politeiawww) processVerifyUpdateUserKey(u *user.User, vu www.VerifyUpda
 	return u, p.db.UserUpdate(*u)
 }
 
-// processLogin logs a user into politeiawww using the provided username and
-// password.
+// processLogin checks that the provided user credentials are valid and updates
+// the login fields for the user.
 func (p *politeiawww) processLogin(l www.Login) (*www.LoginReply, error) {
 	log.Tracef("processLogin: %v", l.Username)
 

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -37,19 +37,7 @@ const (
 var (
 	validUsername = regexp.MustCompile(createUsernameRegex())
 	validEmail    = regexp.MustCompile(emailRegex)
-
-	// MinimumLoginWaitTime is the minimum amount of time to wait before the
-	// server sends a response to the client for the login route. This is done
-	// to prevent an attacker from executing a timing attack to determine whether
-	// the ErrorStatusInvalidEmailOrPassword response is specific to a bad email
-	// or bad password.
-	MinimumLoginWaitTime = 500 * time.Millisecond
 )
-
-type loginReplyWithError struct {
-	reply *www.LoginReply
-	err   error
-}
 
 // createUsernameRegex generates a regex based on the policy supplied valid
 // characters in a user name.
@@ -687,119 +675,6 @@ func (p *politeiawww) processUserCommentsLikes(user *user.User, token string) (*
 	}, nil
 }
 
-// login attempts to login a a user.
-func (p *politeiawww) login(l *www.Login) loginReplyWithError {
-	// Get user from db.
-	u, err := p.userByEmail(l.Email)
-	if err != nil {
-		if err == user.ErrUserNotFound {
-			log.Debugf("Login failure for %v: user not found in database",
-				l.Email)
-			return loginReplyWithError{
-				reply: nil,
-				err: www.UserError{
-					ErrorCode: www.ErrorStatusInvalidEmailOrPassword,
-				},
-			}
-		}
-
-		return loginReplyWithError{
-			reply: nil,
-			err:   err,
-		}
-	}
-
-	// Check the user's password.
-	err = bcrypt.CompareHashAndPassword(u.HashedPassword,
-		[]byte(l.Password))
-	if err != nil {
-		if !userIsLocked(u.FailedLoginAttempts) {
-			u.FailedLoginAttempts++
-			err := p.db.UserUpdate(*u)
-			if err != nil {
-				return loginReplyWithError{
-					reply: nil,
-					err:   err,
-				}
-			}
-
-			// Check if the user is locked again so we can send an
-			// email.
-			if userIsLocked(u.FailedLoginAttempts) && !p.test {
-				// This is conditional on the email server
-				// being setup.
-				err := p.emailUserLocked(u.Email)
-				if err != nil {
-					return loginReplyWithError{
-						reply: nil,
-						err:   err,
-					}
-				}
-			}
-		}
-
-		log.Debugf("Login failure for %v: incorrect password",
-			l.Email)
-		return loginReplyWithError{
-			reply: nil,
-			err: www.UserError{
-				ErrorCode: www.ErrorStatusInvalidEmailOrPassword,
-			},
-		}
-	}
-
-	// Check that the user is verified.
-	if u.NewUserVerificationToken != nil {
-		log.Debugf("Login failure for %v: user not yet verified",
-			l.Email)
-		return loginReplyWithError{
-			reply: nil,
-			err: www.UserError{
-				ErrorCode: www.ErrorStatusEmailNotVerified,
-			},
-		}
-	}
-
-	// Check if the user account is deactivated.
-	if u.Deactivated {
-		log.Debugf("Login failure for %v: user deactivated", l.Email)
-		return loginReplyWithError{
-			reply: nil,
-			err: www.UserError{
-				ErrorCode: www.ErrorStatusUserDeactivated,
-			},
-		}
-	}
-
-	// Check if user is locked due to too many login attempts
-	if userIsLocked(u.FailedLoginAttempts) {
-		log.Debugf("Login failure for %v: user locked",
-			l.Email)
-		return loginReplyWithError{
-			reply: nil,
-			err: www.UserError{
-				ErrorCode: www.ErrorStatusUserLocked,
-			},
-		}
-	}
-
-	lastLoginTime := u.LastLoginTime
-	u.FailedLoginAttempts = 0
-	u.LastLoginTime = time.Now().Unix()
-	err = p.db.UserUpdate(*u)
-	if err != nil {
-		return loginReplyWithError{
-			reply: nil,
-			err:   err,
-		}
-	}
-	reply, err := p.createLoginReply(u, lastLoginTime)
-	return loginReplyWithError{
-		reply: reply,
-		err:   err,
-	}
-}
-
 // emailResetPassword handles the reset password command.
 func (p *politeiawww) emailResetPassword(u *user.User, rp www.ResetPassword, rpr *www.ResetPasswordReply) error {
 	if u.ResetPasswordVerificationToken != nil {
@@ -1275,36 +1150,78 @@ func (p *politeiawww) processVerifyUpdateUserKey(u *user.User, vu www.VerifyUpda
 	return u, p.db.UserUpdate(*u)
 }
 
-// processLogin checks that a user exists, is verified, and has
-// the correct password.
+// processLogin logs a user into politeiawww using the provided username and
+// password.
 func (p *politeiawww) processLogin(l www.Login) (*www.LoginReply, error) {
-	var (
-		r       loginReplyWithError
-		login   = make(chan loginReplyWithError)
-		timeout = make(chan bool)
-	)
+	log.Tracef("processLogin: %v", l.Username)
 
-	go func() {
-		login <- p.login(&l)
-	}()
-	go func() {
-		time.Sleep(MinimumLoginWaitTime)
-		timeout <- true
-	}()
-
-	// Execute both goroutines in parallel, and only return
-	// when both are finished.
-	select {
-	case r = <-login:
-	case <-timeout:
+	// Lookup user
+	u, err := p.db.UserGetByUsername(l.Username)
+	if err != nil {
+		if err == user.ErrUserNotFound {
+			err = www.UserError{
+				ErrorCode: www.ErrorStatusUserNotFound,
+			}
+		}
+		return nil, err
 	}
 
-	select {
-	case r = <-login:
-	case <-timeout:
+	// Ensure the account isn't locked
+	if userIsLocked(u.FailedLoginAttempts) {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusUserLocked,
+		}
 	}
 
-	return r.reply, r.err
+	// Check the password
+	err = bcrypt.CompareHashAndPassword(u.HashedPassword,
+		[]byte(l.Password))
+	if err != nil {
+		// Password is wrong. Increment failed login attempts.
+		u.FailedLoginAttempts++
+		err := p.db.UserUpdate(*u)
+		if err != nil {
+			return nil, err
+		}
+
+		// If the user account has reached the limit for failed
+		// login attempts, send the user an email to notify them
+		// that their account is locked.
+		if userIsLocked(u.FailedLoginAttempts) {
+			err := p.emailUserLocked(u.Email)
+			if err != nil {
+				log.Errorf("processLogin: emailUserLocked '%v': %v",
+					u.Email, err)
+			}
+		}
+
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusInvalidPassword,
+		}
+	}
+
+	// Ensure user has been verified and has not been deactivated.
+	if u.NewUserVerificationToken != nil {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusEmailNotVerified,
+		}
+	}
+	if u.Deactivated {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusUserDeactivated,
+		}
+	}
+
+	// Update user login fields
+	lastLoginTime := u.LastLoginTime
+	u.FailedLoginAttempts = 0
+	u.LastLoginTime = time.Now().Unix()
+	err = p.db.UserUpdate(*u)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.createLoginReply(u, lastLoginTime)
 }
 
 // processChangeUsername checks that the password matches the one
@@ -1377,7 +1294,7 @@ func (p *politeiawww) processChangePassword(email string, cp www.ChangePassword)
 		[]byte(cp.CurrentPassword))
 	if err != nil {
 		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusInvalidEmailOrPassword,
+			ErrorCode: www.ErrorStatusInvalidPassword,
 		}
 	}
 


### PR DESCRIPTION
This is required for #860.

This diff switches the login to require that a user login using their
username instead of their email address. The timing attack protection
was removed since usernames are public.

politeiagui changes will need to be completed before this can be merged.