### PR TITLE
[cms] Fix LineItemByDate db payout request

### DIFF
--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -332,13 +332,15 @@ func (c *cockroachdb) ExchangeRate(month, year int) (*database.ExchangeRate, err
 // LineItemsByDateRange takes a start and end time (in Unix seconds) and returns
 // all line items that have been paid in that range.  This uses the
 // invoice_changes table to discover the token to look up the correct line items.
-func (c *cockroachdb) LineItemsByDateRange(start, end int64) ([]database.LineItem, error) {
+func (c *cockroachdb) LineItemsByDateRange(start, end int64, status int) ([]database.LineItem, error) {
 	log.Debugf("LineItemsByDateRange: %v %v", time.Unix(start, 0),
 		time.Unix(end, 0))
 	// Get all invoice changes of PAID status within date range.
 	invoiceChanges := make([]InvoiceChange, 0, 1024) // PNOOMA
 	err := c.recordsdb.
-		Where("timestamp BETWEEN ? AND ?",
+		Where("new_status = ? AND "+
+			"timestamp BETWEEN ? AND ?",
+			status,
 			time.Unix(start, 0),
 			time.Unix(end, 0)).
 		Find(&invoiceChanges).

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -38,7 +38,7 @@ type Database interface {
 	InvoicesByMonthYear(uint16, uint16) ([]Invoice, error)            // Returns all invoice by month, year
 	InvoicesByStatus(int) ([]Invoice, error)                          // Returns all invoices by status
 	InvoicesAll() ([]Invoice, error)                                  // Returns all invoices
-	LineItemsByDateRange(int64, int64) ([]LineItem, error)            // Returns all paid invoice line items from range provided
+	LineItemsByDateRange(int64, int64, int) ([]LineItem, error)       // Returns all paid invoice line items from range provided
 
 	// ExchangeRate functions
 	NewExchangeRate(*ExchangeRate) error          // Create new exchange rate

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1606,7 +1606,7 @@ func (p *politeiawww) processLineItemPayouts(lip cms.LineItemPayouts) (*cms.Line
 			ErrorCode: cms.ErrorStatusInvalidDatesRequested,
 		}
 	}
-	dbLineItems, err := p.cmsDB.LineItemsByDateRange(lip.StartTime, lip.EndTime)
+	dbLineItems, err := p.cmsDB.LineItemsByDateRange(lip.StartTime, lip.EndTime, int(cms.InvoiceStatusPaid))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes an issue with getting multiple duplicate payout line items.

The db request was not being restricted to only InvoiceStatusPaid invoice changes
as the comments suggested.