### PR TITLE
multi: Return unvetted token inventory to admins.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -897,10 +897,12 @@ func DecodeInventoryReply(payload []byte) (*InventoryReply, error) {
 	return &ir, nil
 }
 
-// TokenInventory requests the tokens of all records in the inventory,
-// categorized by stage of the voting process.
+// TokenInventory requests the tokens of the records in the inventory,
+// categorized by stage of the voting process. By default, only vetted
+// records are returned.
 type TokenInventory struct {
 	BestBlock uint64 `json:"bestblock"` // Best block
+	Unvetted  bool   `json:"unvetted"`  // Include unvetted records
 }
 
 // EncodeTokenInventory encodes a TokenInventory into a JSON byte slice.
@@ -921,16 +923,26 @@ func DecodeTokenInventory(payload []byte) (*TokenInventory, error) {
 }
 
 // TokenInventoryReply is the response to the TokenInventory command and
-// returns the tokens of all records in the inventory.  The tokens are
-// categorized by stage of the voting process.  Pre and abandoned tokens are
-// sorted by timestamp in decending order.  Active, approved, and rejected
-// tokens are sorted by voting period end block height in decending order.
+// returns the tokens of all records in the inventory. The tokens are
+// categorized by stage of the voting process and are sorted according to
+// the following rule.
+//
+// Sorted by record timestamp in descending order:
+// Pre, Abandonded, Unreviewed, Censored
+//
+// Sorted by voting period end block height in descending order:
+// Active, Approved, Rejected
 type TokenInventoryReply struct {
+	// Vetted Records
 	Pre       []string `json:"pre"`       // Tokens of records that are pre-vote
 	Active    []string `json:"active"`    // Tokens of records with an active voting period
 	Approved  []string `json:"approved"`  // Tokens of records that have been approved by a vote
 	Rejected  []string `json:"rejected"`  // Tokens of records that have been rejected by a vote
 	Abandoned []string `json:"abandoned"` // Tokens of records that have been abandoned
+
+	// Unvetted records
+	Unreviewed []string `json:"unreviewied,omitempty"` // Tokens of records that are unreviewed
+	Censored   []string `json:"censored,omitempty"`    // Tokens of records that have been censored
 }
 
 // EncodeTokenInventoryReply encodes a TokenInventoryReply into a JSON byte

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -47,6 +47,7 @@ notifications.  It does not render HTML.
 - [`Proposals vote status`](#proposals-vote-status)
 - [`Vote results`](#vote-results)
 - [`Proposals Stats`](#proposals-stats)
+- [`Token inventory`](#token-inventory)
 - [`New comment`](#new-comment)
 - [`Get comments`](#get-comments)
 - [`Like comment`](#like-comment)
@@ -2530,6 +2531,57 @@ Reply:
   "numofunvetted":0,
   "numofunvettedchanges":1,
   "numofpublic":3
+}
+```
+
+### `Token inventory`
+
+Retrieve the censorship record tokens of all proposals in the inventory. The
+tokens are categorized by stage of the voting process and sorted according to
+the rules listed below. Unvetted proposal tokens are only returned to admins.
+Unvetted proposals include unvreviewed and censored proposals.
+
+Sorted by record timestamp in descending order:
+Pre, Abandonded, Unreviewed, Censored
+
+Sorted by voting period end block height in descending order:
+Active, Approved, Rejected
+
+**Route:** `GET v1/proposals/tokeninventory`
+
+**Params:** none
+
+**Results:**
+
+| | Type | Description |
+| - | - | - |
+| pre | []string | Tokens of all vetted proposals that are pre-vote. |
+| active | []string | Tokens of all vetted proposals with an active voting period. |
+| approved | []string | Tokens of all vetted proposals that have been approved by a vote. |
+| rejected | []string | Tokens of all vetted proposals that have been rejected by a vote. |
+| abandoned | []string | Tokens of all vetted proposals that have been abandoned. |
+| unreviewed | []string | Tokens of all unreviewed proposals. |
+| censored | []string | Tokens of all censored proposals. |
+
+**Example:**
+Request:
+Path: `v1/proposals/tokeninventory`
+
+Reply:
+
+```json
+{
+  "pre": [
+    "567ec4cdca78362f725dbb2b8b5161991fe6ba3bb6da1ad3f99067dd4712e48e"
+  ],
+  "active": [
+    "79cb792d8a15e83ce6809b2846f4dfdd04a65f5aa674c04926599fabf80c1b62"
+  ],
+  "approved": [],
+  "rejected": [],
+  "abandoned": [
+    "99376fbf7b79e30a7ff778743da46e04ae3b360109fa71011930f4c9a15c4ef5"
+  ]
 }
 ```
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -1167,16 +1167,26 @@ type ProposalsStatsReply struct {
 type TokenInventory struct{}
 
 // TokenInventoryReply is used to reply to the TokenInventory command and
-// returns the tokens of all proposals in the inventory.  The tokens are
-// categorized by stage of the voting process.  Pre and abandoned tokens are
-// sorted by timestamp in decending order.  Active, approved, and rejected
-// tokens are sorted by voting period end block height in decending order.
+// returns the tokens of all proposals in the inventory. The tokens are
+// categorized by stage of the voting process and sorted according to the
+// rules listed below. Unvetted proposal tokens are only returned to admins.
+//
+// Sorted by record timestamp in descending order:
+// Pre, Abandonded, Unreviewed, Censored
+//
+// Sorted by voting period end block height in descending order:
+// Active, Approved, Rejected
 type TokenInventoryReply struct {
+	// Vetted
 	Pre       []string `json:"pre"`       // Tokens of all props that are pre-vote
 	Active    []string `json:"active"`    // Tokens of all props with an active voting period
 	Approved  []string `json:"approved"`  // Tokens of all props that have been approved by a vote
 	Rejected  []string `json:"rejected"`  // Tokens of all props that have been rejected by a vote
 	Abandoned []string `json:"abandoned"` // Tokens of all props that have been abandoned
+
+	// Unvetted
+	Unreviewed []string `json:"unreviewed,omitempty"` // Tokens of all unreviewed props
+	Censored   []string `json:"censored,omitempty"`   // Tokens of all censored props
 }
 
 // Websocket commands

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -499,11 +499,13 @@ func convertVoteOptionResultsFromDecred(vor []decredplugin.VoteOptionResult) []w
 
 func convertTokenInventoryReplyFromDecred(r decredplugin.TokenInventoryReply) www.TokenInventoryReply {
 	return www.TokenInventoryReply{
-		Pre:       r.Pre,
-		Active:    r.Active,
-		Approved:  r.Approved,
-		Rejected:  r.Rejected,
-		Abandoned: r.Abandoned,
+		Pre:        r.Pre,
+		Active:     r.Active,
+		Approved:   r.Approved,
+		Rejected:   r.Rejected,
+		Abandoned:  r.Abandoned,
+		Unreviewed: r.Unreviewed,
+		Censored:   r.Censored,
 	}
 }
 

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -301,10 +301,11 @@ func (p *politeiawww) decredInventory() (*decredplugin.InventoryReply, error) {
 
 // decredTokenInventory sends the decred plugin tokeninventory command to the
 // cache.
-func (p *politeiawww) decredTokenInventory(bestBlock uint64) (*decredplugin.TokenInventoryReply, error) {
+func (p *politeiawww) decredTokenInventory(bestBlock uint64, includeUnvetted bool) (*decredplugin.TokenInventoryReply, error) {
 	payload, err := decredplugin.EncodeTokenInventory(
 		decredplugin.TokenInventory{
 			BestBlock: bestBlock,
+			Unvetted:  includeUnvetted,
 		})
 	if err != nil {
 		return nil, err

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -497,7 +497,18 @@ func (p *politeiawww) handleProposalsStats(w http.ResponseWriter, r *http.Reques
 
 // handleTokenInventory returns the tokens of all proposals in the inventory.
 func (p *politeiawww) handleTokenInventory(w http.ResponseWriter, r *http.Request) {
-	reply, err := p.processTokenInventory()
+	user, err := p.getSessionUser(w, r)
+	if err != nil {
+		// This is a public route so a session might not exist
+		if err != ErrSessionUUIDNotFound {
+			RespondWithError(w, r, 0,
+				"handleProposalDetails: getSessionUser %v", err)
+			return
+		}
+	}
+
+	isAdmin := user != nil && user.Admin
+	reply, err := p.processTokenInventory(isAdmin)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleTokenInventory: processTokenInventory: %v", err)

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -2115,7 +2115,7 @@ func (p *politeiawww) processStartVote(sv www.StartVote, u *user.User) (*www.Sta
 
 // processTokenInventory returns the tokens of all proposals in the inventory,
 // categorized by stage of the voting process.
-func (p *politeiawww) processTokenInventory() (*www.TokenInventoryReply, error) {
+func (p *politeiawww) processTokenInventory(isAdmin bool) (*www.TokenInventoryReply, error) {
 	log.Tracef("processTokenInventory")
 
 	bb, err := p.getBestBlock()
@@ -2130,7 +2130,10 @@ func (p *politeiawww) processTokenInventory() (*www.TokenInventoryReply, error) 
 	var done bool
 	var r www.TokenInventoryReply
 	for retries := 0; !done && retries <= 1; retries++ {
-		ti, err := p.decredTokenInventory(bb)
+		// Both vetted and unvetted tokens should be returned
+		// for admins. Only vetted tokens should be returned
+		// for non-admins.
+		ti, err := p.decredTokenInventory(bb, isAdmin)
 		if err != nil {
 			if err == cache.ErrRecordNotFound {
 				// There are missing entries in the vote


### PR DESCRIPTION
This diff updates the token inventory route to also return the unvetted
tokens to admins in addition to the normal vetted tokens.

The gui redesign separates unvetted proposals into "unreviewed" and
"censored" when displaying them to an admin. This diff allows the gui
to fetch the specific proposals required to populate those views instead
of having to use the `AllUnvetted` route which just returns a page of
the most recent unvetted proposals.