### PR TITLE
[www] Add Vote Summary to Proposal Record

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -10,6 +10,7 @@ const (
 	CmdStartVote             = "startvote"
 	CmdVoteDetails           = "votedetails"
 	CmdVoteSummary           = "votesummary"
+	CmdBatchVoteSummary      = "batchvotesummary"
 	CmdLoadVoteResults       = "loadvoteresults"
 	CmdBallot                = "ballot"
 	CmdBestBlock             = "bestblock"
@@ -413,6 +414,55 @@ func DecodeVoteSummaryReply(payload []byte) (*VoteSummaryReply, error) {
 	}
 
 	return &v, nil
+}
+
+// BatchVoteSummary requests a summary of a set of proposal votes. This
+// includes certain voting period parameters and a summary of the vote
+// results.
+type BatchVoteSummary struct {
+	Tokens []string `json:"token"` // Censorship token
+}
+
+// EncodeBatchVoteSummary encodes BatchVoteSummary into a JSON byte slice.
+func EncodeBatchVoteSummary(v BatchVoteSummary) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeBatchVoteSummary decodes a JSON byte slice into a BatchVoteSummary.
+func DecodeBatchVoteSummary(payload []byte) (*BatchVoteSummary, error) {
+	var bv BatchVoteSummary
+
+	err := json.Unmarshal(payload, &bv)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bv, nil
+}
+
+// BatchVoteSummaryReply is the reply to the VoteSummary command and returns certain
+// voting period parameters as well as a summary of the vote results.
+type BatchVoteSummaryReply struct {
+	Summaries map[string]VoteSummaryReply `json:"summaries"` // Vote summaries
+}
+
+// EncodeBatchVoteSummaryReply encodes BatchVoteSummaryReply into a JSON byte
+// slice.
+func EncodeBatchVoteSummaryReply(v BatchVoteSummaryReply) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeBatchVoteSummaryReply decodes a JSON byte slice into a
+// BatchVoteSummaryReply.
+func DecodeBatchVoteSummaryReply(payload []byte) (*BatchVoteSummaryReply, error) {
+	var bv BatchVoteSummaryReply
+
+	err := json.Unmarshal(payload, &bv)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bv, nil
 }
 
 // Comment is the structure that describes the full server side content.  It

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -888,10 +888,10 @@ func (d *decred) cmdTokenInventory(payload string) (string, error) {
 // a set of records.
 func (d *decred) getAuthorizeVotesForRecords(records map[string]Record) (map[string]AuthorizeVote, error) {
 
-	avMap := make(map[string]AuthorizeVote)
+	authorizeVotes := make(map[string]AuthorizeVote)
 
 	if len(records) == 0 {
-		return avMap, nil
+		return authorizeVotes, nil
 	}
 
 	keys := make([]string, 0, len(records))
@@ -909,19 +909,19 @@ func (d *decred) getAuthorizeVotesForRecords(records map[string]Record) (map[str
 	}
 
 	for _, av := range avs {
-		avMap[av.Token] = av
+		authorizeVotes[av.Token] = av
 	}
 
-	return avMap, nil
+	return authorizeVotes, nil
 }
 
 // getStartVotesForAuthorizeVotes looks up the start votes for records which
 // have been authorized to start voting.
 func (d *decred) getStartVotes(authorizeVotes map[string]AuthorizeVote) (map[string]StartVote, error) {
-	svMap := make(map[string]StartVote)
+	startVotes := make(map[string]StartVote)
 
 	if len(authorizeVotes) == 0 {
-		return svMap, nil
+		return startVotes, nil
 	}
 
 	tokens := make([]string, 0, len(authorizeVotes))
@@ -940,10 +940,10 @@ func (d *decred) getStartVotes(authorizeVotes map[string]AuthorizeVote) (map[str
 		return nil, err
 	}
 	for _, sv := range svs {
-		svMap[sv.Token] = sv
+		startVotes[sv.Token] = sv
 	}
 
-	return svMap, nil
+	return startVotes, nil
 }
 
 // lookupResultsForVoteOptions looks in the CastVote to see how many votes

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -981,7 +981,7 @@ func (d *decred) getVoteResultsForStartVotes(svMap map[string]StartVote) (map[st
 }
 
 // lookupResultsForVoteOptions looks in the CastVote to see how many votes
-// each option has recieved.
+// each option has received.
 func (d *decred) lookupResultsForVoteOptions(options []VoteOption) ([]decredplugin.VoteOptionResult, error) {
 
 	results := make([]decredplugin.VoteOptionResult, 0, len(options))

--- a/politeiad/cache/testcache/decred.go
+++ b/politeiad/cache/testcache/decred.go
@@ -115,7 +115,6 @@ func (c *testcache) voteDetails(payload string) (string, error) {
 // This is left as a stub for now. The results of this are not used in any
 // tests.
 func (c *testcache) batchVoteSummary(payload string) (string, error) {
-
 	summaries := make(map[string]decredplugin.VoteSummaryReply)
 
 	bvr, _ := decred.EncodeBatchVoteSummaryReply(
@@ -124,7 +123,6 @@ func (c *testcache) batchVoteSummary(payload string) (string, error) {
 		})
 
 	return string(bvr), nil
-
 }
 
 func (c *testcache) decredExec(cmd, cmdPayload, replyPayload string) (string, error) {

--- a/politeiad/cache/testcache/decred.go
+++ b/politeiad/cache/testcache/decred.go
@@ -5,6 +5,7 @@
 package testcache
 
 import (
+	"github.com/decred/politeia/decredplugin"
 	decred "github.com/decred/politeia/decredplugin"
 	"github.com/decred/politeia/politeiad/cache"
 )
@@ -111,6 +112,21 @@ func (c *testcache) voteDetails(payload string) (string, error) {
 	return string(vdb), nil
 }
 
+// This is left as a stub for now. The results of this are not used in any
+// tests.
+func (c *testcache) batchVoteSummary(payload string) (string, error) {
+
+	summaries := make(map[string]decredplugin.VoteSummaryReply)
+
+	bvr, _ := decred.EncodeBatchVoteSummaryReply(
+		decred.BatchVoteSummaryReply{
+			Summaries: summaries,
+		})
+
+	return string(bvr), nil
+
+}
+
 func (c *testcache) decredExec(cmd, cmdPayload, replyPayload string) (string, error) {
 	switch cmd {
 	case decred.CmdGetComments:
@@ -121,6 +137,9 @@ func (c *testcache) decredExec(cmd, cmdPayload, replyPayload string) (string, er
 		return c.startVote(cmdPayload, replyPayload)
 	case decred.CmdVoteDetails:
 		return c.voteDetails(cmdPayload)
+	case decred.CmdBatchVoteSummary:
+		return c.batchVoteSummary(cmdPayload)
+
 	}
 
 	return "", cache.ErrInvalidPluginCmd

--- a/politeiad/testpoliteiad/decred.go
+++ b/politeiad/testpoliteiad/decred.go
@@ -99,6 +99,8 @@ func (p *TestPoliteiad) decredExec(pc v1.PluginCommand) (string, error) {
 		return p.startVote(pc.Payload)
 	case decred.CmdAuthorizeVote:
 		return p.authorizeVote(pc.Payload)
+	case decred.CmdBestBlock:
+		return strconv.FormatUint(uint64(bestBlock), 10), nil
 	}
 	return "", fmt.Errorf("invalid plugin command")
 }

--- a/politeiad/testpoliteiad/testpoliteiad.go
+++ b/politeiad/testpoliteiad/testpoliteiad.go
@@ -283,6 +283,10 @@ func (p *TestPoliteiad) handlePluginCommand(w http.ResponseWriter, r *http.Reque
 	response := p.identity.SignMessage(challenge)
 
 	payload, err := p.decredExec(t)
+	if err != nil {
+		respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
 
 	util.RespondWithJSON(w, http.StatusOK,
 		v1.PluginCommandReply{

--- a/politeiad/testpoliteiad/testpoliteiad.go
+++ b/politeiad/testpoliteiad/testpoliteiad.go
@@ -264,6 +264,36 @@ func (p *TestPoliteiad) handleSetUnvettedStatus(w http.ResponseWriter, r *http.R
 		})
 }
 
+func (p *TestPoliteiad) handlePluginCommand(w http.ResponseWriter, r *http.Request) {
+	// Decode request
+	var t v1.PluginCommand
+	decoder := json.NewDecoder(r.Body)
+
+	if err := decoder.Decode(&t); err != nil {
+		respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
+
+	// Verify challenge
+	challenge, err := hex.DecodeString(t.Challenge)
+	if err != nil || len(challenge) != v1.ChallengeSize {
+		respondWithUserError(w, v1.ErrorStatusInvalidChallenge, nil)
+		return
+	}
+	response := p.identity.SignMessage(challenge)
+
+	payload, err := p.decredExec(t)
+
+	util.RespondWithJSON(w, http.StatusOK,
+		v1.PluginCommandReply{
+			Response:  hex.EncodeToString(response[:]),
+			ID:        t.ID,
+			Command:   t.Command,
+			CommandID: t.CommandID,
+			Payload:   payload,
+		})
+}
+
 func (p *TestPoliteiad) handleSetVettedStatus(w http.ResponseWriter, r *http.Request) {
 	// Decode request
 	var t v1.SetVettedStatus
@@ -410,6 +440,7 @@ func New(t *testing.T, c cache.Cache) *TestPoliteiad {
 	router.HandleFunc(v1.NewRecordRoute, p.handleNewRecord)
 	router.HandleFunc(v1.SetUnvettedStatusRoute, p.handleSetUnvettedStatus)
 	router.HandleFunc(v1.SetVettedStatusRoute, p.handleSetVettedStatus)
+	router.HandleFunc(v1.PluginCommandRoute, p.handlePluginCommand)
 
 	// Setup the test server
 	p.server = httptest.NewServer(router)

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -2505,7 +2505,9 @@ Reply:
 
 ### `Proposal vote status`
 
-Returns the vote status for a single public proposal
+**This route deprecated by VoteSummary in [`Proposal`](#proposal).**
+
+Returns the vote status for a single public proposal.
 
 **Route:** `GET /V1/proposals/{token}/votestatus`
 
@@ -2584,7 +2586,9 @@ Reply:
 
 ### `Proposals vote status`
 
-Returns the vote status of all public proposals
+**This route deprecated by VoteSummary in [`Proposal`](#proposal).**
+
+Returns the vote status of all public proposals.
 
 **Route:** `GET /V1/proposals/votestatus`
 

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -1215,6 +1215,17 @@ Reply:
             "payload":"RWRpdGVkIHByb3Bvc2FsCmVkaXRlZCBkZXNjcmlwdGlvbg=="
          }
       ],
+      "votesummary": {
+        "status": 1,
+        "totalvotes": 0,
+        "optionsresult": [],
+        "endheight": "",
+        "bestblock": "228207",
+        "numofeligiblevotes": 0,
+        "quorumpercentage": 0,
+        "passpercentage": 0,
+        "testnet" : true
+      },
       "numcomments":0,
       "version":"2",
       "censorshiprecord":{
@@ -1271,6 +1282,17 @@ Reply:
       "publishedat": 0,
       "censoredat": 0,
       "abandonedat": 0,
+      "votesummary": {
+        "status": 1,
+        "totalvotes": 0,
+        "optionsresult": [],
+        "endheight": "",
+        "bestblock": "228207",
+        "numofeligiblevotes": 0,
+        "quorumpercentage": 0,
+        "passpercentage": 0,
+        "testnet": true
+      },
       "censorshiprecord": {
         "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
         "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
@@ -1323,6 +1345,34 @@ Reply:
     "publishedat": 1508296860900,
     "censoredat": 0,
     "abandonedat": 0,
+    "votesummary": {
+      "status": 3,
+      "totalvotes": 0,
+      "optionsresult": [
+        {
+           "option": {
+            "id": "no",
+            "description": "Don't approve proposal",
+            "bits": 1
+          },
+          "votesreceived": 0
+        },
+        {
+          "option": {
+            "id": "yes",
+            "description": "Approve proposal",
+            "bits": 2
+          },
+          "votesreceived": 0
+        }
+      ],
+      "endheight": "229472",
+      "bestblock": "228729",
+      "numofeligiblevotes": 5312,
+      "quorumpercentage": 20,
+      "passpercentage": 60,
+      "testnet": true
+    },
     "censorshiprecord": {
       "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
       "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
@@ -1375,6 +1425,34 @@ Reply:
     "name": "My Proposal",
     "status": 2,
     "timestamp": 1508296860781,
+    "votesummary": {
+      "status": 3,
+      "totalvotes": 0,
+      "optionsresult": [
+        {
+           "option": {
+            "id": "no",
+            "description": "Don't approve proposal",
+            "bits": 1
+          },
+          "votesreceived": 0
+        },
+        {
+          "option": {
+            "id": "yes",
+            "description": "Approve proposal",
+            "bits": 2
+          },
+          "votesreceived": 0
+        }
+      ],
+      "endheight": "229472",
+      "bestblock": "228729",
+      "numofeligiblevotes": 5312,
+      "quorumpercentage": 20,
+      "passpercentage": 60,
+      "testnet": true
+    },
     "censorshiprecord": {
       "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
       "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
@@ -1511,18 +1589,46 @@ Reply:
 
 ```json
 {
-	"proposal": {
-		"name": "My Proposal",
-		"state": "2",
-		"status": 4,
-		"timestamp": 1539212044,
-		"userid": "",
-		"username": "",
-		"publickey": "57cf10a15828c633dc0af423669e7bbad2d30a062e4eb1e9c78919f77ebd1022",
-		"signature": "553beffb3fece5bdd540e0b83e977e4f68c1ac31e6f2e0a85c3c9aef9e65e3efe3d778edc504a9e88c101f68ad25e677dc3574c67a6e8d0ba711de4b91bec40d",
-		"files": [],
-		"numcomments": 0,
-		"version": "1",
+  "proposal": {
+    "name": "My Proposal",
+    "state": "2",
+    "status": 4,
+    "timestamp": 1539212044,
+    "userid": "",
+    "username": "",
+    "publickey": "57cf10a15828c633dc0af423669e7bbad2d30a062e4eb1e9c78919f77ebd1022",
+    "signature": "553beffb3fece5bdd540e0b83e977e4f68c1ac31e6f2e0a85c3c9aef9e65e3efe3d778edc504a9e88c101f68ad25e677dc3574c67a6e8d0ba711de4b91bec40d",
+    "files": [],
+    "numcomments": 0,
+    "version": "1",
+    "votesummary": {
+      "status": 3,
+      "totalvotes": 0,
+      "optionsresult": [
+        {
+           "option": {
+            "id": "no",
+            "description": "Don't approve proposal",
+            "bits": 1
+          },
+          "votesreceived": 0
+        },
+        {
+          "option": {
+            "id": "yes",
+            "description": "Approve proposal",
+            "bits": 2
+          },
+          "votesreceived": 0
+        }
+      ],
+      "endheight": "229472",
+      "bestblock": "228729",
+      "numofeligiblevotes": 5312,
+      "quorumpercentage": 20,
+      "passpercentage": 60,
+      "testnet": true
+    },
 		"censorshiprecord": {
 			"token": "fc320c72bb55b6233a8df388109bf494081f007395489a7cdc945e05d656a467",
 			"merkle": "ffc1e4b6a1b0b1e8eb99d476aed7ace9ed6475b3bbab9470d01028c24ae51992",
@@ -1580,6 +1686,34 @@ Reply:
       "digest": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
       "payload": "VGhpcyBpcyBhIGRlc2NyaXB0aW9u"
     }],
+    "votesummary": {
+      "status": 3,
+      "totalvotes": 0,
+      "optionsresult": [
+        {
+           "option": {
+            "id": "no",
+            "description": "Don't approve proposal",
+            "bits": 1
+          },
+          "votesreceived": 0
+        },
+        {
+          "option": {
+            "id": "yes",
+            "description": "Approve proposal",
+            "bits": 2
+          },
+          "votesreceived": 0
+        }
+      ],
+      "endheight": "229472",
+      "bestblock": "228729",
+      "numofeligiblevotes": 5312,
+      "quorumpercentage": 20,
+      "passpercentage": 60,
+      "testnet": true
+    },
     "censorshiprecord": {
       "token": "c378e0735b5650c9e79f70113323077b107b0d778547f0d40592955668f21ebf",
       "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
@@ -1631,46 +1765,102 @@ Reply:
 
 ```json
 {
-    "proposals": [
-        {
-            "name": "Sample proposal 1",
-            "state": 2,
-            "status": 4,
-            "timestamp": 1561637933,
-            "userid": "bda3852b-f9e8-49a3-924a-147303b7d6b8",
-            "username": "username",
-            "publickey": "e008f83793c023321d54f283698c47fb50083489501a8c3b4b020b7c92930cb9",
-            "signature": "9c05c50b67c74d7c7e80be702afe123f46ddb417583bcd97674073d0d5ddc35804bec88b01d158bc1ab89bdb21e3cabbb4f290365c375ca226f8652d8dc01602",
-            "files": [],
-            "numcomments": 0,
-            "version": "1",
-            "publishedat": 1561637933,
-            "censorshiprecord": {
-                "token": "c9aaf64f9474a0c2aa2227363e3ba575e1926acd4257deba42dc6d5ab85f2cd2",
-                "merkle": "ab7d4fe5d89a1110b0c684d89a48558efaeb0247d13ba8a79200d7fdbde91559",
-                "signature": "8860999e0df2b9b7cc727f2ebc6c32fd26a8c9bb7660524fefbf85202ea4e1296699544acdcc723d70708f9f1561007bac1c4d250eb5aa5ebdecea224a8fd105"
-            }
-        },
-        {
-            "name": "Sample Proposal 2",
-            "state": 2,
-            "status": 4,
-            "timestamp": 1560824670,
-            "userid": "6bd802af-42cc-47af-b1dc-412f93f21689",
-            "username": "user2",
-            "publickey": "ceaca7ba3579620968a1720e0748f3005802a2fd9e5afe0c7916f79c70234664",
-            "signature": "ea41d5f8808892488185d18447f5b8c9d77c0d65932464d5742c1d22dbb0c975b42aaddcb1dae4f5d4a4423f4965c8af4a9273d48faae1f0531abe3039608001",
-            "files": [],
-            "numcomments": 3,
-            "version": "1",
-            "publishedat": 1560824670,
-            "censorshiprecord": {
-                "token": "f08dc22069f854856e27a6cb107e10064a85b85b2a4db41755d54f90bd30b84f",
-                "merkle": "34745ec2aee7ba0bf3111c66f8484efb32bfea3bfe6cdcc46420adc1c7d181cc",
-                "signature": "f0638afa9466ec3e4954f64e77929a0dd22d05b685180eaf36816e6cd65237760d4485be8afee04b824665acc809856aeabe9eade48f23a99b7be42e4508ac05"
-            }
-        }
-    ]
+  "proposals": [
+    {
+      "name": "Sample proposal 1",
+      "state": 2,
+      "status": 4,
+      "timestamp": 1561637933,
+      "userid": "bda3852b-f9e8-49a3-924a-147303b7d6b8",
+      "username": "username",
+      "publickey": "e008f83793c023321d54f283698c47fb50083489501a8c3b4b020b7c92930cb9",
+      "signature": "9c05c50b67c74d7c7e80be702afe123f46ddb417583bcd97674073d0d5ddc35804bec88b01d158bc1ab89bdb21e3cabbb4f290365c375ca226f8652d8dc01602",
+      "files": [],
+      "numcomments": 0,
+      "version": "1",
+      "publishedat": 1561637933,
+      "votesummary": {
+        "status": 3,
+        "totalvotes": 0,
+        "optionsresult": [
+          {
+            "option": {
+              "id": "no",
+              "description": "Don't approve proposal",
+              "bits": 1
+            },
+            "votesreceived": 0
+          },
+          {
+            "option": {
+              "id": "yes",
+              "description": "Approve proposal",
+              "bits": 2
+            },
+            "votesreceived": 0
+          }
+        ],
+        "endheight": "229472",
+        "bestblock": "228729",
+        "numofeligiblevotes": 5312,
+        "quorumpercentage": 20,
+        "passpercentage": 60,
+        "testnet": true
+      },
+      "censorshiprecord": {
+        "token": "c9aaf64f9474a0c2aa2227363e3ba575e1926acd4257deba42dc6d5ab85f2cd2",
+        "merkle": "ab7d4fe5d89a1110b0c684d89a48558efaeb0247d13ba8a79200d7fdbde91559",
+        "signature": "8860999e0df2b9b7cc727f2ebc6c32fd26a8c9bb7660524fefbf85202ea4e1296699544acdcc723d70708f9f1561007bac1c4d250eb5aa5ebdecea224a8fd105"
+      }
+    },
+    {
+      "name": "Sample Proposal 2",
+      "state": 2,
+      "status": 4,
+      "timestamp": 1560824670,
+      "userid": "6bd802af-42cc-47af-b1dc-412f93f21689",
+      "username": "user2",
+      "publickey": "ceaca7ba3579620968a1720e0748f3005802a2fd9e5afe0c7916f79c70234664",
+      "signature": "ea41d5f8808892488185d18447f5b8c9d77c0d65932464d5742c1d22dbb0c975b42aaddcb1dae4f5d4a4423f4965c8af4a9273d48faae1f0531abe3039608001",
+      "files": [],
+      "numcomments": 3,
+      "version": "1",
+      "publishedat": 1560824670,
+      "votesummary": {
+        "status": 3,
+        "totalvotes": 0,
+        "optionsresult": [
+          {
+            "option": {
+              "id": "no",
+              "description": "Don't approve proposal",
+              "bits": 1
+            },
+            "votesreceived": 0
+          },
+          {
+            "option": {
+              "id": "yes",
+              "description": "Approve proposal",
+              "bits": 2
+            },
+            "votesreceived": 0
+          }
+        ],
+        "endheight": "229472",
+        "bestblock": "228729",
+        "numofeligiblevotes": 5312,
+        "quorumpercentage": 20,
+        "passpercentage": 60,
+        "testnet": true
+      },
+      "censorshiprecord": {
+          "token": "f08dc22069f854856e27a6cb107e10064a85b85b2a4db41755d54f90bd30b84f",
+          "merkle": "34745ec2aee7ba0bf3111c66f8484efb32bfea3bfe6cdcc46420adc1c7d181cc",
+          "signature": "f0638afa9466ec3e4954f64e77929a0dd22d05b685180eaf36816e6cd65237760d4485be8afee04b824665acc809856aeabe9eade48f23a99b7be42e4508ac05"
+      }
+  }
+  ]
 }
 ```
 
@@ -2725,6 +2915,7 @@ This is a shortened representation of a user, used for lists.
 | pubishedat | The timestamp of when the proposal has been published. If the proposals has not been pubished, this field will not be present. |
 | censoredat | The timestamp of when the proposal has been censored. If the proposals has not been censored, this field will not be present. |
 | abandonedat | The timestamp of when the proposal has been abandoned. If the proposals has not been abandoned, this field will not be present. |
+| votesummary | A [`summary`](#Vote-Summary) of the proposals voting process |
  
 ### `Identity`
 
@@ -2741,6 +2932,21 @@ This is a shortened representation of a user, used for lists.
 | mime | string | MIME type of the payload. Currently the system only supports md and png files. The server shall reject invalid MIME types. |
 | digest | string | Digest is a SHA256 digest of the payload. The digest shall be verified by politeiad. |
 | payload | string | Payload is the actual file content. It shall be base64 encoded. Files have size limits that can be obtained via the [`Policy`](#policy) call. The server shall strictly enforce policy limits. |
+
+### `Vote Summary`
+
+| | Type | Description |
+|-|-|-|
+| token | string  | Censorship token |
+| status | int | Status identifier |
+| optionsresult | array of VoteOptionResult | Option description along with the number of votes it has received |
+| totalvotes | int | Proposal's total number of votes |
+| bestblock | string | The current chain height |
+| endheight | string | The chain height in which the vote will end |
+| numofeligiblevotes | int | Total number of eligible votes |
+| quorumpercentage | uint32 | Percent of eligible votes required for quorum |
+| passpercentage | uint32 | Percent of total votes required to pass |
+| testnet | boolean | True if voting is using testnet tickets |
 
 ### `Censorship record`
 

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -1223,8 +1223,7 @@ Reply:
         "bestblock": "228207",
         "numofeligiblevotes": 0,
         "quorumpercentage": 0,
-        "passpercentage": 0,
-        "testnet" : true
+        "passpercentage": 0
       },
       "numcomments":0,
       "version":"2",
@@ -1290,8 +1289,7 @@ Reply:
         "bestblock": "228207",
         "numofeligiblevotes": 0,
         "quorumpercentage": 0,
-        "passpercentage": 0,
-        "testnet": true
+        "passpercentage": 0
       },
       "censorshiprecord": {
         "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
@@ -1370,8 +1368,7 @@ Reply:
       "bestblock": "228729",
       "numofeligiblevotes": 5312,
       "quorumpercentage": 20,
-      "passpercentage": 60,
-      "testnet": true
+      "passpercentage": 60
     },
     "censorshiprecord": {
       "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
@@ -1450,8 +1447,7 @@ Reply:
       "bestblock": "228729",
       "numofeligiblevotes": 5312,
       "quorumpercentage": 20,
-      "passpercentage": 60,
-      "testnet": true
+      "passpercentage": 60
     },
     "censorshiprecord": {
       "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
@@ -1626,8 +1622,7 @@ Reply:
       "bestblock": "228729",
       "numofeligiblevotes": 5312,
       "quorumpercentage": 20,
-      "passpercentage": 60,
-      "testnet": true
+      "passpercentage": 60
     },
 		"censorshiprecord": {
 			"token": "fc320c72bb55b6233a8df388109bf494081f007395489a7cdc945e05d656a467",
@@ -1711,8 +1706,7 @@ Reply:
       "bestblock": "228729",
       "numofeligiblevotes": 5312,
       "quorumpercentage": 20,
-      "passpercentage": 60,
-      "testnet": true
+      "passpercentage": 60
     },
     "censorshiprecord": {
       "token": "c378e0735b5650c9e79f70113323077b107b0d778547f0d40592955668f21ebf",
@@ -1804,8 +1798,7 @@ Reply:
         "bestblock": "228729",
         "numofeligiblevotes": 5312,
         "quorumpercentage": 20,
-        "passpercentage": 60,
-        "testnet": true
+        "passpercentage": 60
       },
       "censorshiprecord": {
         "token": "c9aaf64f9474a0c2aa2227363e3ba575e1926acd4257deba42dc6d5ab85f2cd2",
@@ -1851,8 +1844,7 @@ Reply:
         "bestblock": "228729",
         "numofeligiblevotes": 5312,
         "quorumpercentage": 20,
-        "passpercentage": 60,
-        "testnet": true
+        "passpercentage": 60
       },
       "censorshiprecord": {
           "token": "f08dc22069f854856e27a6cb107e10064a85b85b2a4db41755d54f90bd30b84f",
@@ -2946,7 +2938,6 @@ This is a shortened representation of a user, used for lists.
 | numofeligiblevotes | int | Total number of eligible votes |
 | quorumpercentage | uint32 | Percent of eligible votes required for quorum |
 | passpercentage | uint32 | Percent of total votes required to pass |
-| testnet | boolean | True if voting is using testnet tickets |
 
 ### `Censorship record`
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -390,27 +390,26 @@ type VoteSummary struct {
 	NumOfEligibleVotes int                `json:"numofeligiblevotes"` // Total number of eligible votes
 	QuorumPercentage   uint32             `json:"quorumpercentage"`   // Percent of eligible votes required for quorum
 	PassPercentage     uint32             `json:"passpercentage"`     // Percent of total votes required to pass
-	TestNet            bool               `json:"testnet"`            // Is the vote using mainnet or testnet tickets
 }
 
 // ProposalRecord is an entire proposal and it's content.
 type ProposalRecord struct {
-	Name                string      `json:"name"`                          // Suggested short proposal name
-	State               PropStateT  `json:"state"`                         // Current state of proposal
-	Status              PropStatusT `json:"status"`                        // Current status of proposal
-	Timestamp           int64       `json:"timestamp"`                     // Last update of proposal
-	UserId              string      `json:"userid"`                        // ID of user who submitted proposal
-	Username            string      `json:"username"`                      // Username of user who submitted proposal
-	PublicKey           string      `json:"publickey"`                     // Key used for signature.
-	Signature           string      `json:"signature"`                     // Signature of merkle root
-	Files               []File      `json:"files"`                         // Files that make up the proposal
-	NumComments         uint        `json:"numcomments"`                   // Number of comments on the proposal
-	Version             string      `json:"version"`                       // Record version
-	StatusChangeMessage string      `json:"statuschangemessage,omitempty"` // Message associated to the status change
-	PublishedAt         int64       `json:"publishedat,omitempty"`         // The timestamp of when the proposal has been published
-	CensoredAt          int64       `json:"censoredat,omitempty"`          // The timestamp of when the proposal has been censored
-	AbandonedAt         int64       `json:"abandonedat,omitempty"`         // The timestamp of when the proposal has been abandoned
-	VoteSummary         VoteSummary `json:"votesummary"`                   // Summary of current state of voting process
+	Name                string       `json:"name"`                          // Suggested short proposal name
+	State               PropStateT   `json:"state"`                         // Current state of proposal
+	Status              PropStatusT  `json:"status"`                        // Current status of proposal
+	Timestamp           int64        `json:"timestamp"`                     // Last update of proposal
+	UserId              string       `json:"userid"`                        // ID of user who submitted proposal
+	Username            string       `json:"username"`                      // Username of user who submitted proposal
+	PublicKey           string       `json:"publickey"`                     // Key used for signature.
+	Signature           string       `json:"signature"`                     // Signature of merkle root
+	Files               []File       `json:"files"`                         // Files that make up the proposal
+	NumComments         uint         `json:"numcomments"`                   // Number of comments on the proposal
+	Version             string       `json:"version"`                       // Record version
+	StatusChangeMessage string       `json:"statuschangemessage,omitempty"` // Message associated to the status change
+	PublishedAt         int64        `json:"publishedat,omitempty"`         // The timestamp of when the proposal has been published
+	CensoredAt          int64        `json:"censoredat,omitempty"`          // The timestamp of when the proposal has been censored
+	AbandonedAt         int64        `json:"abandonedat,omitempty"`         // The timestamp of when the proposal has been abandoned
+	VoteSummary         *VoteSummary `json:"votesummary"`                   // Summary of current state of voting process
 
 	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
 }
@@ -1068,10 +1067,12 @@ type VoteOptionResult struct {
 }
 
 // VoteStatus is a command to fetch the the current vote status for a single
-// public proposal
+// public proposal.
+// *** This is deprecated by VoteSummary in Proposal Details. ***
 type VoteStatus struct{}
 
 // VoteStatusReply describes the vote status for a given proposal
+// *** This is deprecated by VoteSummary in Proposal Details. ***
 type VoteStatusReply struct {
 	Token              string             `json:"token"`              // Censorship token
 	Status             PropVoteStatusT    `json:"status"`             // Vote status (finished, started, etc)
@@ -1085,9 +1086,11 @@ type VoteStatusReply struct {
 }
 
 // GetAllVoteStatus attempts to fetch the vote status of all public propsals
+// *** This is deprecated by VoteSummary in Proposal Details. ***
 type GetAllVoteStatus struct{}
 
 // GetAllVoteStatusReply returns the vote status of all public proposals
+// *** This is deprecated by VoteSummary in Proposal Details. ***
 type GetAllVoteStatusReply struct {
 	VotesStatus []VoteStatusReply `json:"votesstatus"` // Vote status of all public proposals
 }

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -379,6 +379,20 @@ type CensorshipRecord struct {
 	Signature string `json:"signature"` // Server side signature of []byte(Merkle+Token)
 }
 
+// VoteSummary contains information about the voting state of the process
+// related to a proposal.
+type VoteSummary struct {
+	Status             PropVoteStatusT    `json:"status"`             // Vote status (finished, started, etc)
+	TotalVotes         uint64             `json:"totalvotes"`         // Proposal's total number of votes
+	OptionsResult      []VoteOptionResult `json:"optionsresult"`      // VoteOptionResult for each option
+	EndHeight          string             `json:"endheight"`          // Vote end height
+	BestBlock          string             `json:"bestblock"`          // Current best block height
+	NumOfEligibleVotes int                `json:"numofeligiblevotes"` // Total number of eligible votes
+	QuorumPercentage   uint32             `json:"quorumpercentage"`   // Percent of eligible votes required for quorum
+	PassPercentage     uint32             `json:"passpercentage"`     // Percent of total votes required to pass
+	TestNet            bool               `json:"testnet"`            // Is the vote using mainnet or testnet tickets
+}
+
 // ProposalRecord is an entire proposal and it's content.
 type ProposalRecord struct {
 	Name                string      `json:"name"`                          // Suggested short proposal name
@@ -396,6 +410,7 @@ type ProposalRecord struct {
 	PublishedAt         int64       `json:"publishedat,omitempty"`         // The timestamp of when the proposal has been published
 	CensoredAt          int64       `json:"censoredat,omitempty"`          // The timestamp of when the proposal has been censored
 	AbandonedAt         int64       `json:"abandonedat,omitempty"`         // The timestamp of when the proposal has been abandoned
+	VoteSummary         VoteSummary `json:"votesummary"`                   // Summary of current state of voting process
 
 	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
 }

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -367,6 +367,36 @@ func (p *politeiawww) decredLoadVoteResults(bestBlock uint64) (*decredplugin.Loa
 	return reply, nil
 }
 
+// decredBatchVoteSummary uses the decred plugin batch vote summary command to request a
+// vote summary for a specific proposal from the cache.
+func (p *politeiawww) decredBatchVoteSummary(tokens []string) (*decredplugin.BatchVoteSummaryReply, error) {
+	bvs := decredplugin.BatchVoteSummary{
+		Tokens: tokens,
+	}
+	payload, err := decredplugin.EncodeBatchVoteSummary(bvs)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := cache.PluginCommand{
+		ID:             decredplugin.ID,
+		Command:        decredplugin.CmdBatchVoteSummary,
+		CommandPayload: string(payload),
+	}
+
+	res, err := p.cache.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+
+	reply, err := decredplugin.DecodeBatchVoteSummaryReply([]byte(res.Payload))
+	if err != nil {
+		return nil, err
+	}
+
+	return reply, nil
+}
+
 // decredVoteSummary uses the decred plugin vote summary command to request a
 // vote summary for a specific proposal from the cache.
 func (p *politeiawww) decredVoteSummary(token string) (*decredplugin.VoteSummaryReply, error) {

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -1113,6 +1113,9 @@ func TestProcessAllVetted(t *testing.T) {
 	p, cleanup := newTestPoliteiawww(t)
 	defer cleanup()
 
+	d := newTestPoliteiad(t, p)
+	defer d.Close()
+
 	// Create test data
 	tokenValid := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351b5d"
 	tokenNotHex := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351zzz"
@@ -1207,6 +1210,9 @@ func TestProcessAllUnvetted(t *testing.T) {
 	// Setup test environment
 	p, cleanup := newTestPoliteiawww(t)
 	defer cleanup()
+
+	d := newTestPoliteiad(t, p)
+	defer d.Close()
 
 	// Create test data
 	tokenValid := "3575a65bbc3616c939acf6edf801e1168485dc864efef910034268f695351b5d"

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -35,7 +35,6 @@ import (
 	"github.com/decred/politeia/util"
 	"github.com/decred/politeia/util/version"
 	"github.com/google/uuid"
-	"github.com/gorilla/csrf"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/robfig/cron"
@@ -494,7 +493,7 @@ func _main() error {
 	}
 	fCSRF.Close()
 
-	csrfHandle := csrf.Protect(csrfKey, csrf.Path("/"))
+	//csrfHandle := csrf.Protect(csrfKey, csrf.Path("/"))
 
 	p.router = mux.NewRouter()
 	p.router.Use(recoverMiddleware)
@@ -600,7 +599,7 @@ func _main() error {
 				},
 			}
 			srv := &http.Server{
-				Handler:   csrfHandle(p.router),
+				Handler:   p.router, //csrfHandle(p.router),
 				Addr:      listen,
 				TLSConfig: cfg,
 				TLSNextProto: make(map[string]func(*http.Server,

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -35,6 +35,7 @@ import (
 	"github.com/decred/politeia/util"
 	"github.com/decred/politeia/util/version"
 	"github.com/google/uuid"
+	"github.com/gorilla/csrf"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/robfig/cron"
@@ -493,7 +494,7 @@ func _main() error {
 	}
 	fCSRF.Close()
 
-	//csrfHandle := csrf.Protect(csrfKey, csrf.Path("/"))
+	csrfHandle := csrf.Protect(csrfKey, csrf.Path("/"))
 
 	p.router = mux.NewRouter()
 	p.router.Use(recoverMiddleware)
@@ -599,7 +600,7 @@ func _main() error {
 				},
 			}
 			srv := &http.Server{
-				Handler:   p.router, //csrfHandle(p.router),
+				Handler:   csrfHandle(p.router),
 				Addr:      listen,
 				TLSConfig: cfg,
 				TLSNextProto: make(map[string]func(*http.Server,


### PR DESCRIPTION
Add Vote Summary information to Proposal Record.

This diff includes a new command in decredplugin, CmdBatchVoteSummary,
which fetches voting information for a batch of proposals. This information is
then included in the proposal records.

Closes #952