### PR TITLE
PoliteiaWWW API DOC Update : bestblock removed from responses

### DIFF
--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -2337,7 +2337,6 @@ Returns the vote status for a single public proposal
 | status | int | Status identifier |
 | optionsresult | array of VoteOptionResult | Option description along with the number of votes it has received |
 | totalvotes | int | Proposal's total number of votes |
-| bestblock | string | The current chain height |
 | endheight | string | The chain height in which the vote will end |
 | numofeligiblevotes | int | Total number of eligible votes |
 | quorumpercentage | uint32 | Percent of eligible votes required for quorum |
@@ -2392,7 +2391,6 @@ Reply:
         "votesreceived":0
     }
   ],
-  "bestblock": "45391",
   "endheight": "45567",
   "numofeligiblevotes": 2000,
   "quorumpercentage": 20,
@@ -2423,7 +2421,6 @@ Returns the vote status of all public proposals
 | optionsresult | array of VoteOptionResult | Option description along with the number of votes it has received |
 | totalvotes | int | Proposal's total number of votes |
 | endheight | string | The chain height in which the vote will end |
-| bestblock | string | The current chain height |
 | numofeligiblevotes | int | Total number of eligible votes |
 | quorumpercentage | uint32 | Percent of eligible votes required for quorum |
 | passpercentage | uint32 | Percent of total votes required to pass |
@@ -2461,7 +2458,6 @@ Reply:
             }
          ],
          "totalvotes":0,
-         "bestblock": "45392",
          "endheight": "45567",
          "numofeligiblevotes": 2000,
          "quorumpercentage": 20,
@@ -2472,7 +2468,6 @@ Reply:
          "status":1,
          "optionsresult":null,
          "totalvotes":0,
-         "bestblock": "45392",
          "endheight": "",
          "numofeligiblevotes": 0,
          "quorumpercentage": 0,


### PR DESCRIPTION
bestblock isn't returned in [proposals vote status](https://github.com/decred/politeia/blob/master/politeiawww/api/www/v1/api.md#proposals-vote-status) and [proposal vote status](https://github.com/decred/politeia/blob/master/politeiawww/api/www/v1/api.md#proposal-vote-status) endpoints but it is included in the documentation.