### PR TITLE
www: Doco for BatchProposals and BatchVoteSummary.

### DIFF
--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -384,8 +384,9 @@ type CensorshipRecord struct {
 	Signature string `json:"signature"` // Server side signature of []byte(Merkle+Token)
 }
 
-// VoteSummary contains information about the state of the voting process
-// related to a proposal.
+// VoteSummary contains a summary of the vote information for a specific
+// proposal. It is a light weight version of the VoteResultsReply that is used
+// when the full ticket snapshot or the full cast vote data is not needed.
 type VoteSummary struct {
 	Status           PropVoteStatusT    `json:"status"`                     // Vote status
 	EligibleTickets  uint32             `json:"eligibletickets,omitempty"`  // Number of eligible tickets
@@ -756,10 +757,11 @@ type ProposalDetailsReply struct {
 	Proposal ProposalRecord `json:"proposal"`
 }
 
-// BatchProposals is used to request the details of multiple proposals. The
-// returned proposals do not include the proposal files.
+// BatchProposals is used to request the proposal details for each of the
+// provided censorship tokens. The returned proposals do not include the
+// proposal files.
 type BatchProposals struct {
-	Tokens []string `json:"tokens"`
+	Tokens []string `json:"tokens"` // Censorship tokens
 }
 
 // BatchProposalsReply is used to reply to a BatchProposals command.
@@ -767,16 +769,16 @@ type BatchProposalsReply struct {
 	Proposals []ProposalRecord `json:"proposals"`
 }
 
-// BatchVoteSummary is used to request the voting summary of multiple
-// proposals.
+// BatchVoteSummary is used to request the VoteSummary for the each of the
+// provided censorship tokens.
 type BatchVoteSummary struct {
-	Tokens []string `json:"tokens"`
+	Tokens []string `json:"tokens"` // Censorship tokens
 }
 
 // BatchVoteSummaryReply is used to reply to a BatchVoteSummary command.
 type BatchVoteSummaryReply struct {
-	BestBlock uint64                 `json:"bestblock"`
-	Summaries map[string]VoteSummary `json:"summaries"`
+	BestBlock uint64                 `json:"bestblock"` // Current block height
+	Summaries map[string]VoteSummary `json:"summaries"` // [token]VoteSummary
 }
 
 // SetProposalStatus is used to publish or censor an unreviewed proposal.

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -240,14 +240,13 @@ func (p *politeiawww) handleAllVetted(w http.ResponseWriter, r *http.Request) {
 	util.RespondWithJSON(w, http.StatusOK, vr)
 }
 
-// handleProposalDetails handles the incoming proposal details command. It fetches
-// the complete details for an existing proposal.
+// handleProposalDetails handles the incoming proposal details command. It
+// fetches the complete details for an existing proposal.
 func (p *politeiawww) handleProposalDetails(w http.ResponseWriter, r *http.Request) {
-	// Add the path param to the struct.
 	log.Tracef("handleProposalDetails")
-	var pd www.ProposalsDetails
 
-	// get version from query string parameters
+	// Get version from query string parameters
+	var pd www.ProposalsDetails
 	err := util.ParseGetParams(r, &pd)
 	if err != nil {
 		RespondWithError(w, r, 0, "handleProposalDetails: ParseGetParams",
@@ -281,11 +280,11 @@ func (p *politeiawww) handleProposalDetails(w http.ResponseWriter, r *http.Reque
 }
 
 // handleBatchVoteSummary handles the incoming batch vote summary command. It
-// returns a summary of the voting process for a set of proposals.
+// returns a VoteSummary for each of the provided censorship tokens.
 func (p *politeiawww) handleBatchVoteSummary(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleBatchVoteSummary")
-	var bvs www.BatchVoteSummary
 
+	var bvs www.BatchVoteSummary
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&bvs); err != nil {
 		RespondWithError(w, r, 0, "handleBatchVoteSummary: unmarshal",
@@ -305,12 +304,12 @@ func (p *politeiawww) handleBatchVoteSummary(w http.ResponseWriter, r *http.Requ
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
 
-// handleBatchProposals handles the incoming proposal batch command. It fetches
-// the complete details for a list of proposals.
+// handleBatchProposals handles the incoming batch proposals command. It
+// returns a ProposalRecord for each of the provided censorship tokens.
 func (p *politeiawww) handleBatchProposals(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleBatchProposals")
-	var bp www.BatchProposals
 
+	var bp www.BatchProposals
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&bp); err != nil {
 		RespondWithError(w, r, 0, "handleBatchProposals: unmarshal",

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -979,8 +979,8 @@ func (p *politeiawww) getVoteSummaries(tokens []string, bestBlock uint64) (map[s
 	return voteSummaries, nil
 }
 
-// processBatchVoteSummary the voting summary information for a set of
-// proposals.
+// processBatchVoteSummary returns the vote summaries for the provided list
+// of proposals.
 func (p *politeiawww) processBatchVoteSummary(batchVoteSummary www.BatchVoteSummary) (*www.BatchVoteSummaryReply, error) {
 	log.Tracef("processBatchVoteSummary")
 
@@ -1034,7 +1034,6 @@ func (p *politeiawww) processBatchVoteSummary(batchVoteSummary www.BatchVoteSumm
 // cache and returns them. The returned proposals do not include the
 // proposal files.
 func (p *politeiawww) processBatchProposals(batchProposals www.BatchProposals, user *user.User) (*www.BatchProposalsReply, error) {
-
 	log.Tracef("processBatchProposals")
 
 	if len(batchProposals.Tokens) > www.ProposalListPageSize {


### PR DESCRIPTION
This diff cleans up the doco for the BatchProposals and BatchVoteSummary
routes.  It also removes the api.md documentation for the ProposalStats
route, which no longer exists.