### PR TITLE
[cms] Update EditUser and add ManageUser for CMS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,6 @@ require (
 	github.com/jrick/logrotate v1.0.0
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/marcopeereboom/sbox v1.0.0
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 // indirect
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,8 @@ require (
 	github.com/jrick/logrotate v1.0.0
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/marcopeereboom/sbox v1.0.0
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 // indirect
 	github.com/pmezard/go-difflib v1.0.0

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -703,7 +703,11 @@ Reply:
 
 ### `Edit user`
 
-Allows a user to submit updates to their cms user information.
+Allows a user or administrator to submit updates to their CMS user information.
+Users are allowed to update all fields except domain, contractor type and 
+supervisorid.  These fields require administrator access to update.  Once DCC
+goes into production these fields will primarily be updated upon approved
+DCC issuance.
 
 **Route:** `POST /v1/user/edit`
 

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -711,6 +711,7 @@ Allows a user to submit updates to their cms user information.
 
 | Parameter | Type | Description | Required |
 |-|-|-|-|
+| userid | string | UserID string of the user to be edited. | yes |
 | domain | int | The Domain Type that the user currently has | no |
 | githubname | string | The Github Name tied to the user. | no |
 | matrixname | string | The Matrix Name tied to the user. | no |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -703,11 +703,7 @@ Reply:
 
 ### `Edit user`
 
-Allows a user or administrator to submit updates to their CMS user information.
-Users are allowed to update all fields except domain, contractor type and 
-supervisorid.  These fields require administrator access to update.  Once DCC
-goes into production these fields will primarily be updated upon approved
-DCC issuance.
+Allows a user to submit updates to their cms user information.
 
 **Route:** `POST /v1/user/edit`
 
@@ -715,14 +711,50 @@ DCC issuance.
 
 | Parameter | Type | Description | Required |
 |-|-|-|-|
-| userid | string | UserID string of the user to be edited. | yes |
-| domain | int | The Domain Type that the user currently has | no |
 | githubname | string | The Github Name tied to the user. | no |
 | matrixname | string | The Matrix Name tied to the user. | no |
-| contractortype | int | The contractor type of the user. | no |
 | contractorname | string | The contractors IRL name/identity. | no |
 | contractorlocation | string | Current general locaiton of the contractor. | no |
 | contractorcontact | string | Email or contact information of the contractor. | no |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+
+**Example**
+
+Request:
+
+```json
+{
+  "githubname": "smobs",
+  "matrixname": "smobs:decred.org",
+  "contractorname": "Steve Mobs",
+  "contractorlocation": "Cupertino, CA",
+  "contractorcontact": "smobs@apple.com",
+}
+```
+
+Reply:
+
+```json
+{}
+```
+
+### `Manage CMS user`
+
+Edits a user's details. This call requires admin privileges.
+
+**Route:** `POST /v1/user/manage`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| userid | string | UserID string of the user to be edited. | yes |
+| domain | int | The Domain Type that the user currently has | no |
+| contractortype | int | The contractor type of the user. | no |
 | supervisoruserid | string | The userid of the user (if the user is a sub contractor. ) | no |
 
 **Results:**
@@ -737,12 +769,7 @@ Request:
 ```json
 {
   "domain": 1,
-  "githubname": "smobs",
-  "matrixname": "smobs:decred.org",
   "contractortype": 1,
-  "contractorname": "Steve Mobs",
-  "contractorlocation": "Cupertino, CA",
-  "contractorcontact": "smobs@apple.com",
   "supervisoruserid": "",
 }
 ```

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -567,21 +567,28 @@ type UserDetailsReply struct {
 	User User `json:"user"`
 }
 
-// EditUser edits a user's preferences.
+// EditUser edits a user's CMS information.
 type EditUser struct {
-	UserID             string          `json:"userid"`           // The ID of the user being Edited
-	Domain             DomainTypeT     `json:"domain,omitempty"` // Contractor domain
-	GitHubName         string          `json:"githubname,omitempty"`
-	MatrixName         string          `json:"matrixname,omitempty"`
-	ContractorType     ContractorTypeT `json:"contractortype,omitempty"`
-	ContractorName     string          `json:"contractorname,omitempty"`
-	ContractorLocation string          `json:"contractorlocation,omitempty"`
-	ContractorContact  string          `json:"contractorcontact,omitempty"`
-	SupervisorUserID   string          `json:"supervisoruserid,omitempty"`
+	GitHubName         string `json:"githubname,omitempty"`
+	MatrixName         string `json:"matrixname,omitempty"`
+	ContractorName     string `json:"contractorname,omitempty"`
+	ContractorLocation string `json:"contractorlocation,omitempty"`
+	ContractorContact  string `json:"contractorcontact,omitempty"`
 }
 
 // EditUserReply is the reply for the EditUser command.
 type EditUserReply struct{}
+
+// ManageUser performs the given action on a user.
+type ManageUser struct {
+	UserID           string          `json:"userid"`
+	Domain           DomainTypeT     `json:"domain,omitempty"`
+	ContractorType   ContractorTypeT `json:"contractortype,omitempty"`
+	SupervisorUserID string          `json:"supervisoruserid,omitempty"`
+}
+
+// ManageUserReply is the reply for the ManageUserReply command.
+type ManageUserReply struct{}
 
 // DCCInput contains all of the information concerning a DCC object that
 // will be submitted as a Record to the politeiad backend.

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -569,6 +569,7 @@ type UserDetailsReply struct {
 
 // EditUser edits a user's preferences.
 type EditUser struct {
+	UserID             string          `json:"userid"`           // The ID of the user being Edited
 	Domain             DomainTypeT     `json:"domain,omitempty"` // Contractor domain
 	GitHubName         string          `json:"githubname,omitempty"`
 	MatrixName         string          `json:"matrixname,omitempty"`

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -72,7 +72,7 @@ type cmswww struct {
 	LineItemPayouts     LineItemPayoutsCmd       `command:"lineitempayouts" description:"(admin)  generate line item list for a given date range"`
 	Login               shared.LoginCmd          `command:"login" description:"(public) login to Politeia"`
 	Logout              shared.LogoutCmd         `command:"logout" description:"(public) logout of Politeia"`
-	ManageUser          shared.ManageUserCmd     `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
+	ManageUser          ManageUserCmd            `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
 	Me                  shared.MeCmd             `command:"me" description:"(user)   get user details for the logged in user"`
 	NewComment          shared.NewCommentCmd     `command:"newcomment" description:"(user)   create a new comment"`
 	NewDCC              NewDCCCmd                `command:"newdcc" description:"(user)   creates a new dcc proposal"`

--- a/politeiawww/cmd/cmswww/edituser.go
+++ b/politeiawww/cmd/cmswww/edituser.go
@@ -273,6 +273,7 @@ func (cmd *EditUserCmd) Execute(args []string) error {
 	}
 
 	updateInfo := cms.EditUser{
+		UserID:             lr.UserID,
 		Domain:             userInfo.Domain,
 		ContractorType:     userInfo.ContractorType,
 		ContractorName:     userInfo.ContractorName,

--- a/politeiawww/cmd/cmswww/edituser.go
+++ b/politeiawww/cmd/cmswww/edituser.go
@@ -46,7 +46,7 @@ func (cmd *EditUserCmd) Execute(args []string) error {
 	reader := bufio.NewReader(os.Stdin)
 	if cmd.MatrixName != "" || cmd.GitHubName != "" ||
 		cmd.ContractorName != "" || cmd.ContractorLocation != "" ||
-		cmd.ContractorLocation != "" {
+		cmd.ContractorContact != "" {
 		if cmd.MatrixName == "" {
 			str := fmt.Sprintf(
 				"Your current MatrixName setting is: \"%v\" Update?",

--- a/politeiawww/cmd/cmswww/edituser.go
+++ b/politeiawww/cmd/cmswww/edituser.go
@@ -14,11 +14,8 @@ import (
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
-// EditUserCmd allows a user to edit their own information.  This also
-// allows administrators to update a user's information (and more importantly,
-// domain, contractor type and supervisorid).  Admin's will have to update this
-// information for existing users, but after the DCC is put into production
-// that information will be populated upon approved issuance.
+// EditUserCmd allows a user to edit their own contractor information, such as
+// GithubName, MatrixName, Contractor Name, Location and Contact.
 type EditUserCmd struct {
 	GitHubName         string `long:"githubname" optional:"true" description:"Github handle"`
 	MatrixName         string `long:"matrixname" optional:"true" description:"Matrix name"`
@@ -27,7 +24,7 @@ type EditUserCmd struct {
 	ContractorContact  string `long:"contact" optional:"true" description:"Contact information"`
 }
 
-// Execute executes the cms update user information command.
+// Execute executes the cms edit user information command.
 func (cmd *EditUserCmd) Execute(args []string) error {
 	// Check for user identity
 	if cfg.Identity == nil {

--- a/politeiawww/cmd/cmswww/edituser.go
+++ b/politeiawww/cmd/cmswww/edituser.go
@@ -44,152 +44,151 @@ func (cmd *EditUserCmd) Execute(args []string) error {
 		userInfo = uir.User
 	}
 	reader := bufio.NewReader(os.Stdin)
-	if cmd.MatrixName == "" {
-		str := fmt.Sprintf(
-			"Your current MatrixName setting is: \"%v\" Update?",
-			userInfo.MatrixName)
-		update, err := promptListBool(reader, str, "no")
-		if err != nil {
-			return err
-		}
-		if update {
-			for {
-				fmt.Printf("Please enter your Matrix contact name:  ")
-				cmd.MatrixName, _ = reader.ReadString('\n')
-				cmd.MatrixName = strings.TrimSpace(cmd.MatrixName)
-				str := fmt.Sprintf(
-					"Your current Matrix name setting is: \"%v\" Keep this?",
-					cmd.MatrixName)
-				update, err := promptListBool(reader, str, "yes")
-				if err != nil {
-					return err
-				}
-				if update {
-					userInfo.MatrixName = cmd.MatrixName
-					break
+	if cmd.MatrixName != "" || cmd.GitHubName != "" ||
+		cmd.ContractorName != "" || cmd.ContractorLocation != "" ||
+		cmd.ContractorLocation != "" {
+		if cmd.MatrixName == "" {
+			str := fmt.Sprintf(
+				"Your current MatrixName setting is: \"%v\" Update?",
+				userInfo.MatrixName)
+			update, err := promptListBool(reader, str, "no")
+			if err != nil {
+				return err
+			}
+			if update {
+				for {
+					fmt.Printf("Please enter your Matrix contact name:  ")
+					cmd.MatrixName, _ = reader.ReadString('\n')
+					cmd.MatrixName = strings.TrimSpace(cmd.MatrixName)
+					str := fmt.Sprintf(
+						"Your current Matrix name setting is: \"%v\" Keep this?",
+						cmd.MatrixName)
+					update, err := promptListBool(reader, str, "yes")
+					if err != nil {
+						return err
+					}
+					if update {
+						userInfo.MatrixName = cmd.MatrixName
+						break
+					}
 				}
 			}
 		}
-	} else {
-		userInfo.MatrixName = cmd.MatrixName
-	}
-	if cmd.GitHubName == "" {
-		str := fmt.Sprintf(
-			"Your current GitHubName setting is: \"%v\" Update?",
-			userInfo.GitHubName)
-		update, err := promptListBool(reader, str, "no")
-		if err != nil {
-			return err
-		}
-		if update {
-			for {
-				fmt.Printf("Please enter your GitHubName contact name:  ")
-				cmd.GitHubName, _ = reader.ReadString('\n')
-				cmd.GitHubName = strings.TrimSpace(cmd.GitHubName)
-				str := fmt.Sprintf(
-					"Your current GitHubName name setting is: \"%v\" Keep this?",
-					cmd.GitHubName)
-				update, err := promptListBool(reader, str, "yes")
-				if err != nil {
-					return err
-				}
-				if update {
-					userInfo.GitHubName = cmd.GitHubName
-					break
+		if cmd.GitHubName == "" {
+			str := fmt.Sprintf(
+				"Your current GitHubName setting is: \"%v\" Update?",
+				userInfo.GitHubName)
+			update, err := promptListBool(reader, str, "no")
+			if err != nil {
+				return err
+			}
+			if update {
+				for {
+					fmt.Printf("Please enter your GitHubName contact name:  ")
+					cmd.GitHubName, _ = reader.ReadString('\n')
+					cmd.GitHubName = strings.TrimSpace(cmd.GitHubName)
+					str := fmt.Sprintf(
+						"Your current GitHubName name setting is: \"%v\" Keep this?",
+						cmd.GitHubName)
+					update, err := promptListBool(reader, str, "yes")
+					if err != nil {
+						return err
+					}
+					if update {
+						userInfo.GitHubName = cmd.GitHubName
+						break
+					}
 				}
 			}
 		}
-	} else {
-		userInfo.GitHubName = cmd.GitHubName
-	}
-	if cmd.ContractorName == "" {
-		str := fmt.Sprintf(
-			"Your current Contractor Name setting is: \"%v\" Update?",
-			userInfo.ContractorName)
-		update, err := promptListBool(reader, str, "no")
-		if err != nil {
-			return err
-		}
-		if update {
-			for {
-				fmt.Printf("Please enter your IRL contractor name:  ")
-				cmd.ContractorName, _ = reader.ReadString('\n')
-				cmd.ContractorName = strings.TrimSpace(cmd.ContractorName)
-				str := fmt.Sprintf(
-					"Your current Contractor Name setting is: \"%v\" Keep this?",
-					cmd.ContractorName)
-				update, err := promptListBool(reader, str, "yes")
-				if err != nil {
-					return err
-				}
-				if update {
-					userInfo.ContractorName = cmd.ContractorName
-					break
+		if cmd.ContractorName == "" {
+			str := fmt.Sprintf(
+				"Your current Contractor Name setting is: \"%v\" Update?",
+				userInfo.ContractorName)
+			update, err := promptListBool(reader, str, "no")
+			if err != nil {
+				return err
+			}
+			if update {
+				for {
+					fmt.Printf("Please enter your IRL contractor name:  ")
+					cmd.ContractorName, _ = reader.ReadString('\n')
+					cmd.ContractorName = strings.TrimSpace(cmd.ContractorName)
+					str := fmt.Sprintf(
+						"Your current Contractor Name setting is: \"%v\" Keep this?",
+						cmd.ContractorName)
+					update, err := promptListBool(reader, str, "yes")
+					if err != nil {
+						return err
+					}
+					if update {
+						userInfo.ContractorName = cmd.ContractorName
+						break
+					}
 				}
 			}
 		}
-	} else {
-		userInfo.ContractorName = cmd.ContractorName
-	}
-	if cmd.ContractorLocation == "" {
-		str := fmt.Sprintf("Your current Contractor Location setting is: \"%v\" Update?",
-			userInfo.ContractorLocation)
-		update, err := promptListBool(reader, str, "no")
-		if err != nil {
-			return err
-		}
-		if update {
-			for {
-				fmt.Printf("Please enter your IRL contractor location:  ")
-				cmd.ContractorLocation, _ = reader.ReadString('\n')
-				cmd.ContractorLocation = strings.TrimSpace(cmd.ContractorLocation)
-				str := fmt.Sprintf(
-					"Your current Contractor location setting is: \"%v\" Keep this?",
-					cmd.ContractorLocation)
-				update, err := promptListBool(reader, str, "yes")
-				if err != nil {
-					return err
-				}
-				if update {
-					userInfo.ContractorLocation = cmd.ContractorLocation
-					break
+		if cmd.ContractorLocation == "" {
+			str := fmt.Sprintf("Your current Contractor Location setting is: \"%v\" Update?",
+				userInfo.ContractorLocation)
+			update, err := promptListBool(reader, str, "no")
+			if err != nil {
+				return err
+			}
+			if update {
+				for {
+					fmt.Printf("Please enter your IRL contractor location:  ")
+					cmd.ContractorLocation, _ = reader.ReadString('\n')
+					cmd.ContractorLocation = strings.TrimSpace(cmd.ContractorLocation)
+					str := fmt.Sprintf(
+						"Your current Contractor location setting is: \"%v\" Keep this?",
+						cmd.ContractorLocation)
+					update, err := promptListBool(reader, str, "yes")
+					if err != nil {
+						return err
+					}
+					if update {
+						userInfo.ContractorLocation = cmd.ContractorLocation
+						break
+					}
 				}
 			}
 		}
-	} else {
-		userInfo.ContractorLocation = cmd.ContractorLocation
-	}
-	if cmd.ContractorContact == "" {
-		str := fmt.Sprintf("Your current Contractor Contact setting is: \"%v\" Update?",
-			userInfo.ContractorContact)
-		update, err := promptListBool(reader, str, "no")
-		if err != nil {
-			return err
-		}
-		if update {
-			for {
-				fmt.Printf("Please enter your Contractor contact information:  ")
-				cmd.ContractorContact, _ = reader.ReadString('\n')
-				cmd.ContractorContact = strings.TrimSpace(cmd.ContractorContact)
-				str := fmt.Sprintf("Your current Contractor contact setting is: \"%v\" Keep this?",
-					cmd.ContractorContact)
-				update, err := promptListBool(reader, str, "yes")
-				if err != nil {
-					return err
-				}
-				if update {
-					userInfo.ContractorContact = cmd.ContractorContact
-					break
+		if cmd.ContractorContact == "" {
+			str := fmt.Sprintf("Your current Contractor Contact setting is: \"%v\" Update?",
+				userInfo.ContractorContact)
+			update, err := promptListBool(reader, str, "no")
+			if err != nil {
+				return err
+			}
+			if update {
+				for {
+					fmt.Printf("Please enter your Contractor contact information:  ")
+					cmd.ContractorContact, _ = reader.ReadString('\n')
+					cmd.ContractorContact = strings.TrimSpace(cmd.ContractorContact)
+					str := fmt.Sprintf("Your current Contractor contact setting is: \"%v\" Keep this?",
+						cmd.ContractorContact)
+					update, err := promptListBool(reader, str, "yes")
+					if err != nil {
+						return err
+					}
+					if update {
+						userInfo.ContractorContact = cmd.ContractorContact
+						break
+					}
 				}
 			}
 		}
-	} else {
-		userInfo.ContractorContact = cmd.ContractorContact
+		fmt.Print("\nPlease carefully review your information and ensure it's " +
+			"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
+			"your request.")
+		reader.ReadString('\n')
 	}
-	fmt.Print("\nPlease carefully review your information and ensure it's " +
-		"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
-		"your request.")
-	reader.ReadString('\n')
+	userInfo.MatrixName = cmd.MatrixName
+	userInfo.GitHubName = cmd.GitHubName
+	userInfo.ContractorName = cmd.ContractorName
+	userInfo.ContractorLocation = cmd.ContractorLocation
+	userInfo.ContractorContact = cmd.ContractorContact
 
 	updateInfo := cms.EditUser{
 		ContractorName:     userInfo.ContractorName,

--- a/politeiawww/cmd/cmswww/edituser.go
+++ b/politeiawww/cmd/cmswww/edituser.go
@@ -8,23 +8,23 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
-// EditUserCmd updates a user's information.
+// EditUserCmd allows a user to edit their own information.  This also
+// allows administrators to update a user's information (and more importantly,
+// domain, contractor type and supervisorid).  Admin's will have to update this
+// information for existing users, but after the DCC is put into production
+// that information will be populated upon approved issuance.
 type EditUserCmd struct {
-	Domain             string `long:"domain" optional:"true" description:"Domain type: Developer, Marketing, Design, Documentation, Research, Community"`
 	GitHubName         string `long:"githubname" optional:"true" description:"Github handle"`
 	MatrixName         string `long:"matrixname" optional:"true" description:"Matrix name"`
-	ContractorType     string `long:"contractortype" optional:"true" description:"Contractor type: Direct, Sub, Super"`
 	ContractorName     string `long:"contractorname" optional:"true" description:"Identifying IRL name"`
 	ContractorLocation string `long:"contractorlocation" optional:"true" description:"IRL location (country or continent)"`
 	ContractorContact  string `long:"contact" optional:"true" description:"Contact information"`
-	SupervisorUsername string `long:"supervisoruserid" optional:"true" description:"Supervisor Username"`
 }
 
 // Execute executes the cms update user information command.
@@ -39,243 +39,162 @@ func (cmd *EditUserCmd) Execute(args []string) error {
 	}
 	uir, err := client.CMSUserDetails(lr.UserID)
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+
 	userInfo := cms.User{}
 	if uir != nil {
 		userInfo = uir.User
 	}
-	var domainType, contractorType int
-	if cmd.Domain == "" || cmd.GitHubName == "" ||
-		cmd.MatrixName == "" || cmd.ContractorType == "" ||
-		cmd.ContractorName == "" || cmd.ContractorLocation == "" ||
-		cmd.ContractorContact == "" || cmd.SupervisorUsername == "" {
-		reader := bufio.NewReader(os.Stdin)
-		if cmd.Domain == "" {
-			str := fmt.Sprintf("Your current Domain setting is: \"%v\" Update?",
-				userInfo.Domain)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("Domain Type: (1) Developer, (2) Marketing, (3) " +
-						"Community, (4) Research, (5) Design, (6) Documentation:  ")
-					cmd.Domain, _ = reader.ReadString('\n')
-					domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
-					if err != nil {
-						fmt.Println("Invalid entry, please try again.")
-						continue
-					}
-					if domainType < 1 || domainType > 6 {
-						fmt.Println("Invalid domain type entered, please try again.")
-						continue
-					}
-					str := fmt.Sprintf(
-						"Your current Domain setting is: \"%v\" Keep this?",
-						domainType)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						userInfo.Domain = cms.DomainTypeT(domainType)
-						break
-					}
+	reader := bufio.NewReader(os.Stdin)
+	if cmd.MatrixName == "" {
+		str := fmt.Sprintf(
+			"Your current MatrixName setting is: \"%v\" Update?",
+			userInfo.MatrixName)
+		update, err := promptListBool(reader, str, "no")
+		if err != nil {
+			return err
+		}
+		if update {
+			for {
+				fmt.Printf("Please enter your Matrix contact name:  ")
+				cmd.MatrixName, _ = reader.ReadString('\n')
+				cmd.MatrixName = strings.TrimSpace(cmd.MatrixName)
+				str := fmt.Sprintf(
+					"Your current Matrix name setting is: \"%v\" Keep this?",
+					cmd.MatrixName)
+				update, err := promptListBool(reader, str, "yes")
+				if err != nil {
+					return err
+				}
+				if update {
+					userInfo.MatrixName = cmd.MatrixName
+					break
 				}
 			}
 		}
-		if cmd.MatrixName == "" {
-			str := fmt.Sprintf(
-				"Your current MatrixName setting is: \"%v\" Update?",
-				userInfo.MatrixName)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("Please enter your Matrix contact name:  ")
-					cmd.MatrixName, _ = reader.ReadString('\n')
-					cmd.MatrixName = strings.TrimSpace(cmd.MatrixName)
-					str := fmt.Sprintf(
-						"Your current Matrix name setting is: \"%v\" Keep this?",
-						cmd.MatrixName)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						userInfo.MatrixName = cmd.MatrixName
-						break
-					}
-				}
-			}
-		}
-		if cmd.GitHubName == "" {
-			str := fmt.Sprintf(
-				"Your current GitHubName setting is: \"%v\" Update?",
-				userInfo.GitHubName)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("Please enter your GitHubName contact name:  ")
-					cmd.GitHubName, _ = reader.ReadString('\n')
-					cmd.GitHubName = strings.TrimSpace(cmd.GitHubName)
-					str := fmt.Sprintf(
-						"Your current GitHubName name setting is: \"%v\" Keep this?",
-						cmd.GitHubName)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						userInfo.GitHubName = cmd.GitHubName
-						break
-					}
-				}
-			}
-		}
-		if cmd.ContractorType == "" {
-			str := fmt.Sprintf("Your current Contractor Type setting is: \"%v\" Update?",
-				userInfo.ContractorType)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("(1) Direct, (2) Supervisor, (3) Sub contractor:  ")
-					cmd.ContractorType, _ = reader.ReadString('\n')
-					contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
-					if err != nil {
-						fmt.Println("Invalid entry, please try again.")
-						continue
-					}
-					if contractorType < 1 || contractorType > 3 {
-						fmt.Println("Invalid contractor type entered, please try again.")
-						continue
-					}
-					str := fmt.Sprintf(
-						"Your current Contractor Type setting is: \"%v\" Keep this?",
-						contractorType)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						userInfo.ContractorType = cms.ContractorTypeT(contractorType)
-						break
-					}
-				}
-			}
-		}
-		if cmd.ContractorName == "" {
-			str := fmt.Sprintf(
-				"Your current Contractor Name setting is: \"%v\" Update?",
-				userInfo.ContractorName)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("Please enter your IRL contractor name:  ")
-					cmd.ContractorName, _ = reader.ReadString('\n')
-					cmd.ContractorName = strings.TrimSpace(cmd.ContractorName)
-					str := fmt.Sprintf(
-						"Your current Contractor Name setting is: \"%v\" Keep this?",
-						cmd.ContractorName)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						userInfo.ContractorName = cmd.ContractorName
-						break
-					}
-				}
-			}
-		}
-		if cmd.ContractorLocation == "" {
-			str := fmt.Sprintf("Your current Contractor Location setting is: \"%v\" Update?",
-				userInfo.ContractorLocation)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("Please enter your IRL contractor location:  ")
-					cmd.ContractorLocation, _ = reader.ReadString('\n')
-					cmd.ContractorLocation = strings.TrimSpace(cmd.ContractorLocation)
-					str := fmt.Sprintf(
-						"Your current Contractor location setting is: \"%v\" Keep this?",
-						cmd.ContractorLocation)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						userInfo.ContractorLocation = cmd.ContractorLocation
-						break
-					}
-				}
-			}
-		}
-		if cmd.ContractorContact == "" {
-			str := fmt.Sprintf("Your current Contractor Contact setting is: \"%v\" Update?",
-				userInfo.ContractorContact)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("Please enter your Contractor contact information:  ")
-					cmd.ContractorContact, _ = reader.ReadString('\n')
-					cmd.ContractorContact = strings.TrimSpace(cmd.ContractorContact)
-					str := fmt.Sprintf("Your current Contractor contact setting is: \"%v\" Keep this?",
-						cmd.ContractorContact)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						userInfo.ContractorContact = cmd.ContractorContact
-						break
-					}
-				}
-			}
-		}
-		/*
-			XXX Need to decide how to handle Supervisor name lookup for CLI.
-				if cmd.SupervisorUsername == "" {
-					str := fmt.Sprintf("Your current Supervisor ID setting is: %v Update?", userInfo.SupervisorUserID)
-					update, err := promptListBool(reader, str, "no")
-					if err != nil {
-						return err
-					}
-					if update {
-						cmd.SupervisorUsername, _ = reader.ReadString('\n')
-					}
-					userInfo.SupervisorUserID = cmd.SupervisorUsername
-				}
-		*/
-		fmt.Print("\nPlease carefully review your information and ensure it's " +
-			"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
-			"your registration.")
-		reader.ReadString('\n')
+	} else {
+		userInfo.MatrixName = cmd.MatrixName
 	}
+	if cmd.GitHubName == "" {
+		str := fmt.Sprintf(
+			"Your current GitHubName setting is: \"%v\" Update?",
+			userInfo.GitHubName)
+		update, err := promptListBool(reader, str, "no")
+		if err != nil {
+			return err
+		}
+		if update {
+			for {
+				fmt.Printf("Please enter your GitHubName contact name:  ")
+				cmd.GitHubName, _ = reader.ReadString('\n')
+				cmd.GitHubName = strings.TrimSpace(cmd.GitHubName)
+				str := fmt.Sprintf(
+					"Your current GitHubName name setting is: \"%v\" Keep this?",
+					cmd.GitHubName)
+				update, err := promptListBool(reader, str, "yes")
+				if err != nil {
+					return err
+				}
+				if update {
+					userInfo.GitHubName = cmd.GitHubName
+					break
+				}
+			}
+		}
+	} else {
+		userInfo.GitHubName = cmd.GitHubName
+	}
+	if cmd.ContractorName == "" {
+		str := fmt.Sprintf(
+			"Your current Contractor Name setting is: \"%v\" Update?",
+			userInfo.ContractorName)
+		update, err := promptListBool(reader, str, "no")
+		if err != nil {
+			return err
+		}
+		if update {
+			for {
+				fmt.Printf("Please enter your IRL contractor name:  ")
+				cmd.ContractorName, _ = reader.ReadString('\n')
+				cmd.ContractorName = strings.TrimSpace(cmd.ContractorName)
+				str := fmt.Sprintf(
+					"Your current Contractor Name setting is: \"%v\" Keep this?",
+					cmd.ContractorName)
+				update, err := promptListBool(reader, str, "yes")
+				if err != nil {
+					return err
+				}
+				if update {
+					userInfo.ContractorName = cmd.ContractorName
+					break
+				}
+			}
+		}
+	} else {
+		userInfo.ContractorName = cmd.ContractorName
+	}
+	if cmd.ContractorLocation == "" {
+		str := fmt.Sprintf("Your current Contractor Location setting is: \"%v\" Update?",
+			userInfo.ContractorLocation)
+		update, err := promptListBool(reader, str, "no")
+		if err != nil {
+			return err
+		}
+		if update {
+			for {
+				fmt.Printf("Please enter your IRL contractor location:  ")
+				cmd.ContractorLocation, _ = reader.ReadString('\n')
+				cmd.ContractorLocation = strings.TrimSpace(cmd.ContractorLocation)
+				str := fmt.Sprintf(
+					"Your current Contractor location setting is: \"%v\" Keep this?",
+					cmd.ContractorLocation)
+				update, err := promptListBool(reader, str, "yes")
+				if err != nil {
+					return err
+				}
+				if update {
+					userInfo.ContractorLocation = cmd.ContractorLocation
+					break
+				}
+			}
+		}
+	} else {
+		userInfo.ContractorLocation = cmd.ContractorLocation
+	}
+	if cmd.ContractorContact == "" {
+		str := fmt.Sprintf("Your current Contractor Contact setting is: \"%v\" Update?",
+			userInfo.ContractorContact)
+		update, err := promptListBool(reader, str, "no")
+		if err != nil {
+			return err
+		}
+		if update {
+			for {
+				fmt.Printf("Please enter your Contractor contact information:  ")
+				cmd.ContractorContact, _ = reader.ReadString('\n')
+				cmd.ContractorContact = strings.TrimSpace(cmd.ContractorContact)
+				str := fmt.Sprintf("Your current Contractor contact setting is: \"%v\" Keep this?",
+					cmd.ContractorContact)
+				update, err := promptListBool(reader, str, "yes")
+				if err != nil {
+					return err
+				}
+				if update {
+					userInfo.ContractorContact = cmd.ContractorContact
+					break
+				}
+			}
+		}
+	} else {
+		userInfo.ContractorContact = cmd.ContractorContact
+	}
+	fmt.Print("\nPlease carefully review your information and ensure it's " +
+		"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
+		"your request.")
+	reader.ReadString('\n')
 
 	updateInfo := cms.EditUser{
-		UserID:             lr.UserID,
-		Domain:             userInfo.Domain,
-		ContractorType:     userInfo.ContractorType,
 		ContractorName:     userInfo.ContractorName,
 		ContractorLocation: userInfo.ContractorLocation,
 		ContractorContact:  userInfo.ContractorContact,
@@ -290,38 +209,4 @@ func (cmd *EditUserCmd) Execute(args []string) error {
 
 	// Print update user information reply. (should be empty)
 	return shared.PrintJSON(ecur)
-}
-
-func parseDomain(domain string) (cms.DomainTypeT, error) {
-	domain = strings.ToLower(strings.TrimSpace(domain))
-	switch domain {
-	case "developer":
-		return cms.DomainTypeDeveloper, nil
-	case "marketing":
-		return cms.DomainTypeMarketing, nil
-	case "community":
-		return cms.DomainTypeCommunity, nil
-	case "documentation":
-		return cms.DomainTypeDocumentation, nil
-	case "research":
-		return cms.DomainTypeResearch, nil
-	case "design":
-		return cms.DomainTypeDesign, nil
-	default:
-		return cms.DomainTypeInvalid, fmt.Errorf("invalid domain type")
-	}
-}
-
-func parseContractorType(contractorType string) (cms.ContractorTypeT, error) {
-	contractorType = strings.ToLower(strings.TrimSpace(contractorType))
-	switch contractorType {
-	case "direct":
-		return cms.ContractorTypeDirect, nil
-	case "sub":
-		return cms.ContractorTypeSubContractor, nil
-	case "super":
-		return cms.ContractorTypeSupervisor, nil
-	default:
-		return cms.ContractorTypeInvalid, fmt.Errorf("invalid domain type")
-	}
 }

--- a/politeiawww/cmd/cmswww/help.go
+++ b/politeiawww/cmd/cmswww/help.go
@@ -39,7 +39,7 @@ func (cmd *HelpCmd) Execute(args []string) error {
 	case "censorcomment":
 		fmt.Printf("%s\n", shared.CensorCommentHelpMsg)
 	case "manageuser":
-		fmt.Printf("%s\n", shared.ManageUserHelpMsg)
+		fmt.Printf("%s\n", manageUserHelpMsg)
 	case "version":
 		fmt.Printf("%s\n", shared.VersionHelpMsg)
 	case "me":

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -15,11 +15,8 @@ import (
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
-// ManageUserCmd allows a user to edit their own information.  This also
-// allows administrators to update a user's information (and more importantly,
-// domain, contractor type and supervisorid).  Admin's will have to update this
-// information for existing users, but after the DCC is put into production
-// that information will be populated upon approved issuance.
+// ManageUserCmd allows an administrator to update Domain, ContractorType
+// and SupervisorID of a given user.
 type ManageUserCmd struct {
 	UserID             string `long:"userid" optional:"true" description:"User ID of the user to edit information"`
 	Domain             string `long:"domain" optional:"true" description:"Domain type: Developer, Marketing, Design, Documentation, Research, Community"`
@@ -27,7 +24,7 @@ type ManageUserCmd struct {
 	SupervisorUsername string `long:"supervisoruserid" optional:"true" description:"Supervisor Username"`
 }
 
-// Execute executes the cms update user information command.
+// Execute executes the cms manage user command.
 func (cmd *ManageUserCmd) Execute(args []string) error {
 	// Check for user identity
 	if cfg.Identity == nil {

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -40,17 +40,18 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 	var userID string
 	// If it's an admin requesting, get the userID from the options or
 	// commandline entry.  Otherwise just request with the current user's ID.
-	if lr.IsAdmin {
-		reader := bufio.NewReader(os.Stdin)
-		if cmd.UserID == "" {
-			fmt.Print("Enter the id of the user to edit:")
-			userID, _ = reader.ReadString('\n')
-		} else {
-			userID = cmd.UserID
-		}
-	} else {
-		userID = lr.UserID
+	if !lr.IsAdmin {
+		return fmt.Errorf("must be an administrator to complete this request")
 	}
+
+	reader := bufio.NewReader(os.Stdin)
+	if cmd.UserID == "" {
+		fmt.Print("Enter the id of the user to edit: ")
+		userID, _ = reader.ReadString('\n')
+	} else {
+		userID = cmd.UserID
+	}
+
 	uir, err := client.CMSUserDetails(strings.TrimSpace(userID))
 	if err != nil {
 		return err
@@ -61,7 +62,6 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 		userInfo = uir.User
 	}
 	var domainType, contractorType int
-	reader := bufio.NewReader(os.Stdin)
 	if cmd.Domain == "" && lr.IsAdmin {
 		str := fmt.Sprintf("The current Domain setting is: \"%v\" Update?",
 			userInfo.Domain)

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -59,103 +59,110 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 		userInfo = uir.User
 	}
 	var domainType, contractorType int
-	if cmd.Domain == "" && lr.IsAdmin {
-		str := fmt.Sprintf("The current Domain setting is: \"%v\" Update?",
-			userInfo.Domain)
-		update, err := promptListBool(reader, str, "no")
-		if err != nil {
-			return err
-		}
-		if update {
-			for {
-				fmt.Printf("Domain Type: (1) Developer, (2) Marketing, (3) " +
-					"Community, (4) Research, (5) Design, (6) Documentation:  ")
-				cmd.Domain, _ = reader.ReadString('\n')
-				domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
-				if err != nil {
-					fmt.Println("Invalid entry, please try again.")
-					continue
-				}
-				if domainType < 1 || domainType > 6 {
-					fmt.Println("Invalid domain type entered, please try again.")
-					continue
-				}
-				str := fmt.Sprintf(
-					"Your current Domain setting is: \"%v\" Keep this?",
-					domainType)
-				update, err := promptListBool(reader, str, "yes")
-				if err != nil {
-					return err
-				}
-				if update {
-					userInfo.Domain = cms.DomainTypeT(domainType)
-					break
+	if cmd.Domain != "" || cmd.ContractorType != "" {
+		if cmd.Domain == "" {
+			str := fmt.Sprintf("The current Domain setting is: \"%v\" Update?",
+				userInfo.Domain)
+			update, err := promptListBool(reader, str, "no")
+			if err != nil {
+				return err
+			}
+			if update {
+				for {
+					fmt.Printf("Domain Type: (1) Developer, (2) Marketing, (3) " +
+						"Community, (4) Research, (5) Design, (6) Documentation:  ")
+					cmd.Domain, _ = reader.ReadString('\n')
+					domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
+					if err != nil {
+						fmt.Println("Invalid entry, please try again.")
+						continue
+					}
+					if domainType < 1 || domainType > 6 {
+						fmt.Println("Invalid domain type entered, please try again.")
+						continue
+					}
+					str := fmt.Sprintf(
+						"Your current Domain setting is: \"%v\" Keep this?",
+						domainType)
+					update, err := promptListBool(reader, str, "yes")
+					if err != nil {
+						return err
+					}
+					if update {
+						break
+					}
 				}
 			}
 		}
-	} else if cmd.Domain != "" && lr.IsAdmin {
-		domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
-		if err != nil {
-			return fmt.Errorf("invalid domain attempted, please try again")
+		if cmd.ContractorType == "" {
+			str := fmt.Sprintf("Your current Contractor Type setting is: \"%v\" Update?",
+				userInfo.ContractorType)
+			update, err := promptListBool(reader, str, "no")
+			if err != nil {
+				return err
+			}
+			if update {
+				for {
+					fmt.Printf("(1) Direct, (2) Supervisor, (3) Sub contractor:  ")
+					cmd.ContractorType, _ = reader.ReadString('\n')
+					contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
+					if err != nil {
+						fmt.Println("Invalid entry, please try again.")
+						continue
+					}
+					if contractorType < 1 || contractorType > 3 {
+						fmt.Println("Invalid contractor type entered, please try again.")
+						continue
+					}
+					str := fmt.Sprintf(
+						"Your current Contractor Type setting is: \"%v\" Keep this?",
+						contractorType)
+					update, err := promptListBool(reader, str, "yes")
+					if err != nil {
+						return err
+					}
+					if update {
+						break
+					}
+				}
+			}
 		}
-		userInfo.Domain = cms.DomainTypeT(domainType)
 	}
-	if cmd.ContractorType == "" && lr.IsAdmin {
-		str := fmt.Sprintf("Your current Contractor Type setting is: \"%v\" Update?",
-			userInfo.ContractorType)
-		update, err := promptListBool(reader, str, "no")
-		if err != nil {
-			return err
-		}
-		if update {
-			for {
-				fmt.Printf("(1) Direct, (2) Supervisor, (3) Sub contractor:  ")
-				cmd.ContractorType, _ = reader.ReadString('\n')
-				contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
-				if err != nil {
-					fmt.Println("Invalid entry, please try again.")
-					continue
-				}
-				if contractorType < 1 || contractorType > 3 {
-					fmt.Println("Invalid contractor type entered, please try again.")
-					continue
-				}
-				str := fmt.Sprintf(
-					"Your current Contractor Type setting is: \"%v\" Keep this?",
-					contractorType)
-				update, err := promptListBool(reader, str, "yes")
-				if err != nil {
-					return err
-				}
-				if update {
-					userInfo.ContractorType = cms.ContractorTypeT(contractorType)
-					break
-				}
-			}
-		}
-	} else if cmd.ContractorType != "" && lr.IsAdmin {
-		contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
-		if err != nil {
-			return fmt.Errorf("invalid contractor type entered, please try again")
+	domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
+	if err != nil {
+		return fmt.Errorf("invalid domain attempted, please try again")
+	}
+	userInfo.Domain = cms.DomainTypeT(domainType)
+	contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
+	if err != nil {
+		return fmt.Errorf("invalid domain attempted, please try again")
+	}
+	userInfo.ContractorType = cms.ContractorTypeT(contractorType)
 
-		}
-		userInfo.ContractorType = cms.ContractorTypeT(contractorType)
-	}
 	/*
-		XXX Need to decide how to handle Supervisor name lookup for CLI.
-			if cmd.SupervisorUsername == "" && lr.IsAdmin  {
-				str := fmt.Sprintf("Your current Supervisor ID setting is: %v Update?", userInfo.SupervisorUserID)
-				update, err := promptListBool(reader, str, "no")
-				if err != nil {
-					return err
-				}
-				if update {
-					cmd.SupervisorUsername, _ = reader.ReadString('\n')
-				}
-				userInfo.SupervisorUserID = cmd.SupervisorUsername
-			} else if cmd.SupervisorUsername == "" && lr.IsAdmin {
-				userInfo.SupervisorUserID = cmd.SupervisorUsername
+
+		else if cmd.ContractorType != "" {
+			contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
+			if err != nil {
+				return fmt.Errorf("invalid contractor type entered, please try again")
+
 			}
+			userInfo.ContractorType = cms.ContractorTypeT(contractorType)
+		}
+			XXX Need to decide how to handle Supervisor name lookup for CLI.
+				if cmd.SupervisorUsername == "" && lr.IsAdmin  {
+					str := fmt.Sprintf("Your current Supervisor ID setting is: %v Update?", userInfo.SupervisorUserID)
+					update, err := promptListBool(reader, str, "no")
+					if err != nil {
+						return err
+					}
+					if update {
+						cmd.SupervisorUsername, _ = reader.ReadString('\n')
+					}
+					userInfo.SupervisorUserID = cmd.SupervisorUsername
+				} else if cmd.SupervisorUsername == "" && lr.IsAdmin {
+					userInfo.SupervisorUserID = cmd.SupervisorUsername
+				}
 	*/
 	fmt.Print("\nPlease carefully review your information and ensure it's " +
 		"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -19,7 +19,7 @@ import (
 // and SupervisorID of a given user.
 type ManageUserCmd struct {
 	Args struct {
-		UserID string `positional-arg-name:"month" required:"true"`
+		UserID string `positional-arg-name:"userid" required:"true"`
 	} `positional-args:"true" optional:"true"`
 	Domain             string `long:"domain" optional:"true" description:"Domain type: Developer, Marketing, Design, Documentation, Research, Community"`
 	ContractorType     string `long:"contractortype" optional:"true" description:"Contractor type: Direct, Sub, Super"`

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// ManageUserCmd allows a user to edit their own information.  This also
+// allows administrators to update a user's information (and more importantly,
+// domain, contractor type and supervisorid).  Admin's will have to update this
+// information for existing users, but after the DCC is put into production
+// that information will be populated upon approved issuance.
+type ManageUserCmd struct {
+	UserID             string `long:"userid" optional:"true" description:"User ID of the user to edit information"`
+	Domain             string `long:"domain" optional:"true" description:"Domain type: Developer, Marketing, Design, Documentation, Research, Community"`
+	ContractorType     string `long:"contractortype" optional:"true" description:"Contractor type: Direct, Sub, Super"`
+	SupervisorUsername string `long:"supervisoruserid" optional:"true" description:"Supervisor Username"`
+}
+
+// Execute executes the cms update user information command.
+func (cmd *ManageUserCmd) Execute(args []string) error {
+	// Check for user identity
+	if cfg.Identity == nil {
+		return shared.ErrUserIdentityNotFound
+	}
+	lr, err := client.Me()
+	if err != nil {
+		return err
+	}
+	var userID string
+	// If it's an admin requesting, get the userID from the options or
+	// commandline entry.  Otherwise just request with the current user's ID.
+	if lr.IsAdmin {
+		reader := bufio.NewReader(os.Stdin)
+		if cmd.UserID == "" {
+			fmt.Print("Enter the id of the user to edit:")
+			userID, _ = reader.ReadString('\n')
+		} else {
+			userID = cmd.UserID
+		}
+	} else {
+		userID = lr.UserID
+	}
+	uir, err := client.CMSUserDetails(strings.TrimSpace(userID))
+	if err != nil {
+		return err
+	}
+
+	userInfo := cms.User{}
+	if uir != nil {
+		userInfo = uir.User
+	}
+	var domainType, contractorType int
+	reader := bufio.NewReader(os.Stdin)
+	if cmd.Domain == "" && lr.IsAdmin {
+		str := fmt.Sprintf("The current Domain setting is: \"%v\" Update?",
+			userInfo.Domain)
+		update, err := promptListBool(reader, str, "no")
+		if err != nil {
+			return err
+		}
+		if update {
+			for {
+				fmt.Printf("Domain Type: (1) Developer, (2) Marketing, (3) " +
+					"Community, (4) Research, (5) Design, (6) Documentation:  ")
+				cmd.Domain, _ = reader.ReadString('\n')
+				domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
+				if err != nil {
+					fmt.Println("Invalid entry, please try again.")
+					continue
+				}
+				if domainType < 1 || domainType > 6 {
+					fmt.Println("Invalid domain type entered, please try again.")
+					continue
+				}
+				str := fmt.Sprintf(
+					"Your current Domain setting is: \"%v\" Keep this?",
+					domainType)
+				update, err := promptListBool(reader, str, "yes")
+				if err != nil {
+					return err
+				}
+				if update {
+					userInfo.Domain = cms.DomainTypeT(domainType)
+					break
+				}
+			}
+		}
+	} else if cmd.Domain != "" && lr.IsAdmin {
+		domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
+		if err != nil {
+			return fmt.Errorf("invalid domain attempted, please try again")
+		}
+		userInfo.Domain = cms.DomainTypeT(domainType)
+	}
+	if cmd.ContractorType == "" && lr.IsAdmin {
+		str := fmt.Sprintf("Your current Contractor Type setting is: \"%v\" Update?",
+			userInfo.ContractorType)
+		update, err := promptListBool(reader, str, "no")
+		if err != nil {
+			return err
+		}
+		if update {
+			for {
+				fmt.Printf("(1) Direct, (2) Supervisor, (3) Sub contractor:  ")
+				cmd.ContractorType, _ = reader.ReadString('\n')
+				contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
+				if err != nil {
+					fmt.Println("Invalid entry, please try again.")
+					continue
+				}
+				if contractorType < 1 || contractorType > 3 {
+					fmt.Println("Invalid contractor type entered, please try again.")
+					continue
+				}
+				str := fmt.Sprintf(
+					"Your current Contractor Type setting is: \"%v\" Keep this?",
+					contractorType)
+				update, err := promptListBool(reader, str, "yes")
+				if err != nil {
+					return err
+				}
+				if update {
+					userInfo.ContractorType = cms.ContractorTypeT(contractorType)
+					break
+				}
+			}
+		}
+	} else if cmd.ContractorType != "" && lr.IsAdmin {
+		contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
+		if err != nil {
+			return fmt.Errorf("invalid contractor type entered, please try again")
+
+		}
+		userInfo.ContractorType = cms.ContractorTypeT(contractorType)
+	}
+	/*
+		XXX Need to decide how to handle Supervisor name lookup for CLI.
+			if cmd.SupervisorUsername == "" && lr.IsAdmin  {
+				str := fmt.Sprintf("Your current Supervisor ID setting is: %v Update?", userInfo.SupervisorUserID)
+				update, err := promptListBool(reader, str, "no")
+				if err != nil {
+					return err
+				}
+				if update {
+					cmd.SupervisorUsername, _ = reader.ReadString('\n')
+				}
+				userInfo.SupervisorUserID = cmd.SupervisorUsername
+			} else if cmd.SupervisorUsername == "" && lr.IsAdmin {
+				userInfo.SupervisorUserID = cmd.SupervisorUsername
+			}
+	*/
+	fmt.Print("\nPlease carefully review your information and ensure it's " +
+		"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
+		"your request.")
+	reader.ReadString('\n')
+
+	updateInfo := cms.ManageUser{
+		UserID:         lr.UserID,
+		Domain:         userInfo.Domain,
+		ContractorType: userInfo.ContractorType,
+	}
+
+	ecur, err := client.CMSManageUser(updateInfo)
+	if err != nil {
+		return err
+	}
+
+	// Print update user information reply. (should be empty)
+	return shared.PrintJSON(ecur)
+}
+
+func parseDomain(domain string) (cms.DomainTypeT, error) {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	switch domain {
+	case "developer":
+		return cms.DomainTypeDeveloper, nil
+	case "marketing":
+		return cms.DomainTypeMarketing, nil
+	case "community":
+		return cms.DomainTypeCommunity, nil
+	case "documentation":
+		return cms.DomainTypeDocumentation, nil
+	case "research":
+		return cms.DomainTypeResearch, nil
+	case "design":
+		return cms.DomainTypeDesign, nil
+	default:
+		return cms.DomainTypeInvalid, fmt.Errorf("invalid domain type")
+	}
+}
+
+func parseContractorType(contractorType string) (cms.ContractorTypeT, error) {
+	contractorType = strings.ToLower(strings.TrimSpace(contractorType))
+	switch contractorType {
+	case "direct":
+		return cms.ContractorTypeDirect, nil
+	case "sub":
+		return cms.ContractorTypeSubContractor, nil
+	case "super":
+		return cms.ContractorTypeSupervisor, nil
+	default:
+		return cms.ContractorTypeInvalid, fmt.Errorf("invalid domain type")
+	}
+}

--- a/politeiawww/cmd/piwww/help.go
+++ b/politeiawww/cmd/piwww/help.go
@@ -63,7 +63,7 @@ func (cmd *HelpCmd) Execute(args []string) error {
 	case "editproposal":
 		fmt.Printf("%s\n", editProposalHelpMsg)
 	case "manageuser":
-		fmt.Printf("%s\n", shared.ManageUserHelpMsg)
+		fmt.Printf("%s\n", ManageUserHelpMsg)
 	case "users":
 		fmt.Printf("%s\n", shared.UsersHelpMsg)
 	case "verifyuseremail":

--- a/politeiawww/cmd/piwww/manageuser.go
+++ b/politeiawww/cmd/piwww/manageuser.go
@@ -2,13 +2,14 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package shared
+package main
 
 import (
 	"fmt"
 	"strconv"
 
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
 // ManageUserCmd allows an admin to edit certain properties of the specified
@@ -62,7 +63,7 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 	}
 
 	// Print request details
-	err = PrintJSON(mu)
+	err = shared.PrintJSON(mu)
 	if err != nil {
 		return err
 	}
@@ -74,7 +75,7 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 	}
 
 	// Print response details
-	return PrintJSON(mur)
+	return shared.PrintJSON(mur)
 }
 
 // ManageUserHelpMsg is the output of the help command when 'edituser' is

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -66,7 +66,7 @@ type piwww struct {
 	LikeComment        LikeCommentCmd           `command:"likecomment" description:"(user)   upvote/downvote a comment"`
 	Login              shared.LoginCmd          `command:"login" description:"(public) login to Politeia"`
 	Logout             shared.LogoutCmd         `command:"logout" description:"(public) logout of Politeia"`
-	ManageUser         ManageUserCmd     `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
+	ManageUser         ManageUserCmd            `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
 	Me                 shared.MeCmd             `command:"me" description:"(user)   get user details for the logged in user"`
 	NewComment         shared.NewCommentCmd     `command:"newcomment" description:"(user)   create a new comment"`
 	NewProposal        NewProposalCmd           `command:"newproposal" description:"(user)   create a new proposal"`

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -66,7 +66,7 @@ type piwww struct {
 	LikeComment        LikeCommentCmd           `command:"likecomment" description:"(user)   upvote/downvote a comment"`
 	Login              shared.LoginCmd          `command:"login" description:"(public) login to Politeia"`
 	Logout             shared.LogoutCmd         `command:"logout" description:"(public) logout of Politeia"`
-	ManageUser         shared.ManageUserCmd     `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
+	ManageUser         ManageUserCmd     `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
 	Me                 shared.MeCmd             `command:"me" description:"(user)   get user details for the logged in user"`
 	NewComment         shared.NewCommentCmd     `command:"newcomment" description:"(user)   create a new comment"`
 	NewProposal        NewProposalCmd           `command:"newproposal" description:"(user)   create a new proposal"`

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -1701,7 +1701,7 @@ func (c *Client) CMSUserDetails(userID string) (*cms.UserDetailsReply, error) {
 	return &uir, nil
 }
 
-// CMSEditUser returns the current user's information.
+// CMSEditUser edits the current user's information.
 func (c *Client) CMSEditUser(uui cms.EditUser) (*cms.EditUserReply, error) {
 	responseBody, err := c.makeRequest("POST", v1.RouteEditUser,
 		uui)
@@ -1713,6 +1713,30 @@ func (c *Client) CMSEditUser(uui cms.EditUser) (*cms.EditUserReply, error) {
 	err = json.Unmarshal(responseBody, &eur)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal CMSEditUserReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(eur)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &eur, nil
+}
+
+// CMSManageUser updates the given user's information.
+func (c *Client) CMSManageUser(uui cms.ManageUser) (*cms.ManageUserReply, error) {
+	responseBody, err := c.makeRequest("POST", v1.RouteManageUser,
+		uui)
+	if err != nil {
+		return nil, err
+	}
+
+	var eur cms.ManageUserReply
+	err = json.Unmarshal(responseBody, &eur)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal CMSManageUserReply: %v", err)
 	}
 
 	if c.cfg.Verbose {

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -298,11 +298,9 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 		}
 	}
 
-	userID, err := uuid.Parse(ecu.UserID)
+	editUser, err := p.userByIDStr(ecu.UserID)
 	if err != nil {
-		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusInvalidUUID,
-		}
+		return nil, err
 	}
 
 	err = validateUserInformation(ecu)
@@ -311,7 +309,7 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 	}
 
 	uu := user.UpdateCMSUser{
-		ID: userID,
+		ID: editUser.ID,
 	}
 
 	// Only allow Domain, ContractorType and SupervisorID to be updated by an

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -291,51 +291,20 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.EditUserReply, error) {
 	reply := cms.EditUserReply{}
 
-	// Return error in case the user isn't the admin or the current user.
-	if !u.Admin && u.ID.String() != ecu.UserID {
-		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusUserActionNotAllowed,
-		}
-	}
-
-	editUser, err := p.userByIDStr(ecu.UserID)
-	if err != nil {
-		return nil, err
-	}
-
-	err = validateUserInformation(ecu)
+	err := validateUserInformation(ecu)
 	if err != nil {
 		return nil, err
 	}
 
 	uu := user.UpdateCMSUser{
-		ID: editUser.ID,
+		ID: u.ID,
 	}
 
-	// Only allow Domain, ContractorType and SupervisorID to be updated by an
-	// administrator.
-	if !u.Admin && (ecu.Domain != 0 ||
-		ecu.ContractorType != 0 ||
-		ecu.SupervisorUserID != "") {
-		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusUserActionNotAllowed,
-		}
-	}
-
-	// Update a cms user with the provided information.
-	// Only set fields in dbUserInfo if they are set in the request,
-	// otherwise use the existing fields from the above db request.
-	if ecu.Domain != 0 {
-		uu.Domain = int(ecu.Domain)
-	}
 	if ecu.GitHubName != "" {
 		uu.GitHubName = ecu.GitHubName
 	}
 	if ecu.MatrixName != "" {
 		uu.MatrixName = ecu.MatrixName
-	}
-	if ecu.ContractorType != 0 {
-		uu.ContractorType = int(ecu.ContractorType)
 	}
 	if ecu.ContractorName != "" {
 		uu.ContractorName = ecu.ContractorName
@@ -345,9 +314,6 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 	}
 	if ecu.ContractorContact != "" {
 		uu.ContractorContact = ecu.ContractorContact
-	}
-	if ecu.SupervisorUserID != "" {
-		uu.SupervisorUserID = ecu.SupervisorUserID
 	}
 	payload, err := user.EncodeUpdateCMSUser(uu)
 	if err != nil {
@@ -363,6 +329,41 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 		return nil, err
 	}
 	return &reply, nil
+}
+
+func (p *politeiawww) processManageCMSUser(mu cms.ManageUser) (*cms.ManageUserReply, error) {
+	editUser, err := p.userByIDStr(mu.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	uu := user.UpdateCMSUser{
+		ID: editUser.ID,
+	}
+
+	if mu.Domain != 0 {
+		uu.Domain = int(mu.Domain)
+	}
+	if mu.ContractorType != 0 {
+		uu.ContractorType = int(mu.ContractorType)
+	}
+	if mu.SupervisorUserID != "" {
+		uu.SupervisorUserID = mu.SupervisorUserID
+	}
+	payload, err := user.EncodeUpdateCMSUser(uu)
+	if err != nil {
+		return nil, err
+	}
+	pc := user.PluginCommand{
+		ID:      user.CMSPluginID,
+		Command: user.CmdUpdateCMSUser,
+		Payload: string(payload),
+	}
+	_, err = p.db.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+	return &cms.ManageUserReply{}, nil
 }
 
 func (p *politeiawww) processCMSUserDetails(ud *cms.UserDetails, isCurrentUser bool, isAdmin bool) (*cms.UserDetailsReply, error) {
@@ -428,9 +429,6 @@ func validateUserInformation(userInfo cms.EditUser) error {
 				ErrorCode: cms.ErrorStatusInvoiceMalformedContact,
 			}
 		}
-	}
-	if userInfo.SupervisorUserID != "" {
-		// check if it is a valid user id, and that user is a super?
 	}
 	return nil
 }

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -289,6 +289,8 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 }
 
 func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.EditUserReply, error) {
+	log.Tracef("processEditCMSUser: %v", u.Email)
+
 	reply := cms.EditUserReply{}
 
 	err := validateUserInformation(ecu)
@@ -332,6 +334,8 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 }
 
 func (p *politeiawww) processManageCMSUser(mu cms.ManageUser) (*cms.ManageUserReply, error) {
+	log.Tracef("processManageCMSUser: %v", mu.UserID)
+
 	editUser, err := p.userByIDStr(mu.UserID)
 	if err != nil {
 		return nil, err

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -10,7 +10,6 @@ import (
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/user"
-	"github.com/google/uuid"
 )
 
 // cmsUsersByDomain returns all cms user within the provided contractor domain.
@@ -298,20 +297,13 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 		}
 	}
 
-	userID, err := uuid.Parse(ecu.UserID)
-	if err != nil {
-		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusInvalidUUID,
-		}
-	}
-
-	err = validateUserInformation(ecu)
+	err := validateUserInformation(ecu)
 	if err != nil {
 		return nil, err
 	}
 
 	uu := user.UpdateCMSUser{
-		ID: userID,
+		ID: u.ID,
 	}
 
 	// Only allow Domain, ContractorType and SupervisorID to be updated by an

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -10,6 +10,7 @@ import (
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/user"
+	"github.com/google/uuid"
 )
 
 // cmsUsersByDomain returns all cms user within the provided contractor domain.
@@ -297,13 +298,20 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 		}
 	}
 
-	err := validateUserInformation(ecu)
+	userID, err := uuid.Parse(ecu.UserID)
+	if err != nil {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusInvalidUUID,
+		}
+	}
+
+	err = validateUserInformation(ecu)
 	if err != nil {
 		return nil, err
 	}
 
 	uu := user.UpdateCMSUser{
-		ID: u.ID,
+		ID: userID,
 	}
 
 	// Only allow Domain, ContractorType and SupervisorID to be updated by an

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -462,6 +462,31 @@ func (p *politeiawww) handleEditCMSUser(w http.ResponseWriter, r *http.Request) 
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
 
+// handleManageCMSUser handles the request to edit a given user's
+// additional user information.
+func (p *politeiawww) handleManageCMSUser(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleManageCMSUser")
+
+	var mu cms.ManageUser
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&mu); err != nil {
+		RespondWithError(w, r, 0, "handleManageCMSUser: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	reply, err := p.processManageCMSUser(mu)
+	if err != nil {
+		RespondWithError(w, r, 0, "handleManageCMSUser: "+
+			"processManageCMSUser %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, reply)
+}
+
 func (p *politeiawww) handleCMSUserDetails(w http.ResponseWriter, r *http.Request) {
 	// Add the path param to the struct.
 	log.Tracef("handleCMSUserDetails")

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -842,5 +842,5 @@ func (p *politeiawww) setCMSUserWWWRoutes() {
 	p.addRoute(http.MethodGet, www.RouteUsers,
 		p.handleUsers, permissionAdmin)
 	p.addRoute(http.MethodPost, www.RouteManageUser,
-		p.handleManageUser, permissionAdmin)
+		p.handleManageCMSUser, permissionAdmin)
 }


### PR DESCRIPTION
This PR updates the usage of EditUser to basic contractor information.
Now all of the important fields which need to be restricted have
been added to a new request ManageUser.  

ManageUser requires admin credentials to update Domain,
ContractorType and SupervisorID. 

Once DCC has been put into production, these fields will be populated
by an approved DCC issuance, rather than administrator intervention.