### PR TITLE
multi: Add duration to VoteSummary.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -421,6 +421,7 @@ type VoteOptionResult struct {
 // voting period parameters as well as a summary of the vote results.
 type VoteSummaryReply struct {
 	Authorized          bool               `json:"authorized"`          // Vote is authorized
+	Duration            uint32             `json:"duration"`            // Vote duration
 	EndHeight           string             `json:"endheight"`           // End block height
 	EligibleTicketCount int                `json:"eligibleticketcount"` // Number of eligible tickets
 	QuorumPercentage    uint32             `json:"quorumpercentage"`    // Percent of eligible votes required for quorum

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -1150,6 +1150,7 @@ func (d *decred) cmdBatchVoteSummary(payload string) (string, error) {
 		authorized := av.Action == decredplugin.AuthVoteActionAuthorize
 		vsr := decredplugin.VoteSummaryReply{
 			Authorized:          authorized,
+			Duration:            sv.Duration,
 			EndHeight:           endHeight,
 			EligibleTicketCount: sv.EligibleTicketCount,
 			QuorumPercentage:    sv.QuorumPercentage,
@@ -1266,6 +1267,7 @@ sendReply:
 
 	vsr := decredplugin.VoteSummaryReply{
 		Authorized:          av.Action == decredplugin.AuthVoteActionAuthorize,
+		Duration:            sv.Duration,
 		EndHeight:           endHeight,
 		EligibleTicketCount: sv.EligibleTicketCount,
 		QuorumPercentage:    sv.QuorumPercentage,

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -389,6 +389,7 @@ type CensorshipRecord struct {
 type VoteSummary struct {
 	Status           PropVoteStatusT    `json:"status"`                     // Vote status
 	EligibleTickets  uint32             `json:"eligibletickets,omitempty"`  // Number of eligible tickets
+	Duration         uint32             `json:"duration,omitempty"`         // Duration of vote
 	EndHeight        uint64             `json:"endheight,omitempty"`        // Vote end height
 	QuorumPercentage uint32             `json:"quorumpercentage,omitempty"` // Percent of eligible votes required for quorum
 	PassPercentage   uint32             `json:"passpercentage,omitempty"`   // Percent of total votes required to pass

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -958,6 +958,7 @@ func (p *politeiawww) getVoteSummaries(tokens []string, bestBlock uint64) (map[s
 		vs := www.VoteSummary{
 			Status:           voteStatusFromVoteSummary(summary, bestBlock),
 			EligibleTickets:  uint32(summary.EligibleTicketCount),
+			Duration:         summary.Duration,
 			EndHeight:        endHeight,
 			QuorumPercentage: summary.QuorumPercentage,
 			PassPercentage:   summary.PassPercentage,


### PR DESCRIPTION
Closes #1012.

This diff adds the duration to the VoteSummary struct. This was
previously overlooked because the gui doesn't use the duration, but it
makes sense to include it and Decrediton needs it.