### PR TITLE
multi: Prevent duplicate comments.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -609,10 +609,12 @@ func DecodeCensorCommentReply(payload []byte) (*CensorCommentReply, error) {
 	return &ccr, nil
 }
 
-// GetComment retrieves a single comment.
+// GetComment retrieves a single comment. The comment can be retrieved by
+// either comment ID or by signature.
 type GetComment struct {
-	Token     string `json:"token"`     // Proposal ID
-	CommentID string `json:"commentid"` // Comment ID
+	Token     string `json:"token"`               // Proposal ID
+	CommentID string `json:"commentid,omitempty"` // Comment ID
+	Signature string `json:"signature,omitempty"` // Client signature
 }
 
 // EncodeGetComment encodes a GetComment into a JSON byte slice.

--- a/politeiad/cache/cache.go
+++ b/politeiad/cache/cache.go
@@ -35,6 +35,10 @@ var (
 	// ErrInvalidPluginCmd is emitted when an invalid plugin command
 	// is used.
 	ErrInvalidPluginCmd = errors.New("invalid plugin command")
+
+	// ErrInvalidPluginCmdArgs is emitted when a plugin command is used
+	// with invalid arguments.
+	ErrInvalidPluginCmdArgs = errors.New("invalid plugin command arguments")
 )
 
 const (

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -10,6 +10,7 @@ notifications.  It does not render HTML.
 **Methods**
 
 - [`Version`](#version)
+- [`Policy`](#policy)
 - [`New user`](#new-user)
 - [`Verify user`](#verify-user)
 - [`Resend verification`](#resend-verification)
@@ -24,18 +25,14 @@ notifications.  It does not render HTML.
 - [`Change username`](#change-username)
 - [`Change password`](#change-password)
 - [`Reset password`](#reset-password)
-- [`New comment`](#new-comment)
-- [`Get comments`](#get-comments)
-- [`Like comment`](#like-comment)
-- [`Censor comment`](#censor-comment)
-- [`Policy`](#policy)
+- [`User proposal credits`](#user-proposal-credits)
+- [`User comments votes`](#user-comments-votes)
 
-***Proposal Routes***
+**Proposal Routes**
 - [`Vetted`](#vetted)
 - [`Unvetted`](#unvetted)
 - [`User proposals`](#user-proposals)
 - [`Proposal paywall details`](#proposal-paywall-details)
-- [`User proposal credits`](#user-proposal-credits)
 - [`Verify user payment`](#verify-user-payment)
 - [`New proposal`](#new-proposal)
 - [`Edit Proposal`](#edit-proposal)
@@ -49,8 +46,11 @@ notifications.  It does not render HTML.
 - [`Proposal vote status`](#proposal-vote-status)
 - [`Proposals vote status`](#proposals-vote-status)
 - [`Vote results`](#vote-results)
-- [`User Comments votes`](#user-comments-votes)
 - [`Proposals Stats`](#proposals-stats)
+- [`New comment`](#new-comment)
+- [`Get comments`](#get-comments)
+- [`Like comment`](#like-comment)
+- [`Censor comment`](#censor-comment)
 
 
 **Error status codes**
@@ -97,7 +97,6 @@ notifications.  It does not render HTML.
 - [`ErrorStatusInvalidUserManageAction`](#ErrorStatusInvalidUserManageAction)
 - [`ErrorStatusUserActionNotAllowed`](#ErrorStatusUserActionNotAllowed)
 - [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
-- [`ErrorStatusCannotCommentOnProp`](#ErrorStatusCannotCommentOnProp)
 - [`ErrorStatusCannotVoteOnPropComment`](#ErrorStatusCannotVoteOnPropComment)
 - [`ErrorStatusChangeMessageCannotBeBlank`](#ErrorStatusChangeMessageCannotBeBlank)
 - [`ErrorStatusCensorReasonCannotBeBlank`](#ErrorStatusCensorReasonCannotBeBlank)
@@ -113,44 +112,10 @@ notifications.  It does not render HTML.
 - [`ErrorStatusInvalidUUID`](#ErrorStatusInvalidUUID)
 - [`ErrorStatusInvalidLikeCommentAction`](#ErrorStatusInvalidLikeCommentAction)
 - [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
-- [`ErrorStatusMalformedName`](#ErrorStatusMalformedName)
-- [`ErrorStatusMalformedLocation`](#ErrorStatusMalformedLocation)
-- [`ErrorStatusInvoiceNotFound`](#ErrorStatusInvoiceNotFound)
-- [`ErrorStatusInvalidMonthYearRequest`](#ErrorStatusInvalidMonthYearRequest)
-- [`ErrorStatusMalformedInvoiceFile`](#ErrorStatusMalformedInvoiceFile)
-- [`ErrorStatusInvalidInvoiceStatusTransition`](#ErrorStatusInvalidInvoiceStatusTransition)
-- [`ErrorStatusReasonNotProvided`](#ErrorStatusReasonNotProvided)
-- [`ErrorStatusInvoiceDuplicate`](#ErrorStatusInvoiceDuplicate)
-- [`ErrorStatusInvalidPaymentAddress`](#ErrorStatusInvalidPaymentAddress)
-- [`ErrorStatusMalformedLineItem`](#ErrorStatusMalformedLineItem)
-- [`ErrorStatusInvoiceMissingName`](#ErrorStatusInvoiceMissingName)
-- [`ErrorStatusInvoiceMissingLocation`](#ErrorStatusInvoiceMissingLocation)
-- [`ErrorStatusInvoiceMissingContact`](#ErrorStatusInvoiceMissingContact)
-- [`ErrorStatusInvoiceMissingRate`](#ErrorStatusInvoiceMissingRate)
-- [`ErrorStatusInvoiceInvalidRate`](#ErrorStatusInvoiceInvalidRate)
-- [`ErrorStatusInvoiceMalformedContact`](#ErrorStatusInvoiceMalformedContact)
-- [`ErrorStatusMalformedProposalToken`](#ErrorStatusMalformedProposalToken)
-- [`ErrorStatusMalformedDomain`](#ErrorStatusMalformedDomain)
-- [`ErrorStatusMalformedSubdomain`](#ErrorStatusMalformedSubdomain)
-- [`ErrorStatusMalformedDescription`](#ErrorStatusMalformedDescription) 
-- [`ErrorStatusWrongInvoiceStatus`](#ErrorStatusWrongInvoiceStatus) 
-- [`ErrorStatusInvoiceRequireLineItems`](#ErrorStatusInvoiceRequireLineItems)
-- [`ErrorStatusInvalidInvoiceMonthYear`](#ErrorStatusInvalidInvoiceMonthYear)
-- [`ErrorStatusMultipleInvoiceMonthYear`](#ErrorStatusMultipleInvoiceMonthYear)
-- [`ErrorStatusInvalidLineItemType`](#ErrorStatusInvalidLineItemType) 
-- [`ErrorStatusInvalidLaborExpense`](#ErrorStatusInvalidLaborExpense)
+- [`ErrorStatusEmailAlreadyVerified`](#ErrorStatusEmailAlreadyVerified)
 - [`ErrorStatusNoProposalChanges`](#ErrorStatusNoProposalChanges)
-- [`ErrorStatusDuplicatePaymentAddress`](#ErrorStatusDuplicatePaymentAddress)
 - [`ErrorStatusMaxProposalsExceededPolicy`](#ErrorStatusMaxProposalsExceededPolicy)
-
-**Proposal status codes**
-
-- [`PropStatusInvalid`](#PropStatusInvalid)
-- [`PropStatusNotFound`](#PropStatusNotFound)
-- [`PropStatusNotReviewed`](#PropStatusNotReviewed)
-- [`PropStatusCensored`](#PropStatusCensored)
-- [`PropStatusPublic`](#PropStatusPublic)
-- [`PropStatusAbandoned`](#PropStatusAbandoned)
+- [`ErrorStatusDuplicateComment`](#ErrorStatusDuplicateComment)
 
 **Websockets**
 
@@ -1696,23 +1661,31 @@ proposal"; if the value is not empty it means "reply to comment".
 
 | | Type | Description |
 | - | - | - |
+| token | string | Censorship token |
+| parentid | string | Parent comment identifier |
+| comment | string | Comment text |
+| signature | string | Signature of Token, ParentID and Comment |
+| publickey | string | Public key from the client side, sent to politeiawww for verification |
+| commentid | string | Unique comment identifier |
+| receipt | string | Server signature of the client Signature |
+| timestamp | int64 | UNIX time when comment was accepted |
+| resultvotes | int64 | Vote score |
+| censored | bool | Has the comment been censored |
 | userid | string | Unique user identifier |
 | username | string | Unique username |
-| timestamp | int64 | UNIX time when comment was accepted |
-| commentid | string | Unique comment identifier |
-| parentid | string | Parent comment identifier |
-| token | string | Censorship token |
-| comment | string | Comment text |
-| publickey | string | Public key from the client side, sent to politeiawww for verification |
-| signature | string | Signature of Token, ParentID and Comment |
-| receipt | string | Server signature of the client Signature |
-| resultvotes | int64 | Vote score |
 
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
 
-- [`ErrorStatusCommentLengthExceededPolicy`](#ErrorStatusCommentLengthExceededPolicy)
 - [`ErrorStatusUserNotPaid`](#ErrorStatusUserNotPaid)
+- [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
+- [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
+- [`ErrorStatusCommentLengthExceededPolicy`](#ErrorStatusCommentLengthExceededPolicy)
+- [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
+- [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
+- [`ErrorStatusWrongStatus`](#ErrorStatusWrongStatus)
+- [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
+- [`ErrorStatusDuplicateComment`](#ErrorStatusDuplicateComment)
 
 **Example**
 
@@ -1732,18 +1705,18 @@ Reply:
 
 ```json
 {
-  "comment": "I dont like this prop",
-  "commentid": "4",
-  "parentid": "0",
-  "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
-  "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
-  "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
-  "timestamp": 1527277504,
   "token": "abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+  "parentid": "0",
+  "comment": "I dont like this prop",
+  "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+  "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
+  "commentid": "4",
+  "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
+  "timestamp": 1527277504,
+  "resultvotes": 0,
+  "censored": false,
   "userid": "124",
   "username": "john",
-  "totalvotes": 0,
-  "resultvotes": 0
 }
 ```
 
@@ -2607,7 +2580,6 @@ Reply:
 | <a name="ErrorStatusInvalidUserManageAction">ErrorStatusInvalidUserManageAction</a> | 40 | Invalid action for editing a user. |
 | <a name="ErrorStatusUserActionNotAllowed">ErrorStatusUserActionNotAllowed</a> | 41 | User action is not allowed. |
 | <a name="ErrorStatusWrongVoteStatus">ErrorStatusWrongVoteStatus</a> | 42 | The proposal has the wrong vote status for the action to be performed. |
-| <a name="ErrorStatusCannotCommentOnProp">ErrorStatusCannotCommentOnProp</a> | 43 | Cannot comment on proposal. |
 | <a name="ErrorStatusCannotVoteOnPropComment">ErrorStatusCannotVoteOnPropComment</a> | 44 | Cannot vote on proposal comment. |
 | <a name="ErrorStatusChangeMessageCannotBeBlank">ErrorStatusChangeMessageCannotBeBlank</a> | 45 | Status change message cannot be blank. |
 | <a name="ErrorStatusCensorReasonCannotBeBlank">ErrorStatusCensorReasonCannotBeBlank</a> | 46 | Censor comment reason cannot be blank. |
@@ -2623,8 +2595,10 @@ Reply:
 | <a name="ErrorStatusInvalidUUID">ErrorStatusInvalidUUID</a> | 56 | Invalid user UUID. |
 | <a name="ErrorStatusInvalidLikeCommentAction">ErrorStatusInvalidLikeCommentAction</a> | 57 | Invalid like comment action. |
 | <a name="ErrorStatusInvalidCensorshipToken">ErrorStatusInvalidCensorshipToken</a> | 58 | Invalid proposal censorship token. |
-| <a name="ErrorStatusNoProposalChanges">ErrorStatusNoProposalChanges</a> | 88 | No changes found in proposal. |
-| <a name="ErrorStatusNoProposalChanges">ErrorStatusMaxProposalsExceededPolicy</a> | 89 | Number of proposals request exceeded ProposalListPageSize. |
+| <a name="ErrorStatusEmailAlreadyVerified">ErrorStatusEmailAlreadyVerified</a> | 59 | Email address is already verified. |
+| <a name="ErrorStatusNoProposalChanges">ErrorStatusNoProposalChanges</a> | 60 | No changes found in proposal. |
+| <a name="ErrorStatusMaxProposalsExceedsPolicy">ErrorStatusMaxProposalsExceededPolicy</a> | 61 | Number of proposals requested exceeded the ProposalListPageSize. |
+| <a name="ErrorStatusDuplicateComment">ErrorStatusDuplicateComment</a> | 62 | Duplicate comment. |
 
 
 ### Proposal status codes

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -161,7 +161,6 @@ const (
 	ErrorStatusInvalidUserManageAction     ErrorStatusT = 40
 	ErrorStatusUserActionNotAllowed        ErrorStatusT = 41
 	ErrorStatusWrongVoteStatus             ErrorStatusT = 42
-	ErrorStatusCannotCommentOnProp         ErrorStatusT = 43
 	ErrorStatusCannotVoteOnPropComment     ErrorStatusT = 44
 	ErrorStatusChangeMessageCannotBeBlank  ErrorStatusT = 45
 	ErrorStatusCensorReasonCannotBeBlank   ErrorStatusT = 46
@@ -178,8 +177,9 @@ const (
 	ErrorStatusInvalidLikeCommentAction    ErrorStatusT = 57
 	ErrorStatusInvalidCensorshipToken      ErrorStatusT = 58
 	ErrorStatusEmailAlreadyVerified        ErrorStatusT = 59
-	ErrorStatusNoProposalChanges           ErrorStatusT = 88
-	ErrorStatusMaxProposalsExceededPolicy  ErrorStatusT = 89
+	ErrorStatusNoProposalChanges           ErrorStatusT = 60
+	ErrorStatusMaxProposalsExceededPolicy  ErrorStatusT = 61
+	ErrorStatusDuplicateComment            ErrorStatusT = 62
 
 	// Proposal state codes
 	//
@@ -300,7 +300,6 @@ var (
 		ErrorStatusInvalidUserManageAction:     "invalid user edit action",
 		ErrorStatusUserActionNotAllowed:        "user action is not allowed",
 		ErrorStatusWrongVoteStatus:             "wrong proposal vote status",
-		ErrorStatusCannotCommentOnProp:         "cannot comment on proposal",
 		ErrorStatusCannotVoteOnPropComment:     "cannot vote on proposal comment",
 		ErrorStatusChangeMessageCannotBeBlank:  "status change message cannot be blank",
 		ErrorStatusCensorReasonCannotBeBlank:   "censor comment reason cannot be blank",
@@ -318,6 +317,7 @@ var (
 		ErrorStatusInvalidCensorshipToken:      "invalid proposal censorship token",
 		ErrorStatusEmailAlreadyVerified:        "email address is already verified",
 		ErrorStatusNoProposalChanges:           "no changes found in proposal",
+		ErrorStatusDuplicateComment:            "duplicate comment",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -19,13 +19,8 @@ import (
 
 // decredGetComment sends the decred plugin getcomment command to the cache and
 // returns the specified comment.
-func (p *politeiawww) decredGetComment(token, commentID string) (*decredplugin.Comment, error) {
+func (p *politeiawww) decredGetComment(gc decredplugin.GetComment) (*decredplugin.Comment, error) {
 	// Setup plugin command
-	gc := decredplugin.GetComment{
-		Token:     token,
-		CommentID: commentID,
-	}
-
 	payload, err := decredplugin.EncodeGetComment(gc)
 	if err != nil {
 		return nil, err
@@ -49,6 +44,26 @@ func (p *politeiawww) decredGetComment(token, commentID string) (*decredplugin.C
 	}
 
 	return &gcr.Comment, nil
+}
+
+// decredCommentGetByID retrieves the specified decred plugin comment from the
+// cache.
+func (p *politeiawww) decredCommentGetByID(token, commentID string) (*decredplugin.Comment, error) {
+	gc := decredplugin.GetComment{
+		Token:     token,
+		CommentID: commentID,
+	}
+	return p.decredGetComment(gc)
+}
+
+// decredCommentGetBySignature retrieves the specified decred plugin comment
+// from the cache.
+func (p *politeiawww) decredCommentGetBySignature(token, sig string) (*decredplugin.Comment, error) {
+	gc := decredplugin.GetComment{
+		Token:     token,
+		Signature: sig,
+	}
+	return p.decredGetComment(gc)
 }
 
 // decredGetComments sends the decred plugin getcomments command to the cache

--- a/politeiawww/events.go
+++ b/politeiawww/events.go
@@ -425,7 +425,7 @@ func (p *politeiawww) _setupCommentReplyEmailNotifications() {
 						c.Comment.Token, c.Comment.CommentID, err)
 				}
 			} else {
-				parent, err := p.decredGetComment(token, c.Comment.ParentID)
+				parent, err := p.decredCommentGetByID(token, c.Comment.ParentID)
 				if err != nil {
 					log.Errorf("EventManager: getComment failed for token %v "+
 						"commentID %v: %v", token, c.Comment.ParentID, err)


### PR DESCRIPTION
Closes #931.

This diff adds validation to politeiawww to prevent a user from
submitting a duplicate comment. A duplicate comment is defined as a
comment with the same signature as an existing comment.  The comment
signature is the token+parentID+comment.

The scenerio that this is meant to prevent is when a user submits the
same comment request multiple times due to some network/browser hiccups.
This has happened to multiple users on production pi.

It also cleans up some documentation that was out of date in `www/v1/api.md`.

Note: this only adds validation to politeiawww. It does not add any
validation to politeiad. This means thats its still possible to for
duplicate comments to make it into the politeiad repo if the duplicate
comment request is submitted before the original comment is added to the
cache. I explored the possibility of adding duplicate comment validation
to politeiad, but doing so would make the politeiad new comment call
much more expensive and I don't think the tradeoff is worth it.