### PR TITLE
[cms] Add ContractorType to DCCInput

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1281,6 +1281,8 @@ Reply:
 | <a name="ErrorStatusDuplicateSupportOppose">ErrorStatusDuplicateSupportOppose</a> | 1043 | A user attempted to support or oppose a DCC multiple times. |
 | <a name="ErrorStatusUserIsAuthor">ErrorStatusUserIsAuthor</a> | 1044 | A user attempted to support or oppose a DCC that they authored. |
 | <a name="ErrorStatusInvalidUserDCC">ErrorStatusInvalidUserDCC</a> | 1045 | A user with an invalid status attempted to complete a DCC task. |
+| <a name="ErrorStatusInvalidDCCContractorType">ErrorStatusInvalidDCCContractorType</a> | 1046 | An invalid contractor type was attempted to be used in a DCC proposal. |
+
 ### Invoice status codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -192,6 +192,7 @@ const (
 	ErrorStatusDuplicateSupportOppose         www.ErrorStatusT = 1043
 	ErrorStatusUserIsAuthor                   www.ErrorStatusT = 1044
 	ErrorStatusInvalidUserDCC                 www.ErrorStatusT = 1045
+	ErrorStatusInvalidDCCContractorType       www.ErrorStatusT = 1046
 )
 
 var (
@@ -267,6 +268,7 @@ var (
 		ErrorStatusDuplicateSupportOppose:         "user has already supported or opposed the given DCC",
 		ErrorStatusUserIsAuthor:                   "user cannot support or oppose their own sponsored DCC",
 		ErrorStatusInvalidUserDCC:                 "user is not authorized to complete the DCC request",
+		ErrorStatusInvalidDCCContractorType:       "DCC must have a valid contractor type",
 	}
 )
 
@@ -579,10 +581,11 @@ type EditUserReply struct{}
 // DCCInput contains all of the information concerning a DCC object that
 // will be submitted as a Record to the politeiad backend.
 type DCCInput struct {
-	Type             DCCTypeT    `json:"type"`          // Type of DCC object
-	NomineeUserID    string      `json:"nomineeuserid"` // UserID of the DCC nominee (issuance or revocation)
-	SponsorStatement string      `json:"statement"`     // Statement from sponsoring user about why DCC should be approved
-	Domain           DomainTypeT `json:"domain"`        // Domain of proposed contractor issuance
+	Type             DCCTypeT        `json:"type"`           // Type of DCC object
+	NomineeUserID    string          `json:"nomineeuserid"`  // UserID of the DCC nominee (issuance or revocation)
+	SponsorStatement string          `json:"statement"`      // Statement from sponsoring user about why DCC should be approved
+	Domain           DomainTypeT     `json:"domain"`         // Domain of proposed contractor issuance
+	ContractorType   ContractorTypeT `json:"contractortype"` // The Contractor Type of the nominee for when they are approved
 }
 
 // DCCRecord is what will be decoded from a Record for a DCC object to the

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -218,6 +218,7 @@ func encodeDCC(dbDCC *database.DCC) *DCC {
 		ServerSignature:    dbDCC.ServerSignature,
 		SponsorStatement:   dbDCC.SponsorStatement,
 		Domain:             int(dbDCC.Domain),
+		ContractorType:     int(dbDCC.ContractorType),
 
 		SupportUserIDs:    dbDCC.SupportUserIDs,
 		OppositionUserIDs: dbDCC.OppositionUserIDs,
@@ -239,6 +240,7 @@ func decodeDCC(dcc *DCC) *database.DCC {
 		ServerSignature:    dcc.ServerSignature,
 		SponsorStatement:   dcc.SponsorStatement,
 		Domain:             cms.DomainTypeT(dcc.Domain),
+		ContractorType:     cms.ContractorTypeT(dcc.ContractorType),
 
 		SupportUserIDs:    dcc.SupportUserIDs,
 		OppositionUserIDs: dcc.OppositionUserIDs,

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -117,6 +117,7 @@ type DCC struct {
 	ServerSignature    string
 	SponsorStatement   string
 	Domain             int
+	ContractorType     int
 
 	SupportUserIDs    string
 	OppositionUserIDs string

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -140,6 +140,7 @@ type Payments struct {
 	Status          cms.PaymentStatusT
 }
 
+// DCC contains information about a DCC proposal for issuance or revocation.
 type DCC struct {
 	Token              string
 	SponsorUserID      string
@@ -154,6 +155,7 @@ type DCC struct {
 	ServerSignature    string
 	SponsorStatement   string
 	Domain             cms.DomainTypeT
+	ContractorType     cms.ContractorTypeT
 
 	SupportUserIDs    string
 	OppositionUserIDs string

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -924,6 +924,7 @@ func convertRecordToDatabaseDCC(p pd.Record) (*cmsdatabase.DCC, error) {
 			dbDCC.NomineeUserID = dcc.NomineeUserID
 			dbDCC.SponsorStatement = dcc.SponsorStatement
 			dbDCC.Domain = dcc.Domain
+			dbDCC.ContractorType = dcc.ContractorType
 		}
 	}
 
@@ -972,6 +973,7 @@ func convertDCCDatabaseToRecord(dbDCC *cmsdatabase.DCC) cms.DCCRecord {
 	dccRecord.DCC.NomineeUserID = dbDCC.NomineeUserID
 	dccRecord.DCC.SponsorStatement = dbDCC.SponsorStatement
 	dccRecord.DCC.Domain = dbDCC.Domain
+	dccRecord.DCC.ContractorType = dbDCC.ContractorType
 	dccRecord.Status = dbDCC.Status
 	dccRecord.StatusChangeReason = dbDCC.StatusChangeReason
 	dccRecord.Timestamp = dbDCC.Timestamp

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -332,6 +332,13 @@ func (p *politeiawww) validateDCC(nd cms.NewDCC, u *user.User) error {
 		}
 	}
 
+	if dcc.ContractorType != cms.ContractorTypeDirect &&
+		dcc.ContractorType != cms.ContractorTypeSubContractor {
+		return www.UserError{
+			ErrorCode: cms.ErrorStatusInvalidDCCContractorType,
+		}
+
+	}
 	// Append digest to array for merkle root calculation
 	digest := util.Digest(data)
 	var d [sha256.Size]byte

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -332,7 +332,10 @@ func (p *politeiawww) validateDCC(nd cms.NewDCC, u *user.User) error {
 		}
 	}
 
-	if dcc.ContractorType != cms.ContractorTypeDirect &&
+	// Check to see that ContractorType is valid for any issuance
+	// DCC Proposal
+	if dcc.Type == cms.DCCTypeIssuance &&
+		dcc.ContractorType != cms.ContractorTypeDirect &&
 		dcc.ContractorType != cms.ContractorTypeSubContractor {
 		return www.UserError{
 			ErrorCode: cms.ErrorStatusInvalidDCCContractorType,


### PR DESCRIPTION
This PR adds the ContractorType to the DCCInput data structure. 

This will allow us to set the contractor type of the nominee upon issuance
approval.  For now, we will be only allowing Direct and Sub contractor types.
Upon successful sub contractor issuance approval, the userid of the sponsor
will be set as their SupervisorUserID.