### PR TITLE
[cms] Add Support, Oppose and Comment DCC functionality

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1066,7 +1066,173 @@ Reply:
 {}
 ```
 
+### `New DCC comment`
 
+Submit comment on given DCC.  ParentID value "0" means "comment on
+proposal"; if the value is not empty it means "reply to comment".
+
+**Route:** `POST /v1/dcc/newcomment`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+| - | - | - | - |
+| token | string | Censorship token | Yes |
+| parentid | string | Parent comment identifier | Yes |
+| comment | string | Comment | Yes |
+| signature | string | Signature of Token, ParentID and Comment | Yes |
+| publickey | string | Public key from the client side, sent to politeiawww for verification | Yes |
+
+**Results:**
+
+| | Type | Description |
+| - | - | - |
+| token | string | Censorship token |
+| parentid | string | Parent comment identifier |
+| comment | string | Comment text |
+| signature | string | Signature of Token, ParentID and Comment |
+| publickey | string | Public key from the client side, sent to politeiawww for verification |
+| commentid | string | Unique comment identifier |
+| receipt | string | Server signature of the client Signature |
+| timestamp | int64 | UNIX time when comment was accepted |
+| resultvotes | int64 | Vote score |
+| censored | bool | Has the comment been censored |
+| userid | string | Unique user identifier |
+| username | string | Unique username |
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+
+- [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
+- [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
+- [`ErrorStatusCommentLengthExceededPolicy`](#ErrorStatusCommentLengthExceededPolicy)
+- [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
+- [`ErrorStatusDCCNotFound`](#ErrorStatusDCCNotFound)
+- [`ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC`](#ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC)
+- [`ErrorStatusDuplicateComment`](#ErrorStatusDuplicateComment)
+
+**Example**
+
+Request:
+
+```json
+{
+  "token":"abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+  "parentid":"0",
+  "comment":"I dont like this dcc",
+  "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+  "publickey":"4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7"
+}
+```
+
+Reply:
+
+```json
+{
+  "token": "abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+  "parentid": "0",
+  "comment": "I dont like this dcc",
+  "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+  "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
+  "commentid": "4",
+  "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
+  "timestamp": 1527277504,
+  "resultvotes": 0,
+  "censored": false,
+  "userid": "124",
+  "username": "john",
+}
+```
+
+### `DCC comments`
+
+Retrieve all comments for given DCC.  Note that the comments are not
+sorted.
+
+**Route:** `GET /v1/dcc/{token}/comments`
+
+**Params:**
+
+**Results:**
+
+| | Type | Description |
+| - | - | - |
+| Comments | Comment | Unsorted array of all comments |
+| AccessTime | int64 | UNIX timestamp of last access time. Omitted if no session cookie is present. |
+
+**Comment:**
+
+| | Type | Description |
+| - | - | - |
+| userid | string | Unique user identifier |
+| username | string | Unique username |
+| timestamp | int64 | UNIX time when comment was accepted |
+| commentid | string | Unique comment identifier |
+| parentid | string | Parent comment identifier |
+| token | string | Censorship token |
+| comment | string | Comment text |
+| publickey | string | Public key from the client side, sent to politeiawww for verification |
+| signature | string | Signature of Token, ParentID and Comment |
+| receipt | string | Server signature of the client Signature |
+| resultvotes | int64 | Vote score |
+
+**Example**
+
+Request:
+
+The request params should be provided within the URL:
+
+```
+/v1/dcc/f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde/comments
+```
+
+Reply:
+
+```json
+{
+  "comments": [{
+    "comment": "I dont like this dcc",
+    "commentid": "4",
+    "parentid": "0",
+    "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
+    "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
+    "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+    "timestamp": 1527277504,
+    "token": "abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+    "userid": "124",
+    "username": "admin",
+    "totalvotes": 0,
+    "resultvotes": 0
+  },{
+    "comment":"Yah this user stinks!",
+    "commentid": "4",
+    "parentid": "0",
+    "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
+    "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
+    "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+    "timestamp": 1527277504,
+    "token": "abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+    "userid": "122",
+    "username": "steve",
+    "totalvotes": 0,
+    "resultvotes": 0
+  },{
+    "comment":"you're right, approving",
+    "commentid": "4",
+    "parentid": "0",
+    "publickey": "4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7",
+    "receipt": "96f3956ea3decb75ee129e6ee4e77c6c608f0b5c99ff41960a4e6078d8bb74e8ad9d2545c01fff2f8b7e0af38ee9de406aea8a0b897777d619e93d797bc1650a",
+    "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+    "timestamp": 1527277504,
+    "token": "abf0fd1fc1b8c1c9535685373dce6c54948b7eb018e17e3a8cea26a3c9b85684",
+    "userid": "124",
+    "username": "admin",
+    "totalvotes": 0,
+    "resultvotes": 0
+  }],
+  "accesstime": 1543539276
+}
+```
 ### Error codes
 
 | Status | Value | Description |
@@ -1110,7 +1276,7 @@ Reply:
 | <a name="ErrorStatusInvalidUserNewInvoice">ErrorStatusInvalidUserNewInvoice</a> | 1038 | The user was not allowed to create a new invoice. |
 | <a name="ErrorStatusInvalidDCCNominee">ErrorStatusInvalidDCCNominee</a> | 1039 | The user that was nominated was invalid, either not found or not a potential nominee. |
 | <a name="ErrorStatusDCCNotFound">ErrorStatusDCCNotFound</a> | 1040 | A requested DCC proposal was not able to be located based on the provided token. |
-| <a name="ErrorStatusCannotCommentOnDCC">ErrorStatusCannotCommentOnDCC</a> | 1041 | A user is unable to comment on a DCC, due to them being the author or some other situation. |
+| <a name="ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC">ErrorStatusCannotCommentOnDCC</a> | 1041 | A user is unable to support/oppose/comment on a DCC that is not active. |
 
 ### Invoice status codes
 

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1276,10 +1276,10 @@ Reply:
 | <a name="ErrorStatusInvalidUserNewInvoice">ErrorStatusInvalidUserNewInvoice</a> | 1038 | The user was not allowed to create a new invoice. |
 | <a name="ErrorStatusInvalidDCCNominee">ErrorStatusInvalidDCCNominee</a> | 1039 | The user that was nominated was invalid, either not found or not a potential nominee. |
 | <a name="ErrorStatusDCCNotFound">ErrorStatusDCCNotFound</a> | 1040 | A requested DCC proposal was not able to be located based on the provided token. |
-| <a name="ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC">ErrorStatusCannotCommentOnDCC</a> | 1041 | A user is unable to support/oppose/comment on a DCC that is not active. |
+| <a name="ErrorStatusWrongDCCStatus">ErrorStatusWrongDCCStatus</a> | 1041 | A user is unable to support/oppose/comment on a DCC that is not active. |
 | <a name="ErrorStatusInvalidSupportOppose">ErrorStatusInvalidSupportOppose</a> | 1042 | An invalid "vote" for a support or oppose request.  Must be "aye" or "nay". |
-| <a name="ErrorStatusUserDuplicateSupportOppose">ErrorStatusUserDuplicateSupportOppose</a> | 1043 | A user attempted to support or oppose a DCC multiple times. |
-| <a name="ErrorStatusUserCannotSupportOpposeOwn">ErrorStatusUserCannotSupportOpposeOwn</a> | 1044 | A user attempted to support or oppose a DCC that they authored. |
+| <a name="ErrorStatusDuplicateSupportOppose">ErrorStatusDuplicateSupportOppose</a> | 1043 | A user attempted to support or oppose a DCC multiple times. |
+| <a name="ErrorStatusUserIsAuthor">ErrorStatusUserIsAuthor</a> | 1044 | A user attempted to support or oppose a DCC that they authored. |
 
 ### Invoice status codes
 

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -873,7 +873,7 @@ Reply:
 
 ### `DCC Details`
 
-Retrieve DCC by its token.
+Retrieve DCC and its details.
 
 **Routes:** `GET /v1/dcc/{token}`
 
@@ -906,11 +906,7 @@ The request params should be provided within the URL:
 Reply:
 
 ```json
-
-Reply:
-
-```json
-{  
+{
     "dcc": {
       "status": 4,
       "statuschangereason": "This has been revoked due to strong support.",
@@ -942,8 +938,24 @@ Reply:
         "token": "edd0882152f9800e7a6240f23d7310bd45145eb85ec463458de828b631083d84",
         "merkle": "cd5176184a510776abf1c394d830427f94d2f7fe4622e27ac839ceefa7fcf277",
         "signature": "4ea9f76a6c6659d4936aa556182604a3099778a981ebf500d5d47424b7ba0127ab033202b0be7872d09473088c04e9d1145f801455f0ae07be29e2f2d99ac00f"
-      }
+      },
+    "publickey": "311fa61d27b18c0033589ef1fb49edd162d791d0702cbab623ffd4486452322a",
+    "signature": "8a3c5b5cb984cfb7fd59a11d2d7d11a8d50b936358541d917ba348d30bfb1d805c26686836695a9b4b347feee6a674b689b448ed941280874a4b8dbdf360600b",
+    "version": "1",
+    "statement": "",
+    "domain": 0,
+    "sponsoruserid": "b35ab9d3-a98d-4170-ad5a-85b5bce9fb10",
+    "sponsorusername": "bsaget",
+    "supportuserids": [],
+    "againstuserids": [
+      "a5c98ca0-7369-4147-8902-3d268ec2fb24"
+    ],
+    "censorshiprecord": {
+      "token": "edd0882152f9800e7a6240f23d7310bd45145eb85ec463458de828b631083d84",
+      "merkle": "cd5176184a510776abf1c394d830427f94d2f7fe4622e27ac839ceefa7fcf277",
+      "signature": "4ea9f76a6c6659d4936aa556182604a3099778a981ebf500d5d47424b7ba0127ab033202b0be7872d09473088c04e9d1145f801455f0ae07be29e2f2d99ac00f"
     }
+  }
 }
 ```
 
@@ -1019,6 +1031,42 @@ Reply:
 }
 ```
 
+### `Support/Oppose DCC`
+
+Creates a vote on a DCC Record that is used to tabulate support or opposition .
+
+**Route:** `POST /v1/dcc/supportoppose`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| vote | string | The vote for the given DCC | Yes |
+| token | string | The token of the DCC to support | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+
+**Example**
+
+Request:
+
+```json
+{
+  "vote": "aye",
+  "token":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b"
+}
+```
+
+Reply:
+
+```json
+{}
+```
+
+
 ### Error codes
 
 | Status | Value | Description |
@@ -1061,6 +1109,8 @@ Reply:
 | <a name="ErrorStatusDuplicateEmail">ErrorStatusDuplicateEmail</a> | 1037 | A duplicate email address was detected. |
 | <a name="ErrorStatusInvalidUserNewInvoice">ErrorStatusInvalidUserNewInvoice</a> | 1038 | The user was not allowed to create a new invoice. |
 | <a name="ErrorStatusInvalidDCCNominee">ErrorStatusInvalidDCCNominee</a> | 1039 | The user that was nominated was invalid, either not found or not a potential nominee. |
+| <a name="ErrorStatusDCCNotFound">ErrorStatusDCCNotFound</a> | 1040 | A requested DCC proposal was not able to be located based on the provided token. |
+| <a name="ErrorStatusCannotCommentOnDCC">ErrorStatusCannotCommentOnDCC</a> | 1041 | A user is unable to comment on a DCC, due to them being the author or some other situation. |
 
 ### Invoice status codes
 

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1280,7 +1280,7 @@ Reply:
 | <a name="ErrorStatusInvalidSupportOppose">ErrorStatusInvalidSupportOppose</a> | 1042 | An invalid "vote" for a support or oppose request.  Must be "aye" or "nay". |
 | <a name="ErrorStatusDuplicateSupportOppose">ErrorStatusDuplicateSupportOppose</a> | 1043 | A user attempted to support or oppose a DCC multiple times. |
 | <a name="ErrorStatusUserIsAuthor">ErrorStatusUserIsAuthor</a> | 1044 | A user attempted to support or oppose a DCC that they authored. |
-
+| <a name="ErrorStatusInvalidUserDCC">ErrorStatusInvalidUserDCC</a> | 1045 | A user with an invalid status attempted to complete a DCC task. |
 ### Invoice status codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1277,6 +1277,9 @@ Reply:
 | <a name="ErrorStatusInvalidDCCNominee">ErrorStatusInvalidDCCNominee</a> | 1039 | The user that was nominated was invalid, either not found or not a potential nominee. |
 | <a name="ErrorStatusDCCNotFound">ErrorStatusDCCNotFound</a> | 1040 | A requested DCC proposal was not able to be located based on the provided token. |
 | <a name="ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC">ErrorStatusCannotCommentOnDCC</a> | 1041 | A user is unable to support/oppose/comment on a DCC that is not active. |
+| <a name="ErrorStatusInvalidSupportOppose">ErrorStatusInvalidSupportOppose</a> | 1042 | An invalid "vote" for a support or oppose request.  Must be "aye" or "nay". |
+| <a name="ErrorStatusUserDuplicateSupportOppose">ErrorStatusUserDuplicateSupportOppose</a> | 1043 | A user attempted to support or oppose a DCC multiple times. |
+| <a name="ErrorStatusUserCannotSupportOpposeOwn">ErrorStatusUserCannotSupportOpposeOwn</a> | 1044 | A user attempted to support or oppose a DCC that they authored. |
 
 ### Invoice status codes
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -29,6 +29,7 @@ const (
 	RouteGetDCCs             = "/dcc/status"
 	RouteSupportOpposeDCC    = "/dcc/supportoppose"
 	RouteNewCommentDCC       = "/dcc/comment"
+	RouteDCCComments         = "/dcc/{token:[A-z0-9]{64}}/comments"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteAdminUserInvoices   = "/admin/userinvoices"
 	RouteGeneratePayouts     = "/admin/generatepayouts"

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -191,6 +191,7 @@ const (
 	ErrorStatusInvalidSupportOppose           www.ErrorStatusT = 1042
 	ErrorStatusDuplicateSupportOppose         www.ErrorStatusT = 1043
 	ErrorStatusUserIsAuthor                   www.ErrorStatusT = 1044
+	ErrorStatusInvalidUserDCC                 www.ErrorStatusT = 1045
 )
 
 var (
@@ -265,6 +266,7 @@ var (
 		ErrorStatusInvalidSupportOppose:           "invalid support or opposition vote was included in the request, must be aye or nay",
 		ErrorStatusDuplicateSupportOppose:         "user has already supported or opposed the given DCC",
 		ErrorStatusUserIsAuthor:                   "user cannot support or oppose their own sponsored DCC",
+		ErrorStatusInvalidUserDCC:                 "user is not authorized to complete the DCC request",
 	}
 )
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -26,7 +26,9 @@ const (
 	RouteUserInvoices        = "/user/invoices"
 	RouteNewDCC              = "/dcc/new"
 	RouteDCCDetails          = "/dcc/{token:[A-z0-9]{64}}"
-	RouteGetDCCs             = "/dcc"
+	RouteGetDCCs             = "/dcc/status"
+	RouteSupportOpposeDCC    = "/dcc/supportoppose"
+	RouteNewCommentDCC       = "/dcc/comment"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteAdminUserInvoices   = "/admin/userinvoices"
 	RouteGeneratePayouts     = "/admin/generatepayouts"
@@ -184,6 +186,7 @@ const (
 	ErrorStatusInvalidUserNewInvoice          www.ErrorStatusT = 1038
 	ErrorStatusInvalidDCCNominee              www.ErrorStatusT = 1039
 	ErrorStatusDCCNotFound                    www.ErrorStatusT = 1040
+	ErrorStatusCannotCommentOnDCC             www.ErrorStatusT = 1041
 )
 
 var (
@@ -254,6 +257,7 @@ var (
 		ErrorStatusInvalidUserNewInvoice:          "current contractor status does not allow new invoices to be created",
 		ErrorStatusInvalidDCCNominee:              "invalid nominee user was submitted for a DCC",
 		ErrorStatusDCCNotFound:                    "a requested dcc was not found",
+		ErrorStatusCannotCommentOnDCC:             "cannot comment/approve/oppose DCC in its current state",
 	}
 )
 
@@ -622,3 +626,12 @@ type GetDCCs struct {
 type GetDCCsReply struct {
 	DCCs []DCCRecord `json:"dccs"` // DCCRecords of matching status
 }
+
+// SupportOpposeDCC request allows a user to support a given DCC issuance or revocation.
+type SupportOpposeDCC struct {
+	Vote  string `json:"comment"` // Vote must be "aye" or "nay"
+	Token string `json:"token"`   // The censorship token of the given DCC issuance or revocation.
+}
+
+// SupportOpposeDCCReply returns an empty response when successful.
+type SupportOpposeDCCReply struct{}

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -188,6 +188,9 @@ const (
 	ErrorStatusInvalidDCCNominee                        www.ErrorStatusT = 1039
 	ErrorStatusDCCNotFound                              www.ErrorStatusT = 1040
 	ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC www.ErrorStatusT = 1041
+	ErrorStatusInvalidSupportOppose                     www.ErrorStatusT = 1042
+	ErrorStatusUserDuplicateSupportOppose               www.ErrorStatusT = 1043
+	ErrorStatusUserCannotSupportOpposeOwn               www.ErrorStatusT = 1044
 )
 
 var (
@@ -259,6 +262,9 @@ var (
 		ErrorStatusInvalidDCCNominee:                        "invalid nominee user was submitted for a DCC",
 		ErrorStatusDCCNotFound:                              "a requested dcc was not found",
 		ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC: "cannot comment/approve/oppose DCC if it's not active state",
+		ErrorStatusInvalidSupportOppose:                     "invalid support or opposition vote was included in the request, must be aye or nay",
+		ErrorStatusUserDuplicateSupportOppose:               "user has already supported or opposed the given DCC",
+		ErrorStatusUserCannotSupportOpposeOwn:               "user cannot support or oppose their own sponsored DCC",
 	}
 )
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -28,7 +28,7 @@ const (
 	RouteDCCDetails          = "/dcc/{token:[A-z0-9]{64}}"
 	RouteGetDCCs             = "/dcc"
 	RouteSupportOpposeDCC    = "/dcc/supportoppose"
-	RouteNewCommentDCC       = "/dcc/comment"
+	RouteNewCommentDCC       = "/dcc/newcomment"
 	RouteDCCComments         = "/dcc/{token:[A-z0-9]{64}}/comments"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteAdminUserInvoices   = "/admin/userinvoices"

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -26,7 +26,7 @@ const (
 	RouteUserInvoices        = "/user/invoices"
 	RouteNewDCC              = "/dcc/new"
 	RouteDCCDetails          = "/dcc/{token:[A-z0-9]{64}}"
-	RouteGetDCCs             = "/dcc/status"
+	RouteGetDCCs             = "/dcc"
 	RouteSupportOpposeDCC    = "/dcc/supportoppose"
 	RouteNewCommentDCC       = "/dcc/comment"
 	RouteDCCComments         = "/dcc/{token:[A-z0-9]{64}}/comments"
@@ -148,46 +148,46 @@ const (
 	// statement contained within a DCC
 	PolicyMaxSponsorStatementLength = 500
 
-	ErrorStatusMalformedName                  www.ErrorStatusT = 1001
-	ErrorStatusMalformedLocation              www.ErrorStatusT = 1002
-	ErrorStatusInvoiceNotFound                www.ErrorStatusT = 1003
-	ErrorStatusInvalidMonthYearRequest        www.ErrorStatusT = 1004
-	ErrorStatusMalformedInvoiceFile           www.ErrorStatusT = 1005
-	ErrorStatusInvalidInvoiceStatusTransition www.ErrorStatusT = 1006
-	ErrorStatusReasonNotProvided              www.ErrorStatusT = 1007
-	ErrorStatusInvoiceDuplicate               www.ErrorStatusT = 1008
-	ErrorStatusInvalidPaymentAddress          www.ErrorStatusT = 1009
-	ErrorStatusMalformedLineItem              www.ErrorStatusT = 1010
-	ErrorStatusInvoiceMissingName             www.ErrorStatusT = 1011
-	ErrorStatusInvoiceMissingLocation         www.ErrorStatusT = 1012
-	ErrorStatusInvoiceMissingContact          www.ErrorStatusT = 1013
-	ErrorStatusInvoiceMissingRate             www.ErrorStatusT = 1014
-	ErrorStatusInvoiceInvalidRate             www.ErrorStatusT = 1015
-	ErrorStatusInvoiceMalformedContact        www.ErrorStatusT = 1016
-	ErrorStatusMalformedProposalToken         www.ErrorStatusT = 1017
-	ErrorStatusMalformedDomain                www.ErrorStatusT = 1018
-	ErrorStatusMalformedSubdomain             www.ErrorStatusT = 1019
-	ErrorStatusMalformedDescription           www.ErrorStatusT = 1020
-	ErrorStatusWrongInvoiceStatus             www.ErrorStatusT = 1021
-	ErrorStatusInvoiceRequireLineItems        www.ErrorStatusT = 1022
-	ErrorStatusInvalidInvoiceMonthYear        www.ErrorStatusT = 1024
-	ErrorStatusInvalidExchangeRate            www.ErrorStatusT = 1025
-	ErrorStatusInvalidLineItemType            www.ErrorStatusT = 1026
-	ErrorStatusInvalidLaborExpense            www.ErrorStatusT = 1027
-	ErrorStatusDuplicatePaymentAddress        www.ErrorStatusT = 1028
-	ErrorStatusInvalidDatesRequested          www.ErrorStatusT = 1029
-	ErrorStatusInvalidInvoiceEditMonthYear    www.ErrorStatusT = 1030
-	ErrorStatusInvalidDCCType                 www.ErrorStatusT = 1031
-	ErrorStatusInvalidNominatingDomain        www.ErrorStatusT = 1032
-	ErrorStatusMalformedSponsorStatement      www.ErrorStatusT = 1033
-	ErrorStatusMalformedDCCFile               www.ErrorStatusT = 1034
-	ErrorStatusInvalidDCCComment              www.ErrorStatusT = 1035
-	ErrorStatusInvalidDCCStatusTransition     www.ErrorStatusT = 1036
-	ErrorStatusDuplicateEmail                 www.ErrorStatusT = 1037
-	ErrorStatusInvalidUserNewInvoice          www.ErrorStatusT = 1038
-	ErrorStatusInvalidDCCNominee              www.ErrorStatusT = 1039
-	ErrorStatusDCCNotFound                    www.ErrorStatusT = 1040
-	ErrorStatusCannotCommentOnDCC             www.ErrorStatusT = 1041
+	ErrorStatusMalformedName                            www.ErrorStatusT = 1001
+	ErrorStatusMalformedLocation                        www.ErrorStatusT = 1002
+	ErrorStatusInvoiceNotFound                          www.ErrorStatusT = 1003
+	ErrorStatusInvalidMonthYearRequest                  www.ErrorStatusT = 1004
+	ErrorStatusMalformedInvoiceFile                     www.ErrorStatusT = 1005
+	ErrorStatusInvalidInvoiceStatusTransition           www.ErrorStatusT = 1006
+	ErrorStatusReasonNotProvided                        www.ErrorStatusT = 1007
+	ErrorStatusInvoiceDuplicate                         www.ErrorStatusT = 1008
+	ErrorStatusInvalidPaymentAddress                    www.ErrorStatusT = 1009
+	ErrorStatusMalformedLineItem                        www.ErrorStatusT = 1010
+	ErrorStatusInvoiceMissingName                       www.ErrorStatusT = 1011
+	ErrorStatusInvoiceMissingLocation                   www.ErrorStatusT = 1012
+	ErrorStatusInvoiceMissingContact                    www.ErrorStatusT = 1013
+	ErrorStatusInvoiceMissingRate                       www.ErrorStatusT = 1014
+	ErrorStatusInvoiceInvalidRate                       www.ErrorStatusT = 1015
+	ErrorStatusInvoiceMalformedContact                  www.ErrorStatusT = 1016
+	ErrorStatusMalformedProposalToken                   www.ErrorStatusT = 1017
+	ErrorStatusMalformedDomain                          www.ErrorStatusT = 1018
+	ErrorStatusMalformedSubdomain                       www.ErrorStatusT = 1019
+	ErrorStatusMalformedDescription                     www.ErrorStatusT = 1020
+	ErrorStatusWrongInvoiceStatus                       www.ErrorStatusT = 1021
+	ErrorStatusInvoiceRequireLineItems                  www.ErrorStatusT = 1022
+	ErrorStatusInvalidInvoiceMonthYear                  www.ErrorStatusT = 1024
+	ErrorStatusInvalidExchangeRate                      www.ErrorStatusT = 1025
+	ErrorStatusInvalidLineItemType                      www.ErrorStatusT = 1026
+	ErrorStatusInvalidLaborExpense                      www.ErrorStatusT = 1027
+	ErrorStatusDuplicatePaymentAddress                  www.ErrorStatusT = 1028
+	ErrorStatusInvalidDatesRequested                    www.ErrorStatusT = 1029
+	ErrorStatusInvalidInvoiceEditMonthYear              www.ErrorStatusT = 1030
+	ErrorStatusInvalidDCCType                           www.ErrorStatusT = 1031
+	ErrorStatusInvalidNominatingDomain                  www.ErrorStatusT = 1032
+	ErrorStatusMalformedSponsorStatement                www.ErrorStatusT = 1033
+	ErrorStatusMalformedDCCFile                         www.ErrorStatusT = 1034
+	ErrorStatusInvalidDCCComment                        www.ErrorStatusT = 1035
+	ErrorStatusInvalidDCCStatusTransition               www.ErrorStatusT = 1036
+	ErrorStatusDuplicateEmail                           www.ErrorStatusT = 1037
+	ErrorStatusInvalidUserNewInvoice                    www.ErrorStatusT = 1038
+	ErrorStatusInvalidDCCNominee                        www.ErrorStatusT = 1039
+	ErrorStatusDCCNotFound                              www.ErrorStatusT = 1040
+	ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC www.ErrorStatusT = 1041
 )
 
 var (
@@ -221,44 +221,44 @@ var (
 
 	// ErrorStatus converts error status codes to human readable text.
 	ErrorStatus = map[www.ErrorStatusT]string{
-		ErrorStatusMalformedName:                  "malformed name",
-		ErrorStatusMalformedLocation:              "malformed location",
-		ErrorStatusInvoiceNotFound:                "invoice cannot be found",
-		ErrorStatusInvalidMonthYearRequest:        "month or year was set, while the other was not",
-		ErrorStatusInvalidInvoiceStatusTransition: "invalid invoice status transition",
-		ErrorStatusReasonNotProvided:              "reason for action not provided",
-		ErrorStatusMalformedInvoiceFile:           "submitted invoice file is malformed",
-		ErrorStatusInvoiceDuplicate:               "submitted invoice is a duplicate of an existing invoice",
-		ErrorStatusInvalidPaymentAddress:          "invalid payment address",
-		ErrorStatusMalformedLineItem:              "malformed line item submitted",
-		ErrorStatusInvoiceMissingName:             "invoice missing contractor name",
-		ErrorStatusInvoiceMissingLocation:         "invoice missing contractor location",
-		ErrorStatusInvoiceMissingContact:          "invoice missing contractor contact",
-		ErrorStatusInvoiceMalformedContact:        "invoice has malformed contractor contact",
-		ErrorStatusInvoiceMissingRate:             "invoice missing contractor rate",
-		ErrorStatusInvoiceInvalidRate:             "invoice has invalid contractor rate",
-		ErrorStatusMalformedProposalToken:         "line item has malformed proposal token",
-		ErrorStatusMalformedDomain:                "line item has malformed domain",
-		ErrorStatusMalformedSubdomain:             "line item has malformed subdomain",
-		ErrorStatusMalformedDescription:           "line item has malformed description",
-		ErrorStatusWrongInvoiceStatus:             "invoice is an wrong status to be editted (approved, rejected or paid)",
-		ErrorStatusInvoiceRequireLineItems:        "invoices require at least 1 line item",
-		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
-		ErrorStatusInvalidExchangeRate:            "exchange rate was invalid or didn't match expected result",
-		ErrorStatusDuplicatePaymentAddress:        "a duplicate payment address was used",
-		ErrorStatusInvalidDatesRequested:          "invalid dates were requested",
-		ErrorStatusInvalidInvoiceEditMonthYear:    "invalid attempt to edit invoice month/year",
-		ErrorStatusInvalidDCCType:                 "invalid DCC type was included",
-		ErrorStatusInvalidNominatingDomain:        "non-matching domain was attempt",
-		ErrorStatusMalformedSponsorStatement:      "DCC sponsor statement was malformed",
-		ErrorStatusMalformedDCCFile:               "submitted DCC file was malformed according to standards",
-		ErrorStatusInvalidDCCComment:              "submitted DCC comment must either be aye or nay",
-		ErrorStatusInvalidDCCStatusTransition:     "invalid status transition for a DCC",
-		ErrorStatusDuplicateEmail:                 "another user already has that email registered",
-		ErrorStatusInvalidUserNewInvoice:          "current contractor status does not allow new invoices to be created",
-		ErrorStatusInvalidDCCNominee:              "invalid nominee user was submitted for a DCC",
-		ErrorStatusDCCNotFound:                    "a requested dcc was not found",
-		ErrorStatusCannotCommentOnDCC:             "cannot comment/approve/oppose DCC in its current state",
+		ErrorStatusMalformedName:                            "malformed name",
+		ErrorStatusMalformedLocation:                        "malformed location",
+		ErrorStatusInvoiceNotFound:                          "invoice cannot be found",
+		ErrorStatusInvalidMonthYearRequest:                  "month or year was set, while the other was not",
+		ErrorStatusInvalidInvoiceStatusTransition:           "invalid invoice status transition",
+		ErrorStatusReasonNotProvided:                        "reason for action not provided",
+		ErrorStatusMalformedInvoiceFile:                     "submitted invoice file is malformed",
+		ErrorStatusInvoiceDuplicate:                         "submitted invoice is a duplicate of an existing invoice",
+		ErrorStatusInvalidPaymentAddress:                    "invalid payment address",
+		ErrorStatusMalformedLineItem:                        "malformed line item submitted",
+		ErrorStatusInvoiceMissingName:                       "invoice missing contractor name",
+		ErrorStatusInvoiceMissingLocation:                   "invoice missing contractor location",
+		ErrorStatusInvoiceMissingContact:                    "invoice missing contractor contact",
+		ErrorStatusInvoiceMalformedContact:                  "invoice has malformed contractor contact",
+		ErrorStatusInvoiceMissingRate:                       "invoice missing contractor rate",
+		ErrorStatusInvoiceInvalidRate:                       "invoice has invalid contractor rate",
+		ErrorStatusMalformedProposalToken:                   "line item has malformed proposal token",
+		ErrorStatusMalformedDomain:                          "line item has malformed domain",
+		ErrorStatusMalformedSubdomain:                       "line item has malformed subdomain",
+		ErrorStatusMalformedDescription:                     "line item has malformed description",
+		ErrorStatusWrongInvoiceStatus:                       "invoice is an wrong status to be editted (approved, rejected or paid)",
+		ErrorStatusInvoiceRequireLineItems:                  "invoices require at least 1 line item",
+		ErrorStatusInvalidInvoiceMonthYear:                  "an invalid month/year was submitted on an invoice",
+		ErrorStatusInvalidExchangeRate:                      "exchange rate was invalid or didn't match expected result",
+		ErrorStatusDuplicatePaymentAddress:                  "a duplicate payment address was used",
+		ErrorStatusInvalidDatesRequested:                    "invalid dates were requested",
+		ErrorStatusInvalidInvoiceEditMonthYear:              "invalid attempt to edit invoice month/year",
+		ErrorStatusInvalidDCCType:                           "invalid DCC type was included",
+		ErrorStatusInvalidNominatingDomain:                  "non-matching domain was attempt",
+		ErrorStatusMalformedSponsorStatement:                "DCC sponsor statement was malformed",
+		ErrorStatusMalformedDCCFile:                         "submitted DCC file was malformed according to standards",
+		ErrorStatusInvalidDCCComment:                        "submitted DCC comment must either be aye or nay",
+		ErrorStatusInvalidDCCStatusTransition:               "invalid status transition for a DCC",
+		ErrorStatusDuplicateEmail:                           "another user already has that email registered",
+		ErrorStatusInvalidUserNewInvoice:                    "current contractor status does not allow new invoices to be created",
+		ErrorStatusInvalidDCCNominee:                        "invalid nominee user was submitted for a DCC",
+		ErrorStatusDCCNotFound:                              "a requested dcc was not found",
+		ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC: "cannot comment/approve/oppose DCC if it's not active state",
 	}
 )
 
@@ -577,7 +577,8 @@ type DCCInput struct {
 	Domain           DomainTypeT `json:"domain"`        // Domain of proposed contractor issuance
 }
 
-// DCCRecord is what will be decoded from a Record for a DCC object to the politeiad backend.
+// DCCRecord is what will be decoded from a Record for a DCC object to the
+// politeiad backend.
 type DCCRecord struct {
 	Status             DCCStatusT `json:"status"`             // Current status of the DCC
 	StatusChangeReason string     `json:"statuschangereason"` // The reason for changing the DCC status.
@@ -603,7 +604,8 @@ type NewDCC struct {
 	Signature string   `json:"signature"` // Signature of the issuance struct by the sponsoring user.
 }
 
-// NewDCCReply returns the censorship record when the DCC is successfully submitted to the backend.
+// NewDCCReply returns the censorship record when the DCC is successfully
+// submitted to the backend.
 type NewDCCReply struct {
 	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
 }
@@ -628,10 +630,13 @@ type GetDCCsReply struct {
 	DCCs []DCCRecord `json:"dccs"` // DCCRecords of matching status
 }
 
-// SupportOpposeDCC request allows a user to support a given DCC issuance or revocation.
+// SupportOpposeDCC request allows a user to support a given DCC issuance or
+// revocation.
 type SupportOpposeDCC struct {
-	Vote  string `json:"comment"` // Vote must be "aye" or "nay"
-	Token string `json:"token"`   // The censorship token of the given DCC issuance or revocation.
+	Vote      string `json:"comment"`   // Vote must be "aye" or "nay"
+	Token     string `json:"token"`     // The censorship token of the given DCC issuance or revocation.
+	PublicKey string `json:"publickey"` // Pubkey of the submitting user
+	Signature string `json:"signature"` // Signature of the Token+Vote by the submitting user.
 }
 
 // SupportOpposeDCCReply returns an empty response when successful.

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -148,49 +148,49 @@ const (
 	// statement contained within a DCC
 	PolicyMaxSponsorStatementLength = 500
 
-	ErrorStatusMalformedName                            www.ErrorStatusT = 1001
-	ErrorStatusMalformedLocation                        www.ErrorStatusT = 1002
-	ErrorStatusInvoiceNotFound                          www.ErrorStatusT = 1003
-	ErrorStatusInvalidMonthYearRequest                  www.ErrorStatusT = 1004
-	ErrorStatusMalformedInvoiceFile                     www.ErrorStatusT = 1005
-	ErrorStatusInvalidInvoiceStatusTransition           www.ErrorStatusT = 1006
-	ErrorStatusReasonNotProvided                        www.ErrorStatusT = 1007
-	ErrorStatusInvoiceDuplicate                         www.ErrorStatusT = 1008
-	ErrorStatusInvalidPaymentAddress                    www.ErrorStatusT = 1009
-	ErrorStatusMalformedLineItem                        www.ErrorStatusT = 1010
-	ErrorStatusInvoiceMissingName                       www.ErrorStatusT = 1011
-	ErrorStatusInvoiceMissingLocation                   www.ErrorStatusT = 1012
-	ErrorStatusInvoiceMissingContact                    www.ErrorStatusT = 1013
-	ErrorStatusInvoiceMissingRate                       www.ErrorStatusT = 1014
-	ErrorStatusInvoiceInvalidRate                       www.ErrorStatusT = 1015
-	ErrorStatusInvoiceMalformedContact                  www.ErrorStatusT = 1016
-	ErrorStatusMalformedProposalToken                   www.ErrorStatusT = 1017
-	ErrorStatusMalformedDomain                          www.ErrorStatusT = 1018
-	ErrorStatusMalformedSubdomain                       www.ErrorStatusT = 1019
-	ErrorStatusMalformedDescription                     www.ErrorStatusT = 1020
-	ErrorStatusWrongInvoiceStatus                       www.ErrorStatusT = 1021
-	ErrorStatusInvoiceRequireLineItems                  www.ErrorStatusT = 1022
-	ErrorStatusInvalidInvoiceMonthYear                  www.ErrorStatusT = 1024
-	ErrorStatusInvalidExchangeRate                      www.ErrorStatusT = 1025
-	ErrorStatusInvalidLineItemType                      www.ErrorStatusT = 1026
-	ErrorStatusInvalidLaborExpense                      www.ErrorStatusT = 1027
-	ErrorStatusDuplicatePaymentAddress                  www.ErrorStatusT = 1028
-	ErrorStatusInvalidDatesRequested                    www.ErrorStatusT = 1029
-	ErrorStatusInvalidInvoiceEditMonthYear              www.ErrorStatusT = 1030
-	ErrorStatusInvalidDCCType                           www.ErrorStatusT = 1031
-	ErrorStatusInvalidNominatingDomain                  www.ErrorStatusT = 1032
-	ErrorStatusMalformedSponsorStatement                www.ErrorStatusT = 1033
-	ErrorStatusMalformedDCCFile                         www.ErrorStatusT = 1034
-	ErrorStatusInvalidDCCComment                        www.ErrorStatusT = 1035
-	ErrorStatusInvalidDCCStatusTransition               www.ErrorStatusT = 1036
-	ErrorStatusDuplicateEmail                           www.ErrorStatusT = 1037
-	ErrorStatusInvalidUserNewInvoice                    www.ErrorStatusT = 1038
-	ErrorStatusInvalidDCCNominee                        www.ErrorStatusT = 1039
-	ErrorStatusDCCNotFound                              www.ErrorStatusT = 1040
-	ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC www.ErrorStatusT = 1041
-	ErrorStatusInvalidSupportOppose                     www.ErrorStatusT = 1042
-	ErrorStatusUserDuplicateSupportOppose               www.ErrorStatusT = 1043
-	ErrorStatusUserCannotSupportOpposeOwn               www.ErrorStatusT = 1044
+	ErrorStatusMalformedName                  www.ErrorStatusT = 1001
+	ErrorStatusMalformedLocation              www.ErrorStatusT = 1002
+	ErrorStatusInvoiceNotFound                www.ErrorStatusT = 1003
+	ErrorStatusInvalidMonthYearRequest        www.ErrorStatusT = 1004
+	ErrorStatusMalformedInvoiceFile           www.ErrorStatusT = 1005
+	ErrorStatusInvalidInvoiceStatusTransition www.ErrorStatusT = 1006
+	ErrorStatusReasonNotProvided              www.ErrorStatusT = 1007
+	ErrorStatusInvoiceDuplicate               www.ErrorStatusT = 1008
+	ErrorStatusInvalidPaymentAddress          www.ErrorStatusT = 1009
+	ErrorStatusMalformedLineItem              www.ErrorStatusT = 1010
+	ErrorStatusInvoiceMissingName             www.ErrorStatusT = 1011
+	ErrorStatusInvoiceMissingLocation         www.ErrorStatusT = 1012
+	ErrorStatusInvoiceMissingContact          www.ErrorStatusT = 1013
+	ErrorStatusInvoiceMissingRate             www.ErrorStatusT = 1014
+	ErrorStatusInvoiceInvalidRate             www.ErrorStatusT = 1015
+	ErrorStatusInvoiceMalformedContact        www.ErrorStatusT = 1016
+	ErrorStatusMalformedProposalToken         www.ErrorStatusT = 1017
+	ErrorStatusMalformedDomain                www.ErrorStatusT = 1018
+	ErrorStatusMalformedSubdomain             www.ErrorStatusT = 1019
+	ErrorStatusMalformedDescription           www.ErrorStatusT = 1020
+	ErrorStatusWrongInvoiceStatus             www.ErrorStatusT = 1021
+	ErrorStatusInvoiceRequireLineItems        www.ErrorStatusT = 1022
+	ErrorStatusInvalidInvoiceMonthYear        www.ErrorStatusT = 1024
+	ErrorStatusInvalidExchangeRate            www.ErrorStatusT = 1025
+	ErrorStatusInvalidLineItemType            www.ErrorStatusT = 1026
+	ErrorStatusInvalidLaborExpense            www.ErrorStatusT = 1027
+	ErrorStatusDuplicatePaymentAddress        www.ErrorStatusT = 1028
+	ErrorStatusInvalidDatesRequested          www.ErrorStatusT = 1029
+	ErrorStatusInvalidInvoiceEditMonthYear    www.ErrorStatusT = 1030
+	ErrorStatusInvalidDCCType                 www.ErrorStatusT = 1031
+	ErrorStatusInvalidNominatingDomain        www.ErrorStatusT = 1032
+	ErrorStatusMalformedSponsorStatement      www.ErrorStatusT = 1033
+	ErrorStatusMalformedDCCFile               www.ErrorStatusT = 1034
+	ErrorStatusInvalidDCCComment              www.ErrorStatusT = 1035
+	ErrorStatusInvalidDCCStatusTransition     www.ErrorStatusT = 1036
+	ErrorStatusDuplicateEmail                 www.ErrorStatusT = 1037
+	ErrorStatusInvalidUserNewInvoice          www.ErrorStatusT = 1038
+	ErrorStatusInvalidDCCNominee              www.ErrorStatusT = 1039
+	ErrorStatusDCCNotFound                    www.ErrorStatusT = 1040
+	ErrorStatusWrongDCCStatus                 www.ErrorStatusT = 1041
+	ErrorStatusInvalidSupportOppose           www.ErrorStatusT = 1042
+	ErrorStatusDuplicateSupportOppose         www.ErrorStatusT = 1043
+	ErrorStatusUserIsAuthor                   www.ErrorStatusT = 1044
 )
 
 var (
@@ -224,47 +224,47 @@ var (
 
 	// ErrorStatus converts error status codes to human readable text.
 	ErrorStatus = map[www.ErrorStatusT]string{
-		ErrorStatusMalformedName:                            "malformed name",
-		ErrorStatusMalformedLocation:                        "malformed location",
-		ErrorStatusInvoiceNotFound:                          "invoice cannot be found",
-		ErrorStatusInvalidMonthYearRequest:                  "month or year was set, while the other was not",
-		ErrorStatusInvalidInvoiceStatusTransition:           "invalid invoice status transition",
-		ErrorStatusReasonNotProvided:                        "reason for action not provided",
-		ErrorStatusMalformedInvoiceFile:                     "submitted invoice file is malformed",
-		ErrorStatusInvoiceDuplicate:                         "submitted invoice is a duplicate of an existing invoice",
-		ErrorStatusInvalidPaymentAddress:                    "invalid payment address",
-		ErrorStatusMalformedLineItem:                        "malformed line item submitted",
-		ErrorStatusInvoiceMissingName:                       "invoice missing contractor name",
-		ErrorStatusInvoiceMissingLocation:                   "invoice missing contractor location",
-		ErrorStatusInvoiceMissingContact:                    "invoice missing contractor contact",
-		ErrorStatusInvoiceMalformedContact:                  "invoice has malformed contractor contact",
-		ErrorStatusInvoiceMissingRate:                       "invoice missing contractor rate",
-		ErrorStatusInvoiceInvalidRate:                       "invoice has invalid contractor rate",
-		ErrorStatusMalformedProposalToken:                   "line item has malformed proposal token",
-		ErrorStatusMalformedDomain:                          "line item has malformed domain",
-		ErrorStatusMalformedSubdomain:                       "line item has malformed subdomain",
-		ErrorStatusMalformedDescription:                     "line item has malformed description",
-		ErrorStatusWrongInvoiceStatus:                       "invoice is an wrong status to be editted (approved, rejected or paid)",
-		ErrorStatusInvoiceRequireLineItems:                  "invoices require at least 1 line item",
-		ErrorStatusInvalidInvoiceMonthYear:                  "an invalid month/year was submitted on an invoice",
-		ErrorStatusInvalidExchangeRate:                      "exchange rate was invalid or didn't match expected result",
-		ErrorStatusDuplicatePaymentAddress:                  "a duplicate payment address was used",
-		ErrorStatusInvalidDatesRequested:                    "invalid dates were requested",
-		ErrorStatusInvalidInvoiceEditMonthYear:              "invalid attempt to edit invoice month/year",
-		ErrorStatusInvalidDCCType:                           "invalid DCC type was included",
-		ErrorStatusInvalidNominatingDomain:                  "non-matching domain was attempt",
-		ErrorStatusMalformedSponsorStatement:                "DCC sponsor statement was malformed",
-		ErrorStatusMalformedDCCFile:                         "submitted DCC file was malformed according to standards",
-		ErrorStatusInvalidDCCComment:                        "submitted DCC comment must either be aye or nay",
-		ErrorStatusInvalidDCCStatusTransition:               "invalid status transition for a DCC",
-		ErrorStatusDuplicateEmail:                           "another user already has that email registered",
-		ErrorStatusInvalidUserNewInvoice:                    "current contractor status does not allow new invoices to be created",
-		ErrorStatusInvalidDCCNominee:                        "invalid nominee user was submitted for a DCC",
-		ErrorStatusDCCNotFound:                              "a requested dcc was not found",
-		ErrorStatusCannotSupportOpposeCommentOnNonActiveDCC: "cannot comment/approve/oppose DCC if it's not active state",
-		ErrorStatusInvalidSupportOppose:                     "invalid support or opposition vote was included in the request, must be aye or nay",
-		ErrorStatusUserDuplicateSupportOppose:               "user has already supported or opposed the given DCC",
-		ErrorStatusUserCannotSupportOpposeOwn:               "user cannot support or oppose their own sponsored DCC",
+		ErrorStatusMalformedName:                  "malformed name",
+		ErrorStatusMalformedLocation:              "malformed location",
+		ErrorStatusInvoiceNotFound:                "invoice cannot be found",
+		ErrorStatusInvalidMonthYearRequest:        "month or year was set, while the other was not",
+		ErrorStatusInvalidInvoiceStatusTransition: "invalid invoice status transition",
+		ErrorStatusReasonNotProvided:              "reason for action not provided",
+		ErrorStatusMalformedInvoiceFile:           "submitted invoice file is malformed",
+		ErrorStatusInvoiceDuplicate:               "submitted invoice is a duplicate of an existing invoice",
+		ErrorStatusInvalidPaymentAddress:          "invalid payment address",
+		ErrorStatusMalformedLineItem:              "malformed line item submitted",
+		ErrorStatusInvoiceMissingName:             "invoice missing contractor name",
+		ErrorStatusInvoiceMissingLocation:         "invoice missing contractor location",
+		ErrorStatusInvoiceMissingContact:          "invoice missing contractor contact",
+		ErrorStatusInvoiceMalformedContact:        "invoice has malformed contractor contact",
+		ErrorStatusInvoiceMissingRate:             "invoice missing contractor rate",
+		ErrorStatusInvoiceInvalidRate:             "invoice has invalid contractor rate",
+		ErrorStatusMalformedProposalToken:         "line item has malformed proposal token",
+		ErrorStatusMalformedDomain:                "line item has malformed domain",
+		ErrorStatusMalformedSubdomain:             "line item has malformed subdomain",
+		ErrorStatusMalformedDescription:           "line item has malformed description",
+		ErrorStatusWrongInvoiceStatus:             "invoice is an wrong status to be editted (approved, rejected or paid)",
+		ErrorStatusInvoiceRequireLineItems:        "invoices require at least 1 line item",
+		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
+		ErrorStatusInvalidExchangeRate:            "exchange rate was invalid or didn't match expected result",
+		ErrorStatusDuplicatePaymentAddress:        "a duplicate payment address was used",
+		ErrorStatusInvalidDatesRequested:          "invalid dates were requested",
+		ErrorStatusInvalidInvoiceEditMonthYear:    "invalid attempt to edit invoice month/year",
+		ErrorStatusInvalidDCCType:                 "invalid DCC type was included",
+		ErrorStatusInvalidNominatingDomain:        "non-matching domain was attempt",
+		ErrorStatusMalformedSponsorStatement:      "DCC sponsor statement was malformed",
+		ErrorStatusMalformedDCCFile:               "submitted DCC file was malformed according to standards",
+		ErrorStatusInvalidDCCComment:              "submitted DCC comment must either be aye or nay",
+		ErrorStatusInvalidDCCStatusTransition:     "invalid status transition for a DCC",
+		ErrorStatusDuplicateEmail:                 "another user already has that email registered",
+		ErrorStatusInvalidUserNewInvoice:          "current contractor status does not allow new invoices to be created",
+		ErrorStatusInvalidDCCNominee:              "invalid nominee user was submitted for a DCC",
+		ErrorStatusDCCNotFound:                    "a requested dcc was not found",
+		ErrorStatusWrongDCCStatus:                 "cannot comment/approve/oppose DCC if it's not active state",
+		ErrorStatusInvalidSupportOppose:           "invalid support or opposition vote was included in the request, must be aye or nay",
+		ErrorStatusDuplicateSupportOppose:         "user has already supported or opposed the given DCC",
+		ErrorStatusUserIsAuthor:                   "user cannot support or oppose their own sponsored DCC",
 	}
 )
 

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -1751,6 +1751,30 @@ func (c *Client) NewDCC(nd cms.NewDCC) (*cms.NewDCCReply, error) {
 	return &ndr, nil
 }
 
+// SupportOpposeDCC issues support for a given DCC proposal.
+func (c *Client) SupportOpposeDCC(sd cms.SupportOpposeDCC) (*cms.SupportOpposeDCCReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteSupportOpposeDCC,
+		sd)
+	if err != nil {
+		return nil, err
+	}
+
+	var sdr cms.SupportOpposeDCCReply
+	err = json.Unmarshal(responseBody, &sdr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal SupportOpposeDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(sdr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &sdr, nil
+}
+
 // DCCDetails retrieves the specified dcc.
 func (c *Client) DCCDetails(token string) (*cms.DCCDetailsReply, error) {
 	responseBody, err := c.makeRequest("GET", "/dcc/"+token, nil)

--- a/politeiawww/cmd/politeiawwwcli/client/client.go
+++ b/politeiawww/cmd/politeiawwwcli/client/client.go
@@ -1775,6 +1775,53 @@ func (c *Client) SupportOpposeDCC(sd cms.SupportOpposeDCC) (*cms.SupportOpposeDC
 	return &sdr, nil
 }
 
+// NewDCCComment submits a new dcc comment for the logged in user.
+func (c *Client) NewDCCComment(nc *v1.NewComment) (*v1.NewCommentReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.RouteNewCommentDCC, nc)
+	if err != nil {
+		return nil, err
+	}
+
+	var ncr v1.NewCommentReply
+	err = json.Unmarshal(responseBody, &ncr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal NewDCCCommentReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(ncr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ncr, nil
+}
+
+// DCCComments retrieves the comments for the specified proposal.
+func (c *Client) DCCComments(token string) (*v1.GetCommentsReply, error) {
+	responseBody, err := c.makeRequest("GET", "/dcc/"+token+"/comments",
+		nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var gcr v1.GetCommentsReply
+	err = json.Unmarshal(responseBody, &gcr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal DCCCommentsReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(gcr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &gcr, nil
+}
+
 // DCCDetails retrieves the specified dcc.
 func (c *Client) DCCDetails(token string) (*cms.DCCDetailsReply, error) {
 	responseBody, err := c.makeRequest("GET", "/dcc/"+token, nil)

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -73,6 +73,7 @@ type Cmds struct {
 	CMSUserDetails      CMSUserDetailsCmd      `command:"cmsuserdetails" description:"(user) get current cms user details"`
 	CMSEditUser         CMSEditUserCmd         `command:"cmsedituser" description:"(user) edit current cms user information"`
 	DCCDetails          DCCDetailsCmd          `command:"dccdetails" description:"(user) get the details of a dcc"`
+	DCCComments         DCCCommentsCmd         `command:"dcccomments" description:"(user) get the comments for a dcc proposal"`
 	GetDCCs             GetDCCsCmd             `command:"getdccs" description:"(user) get all dccs (optional by status)"`
 	EditInvoice         EditInvoiceCmd         `command:"editinvoice" description:"(user)    edit a invoice"`
 	EditProposal        EditProposalCmd        `command:"editproposal" description:"(user)   edit a proposal"`
@@ -91,6 +92,7 @@ type Cmds struct {
 	Logout              LogoutCmd              `command:"logout" description:"(public) logout of Politeia"`
 	Me                  MeCmd                  `command:"me" description:"(user)   get user details for the logged in user"`
 	NewDCC              NewDCCCmd              `command:"newdcc" description:"(user)   creates a new dcc proposal"`
+	NewDCCComment       NewDCCCommentCmd       `command:"newdcccomment" description:"(user)   creates a new comment on a dcc proposal"`
 	NewInvoice          NewInvoiceCmd          `command:"newinvoice" description:"(user)   create a new invoice"`
 	NewProposal         NewProposalCmd         `command:"newproposal" description:"(user)   create a new proposal"`
 	NewComment          NewCommentCmd          `command:"newcomment" description:"(user)   create a new proposal comment"`

--- a/politeiawww/cmd/politeiawwwcli/commands/commands.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/commands.go
@@ -111,6 +111,7 @@ type Cmds struct {
 	SetProposalStatus   SetProposalStatusCmd   `command:"setproposalstatus" description:"(admin)  set the status of a proposal"`
 	StartVote           StartVoteCmd           `command:"startvote" description:"(admin)  start the voting period on a proposal"`
 	Subscribe           SubscribeCmd           `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`
+	SupportOpposeDCC    SupportOpposeDCCCmd    `command:"supportopposedcc" description:"(user) support or oppose a given DCC"`
 	Tally               TallyCmd               `command:"tally" description:"(public) get the vote tally for a proposal"`
 	TestRun             TestRunCmd             `command:"testrun" description:"         run a series of tests on the politeiawww routes (dev use only)"`
 	TokenInventory      TokenInventoryCmd      `command:"tokeninventory" description:"(public) get the censorship record tokens of all proposals"`

--- a/politeiawww/cmd/politeiawwwcli/commands/dcccomments.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/dcccomments.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+// DCCCommentsCmd retreives the comments for the specified dcc.
+type DCCCommentsCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"` // Censorship token
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the invoice comments command.
+func (cmd *DCCCommentsCmd) Execute(args []string) error {
+	gcr, err := client.DCCComments(cmd.Args.Token)
+	if err != nil {
+		return err
+	}
+	return printJSON(gcr)
+}
+
+// dccCommentsHelpMsg is the output for the help command when
+// 'dcccomments' is specified.
+const dccCommentsHelpMsg = `dcccomments "token" 
+
+Get the comments for a invoice.
+
+Arguments:
+1. token       (string, required)   DCC censorship token
+
+Result:
+{
+  "comments": [
+    {
+      "token":        (string)  Censorship token
+      "parentid":     (string)  Id of comment (defaults to '0' (top-level))
+      "comment":      (string)  Comment
+      "signature":    (string)  Signature of token+parentID+comment
+      "publickey":    (string)  Public key of user 
+      "commentid":    (string)  Id of the comment
+      "receipt":      (string)  Server signature of the comment signature
+      "timestamp":    (int64)   Received UNIX timestamp
+      "resultvotes":  (int64)   Vote score
+      "censored":     (bool)    If comment has been censored
+      "userid":       (string)  User id
+      "username":     (string)  Username
+    }
+  ]
+}`

--- a/politeiawww/cmd/politeiawwwcli/commands/newdcccomment.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/newdcccomment.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"encoding/hex"
+
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
+)
+
+// NewDCCCommentCmd submits a new dcc comment.
+type NewDCCCommentCmd struct {
+	Args struct {
+		Token    string `positional-arg-name:"token" required:"true"`   // Censorship token
+		Comment  string `positional-arg-name:"comment" required:"true"` // Comment text
+		ParentID string `positional-arg-name:"parentID"`                // Comment parent ID
+	} `positional-args:"true"`
+}
+
+// Execute executes the new comment command.
+func (cmd *NewDCCCommentCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	comment := cmd.Args.Comment
+	parentID := cmd.Args.ParentID
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	// Setup new comment request
+	sig := cfg.Identity.SignMessage([]byte(token + parentID + comment))
+	nc := &v1.NewComment{
+		Token:     token,
+		ParentID:  parentID,
+		Comment:   comment,
+		Signature: hex.EncodeToString(sig[:]),
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+	}
+
+	// Print request details
+	err := printJSON(nc)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	ncr, err := client.NewDCCComment(nc)
+	if err != nil {
+		return err
+	}
+
+	// Print response details
+	return printJSON(ncr)
+}
+
+// newDCCCommentHelpMsg is the output of the help command when 'newcomment' is
+// specified.
+const newDCCCommentHelpMsg = `newcomment "token" "comment"
+
+Comment on proposal as logged in user. 
+
+Arguments:
+1. token       (string, required)   DCC censorship token
+2. comment     (string, required)   Comment
+3. parentID    (string, required if replying to comment)  Id of commment
+
+Request:
+{
+  "token":       (string)  Censorship token
+  "parentid":    (string)  Id of comment (defaults to '0' (top-level comment))
+  "comment":     (string)  Comment
+  "signature":   (string)  Signature of comment (token+parentID+comment)
+  "publickey":   (string)  Public key of user commenting
+}
+
+Response:
+{
+  "comment": {
+    "token":        (string)  Censorship token
+    "parentid":     (string)  Id of comment (defaults to '0' (top-level))
+    "comment":      (string)  Comment
+    "signature":    (string)  Signature of token+parentID+comment
+    "publickey":    (string)  Public key of user 
+    "commentid":    (string)  Id of the comment
+    "receipt":      (string)  Server signature of the comment signature
+    "timestamp":    (int64)   Received UNIX timestamp
+    "resultvotes":  (int64)   Vote score
+    "censored":     (bool)    If comment has been censored
+    "userid":       (string)  User id
+    "username":     (string)  Username
+  }
+}`

--- a/politeiawww/cmd/politeiawwwcli/commands/supportopposedcc.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/supportopposedcc.go
@@ -5,6 +5,7 @@
 package commands
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
@@ -37,9 +38,12 @@ func (cmd *SupportOpposeDCCCmd) Execute(args []string) error {
 		return errUserIdentityNotFound
 	}
 
+	sig := cfg.Identity.SignMessage([]byte(token + vote))
 	sd := v1.SupportOpposeDCC{
-		Vote:  vote,
-		Token: token,
+		Vote:      vote,
+		Token:     token,
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+		Signature: hex.EncodeToString(sig[:]),
 	}
 
 	// Print request details

--- a/politeiawww/cmd/politeiawwwcli/commands/supportopposedcc.go
+++ b/politeiawww/cmd/politeiawwwcli/commands/supportopposedcc.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+)
+
+// SupportOpposeDCCCmd allows a user to support a DCC proposal.
+type SupportOpposeDCCCmd struct {
+	Args struct {
+		Vote  string `positional-arg-name:"vote"`
+		Token string `positional-arg-name:"token"`
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the support DCC command.
+func (cmd *SupportOpposeDCCCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	vote := cmd.Args.Vote
+
+	if vote != "aye" && vote != "nay" {
+		return fmt.Errorf("invalid request: you must either vote aye or nay")
+	}
+
+	if token == "" {
+		return fmt.Errorf("invalid request: you must specify dcc " +
+			"token")
+	}
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return errUserIdentityNotFound
+	}
+
+	sd := v1.SupportOpposeDCC{
+		Vote:  vote,
+		Token: token,
+	}
+
+	// Print request details
+	err := printJSON(sd)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	sdr, err := client.SupportOpposeDCC(sd)
+	if err != nil {
+		return fmt.Errorf("SupportOpposeDCC: %v", err)
+	}
+
+	// Print response details
+	err = printJSON(sdr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -668,6 +668,30 @@ func (p *politeiawww) handleNewCommentDCC(w http.ResponseWriter, r *http.Request
 	util.RespondWithJSON(w, http.StatusOK, cr)
 }
 
+// handleDCCComments handles batched comments get.
+func (p *politeiawww) handleDCCComments(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleDCCComments")
+
+	pathParams := mux.Vars(r)
+	token := pathParams["token"]
+
+	user, err := p.getSessionUser(w, r)
+	if err != nil {
+		if err != ErrSessionUUIDNotFound {
+			RespondWithError(w, r, 0,
+				"handleDCCComments: getSessionUser %v", err)
+			return
+		}
+	}
+	gcr, err := p.processDCCComments(token, user)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleDCCComments: processDCCComments %v", err)
+		return
+	}
+	util.RespondWithJSON(w, http.StatusOK, gcr)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -714,6 +738,8 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleSupportOpposeDCC, permissionLogin)
 	p.addRoute(http.MethodPost, cms.RouteNewCommentDCC,
 		p.handleNewCommentDCC, permissionLogin)
+	p.addRoute(http.MethodGet, cms.RouteDCCComments,
+		p.handleDCCComments, permissionLogin)
 
 	// Unauthenticated websocket
 	p.addRoute("", www.RouteUnauthenticatedWebSocket,

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -608,6 +608,66 @@ func (p *politeiawww) handleGetDCCs(w http.ResponseWriter, r *http.Request) {
 	util.RespondWithJSON(w, http.StatusOK, gdsr)
 }
 
+func (p *politeiawww) handleSupportOpposeDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleSupportOpposeDCC")
+
+	var sd cms.SupportOpposeDCC
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&sd); err != nil {
+		RespondWithError(w, r, 0, "handleSupportOpposeDCC: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleSupportOpposeDCC: getSessionUser %v", err)
+		return
+	}
+
+	sdr, err := p.processSupportOpposeDCC(sd, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleSupportOpposeDCC: processSupportOpposeDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, sdr)
+}
+
+// handleNewCommentDCC handles incomming comments for DCC.
+func (p *politeiawww) handleNewCommentDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleNewCommentDCC")
+
+	var sc www.NewComment
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&sc); err != nil {
+		RespondWithError(w, r, 0, "handleNewCommentDCC: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	user, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleNewCommentDCC: getSessionUser %v", err)
+		return
+	}
+
+	cr, err := p.processNewCommentDCC(sc, user)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleNewCommentDCC: processNewCommentDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, cr)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -650,6 +710,11 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleDCCDetails, permissionLogin)
 	p.addRoute(http.MethodPost, cms.RouteGetDCCs,
 		p.handleGetDCCs, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteSupportOpposeDCC,
+		p.handleSupportOpposeDCC, permissionLogin)
+	p.addRoute(http.MethodPost, cms.RouteNewCommentDCC,
+		p.handleNewCommentDCC, permissionLogin)
+
 	// Unauthenticated websocket
 	p.addRoute("", www.RouteUnauthenticatedWebSocket,
 		p.handleUnauthenticatedWebsocket, permissionPublic)

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -833,8 +833,8 @@ func convertDCCFromCache(r cache.Record) cms.DCCRecord {
 					"token:%v error:%v payload:%v",
 					r.CensorshipRecord.Token, err, v)
 			}
-			supportPubkeys := make([]string, len(so))
-			opposePubkeys := make([]string, len(so))
+			supportPubkeys := make([]string, 0, len(so))
+			opposePubkeys := make([]string, 0, len(so))
 			// Tabulate all support and opposition
 			for _, s := range so {
 				if s.Vote == supportString {

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -794,6 +794,8 @@ func convertInvoiceFromCache(r cache.Record) cms.InvoiceRecord {
 }
 
 func convertDCCFromCache(r cache.Record) cms.DCCRecord {
+
+	dcc := cms.DCCRecord{}
 	// Decode metadata streams
 	var md backendDCCMetadata
 	var c backendDCCStatusChange
@@ -823,6 +825,26 @@ func convertDCCFromCache(r cache.Record) cms.DCCRecord {
 			for _, s := range m {
 				c = s
 			}
+		case mdStreamDCCSupportOpposition:
+			// Support and Opposition
+			so, err := decodeBackendDCCSupportOppositionMetadata([]byte(v.Payload))
+			if err != nil {
+				log.Errorf("convertDCCFromCache: decode md stream: "+
+					"token:%v error:%v payload:%v",
+					r.CensorshipRecord.Token, err, v)
+			}
+			supportPubkeys := make([]string, len(so))
+			opposePubkeys := make([]string, len(so))
+			// Tabulate all support and opposition
+			for _, s := range so {
+				if s.Vote == supportString {
+					supportPubkeys = append(supportPubkeys, s.PublicKey)
+				} else if s.Vote == opposeString {
+					opposePubkeys = append(opposePubkeys, s.PublicKey)
+				}
+			}
+			dcc.SupportUserIDs = supportPubkeys
+			dcc.OppositionUserIDs = opposePubkeys
 		}
 	}
 
@@ -859,24 +881,22 @@ func convertDCCFromCache(r cache.Record) cms.DCCRecord {
 		}
 	}
 
-	// UserID and Username are left intentionally blank.
-	// These fields not part of a cache record.
-	return cms.DCCRecord{
-		Status:             c.NewStatus,
-		StatusChangeReason: c.Reason,
-		Timestamp:          r.Timestamp,
-		SponsorUserID:      "",
-		SponsorUsername:    "",
-		PublicKey:          md.PublicKey,
-		Signature:          md.Signature,
-		File:               f,
-		CensorshipRecord: www.CensorshipRecord{
-			Token:     r.CensorshipRecord.Token,
-			Merkle:    r.CensorshipRecord.Merkle,
-			Signature: r.CensorshipRecord.Signature,
-		},
-		DCC: di,
+	dcc.Status = c.NewStatus
+	dcc.StatusChangeReason = c.Reason
+	dcc.Timestamp = r.Timestamp
+	dcc.SponsorUserID = ""
+	dcc.SponsorUsername = ""
+	dcc.PublicKey = md.PublicKey
+	dcc.Signature = md.Signature
+	dcc.File = f
+	dcc.CensorshipRecord = www.CensorshipRecord{
+		Token:     r.CensorshipRecord.Token,
+		Merkle:    r.CensorshipRecord.Merkle,
+		Signature: r.CensorshipRecord.Signature,
 	}
+	dcc.DCC = di
+
+	return dcc
 }
 
 func convertRecordToDatabaseDCC(p pd.Record) (*cmsdatabase.DCC, error) {

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -607,6 +607,13 @@ func (p *politeiawww) processSupportOpposeDCC(sd cms.SupportOpposeDCC, u *user.U
 		}
 	}
 
+	// Validate signature
+	msg := fmt.Sprintf("%v%v", sd.Token, sd.Vote)
+	err := validateSignature(sd.PublicKey, sd.Signature, msg)
+	if err != nil {
+		return nil, err
+	}
+
 	dcc, err := p.getDCC(sd.Token)
 	if err != nil {
 		if err == cache.ErrRecordNotFound {
@@ -637,13 +644,6 @@ func (p *politeiawww) processSupportOpposeDCC(sd cms.SupportOpposeDCC, u *user.U
 			ErrorCode:    cms.ErrorStatusWrongDCCStatus,
 			ErrorContext: []string{"dcc status must be active"},
 		}
-	}
-
-	// Validate signature
-	msg := fmt.Sprintf("%v%v", sd.Token, sd.Vote)
-	err = validateSignature(sd.PublicKey, sd.Signature, msg)
-	if err != nil {
-		return nil, err
 	}
 
 	cmsUser, err := p.getCMSUserByID(u.ID.String())

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -487,8 +487,8 @@ func (p *politeiawww) getDCC(token string) (*cms.DCCRecord, error) {
 	i := convertDCCFromCache(*r)
 
 	// Get user IDs of support/oppose pubkeys
-	supportUserIDs := make([]string, len(i.SupportUserIDs))
-	opposeUserIDs := make([]string, len(i.OppositionUserIDs))
+	supportUserIDs := make([]string, 0, len(i.SupportUserIDs))
+	opposeUserIDs := make([]string, 0, len(i.OppositionUserIDs))
 	for _, v := range i.SupportUserIDs {
 		// Fill in userID and username fields
 		u, err := p.db.UserGetByPubKey(v)

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -589,23 +589,24 @@ func (p *politeiawww) processSupportOpposeDCC(sd cms.SupportOpposeDCC, u *user.U
 		return nil, err
 	}
 
+	// The submitted Vote in the request must either be "aye" or "nay"
 	if sd.Vote != supportString && sd.Vote != opposeString {
 		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+			ErrorCode: cms.ErrorStatusInvalidSupportOppose,
 		}
 	}
 	// Check to make sure the user has not SupportOpposeed or Opposed this DCC yet
 	if stringInSlice(dcc.SupportUserIDs, u.ID.String()) ||
 		stringInSlice(dcc.OppositionUserIDs, u.ID.String()) {
 		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+			ErrorCode: cms.ErrorStatusUserDuplicateSupportOppose,
 		}
 	}
 
 	// Check to make sure the user is not the author of the DCC.
 	if dcc.SponsorUserID == u.ID.String() {
 		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+			ErrorCode: cms.ErrorStatusUserCannotSupportOpposeOwn,
 		}
 	}
 

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -71,6 +71,7 @@ var (
 	// The valid contractor
 	invalidNewInvoiceContractorType = map[cms.ContractorTypeT]bool{
 		cms.ContractorTypeNominee: true,
+		cms.ContractorTypeInvalid: true,
 	}
 
 	validInvoiceField = regexp.MustCompile(createInvoiceFieldRegex())


### PR DESCRIPTION
Requires https://github.com/decred/politeia/pull/980

This PR adds the ability for users to offer their support, opposition
and comment on active DCC proposals (issuances or revocations).

When an authorized user submits a Support or Opposition request,
metadata from the request is appended to the existing DCC on
the politeiad backend.  This makes them permanent and verifiable.
