### PR TITLE
disable cockroach diagnostic reporting in cachesetup script

### DIFF
--- a/scripts/cachesetup.sh
+++ b/scripts/cachesetup.sh
@@ -72,3 +72,12 @@ cockroach sql \
 cockroach sql \
   --certs-dir="${ROOT_CERTS_DIR}" \
   --execute "GRANT SELECT ON DATABASE ${DB_TESTNET} TO  ${USER_POLITEIAWWW}"
+
+# Disable CockroachDB diagnostic reporting
+cockroach sql \
+  --certs-dir="${ROOT_CERTS_DIR}" \
+  --execute "SET CLUSTER SETTING diagnostics.reporting.enabled=false"
+
+cockroach sql \
+  --certs-dir="${ROOT_CERTS_DIR}" \
+  --execute "SET CLUSTER SETTING diagnostics.reporting.send_crash_reports=false"


### PR DESCRIPTION
This PR resolves https://github.com/decred/politeia/issues/915. Added two sql commands to the newly created DB to disable CockroachDB diagnostic reporting. Verified that it worked by entering the cockroach sql cli client and checking the results (see below). 

```# Welcome to the cockroach SQL interface.
# All statements must be terminated by a semicolon.
# To exit: CTRL + D.
#
# Server version: CockroachDB CCL v19.1.4 (x86_64-unknown-linux-gnu, built 2019/08/06 15:34:13, go1.11.6) (same version as client)
# Cluster ID: 1162e3b8-21d9-43df-970f-fa011cbf2feb
#
# Enter \? for a brief introduction.
#
root@:26257/defaultdb> SHOW CLUSTER SETTING diagnostics.reporting.enabled;
  diagnostics.reporting.enabled  
+-------------------------------+
              false              
(1 row)

Time: 279.069µs

root@:26257/defaultdb> SHOW CLUSTER SETTING diagnostics.reporting.send_crash_reports;
  diagnostics.reporting.send_crash_reports  
+------------------------------------------+
                   false                    
(1 row)

Time: 404.594µs
```