### PR TITLE
[cms] Various email notification fixes

### DIFF
--- a/politeiawww/cmsnotifications.go
+++ b/politeiawww/cmsnotifications.go
@@ -26,6 +26,11 @@ func (p *politeiawww) checkInvoiceNotifications() {
 			if user.Admin {
 				return
 			}
+			// If HashedPassword not set to anything that means the user has
+			// not completed registration.
+			if len(user.HashedPassword) == 0 {
+				return
+			}
 			invoiceFound := false
 			userInvoices, err := p.cmsDB.InvoicesByUserID(user.ID.String())
 			if err != nil {
@@ -36,6 +41,7 @@ func (p *politeiawww) checkInvoiceNotifications() {
 				// Check to see if invoices match last month + current year
 				if inv.Month == uint(currentMonth-1) && inv.Year == uint(currentYear) {
 					invoiceFound = true
+					break
 				}
 			}
 			log.Tracef("Checked user: %v sending email? %v", user.Username,

--- a/politeiawww/email.go
+++ b/politeiawww/email.go
@@ -609,7 +609,7 @@ func (p *politeiawww) emailInvoiceNotifications(email, username string) error {
 		Year:     newDate.Year(),
 	}
 
-	subject := "Awaiting Montly Invoice"
+	subject := "Awaiting Monthly Invoice"
 	body, err := createBody(templateInvoiceNotification, &tplData)
 	if err != nil {
 		return err

--- a/politeiawww/email.go
+++ b/politeiawww/email.go
@@ -602,7 +602,7 @@ func (p *politeiawww) emailInvoiceNotifications(email, username string) error {
 		return nil
 	}
 	// Set the date to the first day of the previous month.
-	newDate := time.Date(time.Now().Year(), time.Now().Month()-1, 0, 0, 0, 0, 0, time.UTC)
+	newDate := time.Date(time.Now().Year(), time.Now().Month()-1, 1, 0, 0, 0, 0, time.UTC)
 	tplData := invoiceNotificationEmailData{
 		Username: username,
 		Month:    newDate.Month().String(),
@@ -634,12 +634,14 @@ func (p *politeiawww) emailUserInvoiceComment(userEmail string) error {
 	return p.sendEmailTo(subject, body, userEmail)
 }
 
-func (p *politeiawww) emailUserInvoiceStatusUpdate(userEmail string) error {
+func (p *politeiawww) emailUserInvoiceStatusUpdate(userEmail, invoiceToken string) error {
 	if p.smtp.disabled {
 		return nil
 	}
 
-	tplData := newInvoiceStatusUpdateTemplate{}
+	tplData := newInvoiceStatusUpdateTemplate{
+		Token: invoiceToken,
+	}
 
 	subject := "Invoice status has been updated"
 	body, err := createBody(templateNewInvoiceStatusUpdate, &tplData)

--- a/politeiawww/events.go
+++ b/politeiawww/events.go
@@ -185,7 +185,7 @@ func (p *politeiawww) _setupInvoiceStatusUpdateEmailNotification() {
 				continue
 			}
 
-			err := p.emailUserInvoiceStatusUpdate(isu.User.Email)
+			err := p.emailUserInvoiceStatusUpdate(isu.User.Email, isu.Token)
 			if err != nil {
 				log.Errorf("email for new admin comment %v: %v",
 					isu.Token, err)

--- a/politeiawww/templates.go
+++ b/politeiawww/templates.go
@@ -91,6 +91,7 @@ type newInvoiceCommentTemplateData struct {
 }
 
 type newInvoiceStatusUpdateTemplate struct {
+	Token string
 }
 
 const templateNewUserEmailRaw = `
@@ -244,4 +245,9 @@ An administrator has submitted a new comment to your invoice, please login to cm
 
 const templateNewInvoiceStatusUpdateRaw = `
 An invoice's status has been updated, please login to cms.decred.org to review the changes.
+
+Updated Invoice Token: {{.Token}}
+
+Regards,
+Contractor Management System
 `


### PR DESCRIPTION
Closes #963 
Closes #950 

Includes a few fixes for various issues with CMS email notifications.
- No longer send emails to unregistered users.
- Fix displayed month for invoice notifications.
- Add invoice token to invoice status update email.