### PR TITLE
[cms] Add DCC Proposal System

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -845,6 +845,14 @@ Reply:
 | <a name="ErrorStatusDuplicatePaymentAddress">ErrorStatusDuplicatePaymentAddress</a> | 1028 | An duplicate payment address was entered. |
 | <a name="ErrorStatusInvalidDatesRequested">ErrorStatusInvalidDatesRequested</a> | 1029 | Invalid dates were submitted for a request. |
 | <a name="ErrorStatusInvalidInvoiceEditMonthYear">ErrorStatusInvalidInvoiceEditMonthYear</a> | 1030 | Invoice month/year was attempted to be edited. |
+| <a name="ErrorStatusInvalidDCCType">ErrorStatusInvalidDCCType</a> | 1031 | An invalid DCC type was detected. |
+| <a name="ErrorStatusInvalidNominatingDomain">ErrorStatusInvalidNominatingDomain</a> | 1032 | An invalid nominating domain was detected.  Domain must match sponsoring user's domain. |
+| <a name="ErrorStatusMalformedSponsorStatement">ErrorStatusMalformedSponsorStatement</a> | 1033 | The sponsor statement was malformed. |
+| <a name="ErrorStatusMalformedDCCFile">ErrorStatusMalformedDCCFile</a> | 1034 | The DCC files was malformed. |
+| <a name="ErrorStatusInvalidDCCComment">ErrorStatusInvalidDCCComment</a> | 1035 | A DCC comment was invalid. |
+| <a name="ErrorStatusInvalidDCCStatusTransition">ErrorStatusInvalidDCCStatusTransition</a> | 1036 | An invalid DCC status transition. |
+| <a name="ErrorStatusDuplicateEmail">ErrorStatusDuplicateEmail</a> | 1037 | A duplicate email address was detected. |
+| <a name="ErrorStatusInvalidUserNewInvoice">ErrorStatusInvalidUserNewInvoice</a> | 1038 | The user was not allowed to create a new invoice. |
 
 ### Invoice status codes
 
@@ -886,3 +894,32 @@ Reply:
 | <a name="ContractorTypeDirect">ContractorTypeDirect</a>| 1 | A direct contractor that does not work under another organization. Able to submit invoices. |
 | <a name="ContractorTypeSupervisor">ContractorTypeSupervisor</a>| 2 | The supervising manager of a team of sub contractors.  Able to submit invoices for themselves and subs. |
 | <a name="ContractorTypeSubContractor">ContractorTypeSubContractor</a>| 3 | A sub contractor that works for a supervising manager.  NOT able to submit invoices. |
+| <a name="ContractorTypeRevoked">ContractorTypeRevoked</a>| 4 | A contractor that has been revoked by a DCC. |
+| <a name="ContractorTypeDormant">ContractorTypeDormant</a>| 5 | A contractor that has left for a period of time without invoice or contact. |
+| <a name="ContractorTypeNominee">ContractorTypeNominee</a>| 6 | A nominated contractor that has an associated DCC. |
+
+
+### Payment status codes
+| Status | Value | Description |
+|-|-|-|
+| <a name="PaymentStatusInvalid">PaymentStatusInvalid</a>| 0 | Invalid status. |
+| <a name="PaymentStatusWatching">PaymentStatusWatching</a>| 1 | Payment is currently watching. |
+| <a name="PaymentStatusPaid">PaymentStatusPaid</a>| 2 | Payment has been observed to have been paid. |
+
+### DCC type codes
+| Type | Value | Description |
+|-|-|-|
+| <a name="DCCTypeInvalid">DCCTypeInvalid</a>| 0 | Invalid type. |
+| <a name="DCCTypeIssuance">DCCTypeIssuance</a>| 1 | DCC issuance proposal. |
+| <a name="DCCTypeRevocation">DCCTypeRevocation</a>| 2 | DCC revocation proposal. |
+
+### DCC status codes
+| Status | Value | Description |
+|-|-|-|
+| <a name="DCCStatusInvalid">DCCStatusInvalid</a>| 0 | Invalid status. |
+| <a name="DCCStatusActive">DCCStatusActive</a>| 1 | Currently active issuance/revocation (awaiting sponsors). |
+| <a name="DCCStatusSupported">DCCStatusSupported</a>| 2 | Fully supported issuance/revocation (received enough sponsors to proceed). |
+| <a name="DCCStatusApproved">DCCStatusApproved</a>| 3 | Approved issuance/revocation |
+| <a name="DCCStatusRejected">DCCStatusRejected</a>| 4 | Rejected issuance/revocation |
+| <a name="DCCStatusDebate">DCCStatusDebate</a>| 5 | If a issuance/revocation receives enough comments, it would enter a "debate" status that would require a full contractor vote (to be added later).  |
+

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -982,6 +982,232 @@ Reply:
 {}
 ```
 
+### `Approve DCC`
+
+Approves a DCC proposal that will then move the nominated user into a fully invited contractor.
+
+Note: This call requires admin privileges.
+
+**Route:** `POST /v1/admin/approvedcc`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| reason | string | The reason for approving the DCC. | Yes |
+| token | string | The token of the DCC to approve. | Yes |
+| publickey | string | The user's public key. | Yes |
+| signature | string | The signature of the string representation of the reason and token payload. | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| verificationtoken | String | The verification token which is required when calling [`Register`](#register). The token will be sent to the email address sent in the request.|
+
+**Example**
+
+Request:
+
+```json
+{
+  "comment":"nay",
+  "token":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e"}
+```
+
+Reply:
+
+```json
+{
+  "verificationtoken": "fc8f660e7f4d590e27e6b11639ceeaaec2ce9bc6b0303344555ac023ab8ee55f"
+}
+```
+
+### `Reject DCC`
+
+Rejects a DCC proposal that will then move the nominated user into a ContractorRevoked status.
+
+Note: This call requires admin privileges.
+
+**Route:** `POST /v1/admin/rejectdcc`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| reason | string | The reason for rejecting the DCC. | Yes |
+| token | string | The token of the DCC to reject. | Yes |
+| publickey | string | The user's public key. | Yes |
+| signature | string | The signature of the string representation of the reason and token payload. | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+
+**Example**
+
+Request:
+
+```json
+{
+  "comment":"nay",
+  "token":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e"}
+```
+
+Reply:
+
+```json
+{}
+```
+
+### `DCC details`
+
+Retrieve DCC and its details.
+
+**Routes:** `GET /v1/dcc/{token}`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| token | string | Token is the unique censorship token that identifies a specific proposal. | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| dcc | [`DCC`](#dcc) | The DCC with the provided token. |
+
+**Example**
+
+Request:
+
+The request params should be provided within the URL:
+
+```
+/v1/dcc/f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde?version=2
+```
+
+Reply:
+
+```json
+{  
+  "dcc": {
+    "type": 2,
+    "status": 4,
+    "statuschangereason": "This has been revoked due to strong support.",
+    "timestamp": 1565374601,
+    "dccpayload": {
+      "type": 2,
+      "nomineeuserid": "6638a1c9-271f-433e-bf2c-6144ddd8bed5",
+      "statement": "This is a statement to support the DCC to revoke this user.",
+      "domain": 2
+    },
+    "file": [
+      {
+        "name": "dcc.json",
+        "mime": "text/plain; charset=utf-8",
+        "digest": "cd5176184a510776abf1c394d830427f94d2f7fe4622e27ac839ceefa7fcf277",
+        "payload": "eyJ0eXBlIjoyLCJub21pbmVldXNlcmlkIjoiNjYzOGExYzktMjcxZi00MzNlLWJmMmMtNjE0NGRkZDhiZWQ1Iiwic3RhdGVtZW50Ijoic2RhZnNkZmFzZmRzZGYiLCJkb21haW4iOjJ9"
+      }
+    ],
+    "publickey": "311fa61d27b18c0033589ef1fb49edd162d791d0702cbab623ffd4486452322a",
+    "signature": "8a3c5b5cb984cfb7fd59a11d2d7d11a8d50b936358541d917ba348d30bfb1d805c26686836695a9b4b347feee6a674b689b448ed941280874a4b8dbdf360600b",
+    "version": "1",
+    "statement": "",
+    "domain": 0,
+    "sponsoruserid": "b35ab9d3-a98d-4170-ad5a-85b5bce9fb10",
+    "sponsorusername": "bsaget",
+    "supportuserids": [],
+    "againstuserids": [
+      "a5c98ca0-7369-4147-8902-3d268ec2fb24"
+    ],
+    "censorshiprecord": {
+      "token": "edd0882152f9800e7a6240f23d7310bd45145eb85ec463458de828b631083d84",
+      "merkle": "cd5176184a510776abf1c394d830427f94d2f7fe4622e27ac839ceefa7fcf277",
+      "signature": "4ea9f76a6c6659d4936aa556182604a3099778a981ebf500d5d47424b7ba0127ab033202b0be7872d09473088c04e9d1145f801455f0ae07be29e2f2d99ac00f"
+    }
+  }
+}
+```
+
+### `Get DCCs`
+
+Retrieve DCCs by status.
+
+**Routes:** `POST /v1/dcc/status`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| status | int | Returns all of the DCCs depending by the provided status. | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| dccs | [`DCC`](#dcc) | The DCCs with the provided status. |
+
+**Example**
+
+Request:
+
+```json
+{
+  "status":1,
+},
+
+Reply:
+
+```json
+{  
+  "dccs": [{
+    "dcc": {
+      "type": 2,
+      "status": 4,
+      "statuschangereason": "This has been revoked due to strong support.",
+      "timestamp": 1565374601,
+      "dccpayload": {
+        "type": 2,
+        "nomineeuserid": "6638a1c9-271f-433e-bf2c-6144ddd8bed5",
+        "statement": "This is a statement to support the DCC to revoke this user.",
+        "domain": 2
+      },
+      "file": [
+        {
+          "name": "dcc.json",
+          "mime": "text/plain; charset=utf-8",
+          "digest": "cd5176184a510776abf1c394d830427f94d2f7fe4622e27ac839ceefa7fcf277",
+          "payload": "eyJ0eXBlIjoyLCJub21pbmVldXNlcmlkIjoiNjYzOGExYzktMjcxZi00MzNlLWJmMmMtNjE0NGRkZDhiZWQ1Iiwic3RhdGVtZW50Ijoic2RhZnNkZmFzZmRzZGYiLCJkb21haW4iOjJ9"
+        }
+      ],
+      "publickey": "311fa61d27b18c0033589ef1fb49edd162d791d0702cbab623ffd4486452322a",
+      "signature": "8a3c5b5cb984cfb7fd59a11d2d7d11a8d50b936358541d917ba348d30bfb1d805c26686836695a9b4b347feee6a674b689b448ed941280874a4b8dbdf360600b",
+      "version": "1",
+      "statement": "",
+      "domain": 0,
+      "sponsoruserid": "b35ab9d3-a98d-4170-ad5a-85b5bce9fb10",
+      "sponsorusername": "bsaget",
+      "supportuserids": [],
+      "againstuserids": [
+        "a5c98ca0-7369-4147-8902-3d268ec2fb24"
+      ],
+      "censorshiprecord": {
+        "token": "edd0882152f9800e7a6240f23d7310bd45145eb85ec463458de828b631083d84",
+        "merkle": "cd5176184a510776abf1c394d830427f94d2f7fe4622e27ac839ceefa7fcf277",
+        "signature": "4ea9f76a6c6659d4936aa556182604a3099778a981ebf500d5d47424b7ba0127ab033202b0be7872d09473088c04e9d1145f801455f0ae07be29e2f2d99ac00f"
+      }
+    }
+  }]
+}
+```
+
 ### Error codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -812,6 +812,176 @@ Reply:
 }
 ```
 
+### `New DCC`
+
+Creates a new DCC Proposal.
+
+**Route:** `POST /v1/dcc/new`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| files | [`[]File`](#file) | The dcc json file and any other attachments. | Yes |
+| publickey | string | The user's public key. | Yes |
+| signature | string | The signature of the string representation of the file payload. | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| censorshiprecord | [CensorshipRecord](#censorship-record) | A censorship record that provides the submitter with a method to extract the dcc and prove that he/she submitted it. |
+
+**Example**
+
+Request:
+
+```json
+{
+  "files": [
+    {
+      "name":"dcc.json",
+      "mime": "text/plain; charset=utf-8",
+      "digest": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+      "payload": "VGhpcyBpcyBhIGRlc2NyaXB0aW9u"
+    }
+  ],
+  "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e"
+}
+```
+
+Reply:
+
+```json
+{
+  "censorshiprecord": {
+    "token": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+    "merkle": "0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+    "signature": "fcc92e26b8f38b90c2887259d88ce614654f32ecd76ade1438a0def40d360e461d995c796f16a17108fad226793fd4f52ff013428eda3b39cd504ed5f1811d0d"
+  }
+}
+```
+
+### `New DCC User`
+
+Returns a logged-in CMS user's information beyond what is stored in the userdb.
+
+**Route:** `POST /v1/dcc/newuser`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| contractorname | string | The name of the nominated DCC user. | Yes |
+| contractorcontact | string | The contact information of the nominated DCC user. | Yes |
+| contractoremail | string | The email address for the nominated DCC user. | Yes |
+| publickey | string | The user's public key. | Yes |
+| signature | string | The signature of the string representation of the file payload. | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| userid | string | The UserID of the newly created nominated user. |
+
+**Example**
+
+Request:
+
+```json
+{
+  "contractorname":"Bob Saget",
+  "contractorcontact":"bsaget:decred.org",
+  "contractoremail":"bsaget@decred.org",
+  "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e"}
+```
+
+Reply:
+
+```json
+{
+  "userid":"a5c98ca0-7369-4147-8902-3d268ec2fb24",
+}
+```
+
+### `Support DCC`
+
+Creates a comment on a DCC Record that is used to tabulate support.
+
+**Route:** `POST /v1/dcc/support`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| comment | string | The comment for support of DCC, needs to be "aye". | Yes |
+| token | string | The token of the DCC to support | Yes |
+| publickey | string | The user's public key. | Yes |
+| signature | string | The signature of the string representation of the comment and token payload. | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+
+**Example**
+
+Request:
+
+```json
+{
+  "comment":"aye",
+  "token":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e"}
+```
+
+Reply:
+
+```json
+{}
+```
+
+### `Oppose DCC`
+
+Creates a comment on a DCC Record that is used to tabulate opposition.
+
+**Route:** `POST /v1/dcc/support`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| comment | string | The comment for support of DCC, needs to be "nay". | Yes |
+| token | string | The token of the DCC to support | Yes |
+| publickey | string | The user's public key. | Yes |
+| signature | string | The signature of the string representation of the comment and token payload. | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+
+**Example**
+
+Request:
+
+```json
+{
+  "comment":"nay",
+  "token":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "publickey":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "signature": "gdd92f26c8g38c90d2887259e88df614654g32fde76bef1438b0efg40e360f461e995d796g16b17108gbe226793ge4g52gg013428feb3c39de504fe5g1811e0e"}
+```
+
+Reply:
+
+```json
+{}
+```
+
 ### Error codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -11,6 +11,8 @@ type LineItemTypeT int
 type PaymentStatusT int
 type DomainTypeT int
 type ContractorTypeT int
+type DCCTypeT int
+type DCCStatusT int
 
 const (
 
@@ -22,6 +24,15 @@ const (
 	RouteInvoiceDetails      = "/invoices/{token:[A-z0-9]{64}}"
 	RouteSetInvoiceStatus    = "/invoices/{token:[A-z0-9]{64}}/status"
 	RouteUserInvoices        = "/user/invoices"
+	RouteNewDCC              = "/dcc/new"
+	RouteNewDCCUser          = "/dcc/newuser"
+	RouteSupportDCC          = "/dcc/support"
+	RouteOpposeDCC           = "/dcc/oppose"
+	RouteDCCDetails          = "/dcc/{token:[A-z0-9]{64}}"
+	RouteGetDCCs             = "/dcc/status"
+	RouteNewCommentDCC       = "/dcc/comment"
+	RouteApproveDCC          = "/admin/approvedcc"
+	RouteRejectDCC           = "/admin/rejectdcc"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteAdminUserInvoices   = "/admin/userinvoices"
 	RouteGeneratePayouts     = "/admin/generatepayouts"
@@ -60,11 +71,27 @@ const (
 	ContractorTypeDirect        ContractorTypeT = 1 // Direct contractor
 	ContractorTypeSupervisor    ContractorTypeT = 2 // Supervisor contractor
 	ContractorTypeSubContractor ContractorTypeT = 3 // SubContractor
+	ContractorTypeRevoked       ContractorTypeT = 4 // Contractors that have been revoked via DCC
+	ContractorTypeDormant       ContractorTypeT = 5 // Contractors that have left for a period of time without invoice or contact
+	ContractorTypeNominee       ContractorTypeT = 6 // Nominated DCC user
 
 	// Payment information status types
 	PaymentStatusInvalid  PaymentStatusT = 0 // Invalid status
 	PaymentStatusWatching PaymentStatusT = 1 // Payment currently watching
 	PaymentStatusPaid     PaymentStatusT = 2 // Payment fully paid
+
+	// DCC types
+	DCCTypeInvalid    DCCTypeT = 0 // Invalid DCC type
+	DCCTypeIssuance   DCCTypeT = 1 // Issuance DCC type
+	DCCTypeRevocation DCCTypeT = 2 // Revocation DCC type
+
+	// DCC status types
+	DCCStatusInvalid   DCCStatusT = 0 // Invalid issuance/revocation status
+	DCCStatusActive    DCCStatusT = 1 // Currently active issuance/revocation (awaiting sponsors)
+	DCCStatusSupported DCCStatusT = 2 // Fully supported issuance/revocation (received enough sponsors to proceed)
+	DCCStatusApproved  DCCStatusT = 3 // Approved issuance/revocation
+	DCCStatusRejected  DCCStatusT = 4 // Rejected issuance/revocation?  In the event of a Debate this would be result of a rejected issuance/revocation (that would override the mere sponsoring).
+	DCCStatusDebate    DCCStatusT = 5 // If a issuance/revocation receives enough comments, it would enter a "debate" status that would require a full contractor vote (to be added later).
 
 	InvoiceInputVersion = 1
 
@@ -122,6 +149,14 @@ const (
 	// each column field of the lineItem structure.
 	PolicyMaxLineItemColLength = 500
 
+	// PolicyMinSponsorStatementLength is the maximum length for the sponsor
+	// statement contained within a DCC
+	PolicyMinSponsorStatementLength = 0
+
+	// PolicyMaxSponsorStatementLength is the maximum length for the sponsor
+	// statement contained within a DCC
+	PolicyMaxSponsorStatementLength = 500
+
 	ErrorStatusMalformedName                  www.ErrorStatusT = 1001
 	ErrorStatusMalformedLocation              www.ErrorStatusT = 1002
 	ErrorStatusInvoiceNotFound                www.ErrorStatusT = 1003
@@ -151,6 +186,14 @@ const (
 	ErrorStatusDuplicatePaymentAddress        www.ErrorStatusT = 1028
 	ErrorStatusInvalidDatesRequested          www.ErrorStatusT = 1029
 	ErrorStatusInvalidInvoiceEditMonthYear    www.ErrorStatusT = 1030
+	ErrorStatusInvalidDCCType                 www.ErrorStatusT = 1031
+	ErrorStatusInvalidNominatingDomain        www.ErrorStatusT = 1032
+	ErrorStatusMalformedSponsorStatement      www.ErrorStatusT = 1033
+	ErrorStatusMalformedDCCFile               www.ErrorStatusT = 1034
+	ErrorStatusInvalidDCCComment              www.ErrorStatusT = 1035
+	ErrorStatusInvalidDCCStatusTransition     www.ErrorStatusT = 1036
+	ErrorStatusDuplicateEmail                 www.ErrorStatusT = 1037
+	ErrorStatusInvalidUserNewInvoice          www.ErrorStatusT = 1038
 )
 
 var (
@@ -175,6 +218,12 @@ var (
 	// contact for registering users on cms.
 	PolicyCMSContactSupportedChars = []string{
 		"A-z", "0-9", "&", ".", ":", "-", "_", "@", "+", ",", " "}
+
+	// PolicySponsorStatementSupportedChars is the regular expression of a valid
+	// sponsor statement for DCC in cms.
+	PolicySponsorStatementSupportedChars = []string{
+		"A-z", "0-9", "&", ".", ",", ":", ";", "-", " ", "@", "+", "#", "/",
+		"(", ")", "!", "?", "\"", "'"}
 
 	// ErrorStatus converts error status codes to human readable text.
 	ErrorStatus = map[www.ErrorStatusT]string{
@@ -205,6 +254,14 @@ var (
 		ErrorStatusDuplicatePaymentAddress:        "a duplicate payment address was used",
 		ErrorStatusInvalidDatesRequested:          "invalid dates were requested",
 		ErrorStatusInvalidInvoiceEditMonthYear:    "invalid attempt to edit invoice month/year",
+		ErrorStatusInvalidDCCType:                 "invalid DCC type was included",
+		ErrorStatusInvalidNominatingDomain:        "non-matching domain was attempt",
+		ErrorStatusMalformedSponsorStatement:      "DCC sponsor statement was malformed",
+		ErrorStatusMalformedDCCFile:               "submitted DCC file was malformed according to standards",
+		ErrorStatusInvalidDCCComment:              "submitted DCC comment must either be aye or nay",
+		ErrorStatusInvalidDCCStatusTransition:     "invalid status transition for a DCC",
+		ErrorStatusDuplicateEmail:                 "another user already has that email registered",
+		ErrorStatusInvalidUserNewInvoice:          "current contractor status does not allow new invoices to be created",
 	}
 )
 
@@ -316,7 +373,7 @@ type LineItemsInput struct {
 	Expenses      uint          `json:"expenses"`      // Total cost (in USD cents) of line item (if expense or misc)
 }
 
-// Policy for CMS
+// PolicyReply for returns the various policy information while in CMS mode.
 type PolicyReply struct {
 	MinPasswordLength             uint     `json:"minpasswordlength"`
 	MinUsernameLength             uint     `json:"minusernamelength"`
@@ -513,3 +570,133 @@ type EditUser struct {
 
 // EditUserReply is the reply for the EditUser command.
 type EditUserReply struct{}
+
+// DCCInput contains all of the information concerning a DCC object that
+// will be submitted as a Record to the politeiad backend.
+type DCCInput struct {
+	Type          DCCTypeT `json:"type"`          // Type of DCC object
+	NomineeUserID string   `json:"nomineeuserid"` // UserID of the DCC nominee (issuance or revocation)
+	//SponsorUserID    string      `json:"sponsoruserid"` // UserID of the sponsoring user
+	SponsorStatement string      `json:"statement"` // Statement from sponsoring user about why DCC should be approved
+	Domain           DomainTypeT `json:"domain"`    // Domain of proposed contractor issuance
+}
+
+// DCCRecord is what will be decoded from a Record for a DCC object to the politeiad backend.
+type DCCRecord struct {
+	Type               DCCTypeT   `json:"type"`               // Type of DCC
+	Status             DCCStatusT `json:"status"`             // Current status of the DCC
+	StatusChangeReason string     `json:"statuschangereason"` // The reason for changing the DCC status.
+	Timestamp          int64      `json:"timestamp"`          // Last update of dcc
+	DCC                DCCInput   `json:"dccpayload"`         // DCC payload for the given object
+	Files              []www.File `json:"file"`               // Actual DCC files (dcc.json, etc)
+	PublicKey          string     `json:"publickey"`          // Sponsoring user's public key, used to verify signature.
+	Signature          string     `json:"signature"`          // Signature of file digest
+	Version            string     `json:"version"`            // Record version
+
+	SponsorStatement string      `json:"statement"` // Sponsor statement in support of the DCC
+	Domain           DomainTypeT `json:"domain"`    // Domain of DCC
+
+	SponsorUserID   string `json:"sponsoruserid"`   // The userid of the sponsoring user.
+	SponsorUsername string `json:"sponsorusername"` // The username of the sponsoring user.
+
+	SupportUserIDs    []string `json:"supportuserids"` // List of UserIDs for those that have shown support of the DCC.
+	OppositionUserIDs []string `json:"againstuserids"` // List of UserIDs for those that have shown opposition of the DCC.
+
+	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
+}
+
+// NewDCC is a request for submitting a new DCC proposal.
+type NewDCC struct {
+	Files     []www.File `json:"files"`     // Issuance/Revocation file and any attachments along with it
+	PublicKey string     `json:"publickey"` // Pubkey of the sponsoring user
+	Signature string     `json:"signature"` // Signature of the issuance struct by the sponsoring user.
+}
+
+// NewDCCReply returns the censorship record when the DCC is successfully submitted to the backend.
+type NewDCCReply struct {
+	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
+}
+
+// NewDCCUser request adds a new user to the userdb (much like Invite), but this
+// user's information and access is limited until they are fully approved.
+type NewDCCUser struct {
+	ContractorName    string `json:"contractorname"`
+	ContractorContact string `json:"contractorcontact"`
+	ContractorEmail   string `json:"contractoremail"`
+	Signature         string `json:"signature"` // Signature of name + contact + email
+	PublicKey         string `json:"publickey"` // Public key of user
+}
+
+// NewDCCUserReply returns an empty response when successful.
+type NewDCCUserReply struct {
+	UserID string `json:"userid"` // UserID of the newly created nominee user.
+}
+
+// SupportDCC request allows a user to support a given DCC issuance or revocation.
+type SupportDCC struct {
+	Comment   string `json:"comment"`   // Comment must be "aye"
+	Signature string `json:"signature"` // Client Signature of Token+Comment
+	PublicKey string `json:"publickey"` // Pubkey used for Signature
+	Token     string `json:"token"`     // The censorship token of the given DCC issuance or revocation.
+}
+
+// SupportDCCReply returns an empty response when successful.
+type SupportDCCReply struct{}
+
+// OpposeDCC request allows a user to oppose a given DCC issuance or revocation.
+type OpposeDCC struct {
+	Comment   string `json:"comment"`   // Comment must be "nay"
+	Signature string `json:"signature"` // Client Signature of Token+Comment
+	PublicKey string `json:"publickey"` // Pubkey used for Signature
+	Token     string `json:"token"`     // The censorship token of the given DCC issuance or revocation.
+}
+
+// OpposeDCCReply returns an empty response when successful.
+type OpposeDCCReply struct{}
+
+// DCCDetails request finds a DCC with a matching token.
+type DCCDetails struct {
+	Token string `json:"token"` // Token of requested DCC
+}
+
+// DCCDetailsReply returns the DCC details if found.
+type DCCDetailsReply struct {
+	DCC DCCRecord `json:"dcc"` // DCCRecord of requested token
+}
+
+// GetDCCs request finds all DCCs that have matching status (if used).
+type GetDCCs struct {
+	Status DCCStatusT `json:"status"` // Return all DCCs of this status
+}
+
+// GetDCCsReply returns the DCCs if found.
+type GetDCCsReply struct {
+	DCCs []DCCRecord `json:"dccs"` // DCCRecords of matching status
+}
+
+// ApproveDCC is an admin request that gives final approval
+// to a given DCC iss or rev.
+type ApproveDCC struct {
+	Token     string `json:"token"`     // Token of the DCC iss/rev
+	Reason    string `json:"comment"`   // Reason for approval
+	Signature string `json:"signature"` // Client Signature of Token+Reason
+	PublicKey string `json:"publickey"` // Pubkey used for Signature
+}
+
+// ApproveDCCReply returns the verification token that has been given to the
+// invited user.
+type ApproveDCCReply struct {
+	VerificationToken string `json:"verificationtoken"`
+}
+
+// RejectDCC is an admin request that gives a final rejection to a given DCC
+// issuance or revocation.
+type RejectDCC struct {
+	Token     string `json:"token"`     // Token of the DCC iss/rev
+	Reason    string `json:"comment"`   // Reason for rejection
+	Signature string `json:"signature"` // Client Signature of Token+Reason
+	PublicKey string `json:"publickey"` // Pubkey used for Signature
+}
+
+// RejectDCCReply returns an empty response when successful.
+type RejectDCCReply struct{}

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -1750,6 +1750,197 @@ func (c *Client) CMSEditUser(uui cms.EditUser) (*cms.EditUserReply, error) {
 	return &eur, nil
 }
 
+// NewDCC creates a new dcc proposal.
+func (c *Client) NewDCC(nd cms.NewDCC) (*cms.NewDCCReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteNewDCC,
+		nd)
+	if err != nil {
+		return nil, err
+	}
+
+	var ndr cms.NewDCCReply
+	err = json.Unmarshal(responseBody, &ndr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal NewDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(ndr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ndr, nil
+}
+
+// NewDCCUser creates a new user that is used for dcc nomination
+func (c *Client) NewDCCUser(ndu cms.NewDCCUser) (*cms.NewDCCUserReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteNewDCCUser,
+		ndu)
+	if err != nil {
+		return nil, err
+	}
+
+	var ndur cms.NewDCCUserReply
+	err = json.Unmarshal(responseBody, &ndur)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal NewDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(ndur)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ndur, nil
+}
+
+// SupportDCC issues support for a given DCC proposal.
+func (c *Client) SupportDCC(sd cms.SupportDCC) (*cms.SupportDCCReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteSupportDCC,
+		sd)
+	if err != nil {
+		return nil, err
+	}
+
+	var sdr cms.SupportDCCReply
+	err = json.Unmarshal(responseBody, &sdr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal SupportDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(sdr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &sdr, nil
+}
+
+// OpposeDCC issues an opposition for a given DCC proposal.
+func (c *Client) OpposeDCC(sd cms.OpposeDCC) (*cms.OpposeDCCReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteOpposeDCC,
+		sd)
+	if err != nil {
+		return nil, err
+	}
+
+	var sdr cms.OpposeDCCReply
+	err = json.Unmarshal(responseBody, &sdr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal OpposeDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(sdr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &sdr, nil
+}
+
+// ApproveDCC issues an admin approval for a given DCC proposal.
+func (c *Client) ApproveDCC(sd cms.ApproveDCC) (*cms.ApproveDCCReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteApproveDCC,
+		sd)
+	if err != nil {
+		return nil, err
+	}
+
+	var sdr cms.ApproveDCCReply
+	err = json.Unmarshal(responseBody, &sdr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal ApproveDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(sdr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &sdr, nil
+}
+
+// RejectDCC issues an admin approval for a given DCC proposal.
+func (c *Client) RejectDCC(rd cms.RejectDCC) (*cms.RejectDCCReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteRejectDCC,
+		rd)
+	if err != nil {
+		return nil, err
+	}
+
+	var rdr cms.RejectDCCReply
+	err = json.Unmarshal(responseBody, &rdr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal RejectDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(rdr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &rdr, nil
+}
+
+// DCCDetails retrieves the specified dcc.
+func (c *Client) DCCDetails(token string) (*cms.DCCDetailsReply, error) {
+	responseBody, err := c.makeRequest("GET", "/dcc/"+token, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var ddr cms.DCCDetailsReply
+	err = json.Unmarshal(responseBody, &ddr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal DCCDetailsReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(ddr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ddr, nil
+}
+
+// GetDCCss retrieves invoices base on possible field set in the request
+// month/year and/or status
+func (c *Client) GetDCCs(gd *cms.GetDCCs) (*cms.GetDCCsReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteGetDCCs, gd)
+	if err != nil {
+		return nil, err
+	}
+
+	var gdr cms.GetDCCsReply
+	err = json.Unmarshal(responseBody, &gdr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal GetDCCsReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(gdr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &gdr, nil
+}
+
 // Close all client connections.
 func (c *Client) Close() {
 	if c.conn != nil {

--- a/politeiawww/cmd/politeiawwwcli/commands/approvedcc.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/approvedcc.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// ApproveDCCCmd allows an administrator to approve a DCC proposal.
+type ApproveDCCCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"`
+	} `positional-args:"true" required:"true"`
+	Reason string `long:"reason" optional:"true" description:"Reason to approve DCC"`
+}
+
+// Execute executes the approve DCC command.
+func (cmd *ApproveDCCCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	if token == "" {
+		return fmt.Errorf("invalid request: you must specify dcc " +
+			"token")
+	}
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	if cmd.Reason == "" {
+		reader := bufio.NewReader(os.Stdin)
+		if cmd.Reason == "" {
+			fmt.Print("Enter your reason to approve the DCC: ")
+			reason, _ := reader.ReadString('\n')
+			cmd.Reason = strings.TrimSpace(reason)
+		}
+		fmt.Print("\nPlease carefully review your information and ensure it's " +
+			"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
+			"your registration.")
+		reader.ReadString('\n')
+	}
+
+	// Setup new comment request
+	sig := cfg.Identity.SignMessage([]byte(token + cmd.Reason))
+
+	ad := v1.ApproveDCC{
+		Token:     cmd.Args.Token,
+		Reason:    cmd.Reason,
+		Signature: hex.EncodeToString(sig[:]),
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+	}
+
+	// Print request details
+	err := printJSON(ad)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	sdr, err := client.ApproveDCC(ad)
+	if err != nil {
+		return fmt.Errorf("ApproveDCC: %v", err)
+	}
+
+	// Print response details
+	err = printJSON(sdr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/dccdetails.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/dccdetails.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+)
+
+// DCCDetailsCmd retrieves the details of a dcc.
+type DCCDetailsCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token" required:"true"` // Censorship token
+	} `positional-args:"true"`
+}
+
+// Execute executes the dcc details command.
+func (cmd *DCCDetailsCmd) Execute(args []string) error {
+	// Get server's public key
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+
+	// Get dcc
+	ddr, err := client.DCCDetails(cmd.Args.Token)
+	if err != nil {
+		return err
+	}
+
+	// Verify dcc censorship record
+	err = verifyDCC(ddr.DCC, vr.PubKey)
+	if err != nil {
+		return fmt.Errorf("unable to verify dcc %v: %v",
+			ddr.DCC.CensorshipRecord.Token, err)
+	}
+
+	// Print invoice details
+	return printJSON(ddr)
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/getdccs.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/getdccs.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// GetDCCsCmd gets all dccs by status.
+type GetDCCsCmd struct {
+	Args struct {
+		Status int `long:"status"`
+	}
+}
+
+// Execute executes the get dccs command.
+func (cmd *GetDCCsCmd) Execute(args []string) error {
+	// Get server public key
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+
+	gdr, err := client.GetDCCs(
+		&v1.GetDCCs{
+			Status: v1.DCCStatusT(cmd.Args.Status),
+		})
+	if err != nil {
+		return err
+	}
+
+	// Verify dcc censorship records
+	for _, p := range gdr.DCCs {
+		err := verifyDCC(p, vr.PubKey)
+		if err != nil {
+			return fmt.Errorf("unable to verify dcc %v: %v",
+				p.CensorshipRecord.Token, err)
+		}
+	}
+
+	// Print user invoices
+	return printJSON(gdr)
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/newdcc.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newdcc.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/decred/politeia/politeiad/api/v1/mime"
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+	www "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/util"
+)
+
+// NewDCCCmd submits a new dcc.
+type NewDCCCmd struct {
+	Args struct {
+		Type        uint     `positional-arg-name:"type"`            // 1 for Issuance, 2 for Revocation
+		Attachments []string `positional-arg-name:"attachmentfiles"` // DCC attachment files
+	} `positional-args:"true" optional:"true"`
+	Type          string ``
+	NomineeUserID string `long:"nomineeuserid" optional:"true" description:"The UserID of the Nominated User"`
+	Statement     string `long:"statement" optional:"true" description:"Statement in support of the DCC"`
+	Domain        string `long:"domain" optional:"true" description:"The domain of the nominated user"`
+}
+
+// Execute executes the new dcc command.
+func (cmd *NewDCCCmd) Execute(args []string) error {
+
+	// Check for a valid DCC type
+	if int(cmd.Args.Type) <= 0 || int(cmd.Args.Type) > 1 {
+		return errInvalidDCCType
+	}
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	// Get server public key
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+
+	if cmd.Statement == "" || cmd.NomineeUserID == "" {
+		reader := bufio.NewReader(os.Stdin)
+		if cmd.Statement == "" {
+			fmt.Print("Enter your statement to support the DCC: ")
+			cmd.Statement, _ = reader.ReadString('\n')
+		}
+		if cmd.NomineeUserID == "" {
+			fmt.Print("Enter the nominee user id: ")
+			cmd.NomineeUserID, _ = reader.ReadString('\n')
+		}
+		fmt.Print("\nPlease carefully review your information and ensure it's " +
+			"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
+			"your registration.")
+		reader.ReadString('\n')
+	}
+
+	dccInput := &cms.DCCInput{}
+	dccInput.SponsorStatement = strings.TrimSpace(cmd.Statement)
+	dccInput.NomineeUserID = strings.TrimSpace(cmd.NomineeUserID)
+	dccInput.Type = cms.DCCTypeT(int(cmd.Args.Type))
+
+	// Print request details
+	err = printJSON(dccInput)
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(dccInput)
+	if err != nil {
+		return fmt.Errorf("Marshal: %v", err)
+	}
+
+	f := www.File{
+		Name:    "dcc.json",
+		MIME:    mime.DetectMimeType(b),
+		Digest:  hex.EncodeToString(util.Digest(b)),
+		Payload: base64.StdEncoding.EncodeToString(b),
+	}
+
+	files := make([]www.File, 0, www.PolicyMaxImages+1)
+	files = append(files, f)
+
+	attachmentFiles := cmd.Args.Attachments
+	// Read attachment files into memory and convert to type File
+	for _, file := range attachmentFiles {
+		path := util.CleanAndExpandPath(file)
+		attachment, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("ReadFile %v: %v", path, err)
+		}
+
+		f := www.File{
+			Name:    filepath.Base(file),
+			MIME:    mime.DetectMimeType(attachment),
+			Digest:  hex.EncodeToString(util.Digest(attachment)),
+			Payload: base64.StdEncoding.EncodeToString(attachment),
+		}
+
+		files = append(files, f)
+	}
+
+	// Compute merkle root and sign it
+	sig, err := signedMerkleRoot(files, cfg.Identity)
+	if err != nil {
+		return fmt.Errorf("SignMerkleRoot: %v", err)
+	}
+
+	// Setup new dcc request
+	nd := cms.NewDCC{
+		Files:     files,
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+		Signature: sig,
+	}
+
+	// Print request details
+	err = printJSON(nd)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	ndr, err := client.NewDCC(nd)
+	if err != nil {
+		return err
+	}
+
+	// Verify the censorship record
+	pr := www.ProposalRecord{
+		Files:            nd.Files,
+		PublicKey:        nd.PublicKey,
+		Signature:        nd.Signature,
+		CensorshipRecord: ndr.CensorshipRecord,
+	}
+	err = verifyProposal(pr, vr.PubKey)
+	if err != nil {
+		return fmt.Errorf("unable to verify proposal %v: %v",
+			pr.CensorshipRecord.Token, err)
+	}
+
+	// Print response details
+	return printJSON(ndr)
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/newdccuser.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newdccuser.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"fmt"
+
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// NewUserCmd creates a new politeia user.
+type NewDCCUserCmd struct {
+	Args struct {
+		ContractorName    string `positional-arg-name:"name"`    // Email address
+		ContractorContact string `positional-arg-name:"contact"` // Email address
+		ContractorEmail   string `positional-arg-name:"email"`   // Email address
+	} `positional-args:"true"`
+}
+
+// Execute executes the new dcc user command.
+func (cmd *NewDCCUserCmd) Execute(args []string) error {
+	email := cmd.Args.ContractorEmail
+	name := cmd.Args.ContractorName
+	contact := cmd.Args.ContractorContact
+
+	// Fetch CSRF tokens
+	_, err := client.Version()
+	if err != nil {
+		return fmt.Errorf("Version: %v", err)
+	}
+
+	// Setup new user request
+	ndu := cms.NewDCCUser{
+		ContractorName:    name,
+		ContractorContact: contact,
+		ContractorEmail:   email,
+	}
+
+	// Print request details
+	err = printJSON(ndu)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	ndur, err := client.NewDCCUser(ndu)
+	if err != nil {
+		return fmt.Errorf("NewUser: %v", err)
+	}
+
+	// Print response details
+	err = printJSON(ndur)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/opposedcc.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/opposedcc.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// OpposeDCCCmd allows a user to oppose a DCC proposal.
+type OpposeDCCCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"`
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the oppose DCC command.
+func (cmd *OpposeDCCCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	comment := "nay"
+	if token == "" {
+		return fmt.Errorf("invalid request: you must specify dcc " +
+			"token")
+	}
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	// Setup new comment request
+	sig := cfg.Identity.SignMessage([]byte(token + comment))
+
+	sd := v1.OpposeDCC{
+		Token:     cmd.Args.Token,
+		Comment:   comment,
+		Signature: hex.EncodeToString(sig[:]),
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+	}
+
+	// Print request details
+	err := printJSON(sd)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	sdr, err := client.OpposeDCC(sd)
+	if err != nil {
+		return fmt.Errorf("OpposeDCC: %v", err)
+	}
+
+	// Print response details
+	err = printJSON(sdr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/rejectdcc.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/rejectdcc.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// RejectDCCCmd allows an administrator to reject a DCC proposal.
+type RejectDCCCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"`
+	} `positional-args:"true" required:"true"`
+	Reason string `long:"reason" optional:"true" description:"Reason to reject DCC"`
+}
+
+// Execute executes the reject DCC command.
+func (cmd *RejectDCCCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	if token == "" {
+		return fmt.Errorf("invalid request: you must specify dcc " +
+			"token")
+	}
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	if cmd.Reason == "" {
+		reader := bufio.NewReader(os.Stdin)
+		if cmd.Reason == "" {
+			fmt.Print("Enter your reason to reject the DCC: ")
+			reason, _ := reader.ReadString('\n')
+			cmd.Reason = strings.TrimSpace(reason)
+		}
+		fmt.Print("\nPlease carefully review your information and ensure it's " +
+			"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
+			"your registration.")
+		reader.ReadString('\n')
+	}
+
+	// Setup new comment request
+	sig := cfg.Identity.SignMessage([]byte(token + cmd.Reason))
+
+	ad := v1.RejectDCC{
+		Token:     cmd.Args.Token,
+		Reason:    cmd.Reason,
+		Signature: hex.EncodeToString(sig[:]),
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+	}
+
+	// Print request details
+	err := printJSON(ad)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	sdr, err := client.RejectDCC(ad)
+	if err != nil {
+		return fmt.Errorf("RejectDCC: %v", err)
+	}
+
+	// Print response details
+	err = printJSON(sdr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiawwwcli/commands/supportdcc.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/supportdcc.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// SupportDCCCmd allows a user to support a DCC proposal.
+type SupportDCCCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"`
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the support DCC command.
+func (cmd *SupportDCCCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	comment := "aye"
+	if token == "" {
+		return fmt.Errorf("invalid request: you must specify dcc " +
+			"token")
+	}
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	// Setup new comment request
+	sig := cfg.Identity.SignMessage([]byte(token + comment))
+
+	sd := v1.SupportDCC{
+		Token:     cmd.Args.Token,
+		Comment:   comment,
+		Signature: hex.EncodeToString(sig[:]),
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+	}
+
+	// Print request details
+	err := printJSON(sd)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	sdr, err := client.SupportDCC(sd)
+	if err != nil {
+		return fmt.Errorf("SupportDCC: %v", err)
+	}
+
+	// Print response details
+	err = printJSON(sdr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -634,7 +634,7 @@ func (c *cockroachdb) DCCsByStatus(status int) ([]*database.DCC, error) {
 	return dbDCCs, nil
 }
 
-// DCCsByStatus Return DCCs by status.
+// DCCsAll Returns all DCCs regardless of status.
 func (c *cockroachdb) DCCsAll() ([]*database.DCC, error) {
 	log.Debugf("DCCsAll:")
 

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -577,7 +577,7 @@ func (c *cockroachdb) PaymentsByStatus(status uint) ([]database.Payments, error)
 func (c *cockroachdb) NewDCC(dbDCC *database.DCC) error {
 	dcc := encodeDCC(dbDCC)
 
-	log.Debugf("NewDCC: %v %v", dcc.Token)
+	log.Debugf("NewDCC: %v", dcc.Token)
 	return c.recordsdb.Create(dcc).Error
 }
 

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -27,6 +27,7 @@ const (
 	tableNameInvoiceChange = "invoice_changes"
 	tableNameExchangeRate  = "exchange_rates"
 	tableNamePayments      = "payments"
+	tableNameDCC           = "dcc"
 
 	userPoliteiawww = "politeiawww" // cmsdb user (read/write access)
 )
@@ -408,6 +409,12 @@ func createCmsTables(tx *gorm.DB) error {
 			return err
 		}
 	}
+	if !tx.HasTable(tableNameDCC) {
+		err := tx.CreateTable(&DCC{}).Error
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -562,4 +569,89 @@ func (c *cockroachdb) PaymentsByStatus(status uint) ([]database.Payments, error)
 		dbPayments = append(dbPayments, decodePayment(&v))
 	}
 	return dbPayments, nil
+}
+
+// Create new dcc.
+//
+// NewDCC satisfies the database interface.
+func (c *cockroachdb) NewDCC(dbDCC *database.DCC) error {
+	dcc := encodeDCC(dbDCC)
+
+	log.Debugf("NewDCC: %v %v", dcc.Token)
+	return c.recordsdb.Create(dcc).Error
+}
+
+// Update existing dcc.
+//
+// UpdateDCC satisfies the database interface.
+func (c *cockroachdb) UpdateDCC(dbDCC *database.DCC) error {
+	dcc := encodeDCC(dbDCC)
+
+	log.Debugf("UpdateDCC: %v", dcc.Token)
+
+	return c.recordsdb.Save(dcc).Error
+}
+
+// DCCByToken Return DCC by its token.
+func (c *cockroachdb) DCCByToken(token string) (*database.DCC, error) {
+	log.Debugf("DCCByToken: %v", token)
+
+	dcc := DCC{
+		Token: token,
+	}
+	err := c.recordsdb.
+		Find(&dcc).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			err = database.ErrDCCNotFound
+		}
+		return nil, err
+	}
+
+	return decodeDCC(&dcc), nil
+}
+
+// DCCsByStatus Return DCCs by status.
+func (c *cockroachdb) DCCsByStatus(status int) ([]*database.DCC, error) {
+	log.Debugf("DCCsByStatus: %v", status)
+
+	dccs := make([]DCC, 0, 1048)
+	err := c.recordsdb.
+		Where("status = ?", status).
+		Find(&dccs).
+		Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			err = database.ErrDCCNotFound
+		}
+		return nil, err
+	}
+
+	dbDCCs := make([]*database.DCC, 0, 1048)
+	for _, v := range dccs {
+		dbDCCs = append(dbDCCs, decodeDCC(&v))
+	}
+	return dbDCCs, nil
+}
+
+// DCCsByStatus Return DCCs by status.
+func (c *cockroachdb) DCCsAll() ([]*database.DCC, error) {
+	log.Debugf("DCCsAll:")
+
+	dccs := make([]DCC, 0, 1048)
+	err := c.recordsdb.
+		Find(&dccs).
+		Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			err = database.ErrDCCNotFound
+		}
+		return nil, err
+	}
+
+	dbDCCs := make([]*database.DCC, 0, 1048)
+	for _, v := range dccs {
+		dbDCCs = append(dbDCCs, decodeDCC(&v))
+	}
+	return dbDCCs, nil
 }

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -203,3 +203,47 @@ func decodePayment(payments *Payments) database.Payments {
 	dbPayments.Status = cms.PaymentStatusT(payments.Status)
 	return dbPayments
 }
+
+func encodeDCC(dbDCC *database.DCC) DCC {
+	dcc := DCC{
+		Token:              dbDCC.Token,
+		SponsorUserID:      dbDCC.SponsorUserID,
+		NomineeUserID:      dbDCC.NomineeUserID,
+		Type:               int(dbDCC.Type),
+		Status:             int(dbDCC.Status),
+		StatusChangeReason: dbDCC.StatusChangeReason,
+		Timestamp:          dbDCC.Timestamp,
+		PublicKey:          dbDCC.PublicKey,
+		UserSignature:      dbDCC.UserSignature,
+		ServerSignature:    dbDCC.ServerSignature,
+		Version:            dbDCC.Version,
+		SponsorStatement:   dbDCC.SponsorStatement,
+		Domain:             int(dbDCC.Domain),
+
+		SupportUserIDs:    dbDCC.SupportUserIDs,
+		OppositionUserIDs: dbDCC.OppositionUserIDs,
+	}
+	return dcc
+}
+
+func decodeDCC(dcc *DCC) *database.DCC {
+	dbDCC := database.DCC{
+		Token:              dcc.Token,
+		SponsorUserID:      dcc.SponsorUserID,
+		NomineeUserID:      dcc.NomineeUserID,
+		Type:               cms.DCCTypeT(dcc.Type),
+		Status:             cms.DCCStatusT(dcc.Status),
+		StatusChangeReason: dcc.StatusChangeReason,
+		Timestamp:          dcc.Timestamp,
+		PublicKey:          dcc.PublicKey,
+		UserSignature:      dcc.UserSignature,
+		ServerSignature:    dcc.ServerSignature,
+		Version:            dcc.Version,
+		SponsorStatement:   dcc.SponsorStatement,
+		Domain:             cms.DomainTypeT(dcc.Domain),
+
+		SupportUserIDs:    dcc.SupportUserIDs,
+		OppositionUserIDs: dcc.OppositionUserIDs,
+	}
+	return &dbDCC
+}

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -204,7 +204,7 @@ func decodePayment(payments *Payments) database.Payments {
 	return dbPayments
 }
 
-func encodeDCC(dbDCC *database.DCC) DCC {
+func encodeDCC(dbDCC *database.DCC) *DCC {
 	dcc := DCC{
 		Token:              dbDCC.Token,
 		SponsorUserID:      dbDCC.SponsorUserID,
@@ -223,7 +223,7 @@ func encodeDCC(dbDCC *database.DCC) DCC {
 		SupportUserIDs:    dbDCC.SupportUserIDs,
 		OppositionUserIDs: dbDCC.OppositionUserIDs,
 	}
-	return dcc
+	return &dcc
 }
 
 func decodeDCC(dcc *DCC) *database.DCC {

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -102,3 +102,28 @@ type Payments struct {
 func (Payments) TableName() string {
 	return tableNamePayments
 }
+
+// DCC contains all the information about a given DCC proposal.
+type DCC struct {
+	Token              string `gorm:"primary_key"`
+	SponsorUserID      string
+	NomineeUserID      string
+	Type               int
+	Status             int
+	StatusChangeReason string
+	Timestamp          int64
+	PublicKey          string
+	UserSignature      string
+	ServerSignature    string
+	Version            string
+	SponsorStatement   string
+	Domain             int
+
+	SupportUserIDs    string
+	OppositionUserIDs string
+}
+
+// TableName returns the table name of the issuance table.
+func (DCC) TableName() string {
+	return tableNameDCC
+}

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -22,6 +22,9 @@ var (
 
 	// ErrExchangeRateNotFound indicates that an exchange rate for a given month/year was not found
 	ErrExchangeRateNotFound = errors.New("exchange rate not found")
+
+	// ErrDCCNotFound indicates that a DCC was not found from a given token
+	ErrDCCNotFound = errors.New("dcc not found")
 )
 
 // Database interface that is required by the web server.
@@ -48,6 +51,14 @@ type Database interface {
 	UpdatePayments(*Payments) error // Update existing payment information
 	PaymentsByAddress(string) (*Payments, error)
 	PaymentsByStatus(uint) ([]Payments, error)
+
+	// DCC
+	NewDCC(*DCC) error
+	UpdateDCC(*DCC) error
+
+	DCCByToken(string) (*DCC, error)
+	DCCsByStatus(int) ([]*DCC, error)
+	DCCsAll() ([]*DCC, error)
 
 	// Setup the invoice tables
 	Setup() error
@@ -127,4 +138,24 @@ type Payments struct {
 	AmountNeeded    int64
 	AmountReceived  int64
 	Status          cms.PaymentStatusT
+}
+
+type DCC struct {
+	Token              string
+	SponsorUserID      string
+	NomineeUserID      string
+	Type               cms.DCCTypeT
+	Status             cms.DCCStatusT
+	Files              []www.File
+	StatusChangeReason string
+	Timestamp          int64
+	PublicKey          string
+	UserSignature      string
+	ServerSignature    string
+	Version            string
+	SponsorStatement   string
+	Domain             cms.DomainTypeT
+
+	SupportUserIDs    string
+	OppositionUserIDs string
 }

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -342,7 +342,7 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 
 func (p *politeiawww) processCMSUserDetails(ud *cms.UserDetails, isCurrentUser bool, isAdmin bool) (*cms.UserDetailsReply, error) {
 	// Return error in case the user isn't the admin or the current user.
-	if !isAdmin || !isCurrentUser {
+	if !isAdmin && !isCurrentUser {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusUserActionNotAllowed,
 		}

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -348,35 +348,11 @@ func (p *politeiawww) processCMSUserDetails(ud *cms.UserDetails, isCurrentUser b
 		}
 	}
 	reply := cms.UserDetailsReply{}
-	ubi := user.CMSUserByID{
-		ID: ud.UserID,
-	}
-	payload, err := user.EncodeCMSUserByID(ubi)
+	u, err := p.getCMSUserByID(ud.UserID)
 	if err != nil {
 		return nil, err
 	}
-	pc := user.PluginCommand{
-		ID:      user.CMSPluginID,
-		Command: user.CmdCMSUserByID,
-		Payload: string(payload),
-	}
-	payloadReply, err := p.db.PluginExec(pc)
-	if err != nil {
-		return nil, err
-	}
-	ubir, err := user.DecodeCMSUserByIDReply([]byte(payloadReply.Payload))
-	if err != nil {
-		return nil, err
-	}
-	reply.User = convertCMSUserFromDatabaseUser(&ubir.User.User)
-	reply.User.Domain = cms.DomainTypeT(ubir.User.Domain)
-	reply.User.ContractorType = cms.ContractorTypeT(ubir.User.ContractorType)
-	reply.User.ContractorName = ubir.User.ContractorName
-	reply.User.ContractorLocation = ubir.User.ContractorLocation
-	reply.User.ContractorContact = ubir.User.ContractorContact
-	reply.User.MatrixName = ubir.User.MatrixName
-	reply.User.GitHubName = ubir.User.GitHubName
-	reply.User.SupervisorUserID = ubir.User.SupervisorUserID
+	reply.User = *u
 
 	return &reply, nil
 }
@@ -433,25 +409,128 @@ func validateUserInformation(userInfo cms.EditUser) error {
 	}
 	return nil
 }
+func (p *politeiawww) getCMSUserByID(id string) (*cms.User, error) {
+	ubi := user.CMSUserByID{
+		ID: id,
+	}
+	payload, err := user.EncodeCMSUserByID(ubi)
+	if err != nil {
+		return nil, err
+	}
+	pc := user.PluginCommand{
+		ID:      user.CMSPluginID,
+		Command: user.CmdCMSUserByID,
+		Payload: string(payload),
+	}
+	payloadReply, err := p.db.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+	ubir, err := user.DecodeCMSUserByIDReply([]byte(payloadReply.Payload))
+	if err != nil {
+		return nil, err
+	}
+	u := convertCMSUserFromDatabaseUser(ubir.User)
+	return &u, nil
+
+}
 
 // convertCMSUserFromDatabaseUser converts a user User to a cms User.
-func convertCMSUserFromDatabaseUser(user *user.User) cms.User {
+func convertCMSUserFromDatabaseUser(user *user.CMSUser) cms.User {
 	return cms.User{
-		ID:                              user.ID.String(),
-		Admin:                           user.Admin,
-		Email:                           user.Email,
-		Username:                        user.Username,
-		NewUserVerificationToken:        user.NewUserVerificationToken,
-		NewUserVerificationExpiry:       user.NewUserVerificationExpiry,
-		UpdateKeyVerificationToken:      user.UpdateKeyVerificationToken,
-		UpdateKeyVerificationExpiry:     user.UpdateKeyVerificationExpiry,
-		ResetPasswordVerificationToken:  user.ResetPasswordVerificationToken,
-		ResetPasswordVerificationExpiry: user.ResetPasswordVerificationExpiry,
-		LastLoginTime:                   user.LastLoginTime,
-		FailedLoginAttempts:             user.FailedLoginAttempts,
-		Deactivated:                     user.Deactivated,
-		Locked:                          userIsLocked(user.FailedLoginAttempts),
-		Identities:                      convertWWWIdentitiesFromDatabaseIdentities(user.Identities),
-		EmailNotifications:              user.EmailNotifications,
+		ID:                              user.User.ID.String(),
+		Admin:                           user.User.Admin,
+		Email:                           user.User.Email,
+		Username:                        user.User.Username,
+		NewUserVerificationToken:        user.User.NewUserVerificationToken,
+		NewUserVerificationExpiry:       user.User.NewUserVerificationExpiry,
+		UpdateKeyVerificationToken:      user.User.UpdateKeyVerificationToken,
+		UpdateKeyVerificationExpiry:     user.User.UpdateKeyVerificationExpiry,
+		ResetPasswordVerificationToken:  user.User.ResetPasswordVerificationToken,
+		ResetPasswordVerificationExpiry: user.User.ResetPasswordVerificationExpiry,
+		LastLoginTime:                   user.User.LastLoginTime,
+		FailedLoginAttempts:             user.User.FailedLoginAttempts,
+		Deactivated:                     user.User.Deactivated,
+		Locked:                          userIsLocked(user.User.FailedLoginAttempts),
+		Identities:                      convertWWWIdentitiesFromDatabaseIdentities(user.User.Identities),
+		EmailNotifications:              user.User.EmailNotifications,
+		Domain:                          cms.DomainTypeT(user.Domain),
+		ContractorType:                  cms.ContractorTypeT(user.ContractorType),
+		ContractorName:                  user.ContractorName,
+		ContractorLocation:              user.ContractorLocation,
+		ContractorContact:               user.ContractorContact,
+		MatrixName:                      user.MatrixName,
+		GitHubName:                      user.GitHubName,
+		SupervisorUserID:                user.SupervisorUserID,
 	}
+}
+
+func (p *politeiawww) processNewDCCUser(ndu cms.NewDCCUser, u *user.User) (*cms.NewDCCUserReply, error) {
+	log.Tracef("processNewDCCUser: %v", ndu.ContractorEmail)
+
+	// Validate email
+	if !validEmail.MatchString(ndu.ContractorEmail) {
+		log.Debugf("processNewDCCUser: invalid email '%v'", ndu.ContractorEmail)
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusMalformedEmail,
+		}
+	}
+
+	// Check if the user is already verified.
+	_, err := p.userByEmail(ndu.ContractorEmail)
+	if err == nil {
+		return nil, www.UserError{
+			ErrorCode: cms.ErrorStatusDuplicateEmail,
+		}
+	}
+
+	/// XXX Should we send the perspective user any information about them getting nominated?
+	/*
+		// Try to email the verification link first; if it fails, then
+		// the new user won't be created.
+		//
+		// This is conditional on the email server being setup.
+		err = p.emailInviteNewUserVerificationLink(u.Email,
+			hex.EncodeToString(token))
+		if err != nil {
+			log.Errorf("processInviteNewUser: verification email "+
+				"failed for '%v': %v", u.Email, err)
+			return &www.NewUserReply{}, nil
+		}
+	*/
+
+	// Create a new cms user with the provided information.
+	// This temporarily sets the username to the given email, which will be
+	// overwritten during registration. This is needed since the constraints
+	// on cockroachdb for usernames requires there to be no duplicates. If
+	// unset, the username of "" will cause a duplicate error to be thrown.
+	nu := user.NewDCCUser{
+		ContractorContact: strings.ToLower(ndu.ContractorContact),
+		ContractorName:    strings.ToLower(ndu.ContractorName),
+		Email:             strings.ToLower(ndu.ContractorEmail),
+		Username:          strings.ToLower(ndu.ContractorEmail),
+	}
+	payload, err := user.EncodeNewDCCUser(nu)
+	if err != nil {
+		return nil, err
+	}
+	pc := user.PluginCommand{
+		ID:      user.CMSPluginID,
+		Command: user.CmdNewCMSUser,
+		Payload: string(payload),
+	}
+	_, err = p.db.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update user emails cache
+	usr, err := p.db.UserGetByUsername(nu.Username)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cms.NewDCCUserReply{
+		UserID: usr.ID.String(),
+	}, nil
 }

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -523,6 +523,277 @@ func (p *politeiawww) handleLineItemPayouts(w http.ResponseWriter, r *http.Reque
 	util.RespondWithJSON(w, http.StatusOK, lipr)
 }
 
+func (p *politeiawww) handleNewDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleNewDCC")
+
+	var nd cms.NewDCC
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&nd); err != nil {
+		RespondWithError(w, r, 0, "handleNewDCC: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleNewDCC: getSessionUser %v", err)
+		return
+	}
+
+	ndr, err := p.processNewDCC(nd, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleNewDCC: processNewDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, ndr)
+}
+
+func (p *politeiawww) handleSupportDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleSupportDCC")
+
+	var sd cms.SupportDCC
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&sd); err != nil {
+		RespondWithError(w, r, 0, "handleSupportDCC: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleSupportDCC: getSessionUser %v", err)
+		return
+	}
+
+	sdr, err := p.processSupportDCC(sd, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleSupportDCC: processSupportDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, sdr)
+}
+
+func (p *politeiawww) handleOpposeDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleOpposeDCC")
+
+	var od cms.OpposeDCC
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&od); err != nil {
+		RespondWithError(w, r, 0, "handleOpposeDCC: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleOpposeDCC: getSessionUser %v", err)
+		return
+	}
+
+	odr, err := p.processOpposeDCC(od, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleOpposeDCC: processOpposeDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, odr)
+}
+
+func (p *politeiawww) handleDCCDetails(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleDCCDetails")
+
+	var gd cms.DCCDetails
+	// get version from query string parameters
+	err := util.ParseGetParams(r, &gd)
+	if err != nil {
+		RespondWithError(w, r, 0, "handleDCCDetails: ParseGetParams",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	// Get dcc token from path parameters
+	pathParams := mux.Vars(r)
+	gd.Token = pathParams["token"]
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&gd); err != nil {
+		RespondWithError(w, r, 0, "handleDCCDetails: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	gdr, err := p.processDCCDetails(gd)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleDCCDetails: processDCCDetails: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, gdr)
+}
+
+func (p *politeiawww) handleGetDCCs(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleGetDCCs")
+
+	var gds cms.GetDCCs
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&gds); err != nil {
+		RespondWithError(w, r, 0, "handleGetDCCs: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	_, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleGetDCCs: getSessionUser %v", err)
+		return
+	}
+
+	gdsr, err := p.processGetDCCs(gds)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleGetDCCs: processGetDCCs: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, gdsr)
+}
+
+func (p *politeiawww) handleApproveDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleApproveDCC")
+
+	var ad cms.ApproveDCC
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&ad); err != nil {
+		RespondWithError(w, r, 0, "handleApproveDCC: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleApproveDCC: getSessionUser %v", err)
+		return
+	}
+
+	adr, err := p.processApproveDCC(ad, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleApproveDCC: processApproveDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, adr)
+}
+
+func (p *politeiawww) handleRejectDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleRejectDCC")
+
+	var rd cms.RejectDCC
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&rd); err != nil {
+		RespondWithError(w, r, 0, "handleRejectDCC: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleRejectDCC: getSessionUser %v", err)
+		return
+	}
+
+	rdr, err := p.processRejectDCC(rd, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleRejectDCC: processRejectDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, rdr)
+}
+
+func (p *politeiawww) handleNewDCCUser(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleNewDCCUser")
+
+	var ndu cms.NewDCCUser
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&ndu); err != nil {
+		RespondWithError(w, r, 0, "handleNewDCCUser: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleNewDCCUser: getSessionUser %v", err)
+		return
+	}
+
+	ndur, err := p.processNewDCCUser(ndu, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleNewDCCUser: processNewDCCUser: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, ndur)
+}
+
+// handleNewCommentDCC handles incomming comments for DCC.
+func (p *politeiawww) handleNewCommentDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleNewCommentDCC")
+
+	var sc www.NewComment
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&sc); err != nil {
+		RespondWithError(w, r, 0, "handleNewCommentDCC: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	user, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleNewCommentDCC: getSessionUser %v", err)
+		return
+	}
+
+	cr, err := p.processNewCommentDCC(sc, user)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleNewCommentDCC: processNewCommentDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, cr)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -559,6 +830,20 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleInvoiceComments, permissionLogin)
 	p.addRoute(http.MethodPost, cms.RouteInvoiceExchangeRate,
 		p.handleInvoiceExchangeRate, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteNewDCC,
+		p.handleNewDCC, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteSupportDCC,
+		p.handleSupportDCC, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteOpposeDCC,
+		p.handleOpposeDCC, permissionLogin)
+	p.addRoute(http.MethodGet, cms.RouteDCCDetails,
+		p.handleDCCDetails, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteGetDCCs,
+		p.handleGetDCCs, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteNewDCCUser,
+		p.handleNewDCCUser, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteNewCommentDCC,
+		p.handleNewCommentDCC, permissionLogin)
 
 	// Unauthenticated websocket
 	p.addRoute("", www.RouteUnauthenticatedWebSocket,
@@ -584,4 +869,8 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleLineItemPayouts, permissionAdmin)
 	p.addRoute(http.MethodGet, cms.RouteAdminUserInvoices,
 		p.handleAdminUserInvoices, permissionAdmin)
+	p.addRoute(http.MethodPost, cms.RouteApproveDCC,
+		p.handleApproveDCC, permissionAdmin)
+	p.addRoute(http.MethodPost, cms.RouteRejectDCC,
+		p.handleRejectDCC, permissionAdmin)
 }

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -623,19 +623,9 @@ func (p *politeiawww) handleDCCDetails(w http.ResponseWriter, r *http.Request) {
 			})
 		return
 	}
-
 	// Get dcc token from path parameters
 	pathParams := mux.Vars(r)
 	gd.Token = pathParams["token"]
-
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&gd); err != nil {
-		RespondWithError(w, r, 0, "handleDCCDetails: unmarshal",
-			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidInput,
-			})
-		return
-	}
 
 	gdr, err := p.processDCCDetails(gd)
 	if err != nil {

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/decred/politeia/decredplugin"
 	pd "github.com/decred/politeia/politeiad/api/v1"
@@ -811,4 +812,179 @@ func convertInvoiceFromCache(r cache.Record) cms.InvoiceRecord {
 		},
 		Input: ii,
 	}
+}
+
+func convertDCCFromCache(r cache.Record) cms.DCCRecord {
+	// Decode metadata streams
+	var md backendDCCMetadata
+	var c backendDCCStatusChange
+	for _, v := range r.Metadata {
+		switch v.ID {
+		case mdStreamDCCGeneral:
+			// General invoice metadata
+			m, err := decodeBackendDCCMetadata([]byte(v.Payload))
+			if err != nil {
+				log.Errorf("convertDCCFromCache: decode md stream: "+
+					"token:%v error:%v payload:%v",
+					r.CensorshipRecord.Token, err, v)
+			}
+			md = *m
+
+		case mdStreamDCCStatusChanges:
+			// Invoice status changes
+			m, err := decodeBackendDCCStatusChanges([]byte(v.Payload))
+			if err != nil {
+				log.Errorf("convertDCCFromCache: decode md stream: "+
+					"token:%v error:%v payload:%v",
+					r.CensorshipRecord.Token, err, v)
+			}
+
+			// We don't need all of the status changes.
+			// Just the most recent one.
+			for _, s := range m {
+				c = s
+			}
+		}
+	}
+
+	// Convert files
+	var di cms.DCCInput
+	fs := make([]www.File, 0, len(r.Files))
+	for _, v := range r.Files {
+		f := www.File{
+			Name:    v.Name,
+			MIME:    v.MIME,
+			Digest:  v.Digest,
+			Payload: v.Payload,
+		}
+		fs = append(fs, f)
+
+		// Parse invoice json
+		if f.Name == dccFile {
+			b, err := base64.StdEncoding.DecodeString(v.Payload)
+			if err != nil {
+				log.Errorf("convertDCCFromCache: decode invoice: "+
+					"token:%v error:%v payload:%v",
+					r.CensorshipRecord.Token, err, f.Payload)
+				continue
+			}
+
+			err = json.Unmarshal(b, &di)
+			if err != nil {
+				log.Errorf("convertDCCFromCache: unmarshal InvoiceInput: "+
+					"token:%v error:%v payload:%v",
+					r.CensorshipRecord.Token, err, f.Payload)
+				continue
+			}
+		}
+	}
+
+	// UserID and Username are left intentionally blank.
+	// These fields not part of a cache record.
+	return cms.DCCRecord{
+		Status:             c.NewStatus,
+		StatusChangeReason: c.Reason,
+		Timestamp:          r.Timestamp,
+		SponsorUserID:      "",
+		SponsorUsername:    "",
+		PublicKey:          md.PublicKey,
+		Signature:          md.Signature,
+		Files:              fs,
+		Version:            r.Version,
+		CensorshipRecord: www.CensorshipRecord{
+			Token:     r.CensorshipRecord.Token,
+			Merkle:    r.CensorshipRecord.Merkle,
+			Signature: r.CensorshipRecord.Signature,
+		},
+		DCC: di,
+	}
+}
+
+func convertRecordToDatabaseDCC(p pd.Record) (*cmsdatabase.DCC, error) {
+	dbDCC := cmsdatabase.DCC{
+		Files:           convertRecordFilesToWWW(p.Files),
+		Token:           p.CensorshipRecord.Token,
+		ServerSignature: p.CensorshipRecord.Signature,
+		Version:         p.Version,
+	}
+
+	// Decode invoice file
+	for _, v := range p.Files {
+		if v.Name == dccFile {
+			b, err := base64.StdEncoding.DecodeString(v.Payload)
+			if err != nil {
+				return nil, err
+			}
+
+			var dcc cms.DCCInput
+			err = json.Unmarshal(b, &dcc)
+			if err != nil {
+				return nil, www.UserError{
+					ErrorCode: www.ErrorStatusInvalidInput,
+				}
+			}
+			dbDCC.Type = dcc.Type
+			dbDCC.NomineeUserID = dcc.NomineeUserID
+			dbDCC.SponsorStatement = dcc.SponsorStatement
+			dbDCC.Domain = dcc.Domain
+		}
+	}
+
+	for _, m := range p.Metadata {
+		switch m.ID {
+		case mdStreamInvoiceGeneral:
+			var mdGeneral backendDCCMetadata
+			err := json.Unmarshal([]byte(m.Payload), &mdGeneral)
+			if err != nil {
+				return nil, fmt.Errorf("could not decode metadata '%v' token '%v': %v",
+					p.Metadata, p.CensorshipRecord.Token, err)
+			}
+
+			dbDCC.Timestamp = mdGeneral.Timestamp
+			dbDCC.PublicKey = mdGeneral.PublicKey
+			dbDCC.UserSignature = mdGeneral.Signature
+
+		case mdStreamInvoiceStatusChanges:
+			sc, err := decodeBackendDCCStatusChanges([]byte(m.Payload))
+			if err != nil {
+				return nil, fmt.Errorf("could not decode metadata '%v' token '%v': %v",
+					m, p.CensorshipRecord.Token, err)
+			}
+
+			// We don't need all of the status changes.
+			// Just the most recent one.
+			for _, s := range sc {
+				dbDCC.Status = s.NewStatus
+				dbDCC.StatusChangeReason = s.Reason
+			}
+		default:
+			// Log error but proceed
+			log.Errorf("initializeInventory: invalid "+
+				"metadata stream ID %v token %v",
+				m.ID, p.CensorshipRecord.Token)
+		}
+	}
+
+	return &dbDCC, nil
+}
+
+func convertDCCDatabaseToRecord(dbDCC *cmsdatabase.DCC) cms.DCCRecord {
+	dccRecord := cms.DCCRecord{}
+
+	dccRecord.Type = dbDCC.Type
+	dccRecord.Status = dbDCC.Status
+	dccRecord.StatusChangeReason = dbDCC.StatusChangeReason
+	dccRecord.Timestamp = dbDCC.Timestamp
+	dccRecord.CensorshipRecord = www.CensorshipRecord{
+		Token: dbDCC.Token,
+	}
+	dccRecord.PublicKey = dbDCC.PublicKey
+	dccRecord.Signature = dbDCC.ServerSignature
+	dccRecord.SponsorUserID = dbDCC.SponsorUserID
+	supportUserIDs := strings.Split(dbDCC.SupportUserIDs, ",")
+	dccRecord.SupportUserIDs = supportUserIDs
+	oppositionUserIDs := strings.Split(dbDCC.OppositionUserIDs, ",")
+	dccRecord.OppositionUserIDs = oppositionUserIDs
+
+	return dccRecord
 }

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -1,0 +1,1221 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/decred/dcrtime/merkle"
+	"github.com/decred/politeia/decredplugin"
+	pd "github.com/decred/politeia/politeiad/api/v1"
+	"github.com/decred/politeia/politeiad/api/v1/identity"
+	"github.com/decred/politeia/politeiad/cache"
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+	www "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/politeiawww/cmsdatabase"
+	"github.com/decred/politeia/politeiawww/user"
+	"github.com/decred/politeia/util"
+	"github.com/google/uuid"
+)
+
+const (
+	// dccFile contains the file name of the dcc file
+	dccFile = "dcc.json"
+
+	// politeiad dcc record metadata streams
+	mdStreamDCCGeneral       = 5 // General DCC metadata
+	mdStreamDCCStatusChanges = 6 // DCC status changes
+
+	// Metadata stream struct versions
+	backendDCCMetadataVersion     = 1
+	backendDCCStatusChangeVersion = 1
+
+	sponsorString = "aye"
+	opposeString  = "nay"
+)
+
+var (
+	validSponsorStatement     = regexp.MustCompile(createSponsorStatementRegex())
+	validDCCStatusTransitions = map[cms.DCCStatusT][]cms.DCCStatusT{
+		cms.DCCStatusActive: {
+			cms.DCCStatusSupported,
+			cms.DCCStatusRejected,
+			cms.DCCStatusDebate,
+		},
+		cms.DCCStatusSupported: {
+			cms.DCCStatusApproved,
+			cms.DCCStatusRejected,
+		},
+	}
+)
+
+// createSponsorStatementRegex generates a regex based on the policy supplied for
+// valid characters sponsor statement.
+func createSponsorStatementRegex() string {
+	var buf bytes.Buffer
+	buf.WriteString("^[")
+
+	for _, supportedChar := range cms.PolicySponsorStatementSupportedChars {
+		if len(supportedChar) > 1 {
+			buf.WriteString(supportedChar)
+		} else {
+			buf.WriteString(`\` + supportedChar)
+		}
+	}
+	buf.WriteString("]{")
+	buf.WriteString(strconv.Itoa(cms.PolicyMinSponsorStatementLength) + ",")
+	buf.WriteString(strconv.Itoa(cms.PolicyMaxSponsorStatementLength) + "}$")
+
+	return buf.String()
+}
+
+func (p *politeiawww) processNewDCC(nd cms.NewDCC, u *user.User) (*cms.NewDCCReply, error) {
+	reply := &cms.NewDCCReply{}
+
+	err := p.validateDCC(nd, u)
+	if err != nil {
+		return nil, err
+	}
+
+	m := backendDCCMetadata{
+		Version:   backendDCCMetadataVersion,
+		Timestamp: time.Now().Unix(),
+		PublicKey: nd.PublicKey,
+		Signature: nd.Signature,
+	}
+	md, err := encodeBackendDCCMetadata(m)
+	if err != nil {
+		return nil, err
+	}
+
+	sc := backendDCCStatusChange{
+		Version:   backendDCCStatusChangeVersion,
+		Timestamp: time.Now().Unix(),
+		NewStatus: cms.DCCStatusActive,
+	}
+	scb, err := encodeBackendDCCStatusChange(sc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup politeiad request
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+	n := pd.NewRecord{
+		Challenge: hex.EncodeToString(challenge),
+		Metadata: []pd.MetadataStream{
+			{
+				ID:      mdStreamDCCGeneral,
+				Payload: string(md),
+			},
+			{
+				ID:      mdStreamDCCStatusChanges,
+				Payload: string(scb),
+			},
+		},
+		Files: convertPropFilesFromWWW(nd.Files),
+	}
+
+	// Send the newrecord politeiad request
+	responseBody, err := p.makeRequest(http.MethodPost,
+		pd.NewRecordRoute, n)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Submitted issuance nomination: %v", u.Username)
+	for k, f := range n.Files {
+		log.Infof("%02v: %v %v", k, f.Name, f.Digest)
+	}
+
+	// Handle newRecord response
+	var pdReply pd.NewRecordReply
+	err = json.Unmarshal(responseBody, &pdReply)
+	if err != nil {
+		return nil, fmt.Errorf("Unmarshal NewDCCReply: %v", err)
+	}
+
+	// Verify NewRecord challenge
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, pdReply.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	// Change politeiad record status to public. DCCs
+	// do not need to be reviewed before becoming public.
+	// An admin signature is not included for this reason.
+	c := MDStreamChanges{
+		Version:   VersionMDStreamChanges,
+		Timestamp: time.Now().Unix(),
+		NewStatus: pd.RecordStatusPublic,
+	}
+	blob, err := encodeMDStreamChanges(c)
+	if err != nil {
+		return nil, err
+	}
+
+	challenge, err = util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+
+	sus := pd.SetUnvettedStatus{
+		Token:     pdReply.CensorshipRecord.Token,
+		Status:    pd.RecordStatusPublic,
+		Challenge: hex.EncodeToString(challenge),
+		MDAppend: []pd.MetadataStream{
+			{
+				ID:      mdStreamChanges,
+				Payload: string(blob),
+			},
+		},
+	}
+
+	// Send SetUnvettedStatus request to politeiad
+	responseBody, err = p.makeRequest(http.MethodPost,
+		pd.SetUnvettedStatusRoute, sus)
+	if err != nil {
+		return nil, err
+	}
+
+	var pdSetUnvettedStatusReply pd.SetUnvettedStatusReply
+	err = json.Unmarshal(responseBody, &pdSetUnvettedStatusReply)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal SetUnvettedStatusReply: %v",
+			err)
+	}
+
+	// Verify the SetUnvettedStatus challenge.
+	err = util.VerifyChallenge(p.cfg.Identity, challenge,
+		pdSetUnvettedStatusReply.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	r := pd.Record{
+		Metadata:         n.Metadata,
+		Files:            n.Files,
+		CensorshipRecord: pdReply.CensorshipRecord,
+	}
+	// Submit issuance to cmsdb
+
+	dccRec, err := convertRecordToDatabaseDCC(r)
+	if err != nil {
+		return nil, err
+	}
+
+	err = p.cmsDB.NewDCC(dccRec)
+	if err != nil {
+		return nil, err
+	}
+
+	cr := convertPropCensorFromPD(pdReply.CensorshipRecord)
+
+	reply.CensorshipRecord = cr
+	return reply, nil
+}
+
+func (p *politeiawww) validateDCC(nd cms.NewDCC, u *user.User) error {
+
+	// Obtain signature
+	sig, err := util.ConvertSignature(nd.Signature)
+	if err != nil {
+		return www.UserError{
+			ErrorCode: www.ErrorStatusInvalidSignature,
+		}
+	}
+
+	// Verify public key
+	if u.PublicKey() != nd.PublicKey {
+		fmt.Println(u.PublicKey(), nd.PublicKey)
+		return www.UserError{
+			ErrorCode: www.ErrorStatusInvalidSigningKey,
+		}
+	}
+
+	pk, err := identity.PublicIdentityFromBytes(u.ActiveIdentity().Key[:])
+	if err != nil {
+		return err
+	}
+
+	// Check for at least 1 markdown file with a non-empty payload.
+	if len(nd.Files) == 0 || nd.Files[0].Payload == "" {
+		return www.UserError{
+			ErrorCode: www.ErrorStatusProposalMissingFiles,
+		}
+	}
+
+	// verify if there are duplicate names
+	filenames := make(map[string]int, len(nd.Files))
+	// Check that the file number policy is followed.
+	var (
+		numFiles, numImages, numDCCFiles        int
+		jsonExceedsMaxSize, imageExceedsMaxSize bool
+		hashes                                  []*[sha256.Size]byte
+	)
+	for _, v := range nd.Files {
+		filenames[v.Name]++
+		var (
+			data []byte
+			err  error
+		)
+		if strings.HasPrefix(v.MIME, "image/") {
+			numImages++
+			data, err = base64.StdEncoding.DecodeString(v.Payload)
+			if err != nil {
+				return err
+			}
+			if len(data) > cms.PolicyMaxImageSize {
+				imageExceedsMaxSize = true
+			}
+		} else {
+			numFiles++
+
+			if v.Name == dccFile {
+				numDCCFiles++
+			}
+
+			data, err = base64.StdEncoding.DecodeString(v.Payload)
+			if err != nil {
+				return err
+			}
+			if len(data) > cms.PolicyMaxMDSize {
+				jsonExceedsMaxSize = true
+			}
+
+			// Check to see if the data can be parsed properly into DCCInput
+			// struct.
+			var issuance cms.DCCInput
+			if err := json.Unmarshal(data, &issuance); err != nil {
+				return www.UserError{
+					ErrorCode: cms.ErrorStatusMalformedDCCFile,
+				}
+			}
+			// Check UserID of Nominee
+			nomineeUser, err := p.getCMSUserByID(issuance.NomineeUserID)
+			if err != nil {
+				return err
+			}
+
+			sponsorUser, err := p.getCMSUserByID(u.ID.String())
+			if err != nil {
+				return err
+			}
+
+			// Check that domains match
+			if sponsorUser.Domain != nomineeUser.Domain {
+				return www.UserError{
+					ErrorCode: cms.ErrorStatusInvalidNominatingDomain,
+				}
+			}
+
+			// Validate sponsor statement input
+			statement := formatSponsorStatement(issuance.SponsorStatement)
+			if !validateSponsorStatement(statement) {
+				return www.UserError{
+					ErrorCode: cms.ErrorStatusMalformedSponsorStatement,
+				}
+			}
+		}
+
+		// Append digest to array for merkle root calculation
+		digest := util.Digest(data)
+		var d [sha256.Size]byte
+		copy(d[:], digest)
+		hashes = append(hashes, &d)
+	}
+	// verify duplicate file names
+	if len(nd.Files) > 1 {
+		var repeated []string
+		for name, count := range filenames {
+			if count > 1 {
+				repeated = append(repeated, name)
+			}
+		}
+		if len(repeated) > 0 {
+			return www.UserError{
+				ErrorCode:    www.ErrorStatusProposalDuplicateFilenames,
+				ErrorContext: repeated,
+			}
+		}
+	}
+
+	// we expect one index file
+	if numDCCFiles == 0 {
+		return www.UserError{
+			ErrorCode:    www.ErrorStatusProposalMissingFiles,
+			ErrorContext: []string{indexFile},
+		}
+	}
+
+	if numFiles > www.PolicyMaxMDs {
+		return www.UserError{
+			ErrorCode: www.ErrorStatusMaxMDsExceededPolicy,
+		}
+	}
+
+	if numImages > www.PolicyMaxImages {
+		return www.UserError{
+			ErrorCode: www.ErrorStatusMaxImagesExceededPolicy,
+		}
+	}
+
+	if jsonExceedsMaxSize {
+		return www.UserError{
+			ErrorCode: www.ErrorStatusMaxMDSizeExceededPolicy,
+		}
+	}
+
+	if imageExceedsMaxSize {
+		return www.UserError{
+			ErrorCode: www.ErrorStatusMaxImageSizeExceededPolicy,
+		}
+	}
+
+	// Note that we need validate the string representation of the merkle
+	mr := merkle.Root(hashes)
+	if !pk.VerifyMessage([]byte(hex.EncodeToString(mr[:])), sig) {
+		return www.UserError{
+			ErrorCode: www.ErrorStatusInvalidSignature,
+		}
+	}
+	return nil
+}
+
+// formatSponsorStatement normalizes a sponsor statement without leading and
+// trailing spaces.
+func formatSponsorStatement(statement string) string {
+	return strings.TrimSpace(statement)
+}
+
+// validateSponsorStatement verifies that a field filled out in invoice.json is
+// valid
+func validateSponsorStatement(statement string) bool {
+	if statement != formatSponsorStatement(statement) {
+		log.Tracef("validateSponsorStatement: not normalized: %s %s",
+			statement, formatSponsorStatement(statement))
+		return false
+	}
+	if len(statement) > cms.PolicyMaxSponsorStatementLength ||
+		len(statement) < cms.PolicyMinSponsorStatementLength {
+		log.Tracef("validateSponsorStatement: not within bounds: have %v expected > %v < %v",
+			len(statement), cms.PolicyMaxSponsorStatementLength,
+			cms.PolicyMinSponsorStatementLength)
+		return false
+	}
+	if !validSponsorStatement.MatchString(statement) {
+		log.Tracef("validateSponsorStatement: not valid: %s %s",
+			statement, validSponsorStatement.String())
+		return false
+	}
+	return true
+}
+
+// backendDCCMetadata represents the general metadata for a DCC and is
+// stored in the metadata stream mdStreamDCCGeneral in politeiad.
+type backendDCCMetadata struct {
+	Version   uint64 `json:"version"`   // Version of the struct
+	Timestamp int64  `json:"timestamp"` // Last update of invoice
+	PublicKey string `json:"publickey"` // Key used for signature
+	Signature string `json:"signature"` // Signature of merkle root
+}
+
+// backendDCCStatusChange represents the metadata for any status change that
+// occurs to a patricular DCC issuance or revocation.
+type backendDCCStatusChange struct {
+	Version        uint           `json:"version"`        // Version of the struct
+	AdminPublicKey string         `json:"adminpublickey"` // Identity of the administrator
+	NewStatus      cms.DCCStatusT `json:"newstatus"`      // Status
+	Reason         string         `json:"reason"`         // Reason
+	Timestamp      int64          `json:"timestamp"`      // Timestamp of the change
+}
+
+// encodeBackendDCCMetadata encodes a backendDCCMetadata into a JSON
+// byte slice.
+func encodeBackendDCCMetadata(md backendDCCMetadata) ([]byte, error) {
+	b, err := json.Marshal(md)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// decodeBackendDCCMetadata decodes a JSON byte slice into a
+// backendDCCMetadata.
+func decodeBackendDCCMetadata(payload []byte) (*backendDCCMetadata, error) {
+	var md backendDCCMetadata
+
+	err := json.Unmarshal(payload, &md)
+	if err != nil {
+		return nil, err
+	}
+
+	return &md, nil
+}
+
+// encodeBackendDCCStatusChange encodes a backendDCCStatusChange into a
+// JSON byte slice.
+func encodeBackendDCCStatusChange(md backendDCCStatusChange) ([]byte, error) {
+	b, err := json.Marshal(md)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// decodeBackendDCCStatusChanges decodes a JSON byte slice into a slice of
+// backendDCCStatusChanges.
+func decodeBackendDCCStatusChanges(payload []byte) ([]backendDCCStatusChange, error) {
+	var md []backendDCCStatusChange
+
+	d := json.NewDecoder(strings.NewReader(string(payload)))
+	for {
+		var m backendDCCStatusChange
+		err := d.Decode(&m)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		md = append(md, m)
+	}
+
+	return md, nil
+}
+
+// getDCC gets the most recent verions of the given DCC from the cache
+// then fills in any missing user fields before returning the DCC record.
+func (p *politeiawww) getDCC(token string) (*cms.DCCRecord, error) {
+	// Get invoice from cache
+	r, err := p.cache.Record(token)
+	if err != nil {
+		return nil, err
+	}
+	i := convertDCCFromCache(*r)
+
+	// Fill in userID and username fields
+	u, err := p.db.UserGetByPubKey(i.PublicKey)
+	if err != nil {
+		log.Errorf("getDCC: getUserByPubKey: token:%v "+
+			"pubKey:%v err:%v", token, i.PublicKey, err)
+	} else {
+		i.SponsorUserID = u.ID.String()
+		i.SponsorUsername = u.Username
+	}
+	support, oppose, err := p.getDCCSupportOppositionComments(token)
+	if err != nil {
+		log.Errorf("getDCC: %v", err)
+	}
+	i.SupportUserIDs = support
+	i.OppositionUserIDs = oppose
+	return &i, nil
+}
+
+func (p *politeiawww) getDCCSupportOppositionComments(token string) ([]string, []string, error) {
+	log.Tracef("getDCCSupportOpposition: %v", token)
+
+	dc, err := p.decredGetComments(token)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decredGetComments: %v", err)
+	}
+
+	support := make([]string, 0, len(dc))
+	oppose := make([]string, 0, len(dc))
+	for _, v := range dc {
+		c := convertCommentFromDecred(v)
+		u, err := p.db.UserGetByPubKey(c.PublicKey)
+		if err != nil {
+			log.Errorf("getDCCSupportOpposition: UserGetByPubKey: "+
+				"token:%v commentID:%v pubKey:%v err:%v",
+				token, c.CommentID, c.PublicKey, err)
+		}
+		if c.Comment == sponsorString {
+			support = append(support, u.ID.String())
+		} else if c.Comment == opposeString {
+			oppose = append(support, u.ID.String())
+		}
+	}
+
+	return support, oppose, nil
+}
+
+/*
+func (p *politeiawww) processIssuances(cr cms.Issuances) (*cms.IssuancesReply, error) {
+	reply := &cms.ContractorRevocationReply{}
+	return reply, nil
+}
+
+func (p *politeiawww) processRevocations(cr cms.Revocations) (*cms.RevocationsReply, error) {
+	reply := &cms.ContractorRevocationReply{}
+	return reply, nil
+}
+*/
+
+func (p *politeiawww) processSupportDCC(sd cms.SupportDCC, u *user.User) (*cms.SupportDCCReply, error) {
+	log.Tracef("processSupportDCC: %v %v", sd.Token, u.ID)
+
+	dcc, err := p.getDCC(sd.Token)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			err = www.UserError{
+				ErrorCode: cms.ErrorStatusInvoiceNotFound,
+			}
+		}
+		return nil, err
+	}
+
+	// Check to make sure the user has not Supported or Opposed this DCC yet
+	if stringInSlice(dcc.SupportUserIDs, u.ID.String()) ||
+		stringInSlice(dcc.OppositionUserIDs, u.ID.String()) {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+	}
+
+	// Check to make sure the user is not the author of the DCC.
+	if dcc.SponsorUserID == u.ID.String() {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+	}
+
+	// Ensure the public key is the user's active key
+	if sd.PublicKey != u.PublicKey() {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusInvalidSigningKey,
+		}
+	}
+
+	// Validate signature
+	msg := sd.Token + sd.Comment
+	err = validateSignature(sd.PublicKey, sd.Signature, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate sponsor comment
+	if strings.TrimSpace(sd.Comment) != sponsorString {
+		return nil, www.UserError{
+			ErrorCode: cms.ErrorStatusInvalidDCCComment,
+		}
+	}
+
+	// Check to make sure that the DCC is still active
+	if dcc.Status != cms.DCCStatusActive {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCannotCommentOnProp,
+		}
+	}
+
+	// Setup plugin command
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create new comment
+	nc := www.NewComment{
+		Token:     sd.Token,
+		ParentID:  "0",
+		Comment:   strings.TrimSpace(sd.Comment),
+		Signature: sd.Signature,
+		PublicKey: sd.PublicKey,
+	}
+
+	dnc := convertNewCommentToDecredPlugin(nc)
+	payload, err := decredplugin.EncodeNewComment(dnc)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        decredplugin.ID,
+		Command:   decredplugin.CmdNewComment,
+		CommandID: decredplugin.CmdNewComment,
+		Payload:   string(payload),
+	}
+
+	// Send polieiad request
+	responseBody, err := p.makeRequest(http.MethodPost,
+		pd.PluginCommandRoute, pc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle response
+	var reply pd.PluginCommandReply
+	err = json.Unmarshal(responseBody, &reply)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal "+
+			"PluginCommandReply: %v", err)
+	}
+
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, reply.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cms.SupportDCCReply{}, nil
+}
+
+func (p *politeiawww) processOpposeDCC(od cms.OpposeDCC, u *user.User) (*cms.OpposeDCCReply, error) {
+	log.Tracef("processOpposeDCC: %v %v", od.Token, u.ID)
+
+	dcc, err := p.getDCC(od.Token)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			err = www.UserError{
+				ErrorCode: cms.ErrorStatusInvoiceNotFound,
+			}
+		}
+		return nil, err
+	}
+
+	// Check to make sure the user has not Supported or Opposed this DCC yet
+	if stringInSlice(dcc.SupportUserIDs, u.ID.String()) ||
+		stringInSlice(dcc.OppositionUserIDs, u.ID.String()) {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+	}
+
+	// Check to make sure the user is not the author of the DCC.
+	if dcc.SponsorUserID == u.ID.String() {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+	}
+
+	// Ensure the public key is the user's active key
+	if od.PublicKey != u.PublicKey() {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusInvalidSigningKey,
+		}
+	}
+
+	// Validate signature
+	msg := od.Token + od.Comment
+	err = validateSignature(od.PublicKey, od.Signature, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate oppose comment
+	if strings.TrimSpace(od.Comment) != opposeString {
+		return nil, www.UserError{
+			ErrorCode: cms.ErrorStatusInvalidDCCComment,
+		}
+	}
+
+	// Check to make sure that the DCC is still active
+	if dcc.Status != cms.DCCStatusActive {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCannotCommentOnProp,
+		}
+	}
+
+	// Setup plugin command
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create new comment
+	nc := www.NewComment{
+		Token:     od.Token,
+		ParentID:  "0",
+		Comment:   strings.TrimSpace(od.Comment),
+		Signature: od.Signature,
+		PublicKey: od.PublicKey,
+	}
+
+	dnc := convertNewCommentToDecredPlugin(nc)
+	payload, err := decredplugin.EncodeNewComment(dnc)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        decredplugin.ID,
+		Command:   decredplugin.CmdNewComment,
+		CommandID: decredplugin.CmdNewComment,
+		Payload:   string(payload),
+	}
+
+	// Send polieiad request
+	responseBody, err := p.makeRequest(http.MethodPost,
+		pd.PluginCommandRoute, pc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle response
+	var reply pd.PluginCommandReply
+	err = json.Unmarshal(responseBody, &reply)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal "+
+			"PluginCommandReply: %v", err)
+	}
+
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, reply.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cms.OpposeDCCReply{}, nil
+}
+
+func (p *politeiawww) processDCCDetails(gd cms.DCCDetails) (*cms.DCCDetailsReply, error) {
+	log.Tracef("processDCCDetails: %v", gd.Token)
+
+	dcc, err := p.getDCC(gd.Token)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			err = www.UserError{
+				ErrorCode: cms.ErrorStatusInvoiceNotFound,
+			}
+		}
+		return nil, err
+	}
+	reply := &cms.DCCDetailsReply{
+		DCC: *dcc,
+	}
+	return reply, nil
+}
+
+func (p *politeiawww) processGetDCCs(gds cms.GetDCCs) (*cms.GetDCCsReply, error) {
+	log.Tracef("processGetDCCs: %v", gds.Status)
+
+	var dbDCCs []*cmsdatabase.DCC
+	var err error
+	switch {
+	case gds.Status != 0:
+		dbDCCs, err = p.cmsDB.DCCsByStatus(int(gds.Status))
+		if err != nil {
+			return nil, err
+		}
+
+	default:
+		dbDCCs, err = p.cmsDB.DCCsAll()
+		if err != nil {
+			return nil, err
+		}
+	}
+	dccs := make([]cms.DCCRecord, 0, len(dbDCCs))
+
+	for _, v := range dbDCCs {
+		dcc := convertDCCDatabaseToRecord(v)
+		dccs = append(dccs, dcc)
+	}
+
+	return &cms.GetDCCsReply{
+		DCCs: dccs,
+	}, nil
+}
+
+func (p *politeiawww) processApproveDCC(ad cms.ApproveDCC, u *user.User) (*cms.ApproveDCCReply, error) {
+	log.Tracef("processApproveDCC: %v", u.PublicKey())
+
+	dcc, err := p.getDCC(ad.Token)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			err = www.UserError{
+				ErrorCode: cms.ErrorStatusInvoiceNotFound,
+			}
+		}
+		return nil, err
+	}
+
+	// Validate signature
+	msg := fmt.Sprintf("%v%v", ad.Token, ad.Reason)
+	err = validateSignature(ad.PublicKey, ad.Signature, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateDCCStatusTransition(dcc.Status, cms.DCCStatusApproved)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the change record.
+	c := backendDCCStatusChange{
+		Version:        backendInvoiceStatusChangeVersion,
+		AdminPublicKey: u.PublicKey(),
+		Timestamp:      time.Now().Unix(),
+		NewStatus:      cms.DCCStatusApproved,
+		Reason:         ad.Reason,
+	}
+	blob, err := encodeBackendDCCStatusChange(c)
+	if err != nil {
+		return nil, err
+	}
+
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+
+	pdCommand := pd.UpdateVettedMetadata{
+		Challenge: hex.EncodeToString(challenge),
+		Token:     ad.Token,
+		MDAppend: []pd.MetadataStream{
+			{
+				ID:      mdStreamDCCStatusChanges,
+				Payload: string(blob),
+			},
+		},
+	}
+
+	responseBody, err := p.makeRequest(http.MethodPost, pd.UpdateVettedMetadataRoute, pdCommand)
+	if err != nil {
+		return nil, err
+	}
+
+	var pdReply pd.UpdateVettedMetadataReply
+	err = json.Unmarshal(responseBody, &pdReply)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal UpdateVettedMetadataReply: %v",
+			err)
+	}
+
+	// Verify the UpdateVettedMetadata challenge.
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, pdReply.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update cmsdb
+
+	nominatedUser, err := p.userByIDStr(dcc.DCC.NomineeUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !validEmail.MatchString(nominatedUser.Email) {
+		log.Debugf("processApproveDCC: invalid email '%v'", u.Email)
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusMalformedEmail,
+		}
+	}
+
+	// Check if the user is already verified.
+	existingUser, err := p.userByEmail(u.Email)
+	if err != nil {
+		if existingUser.NewUserVerificationToken == nil {
+			return &cms.ApproveDCCReply{}, nil
+		}
+	}
+
+	// Generate the verification token and expiry.
+	token, expiry, err := newVerificationTokenAndExpiry()
+	if err != nil {
+		return nil, err
+	}
+
+	// Try to email the verification link first; if it fails, then
+	// the new user won't be created.
+	//
+	// This is conditional on the email server being setup.
+	err = p.emailApproveDCCVerificationLink(u.Email,
+		hex.EncodeToString(token))
+	if err != nil {
+		log.Errorf("processApproveDCC: verification email "+
+			"failed for '%v': %v", u.Email, err)
+		return &cms.ApproveDCCReply{}, nil
+	}
+
+	// If the user already exists, the user record is updated
+	// in the db in order to reset the verification token and
+	// expiry.
+	if existingUser != nil {
+		existingUser.NewUserVerificationToken = token
+		existingUser.NewUserVerificationExpiry = expiry
+		err = p.db.UserUpdate(*existingUser)
+		if err != nil {
+			return nil, err
+		}
+
+		return &cms.ApproveDCCReply{
+			VerificationToken: hex.EncodeToString(token),
+		}, nil
+	}
+	return &cms.ApproveDCCReply{}, nil
+}
+
+func validateDCCStatusTransition(oldStatus cms.DCCStatusT, newStatus cms.DCCStatusT) error {
+	validStatuses, ok := validDCCStatusTransitions[oldStatus]
+	if !ok {
+		log.Errorf("status not supported: %v", oldStatus)
+		return www.UserError{
+			ErrorCode: cms.ErrorStatusInvalidDCCStatusTransition,
+		}
+	}
+
+	if !dccStatusInSlice(validStatuses, newStatus) {
+		return www.UserError{
+			ErrorCode: cms.ErrorStatusInvalidDCCStatusTransition,
+		}
+	}
+
+	return nil
+}
+
+func dccStatusInSlice(arr []cms.DCCStatusT, status cms.DCCStatusT) bool {
+	for _, s := range arr {
+		if status == s {
+			return true
+		}
+	}
+
+	return false
+}
+func (p *politeiawww) processRejectDCC(rd cms.RejectDCC, u *user.User) (*cms.RejectDCCReply, error) {
+	log.Tracef("processRejectDCC: %v", u.PublicKey())
+
+	dcc, err := p.getDCC(rd.Token)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			err = www.UserError{
+				ErrorCode: cms.ErrorStatusInvoiceNotFound,
+			}
+		}
+		return nil, err
+	}
+
+	// Validate signature
+	msg := fmt.Sprintf("%v%v", rd.Token, rd.Reason)
+	err = validateSignature(rd.PublicKey, rd.Signature, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateDCCStatusTransition(dcc.Status, cms.DCCStatusApproved)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the change record.
+	c := backendDCCStatusChange{
+		Version:        backendDCCStatusChangeVersion,
+		AdminPublicKey: u.PublicKey(),
+		Timestamp:      time.Now().Unix(),
+		NewStatus:      cms.DCCStatusRejected,
+		Reason:         rd.Reason,
+	}
+	blob, err := encodeBackendDCCStatusChange(c)
+	if err != nil {
+		return nil, err
+	}
+
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+
+	pdCommand := pd.UpdateVettedMetadata{
+		Challenge: hex.EncodeToString(challenge),
+		Token:     rd.Token,
+		MDAppend: []pd.MetadataStream{
+			{
+				ID:      mdStreamDCCStatusChanges,
+				Payload: string(blob),
+			},
+		},
+	}
+
+	responseBody, err := p.makeRequest(http.MethodPost, pd.UpdateVettedMetadataRoute, pdCommand)
+	if err != nil {
+		return nil, err
+	}
+
+	var pdReply pd.UpdateVettedMetadataReply
+	err = json.Unmarshal(responseBody, &pdReply)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal UpdateVettedMetadataReply: %v",
+			err)
+	}
+
+	// Verify the UpdateVettedMetadata challenge.
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, pdReply.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update cmsdb
+
+	// Do full userdb update and reject user creds
+	nomineeUserID, err := uuid.Parse(dcc.DCC.NomineeUserID)
+	if err != nil {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusInvalidUUID,
+		}
+	}
+	uu := user.UpdateCMSUser{
+		ID:             nomineeUserID,
+		ContractorType: int(cms.ContractorTypeRevoked),
+	}
+	payload, err := user.EncodeUpdateCMSUser(uu)
+	if err != nil {
+		return nil, err
+	}
+	pc := user.PluginCommand{
+		ID:      user.CMSPluginID,
+		Command: user.CmdUpdateCMSUser,
+		Payload: string(payload),
+	}
+	_, err = p.db.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+	return &cms.RejectDCCReply{}, nil
+}
+
+func stringInSlice(arr []string, str string) bool {
+	for _, s := range arr {
+		if str == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+// processNewCommentDCC sends a new comment decred plugin command to politeaid
+// then fetches the new comment from the cache and returns it.
+func (p *politeiawww) processNewCommentDCC(nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
+	log.Tracef("processNewCommentDCC: %v %v", nc.Token, u.ID)
+
+	dcc, err := p.getDCC(nc.Token)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			err = www.UserError{
+				ErrorCode: cms.ErrorStatusInvoiceNotFound,
+			}
+		}
+		return nil, err
+	}
+
+	// Check to make sure the user is either an admin or the
+	// author of the invoice.
+	if !u.Admin && (dcc.SponsorUsername != u.Username) {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+	}
+
+	// Ensure the public key is the user's active key
+	if nc.PublicKey != u.PublicKey() {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusInvalidSigningKey,
+		}
+	}
+
+	// Validate signature
+	msg := nc.Token + nc.ParentID + nc.Comment
+	err = validateSignature(nc.PublicKey, nc.Signature, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Don't allow comments of just "aye" or "nay" that would be confused
+	// with support or opposition.
+	if nc.Comment == sponsorString || nc.Comment == opposeString {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+	}
+
+	// Validate comment
+	err = validateComment(nc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check to make sure that dcc isn't already approved.
+	if dcc.Status != cms.DCCStatusActive {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusCannotCommentOnProp,
+		}
+	}
+
+	// Setup plugin command
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+
+	dnc := convertNewCommentToDecredPlugin(nc)
+	payload, err := decredplugin.EncodeNewComment(dnc)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        decredplugin.ID,
+		Command:   decredplugin.CmdNewComment,
+		CommandID: decredplugin.CmdNewComment,
+		Payload:   string(payload),
+	}
+
+	// Send polieiad request
+	responseBody, err := p.makeRequest(http.MethodPost,
+		pd.PluginCommandRoute, pc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle response
+	var reply pd.PluginCommandReply
+	err = json.Unmarshal(responseBody, &reply)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal "+
+			"PluginCommandReply: %v", err)
+	}
+
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, reply.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	ncr, err := decredplugin.DecodeNewCommentReply([]byte(reply.Payload))
+	if err != nil {
+		return nil, err
+	}
+
+	// Add comment to commentScores in-memory cache
+	p.Lock()
+	p.commentScores[nc.Token+ncr.CommentID] = 0
+	p.Unlock()
+
+	// Get comment from cache
+	c, err := p.getComment(nc.Token, ncr.CommentID)
+	if err != nil {
+		return nil, fmt.Errorf("getComment: %v", err)
+	}
+
+	return &www.NewCommentReply{
+		Comment: *c,
+	}, nil
+}

--- a/politeiawww/email.go
+++ b/politeiawww/email.go
@@ -595,6 +595,32 @@ func (p *politeiawww) emailInviteNewUserVerificationLink(email, token string) er
 	return p.sendEmailTo(subject, body, email)
 }
 
+// emailApproveDCCVerificationLink emails the link to invite a user that
+// has been approved by the other contractors from a DCC proposal.
+func (p *politeiawww) emailApproveDCCVerificationLink(email, token string) error {
+	if p.smtp.disabled {
+		return nil
+	}
+
+	link, err := p.createEmailLink(RegisterNewUserGuiRoute, "", token)
+	if err != nil {
+		return err
+	}
+
+	tplData := approveDCCUserEmailTemplateData{
+		Email: email,
+		Link:  link,
+	}
+
+	subject := "Welcome to the Contractor Management System"
+	body, err := createBody(templateApproveDCCUserEmail, &tplData)
+	if err != nil {
+		return err
+	}
+
+	return p.sendEmailTo(subject, body, email)
+}
+
 // emailInvoiceNotifications emails users that have not yet submitted an invoice
 // for the given month/year
 func (p *politeiawww) emailInvoiceNotifications(email, username string) error {

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -68,6 +68,13 @@ var (
 			cms.InvoiceStatusDisputed,
 		},
 	}
+	// The valid contractor
+	invalidNewInvoiceContractorType = map[cms.ContractorTypeT]bool{
+		cms.ContractorTypeRevoked: true,
+		cms.ContractorTypeDormant: true,
+		cms.ContractorTypeNominee: true,
+	}
+
 	validInvoiceField = regexp.MustCompile(createInvoiceFieldRegex())
 	validName         = regexp.MustCompile(createNameRegex())
 	validLocation     = regexp.MustCompile(createLocationRegex())
@@ -261,7 +268,18 @@ func validateContact(contact string) error {
 func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.NewInvoiceReply, error) {
 	log.Tracef("processNewInvoice")
 
-	err := p.validateInvoice(ni, u)
+	cmsUser, err := p.getCMSUserByID(u.ID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that the user is not unauthorized to create invoices
+	if _, ok := invalidNewInvoiceContractorType[cmsUser.ContractorType]; !ok {
+		return nil, www.UserError{
+			ErrorCode: cms.ErrorStatusInvalidUserNewInvoice,
+		}
+	}
+	err = p.validateInvoice(ni, u)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/templates.go
+++ b/politeiawww/templates.go
@@ -21,6 +21,11 @@ type newInviteUserEmailTemplateData struct {
 	Link  string
 }
 
+type approveDCCUserEmailTemplateData struct {
+	Email string
+	Link  string
+}
+
 type updateUserKeyEmailTemplateData struct {
 	Link      string
 	PublicKey string
@@ -223,6 +228,18 @@ Comment: {{.CommentLink}}
 
 const templateInviteNewUserEmailRaw = `
 You are invited to join Decred as a contractor! To complete your registration, you will need to use the following link and register on the CMS site:
+
+{{.Link}}
+
+You are receiving this email because {{.Email}} was used to be invited to Decred's Contractor Management System.
+If you do not recognize this, please ignore this email.
+`
+
+const templateApproveDCCUserEmailRaw = `
+Congratulations! Your Decred Clearance Proposal has been approved! 
+
+As such, you are being invited to complete your registration on the Contractor Management System.
+Please use the following link and register on the CMS site:
 
 {{.Link}}
 

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -13,6 +13,7 @@ const (
 	CmdCMSUsersByDomain = "cmsusersbydomain"
 	CmdUpdateCMSUser    = "updatecmsuser"
 	CmdCMSUserByID      = "cmsuserbyid"
+	CmdNewDCCUser       = "newdccuser"
 )
 
 // CMSUser represents a CMS user. It contains the standard politeiawww user
@@ -207,6 +208,51 @@ func EncodeCMSUserByIDReply(u CMSUserByIDReply) ([]byte, error) {
 // CMSUserByIDReply.
 func DecodeCMSUserByIDReply(b []byte) (*CMSUserByIDReply, error) {
 	var reply CMSUserByIDReply
+
+	err := json.Unmarshal(b, &reply)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reply, nil
+}
+
+// NewDCCUser creates a new DCC user record in the user database.
+type NewDCCUser struct {
+	ContractorContact string `json:"contractorcontact"`
+	ContractorName    string `json:"contractorname"`
+	Email             string `json:"email"`
+	Username          string `json:"username"`
+}
+
+// EncodeNewDCCUser encodes a NewDCCUser into a JSON byte slice.
+func EncodeNewDCCUser(u NewDCCUser) ([]byte, error) {
+	return json.Marshal(u)
+}
+
+// DecodeNewDCCUser decodes JSON byte slice into a NewDCCUser.
+func DecodeNewDCCUser(b []byte) (*NewDCCUser, error) {
+	var u NewDCCUser
+
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		return nil, err
+	}
+
+	return &u, nil
+}
+
+// NewDCCUserReply is the reply to the NewDCCUser command.
+type NewDCCUserReply struct{}
+
+// EncodeNewDCCUserReply encodes a NewDCCUserReply into a JSON byte slice.
+func EncodeNewDCCUserReply(u NewDCCUserReply) ([]byte, error) {
+	return json.Marshal(u)
+}
+
+// DecodeNewDCCUserReply decodes JSON byte slice into a NewDCCUserReply.
+func DecodeNewDCCUserReply(b []byte) (*NewDCCUserReply, error) {
+	var reply NewDCCUserReply
 
 	err := json.Unmarshal(b, &reply)
 	if err != nil {

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -28,6 +28,8 @@ var (
 		template.New("user_changed_password").Parse(templateUserPasswordChangedRaw))
 	templateInviteNewUserEmail = template.Must(
 		template.New("invite_new_user_email_template").Parse(templateInviteNewUserEmailRaw))
+	templateApproveDCCUserEmail = template.Must(
+		template.New("approve_dcc_user_email_template").Parse(templateApproveDCCUserEmailRaw))
 )
 
 // getSession returns the active cookie session.


### PR DESCRIPTION
This adds the initial implementation of the DCC issuance and revocation
proposal system.

Stakeholder Approved DCC Proposal:
https://proposals.decred.org/proposals/fa38a3593d9a3f6cb2478a24c25114f5097c572f6dadf24c78bb521ed10992a4

All submitted DCC proposals will be processed in a very similar fashion
as proposals and invoices.  They will all be of an expected, versioned
form that will allow them to be submitted as records to politeiad.  This
allows us to use the politeiad backend without any required changes.
And another added benefit of that is we are able to reuse the existing
commenting system to allow for discussions on DCC proposals, as well as
users showing support or opposition of a given DCC proposal.

Authenticated Users are now provided with the following requests:
- NewDCC (/dcc/new)
  Creates a new DCC proposal for issuances or revocations.  Proposals
  must include a statement supporting the nominated user,
- NewDCCUser (/dcc/newuser)
  Creates a new "dummy" user that will be nominated in a coming DCC.
- SupportDCC (/dcc/support)
  Creates a comment on the DCC that simply says "aye."
- OpposeDCC (/dcc/support)
  Creates a comment on the DCC that simply says "nay."
- GetDCC (/dcc/token)
  Returns the DCC given the included token.
- GetDCCs (/dcc/status)
  Returns all DCCs that match the included status.
- NewCommentDCC (/dcc/comment)
  Creates a comment on a DCC (that isn't "aye" or "nay").

Additionally there are 2 new requests for administrators:
- ApproveDCC (/admin/approvedcc)
  Approve a DCC and thereby invite the nominated user to CMS (using
  existing InviteNewUser processing).
- RejectDCC (/admin/rejectdcc)
  Reject a DCC and thereby change the user's status that will cause
  their CMS access to be revoked or altered.

The initial plan is to have administrators give the final approval or
rejection for a DCC based on final Support/Opposition tally and
comments.  Then as other subsystems are put into place, we can begin to
develop the "all contractor vote" system.  This will used in instances
where a DCC is considered contentious or in dispute.