### PR TITLE
www: Do not ommit empty unvetted fields for token inventory

### DIFF
--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -1187,8 +1187,8 @@ type TokenInventoryReply struct {
 	Abandoned []string `json:"abandoned"` // Tokens of all props that have been abandoned
 
 	// Unvetted
-	Unreviewed []string `json:"unreviewed,omitempty"` // Tokens of all unreviewed props
-	Censored   []string `json:"censored,omitempty"`   // Tokens of all censored props
+	Unreviewed []string `json:"unreviewed"` // Tokens of all unreviewed props
+	Censored   []string `json:"censored"`   // Tokens of all censored props
 }
 
 // Websocket commands


### PR DESCRIPTION
While working on politeiagui I bumped into several cases where I had to create workarounds due to the lack of those fields. This PR will keep all the unvetted fields as part of the token inventory despite they are empty or not.