### PR TITLE
multi: Add error codes to CastVoteReply.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -1,6 +1,10 @@
 package decredplugin
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
+
+type ErrorStatusT int
 
 // Plugin settings, kinda doesn;t go here but for now it is fine
 const (
@@ -35,6 +39,28 @@ const (
 	// Authorize vote actions
 	AuthVoteActionAuthorize = "authorize" // Authorize a proposal vote
 	AuthVoteActionRevoke    = "revoke"    // Revoke a proposal vote authorization
+
+	// Error status codes
+	ErrorStatusInvalid          ErrorStatusT = 0
+	ErrorStatusInternalError    ErrorStatusT = 1
+	ErrorStatusProposalNotFound ErrorStatusT = 2
+	ErrorStatusInvalidVoteBit   ErrorStatusT = 3
+	ErrorStatusVoteHasEnded     ErrorStatusT = 4
+	ErrorStatusDuplicateVote    ErrorStatusT = 5
+	ErrorStatusIneligibleTicket ErrorStatusT = 6
+)
+
+var (
+	// ErrorStatus converts error status codes to human readable text.
+	ErrorStatus = map[ErrorStatusT]string{
+		ErrorStatusInvalid:          "invalid error status",
+		ErrorStatusInternalError:    "internal error",
+		ErrorStatusProposalNotFound: "proposal not found",
+		ErrorStatusInvalidVoteBit:   "invalid vote bit",
+		ErrorStatusVoteHasEnded:     "vote has ended",
+		ErrorStatusDuplicateVote:    "duplicate vote",
+		ErrorStatusIneligibleTicket: "ineligbile ticket",
+	}
 )
 
 // CastVote is a signed vote.
@@ -67,11 +93,14 @@ func DecodeBallot(payload []byte) (*Ballot, error) {
 	return &b, nil
 }
 
-// CastVoteReply contains the signature or error to a cast vote command.
+// CastVoteReply contains the signature or error to a cast vote command. The
+// Error and ErrorStatus fields will only be populated if something went wrong
+// while attempting to cast the vote.
 type CastVoteReply struct {
-	ClientSignature string `json:"clientsignature"` // Signature that was sent in
-	Signature       string `json:"signature"`       // Signature of the ClientSignature
-	Error           string `json:"error"`           // Error if something wen't wrong during casting a vote
+	ClientSignature string       `json:"clientsignature"`       // Signature that was sent in
+	Signature       string       `json:"signature"`             // Signature of the ClientSignature
+	Error           string       `json:"error"`                 // Error status message
+	ErrorStatus     ErrorStatusT `json:"errorstatus,omitempty"` // Error status code
 }
 
 // EncodeCastVoteReply encodes CastVoteReply into a JSON byte slice.

--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,6 @@ require (
 	github.com/jrick/logrotate v1.0.0
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/marcopeereboom/sbox v1.0.0
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 // indirect
 	github.com/pmezard/go-difflib v1.0.0

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -2148,7 +2148,10 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 		if !g.propExists(g.vetted, v.Token) {
 			log.Errorf("pluginBallot: proposal not found: %v",
 				v.Token)
-			br.Receipts[k].Error = "proposal not found: " + v.Token
+			e := decredplugin.ErrorStatusProposalNotFound
+			br.Receipts[k].ErrorStatus = e
+			br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+				decredplugin.ErrorStatus[e], v.Token)
 			continue
 		}
 
@@ -2156,14 +2159,19 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 		err = g.validateVoteBit(v.Token, v.VoteBit)
 		if err != nil {
 			if e, ok := err.(invalidVoteBitError); ok {
-				br.Receipts[k].Error = e.err.Error()
+				es := decredplugin.ErrorStatusInvalidVoteBit
+				br.Receipts[k].ErrorStatus = es
+				br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+					decredplugin.ErrorStatus[es], e.err.Error())
 				continue
 			}
 			t := time.Now().Unix()
 			log.Errorf("pluginBallot: validateVoteBit %v %v %v %v",
 				v.Ticket, v.Token, t, err)
-			br.Receipts[k].Error = fmt.Sprintf("internal error %v",
-				t)
+			e := decredplugin.ErrorStatusInternalError
+			br.Receipts[k].ErrorStatus = e
+			br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+				decredplugin.ErrorStatus[e], t)
 			continue
 		}
 
@@ -2173,12 +2181,17 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 			t := time.Now().Unix()
 			log.Errorf("pluginBallot: voteEndHeight %v %v %v %v",
 				v.Ticket, v.Token, t, err)
-			br.Receipts[k].Error = fmt.Sprintf("internal error %v",
-				t)
+			e := decredplugin.ErrorStatusInternalError
+			br.Receipts[k].ErrorStatus = e
+			br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+				decredplugin.ErrorStatus[e], t)
 			continue
 		}
 		if bb.Height >= endHeight {
-			br.Receipts[k].Error = "vote has ended: " + v.Token
+			e := decredplugin.ErrorStatusVoteHasEnded
+			br.Receipts[k].ErrorStatus = e
+			br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+				decredplugin.ErrorStatus[e], v.Token)
 			continue
 		}
 
@@ -2187,8 +2200,10 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 			t := time.Now().Unix()
 			log.Errorf("pluginBallot: ticketAddresses %v %v %v %v",
 				v.Ticket, v.Token, t, err)
-			br.Receipts[k].Error = fmt.Sprintf("internal error %v",
-				t)
+			e := decredplugin.ErrorStatusInternalError
+			br.Receipts[k].ErrorStatus = e
+			br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+				decredplugin.ErrorStatus[e], t)
 			continue
 
 		}
@@ -2200,8 +2215,10 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 			t := time.Now().Unix()
 			log.Errorf("pluginBallot: validateVote %v %v %v %v",
 				v.Ticket, v.Token, t, err)
-			br.Receipts[k].Error = fmt.Sprintf("internal error %v",
-				t)
+			e := decredplugin.ErrorStatusInternalError
+			br.Receipts[k].ErrorStatus = e
+			br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+				decredplugin.ErrorStatus[e], t)
 			continue
 		}
 
@@ -2223,10 +2240,16 @@ func (g *gitBackEnd) pluginBallot(payload string) (string, error) {
 		if err != nil {
 			switch err {
 			case errDuplicateVote:
-				br.Receipts[k].Error = "duplicate vote: " + v.Token
+				e := decredplugin.ErrorStatusDuplicateVote
+				br.Receipts[k].ErrorStatus = e
+				br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+					decredplugin.ErrorStatus[e], v.Token)
 				continue
 			case errIneligibleTicket:
-				br.Receipts[k].Error = "ineligible ticket: " + v.Token
+				e := decredplugin.ErrorStatusIneligibleTicket
+				br.Receipts[k].ErrorStatus = e
+				br.Receipts[k].Error = fmt.Sprintf("%v: %v",
+					decredplugin.ErrorStatus[e], v.Token)
 				continue
 			default:
 				// Should not fail, so return failure to alert people

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"fmt"
+
+	"github.com/decred/politeia/decredplugin"
 )
 
 type ErrorStatusT int
@@ -917,11 +919,14 @@ type Ballot struct {
 	Votes []CastVote `json:"votes"`
 }
 
-// CastVoteReply is the answer to the CastVote command.
+// CastVoteReply is the answer to the CastVote command. The Error and
+// ErrorStatus fields will only be populated if something went wrong while
+// attempting to cast the vote.
 type CastVoteReply struct {
-	ClientSignature string `json:"clientsignature"` // Signature that was sent in
-	Signature       string `json:"signature"`       // Signature of the ClientSignature
-	Error           string `json:"error"`           // Error if something went wrong during casting a vote
+	ClientSignature string                    `json:"clientsignature"`       // Signature that was sent in
+	Signature       string                    `json:"signature"`             // Signature of the ClientSignature
+	Error           string                    `json:"error"`                 // Error status message
+	ErrorStatus     decredplugin.ErrorStatusT `json:"errorstatus,omitempty"` // Error status code
 }
 
 // CastVotesReply is a reply to a batched list of votes.

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -23,6 +23,7 @@ func convertCastVoteReplyFromDecredPlugin(cvr decredplugin.CastVoteReply) www.Ca
 		ClientSignature: cvr.ClientSignature,
 		Signature:       cvr.Signature,
 		Error:           cvr.Error,
+		ErrorStatus:     cvr.ErrorStatus,
 	}
 }
 


### PR DESCRIPTION
This diff adds an ErrorStatus field onto the decredplugin and
politeiawww CastVoteReply structs. CastVote errors were previously only
being returned as human readable strings in the CastVoteReply. The newly
added ErrorStatus field contains the numeric error code. This gives
clients the option to key off the error code.