### PR TITLE
[pivoter] Make politeiavoter less prone to network errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,6 @@ require (
 	github.com/jrick/logrotate v1.0.0
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/marcopeereboom/sbox v1.0.0
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 // indirect
 	github.com/pmezard/go-difflib v1.0.0
@@ -75,3 +73,5 @@ require (
 	google.golang.org/grpc v1.22.0
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
+
+replace github.com/asdine/storm => github.com/asdine/storm v2.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/asdine/storm v2.1.2+incompatible h1:dczuIkyqwY2LrtXPz8ixMrU/OFgZp71kbKTHGrXYt/Q=
 github.com/asdine/storm v2.1.2+incompatible/go.mod h1:RarYDc9hq1UPLImuiXK3BIWPJLdIygvV3PsInK0FbVQ=
 github.com/asdine/storm v2.2.0+incompatible h1:+FsfKd7PRAEZvK9BkgB6O+hKZMxKrA0EMxnEOLiT/kU=
 github.com/asdine/storm v2.2.0+incompatible/go.mod h1:cMLKpjHSP4q0P133fV15ojQgwWWB2IMv+hrFsmBF/wI=

--- a/politeiawww/cmd/politeiavoter/README.md
+++ b/politeiawww/cmd/politeiavoter/README.md
@@ -110,14 +110,25 @@ tickets.  While this information is NOT visible externally the more privacy
 conscience user may want to spread voting out over time and using tor to mask
 IP address.
 
-```politeiavoter``` has two settings to enable that behavior. First there is
-the ```--proxy``` setting to make ```politeiavoter``` use a Tor proxy. The
-second setting is ```--voteduration``` that sets the maximum duration to
+```politeiavoter``` has three settings to control this behavior. First there is
+the ```--proxy``` setting to make ```politeiavoter``` use a Tor proxy. This
+setting is *REQUIRED* since it makes no sense to trickle votes from the same
+IP.  The second setting is ```--trickle```. Tha setting must be set to enable
+trickling.
+
+The third setting is ```--voteduration``` that sets the maximum duration to
 trickle out votes. Valid modifiers are h for hours, m for minutes and s for
-seconds (e.g. 3h18m15s). This value should be picked in the 2 to 5 minute per
-vote range.
+seconds (e.g. 3h18m15s). If this setting is NOT set than ```politeiavoter```
+will try to smear it out over the remaining vote duration minus one day. If it
+can't autodetect a proper duration it will error out so that the user can
+provide one.
 
 E.g. running Tor software on the local machine with 10 votes:
 ```
-politeiavoter --proxy=127.0.0.1:9050 --voteduration=30m vote 8bdebbc55ae74066cc57c76bc574fd1517111e56b3d1295bde5ba3b0bd7c3f67 yes
+politeiavoter --proxy=127.0.0.1:9050 --trickle --voteduration=30m vote 8bdebbc55ae74066cc57c76bc574fd1517111e56b3d1295bde5ba3b0bd7c3f67 yes
+```
+
+Running Tor software on the local machine with 10 votes and autodetect duration:
+```
+politeiavoter --proxy=127.0.0.1:9050 --trickle vote 8bdebbc55ae74066cc57c76bc574fd1517111e56b3d1295bde5ba3b0bd7c3f67 yes
 ```

--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -439,6 +439,11 @@ func loadConfig() (*config, []string, error) {
 		cfg.dial = proxy.Dial
 	}
 
+	// VoteDuration can only be set with trickle enable.
+	if cfg.VoteDuration != "" && !cfg.Trickle {
+		return nil, nil, fmt.Errorf("must use --trickle when " +
+			"--voteduration is set")
+	}
 	// Duration of the vote.
 	if cfg.VoteDuration != "" {
 		// Verify we can parse the duration

--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -457,7 +457,7 @@ func loadConfig() (*config, []string, error) {
 	if !cfg.BypassProxyCheck {
 		if cfg.Trickle && cfg.Proxy == "" {
 			return nil, nil, fmt.Errorf("cannot use --voteduration " +
-				"without --proxy")
+				"without --trickle")
 		}
 	}
 

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -910,11 +910,9 @@ func (c *ctx) _voteTrickler(token string) error {
 	c.retryWG.Add(1)
 	go c.retryLoop()
 
-	var queueDone bool
 	for i := 0; ; {
 		vote := c.voteIntervalPop()
 		if vote == nil {
-			queueDone = true
 			break
 		}
 		log.Tracef("mainLoop pop %v", spew.Sdump(vote))
@@ -990,9 +988,10 @@ func (c *ctx) _voteTrickler(token string) error {
 
 	// Tell retry loop that main loop is done. We can skip
 	// this if the exit is being forced before the vote queue
-	// is done since the force exit event takes care of it.
+	// has been emptied since the force exit event will take
+	// care of it.
 	log.Debugf("_voteTrickler: main loop done")
-	if queueDone {
+	if c.voteIntervalLen() == 0 {
 		fmt.Printf("Awaiting retry vote queue to complete.\n")
 		c.mainLoopDone <- struct{}{}
 	}

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -906,11 +906,6 @@ func (c *ctx) _voteTrickler(token string) error {
 	go c.retryLoop()
 
 	for i := 0; ; {
-		if i == 2 {
-			// XXX
-			break
-		}
-
 		vote := c.voteIntervalPop()
 		if vote == nil {
 			break
@@ -922,15 +917,7 @@ func (c *ctx) _voteTrickler(token string) error {
 
 		// Send off vote
 		b := v1.Ballot{Votes: []v1.CastVote{vote.Vote}}
-		var (
-			br  *v1.CastVoteReply
-			err error
-		)
-		if i == 0 {
-			br, err = c.sendVoteFail(&b)
-		} else {
-			br, err = c.sendVote(&b)
-		}
+		br, err := c.sendVote(&b)
 		if e, ok := err.(ErrRetry); ok {
 			// Append failed vote to retry queue
 			fmt.Printf("Vote rescheduled: %v\n", vote.Vote.Ticket)
@@ -962,7 +949,6 @@ func (c *ctx) _voteTrickler(token string) error {
 		fmt.Printf("Next vote at %v (delay %v)\n",
 			time.Now().Add(vote.At).Format(time.Stamp), vote.At)
 
-		vote.At = time.Second // XXX
 		time.Sleep(vote.At)
 
 		// Go to next vote

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -1156,7 +1156,7 @@ func (c *ctx) _vote(seed int64, token, voteId string) error {
 	cv := v1.Ballot{
 		Votes: make([]v1.CastVote, 0, len(ctres.TicketAddresses)),
 	}
-	c.ballotResults = make([]BallotResult, len(ctres.TicketAddresses))
+	c.ballotResults = make([]BallotResult, 0, len(ctres.TicketAddresses))
 	for k, v := range ctres.TicketAddresses {
 		h, err := chainhash.NewHash(v.Ticket)
 		if err != nil {
@@ -1196,7 +1196,7 @@ func (c *ctx) _vote(seed int64, token, voteId string) error {
 			len(vr.Receipts), len(c.ballotResults))
 	}
 	for k := range vr.Receipts {
-		c.ballotResults[k].Receipt = c.ballotResults[k].Receipt
+		c.ballotResults[k].Receipt = vr.Receipts[k]
 	}
 
 	return nil

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -928,7 +928,10 @@ func (c *ctx) _voteTrickler(token string) error {
 		select {
 		case <-time.After(vote.At):
 		case <-c.retryLoopForceExit:
-			// The retry loop is forcing an exit
+			// The retry loop is forcing an exit. Put vote back
+			// into the queue before exiting so the vote summary
+			// statistics are correct.
+			c.voteIntervalPush(vote)
 			fmt.Printf("Forced exit main vote queue.\n")
 			goto exit
 		}

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -929,6 +929,7 @@ func (c *ctx) _voteTrickler(token string) error {
 		case <-time.After(vote.At):
 		case <-c.retryLoopForceExit:
 			// The retry loop is forcing an exit
+			fmt.Printf("Forced exit main vote queue.\n")
 			goto exit
 		}
 

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -6,13 +6,13 @@ package main
 
 import (
 	"bytes"
+	"container/list"
 	"context"
 	crand "crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"math/big"
@@ -21,10 +21,13 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrec/secp256k1"
@@ -139,18 +142,39 @@ func verifyMessage(address, message, signature string) (bool, error) {
 	return a.EncodeAddress() == address, nil
 }
 
+// ctx is the client context.
 type ctx struct {
+	sync.RWMutex            // retryQ lock
+	retryQ       *list.List // retry message queue FIFO
+	retryWG      sync.WaitGroup
+	mainLoopDone chan struct{} // message when done
+
+	c   chan struct{} // close channel
+	run time.Time     // when this run started
+
+	cfg *config // application config
+
+	// https
 	client    *http.Client
-	cfg       *config
 	id        *identity.PublicIdentity
 	csrf      string
 	userAgent string
 
 	// wallet grpc
-	ctx    context.Context
+	wctx   context.Context
 	creds  credentials.TransportCredentials
 	conn   *grpc.ClientConn
 	wallet pb.WalletServiceClient
+}
+
+// voteInterval is an internal structure that is used to precalculate all
+// timing intervals and vote details. This is a JSON structure for logging
+// purposes.
+type voteInterval struct {
+	Vote  v1.CastVote   `json:"vote"`  // RPC vote
+	Votes int           `json:"votes"` // Always 1 for now
+	Total time.Duration `json:"total"` // Cumulative time
+	At    time.Duration `json:"at"`    // Delay to fire off vote
 }
 
 func newClient(cfg *config) (*ctx, error) {
@@ -186,17 +210,42 @@ func newClient(cfg *config) (*ctx, error) {
 
 	// return context
 	return &ctx{
-		ctx:    context.Background(),
-		creds:  creds,
-		conn:   conn,
-		wallet: wallet,
-		cfg:    cfg,
+		run:          time.Now(),
+		retryQ:       new(list.List),
+		mainLoopDone: make(chan struct{}),
+		c:            make(chan struct{}),
+		wctx:         context.Background(),
+		creds:        creds,
+		conn:         conn,
+		wallet:       wallet,
+		cfg:          cfg,
 		client: &http.Client{
 			Transport: tr,
 			Jar:       jar,
 		},
 		userAgent: fmt.Sprintf("politeiavoter/%s", cfg.Version),
 	}, nil
+}
+
+func (c *ctx) jsonLog(filename, token string, work interface{}) error {
+	dir := filepath.Join(c.cfg.voteDir, token)
+	os.MkdirAll(dir, 0700)
+
+	f := filepath.Join(dir, fmt.Sprintf("%v.%v", filename, c.run.Unix()))
+	fh, err := os.OpenFile(f, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	e := json.NewEncoder(fh)
+	e.SetIndent("", "  ")
+	err = e.Encode(work)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *ctx) getCSRF() (*v1.VersionReply, error) {
@@ -315,11 +364,11 @@ func (c *ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Add(v1.CsrfToken, c.csrf)
 	r, err := c.client.Do(req)
-	if _, ok := err.(*url.Error); ok {
-		return nil, errRetry
-	}
 	if err != nil {
-		return nil, err
+		return nil, ErrRetry{
+			At:  "c.client.Do(req)",
+			Err: err,
+		}
 	}
 	defer func() {
 		r.Body.Close()
@@ -327,9 +376,7 @@ func (c *ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 
 	responseBody := util.ConvertBodyToByteArray(r.Body, false)
 	log.Tracef("Response: %v %v", r.StatusCode, string(responseBody))
-	if r.StatusCode == http.StatusGatewayTimeout {
-		return nil, errRetry
-	}
+
 	if r.StatusCode != http.StatusOK {
 		var ue v1.UserError
 		err = json.Unmarshal(responseBody, &ue)
@@ -339,7 +386,84 @@ func (c *ctx) makeRequest(method, route string, b interface{}) ([]byte, error) {
 				strings.Join(ue.ErrorContext, ", "))
 		}
 
-		return nil, fmt.Errorf("%v", r.StatusCode)
+		return nil, ErrRetry{
+			At:   "r.StatusCode != http.StatusOK",
+			Err:  err,
+			Body: responseBody,
+			Code: r.StatusCode,
+		}
+	}
+
+	return responseBody, nil
+}
+
+func (c *ctx) makeRequestFail(method, route string, b interface{}) ([]byte, error) {
+	var requestBody []byte
+	var queryParams string
+	if b != nil {
+		if method == http.MethodGet {
+			// GET requests don't have a request body; instead we will populate
+			// the query params.
+			form := url.Values{}
+			err := schema.NewEncoder().Encode(b, form)
+			if err != nil {
+				return nil, err
+			}
+
+			queryParams = "?" + form.Encode()
+		} else {
+			var err error
+			requestBody, err = json.Marshal(b)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	fullRoute := c.cfg.PoliteiaWWW + v1.PoliteiaWWWAPIRoute + route +
+		queryParams
+	log.Debugf("Request: %v %v", method, fullRoute)
+	if len(requestBody) != 0 {
+		log.Tracef("%v  ", string(requestBody))
+	}
+
+	req, err := http.NewRequest(method, fullRoute, bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Add(v1.CsrfToken, c.csrf)
+	r, err := c.client.Do(req)
+	if err != nil {
+		return nil, ErrRetry{
+			At:  "c.client.Do(req)",
+			Err: err,
+		}
+	}
+	defer func() {
+		r.Body.Close()
+	}()
+
+	responseBody := util.ConvertBodyToByteArray(r.Body, false)
+	log.Tracef("Response: %v %v", r.StatusCode, string(responseBody))
+
+	r.StatusCode = http.StatusInternalServerError
+	if r.StatusCode != http.StatusOK {
+		var ue v1.UserError
+		err = json.Unmarshal(responseBody, &ue)
+		if err == nil && ue.ErrorCode != 0 {
+			return nil, fmt.Errorf("%v, %v %v", r.StatusCode,
+				v1.ErrorStatus[ue.ErrorCode],
+				strings.Join(ue.ErrorContext, ", "))
+		}
+
+		return nil, ErrRetry{
+			At:   "r.StatusCode != http.StatusOK",
+			Err:  err,
+			Body: responseBody,
+			Code: r.StatusCode,
+		}
 	}
 
 	return responseBody, nil
@@ -437,7 +561,7 @@ func (c *ctx) inventory() error {
 	}
 
 	// Get latest block
-	ar, err := c.wallet.Accounts(c.ctx, &pb.AccountsRequest{})
+	ar, err := c.wallet.Accounts(c.wctx, &pb.AccountsRequest{})
 	if err != nil {
 		return err
 	}
@@ -480,7 +604,7 @@ func (c *ctx) inventory() error {
 				v.StartVote.Vote.Token, err)
 			continue
 		}
-		ctres, err := c.wallet.CommittedTickets(c.ctx,
+		ctres, err := c.wallet.CommittedTickets(c.wctx,
 			&pb.CommittedTicketsRequest{
 				Tickets: tix,
 			})
@@ -539,15 +663,25 @@ func (c *ctx) inventory() error {
 	return nil
 }
 
-var (
-	errRetry  = errors.New("retry")
-	errIgnore = errors.New("ignore")
-)
+type ErrRetry struct {
+	At   string `json:"at"`   // where in the code
+	Body []byte `json:"body"` // http body if we have one
+	Code int    `json:"code"` // http code
+	Err  error  `json:"err"`  // underlying error
+}
 
-// sendVote expects a single vote inside the Ballot structure. It sends the
-// vote off and returns the CastVoteReply for the single vote that came in.
-// Function can return errRetry or errIgnore such that the caller knows if the
-// command should be retried or ignored.
+func (e ErrRetry) Error() string {
+	return fmt.Sprintf("retry error: %v (%v) %v", e.Code, e.At, e.Err)
+}
+
+// sendVoteFail isa test function that will fail a Ballot call with a retryable
+// error.
+func (c *ctx) sendVoteFail(ballot *v1.Ballot) (*v1.CastVoteReply, error) {
+	return nil, ErrRetry{
+		At: "sendVoteFail",
+	}
+}
+
 func (c *ctx) sendVote(ballot *v1.Ballot) (*v1.CastVoteReply, error) {
 	if len(ballot.Votes) != 1 {
 		return nil, fmt.Errorf("sendVote: only one vote allowed")
@@ -576,14 +710,6 @@ func (c *ctx) sendVote(ballot *v1.Ballot) (*v1.CastVoteReply, error) {
 // large number of votes in one go to the server at the same time giving away
 // which IP address owns what votes.
 func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsResponse, smr *pb.SignMessagesResponse) ([]string, *v1.BallotReply, error) {
-	// voteInterval is an internal structure that is used to precalculate
-	// all timing intervals and vote details.
-	type voteInterval struct {
-		vote  v1.CastVote   // RPC vote
-		votes int           // Always 1 for now
-		total time.Duration // Cumulative time
-		at    time.Duration // Delay to fire off vote
-	}
 	votes := uint64(len(ctres.TicketAddresses))
 	duration := c.cfg.voteDuration
 	maxDelay := uint64(duration.Seconds() / float64(votes) * 2)
@@ -635,15 +761,15 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 			t := time.Duration(seconds) * time.Second
 			total += t
 			buckets[i] = voteInterval{
-				vote: v1.CastVote{
+				Vote: v1.CastVote{
 					Token:     token,
 					Ticket:    h.String(),
 					VoteBit:   voteBit,
 					Signature: signature,
 				},
-				votes: 1,
-				total: total,
-				at:    t,
+				Votes: 1,
+				Total: total,
+				At:    t,
 			}
 
 			// Make sure we are not going over our allotted time.
@@ -665,65 +791,102 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 			len(buckets))
 	}
 
-	// Synthesize reply
-	vr := v1.BallotReply{
-		Receipts: make([]v1.CastVoteReply, len(ctres.TicketAddresses)),
+	err := c.jsonLog("work.json", token, buckets)
+	if err != nil {
+		return nil, nil, err
 	}
-	tickets := make([]string, len(ctres.TicketAddresses))
+
+	// Synthesize reply, needs locking
+	vr := v1.BallotReply{
+		Receipts: make([]v1.CastVoteReply, 0, len(ctres.TicketAddresses)),
+	}
+	tickets := make([]string, 0, len(ctres.TicketAddresses))
+
+	// Launch retry loop
+	c.retryWG.Add(1)
+	go c.retryLoop(&vr, &tickets) // XXX these parameters suck and have to change
+
 	for i := 0; ; {
+		if i == 2 {
+			// XXX
+			goto done
+		}
+
 		verb := "Next vote"
 		var delay time.Duration
 
 		fmt.Printf("Voting: %v/%v %v\n", i+1, len(buckets),
-			buckets[i].vote.Ticket)
+			buckets[i].Vote.Ticket)
 
 		// Send off vote
-		b := v1.Ballot{Votes: []v1.CastVote{buckets[i].vote}}
-		br, err := c.sendVote(&b)
-		switch {
-		case err == errRetry:
-			// Retry vote
-			delay = time.Second * 44 // PNOOMA
-			verb = "Retry vote"
-		case err == nil || err == errIgnore:
+		b := v1.Ballot{Votes: []v1.CastVote{buckets[i].Vote}}
+		var br *v1.CastVoteReply
+		if i == 0 {
+			br, err = c.sendVoteFail(&b)
+		} else {
+			br, err = c.sendVote(&b)
+		}
+		if e, ok := err.(ErrRetry); ok {
+			// Append failed vote to retry queue
+			fmt.Printf("Vote rescheduled: %v/%v %v\n",
+				i+1, len(buckets), buckets[i].Vote.Ticket)
+			err := c.jsonLog("failed.json", token, b)
 			if err != nil {
-				// Complain
-				fmt.Printf("Ignoring failed vote: %v\n",
-					buckets[i].vote.Ticket)
+				return nil, nil, err
 			}
-			// Fill in synthesized Receipts
-			if br != nil {
-				vr.Receipts[i] = *br
-			} else {
-				// We may have to make the error a bit more
-				// readable here
-				vr.Receipts[i] = v1.CastVoteReply{
-					Error: "Ignored",
-				}
+			err = c.jsonLog("failed.json", token, e)
+			if err != nil {
+				return nil, nil, err
 			}
-			// Append ticket to return value
-			tickets[i] = buckets[i].vote.Ticket
-
-			// Next delay
-			if len(buckets) == i+1 {
-				// And we are done
-				return tickets, &vr, nil
-			}
-			delay = buckets[i+1].at
-
-			// Go to next vote
-			i++
-		default:
-			// Fatal error
+			c.retryPush(&retry{vote: buckets[i].Vote})
+			goto next
+		} else if err != nil {
+			// Unrecoverable error
 			return nil, nil, fmt.Errorf("unrecoverable error: %v",
 				err)
 		}
 
+		err = c.jsonLog("success.json", token, *br)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		c.Lock()
+		// Record receipt
+		vr.Receipts = append(vr.Receipts, *br)
+		// Append ticket to return value
+		tickets = append(tickets, buckets[i].Vote.Ticket)
+		log.Debug("---- tickets %v", spew.Sdump(tickets))
+		c.Unlock()
+
+	next:
+		// Next delay
+		if len(buckets) == i+1 {
+			// And we are done
+			goto done
+		}
+		delay = buckets[i+1].At
+
+		// Go to next vote
+		i++
+
 		fmt.Printf("%s at %v (delay %v)\n", verb,
 			time.Now().Add(delay).Format(time.Stamp), delay)
 
+		delay = time.Second // XXX
 		time.Sleep(delay)
 	}
+done:
+	// Tell retry loop that main loop is done
+	log.Debugf("_voteTrickler: main loop done")
+	c.mainLoopDone <- struct{}{}
+
+	// Wait for retry loop to exit
+	c.retryWG.Wait()
+	log.Debugf("tickets %v", spew.Sdump(tickets))
+	log.Debugf("vr %v", spew.Sdump(vr))
+
+	return tickets, &vr, nil
 }
 
 // verifyV1Vote verifies the signature of the passed in v1 vote. If the
@@ -756,6 +919,22 @@ func verifyV1Vote(address string, vote *v1.CastVote) bool {
 }
 
 func (c *ctx) _vote(seed int64, token, voteId string) ([]string, *v1.BallotReply, error) {
+	// Pull the vote summary first to make sure the vote is still active.
+	bvsr, err := c._summary(token)
+	if err != nil {
+		return nil, nil, err
+	}
+	spew.Dump(bvsr)
+	summary, ok := bvsr.Summaries[token]
+	if !ok {
+		return nil, nil, fmt.Errorf("Proposal does not exist: %v",
+			token)
+	}
+	if bvsr.BestBlock > summary.EndHeight {
+		return nil, nil, fmt.Errorf("Proposal vote has already "+
+			"completed: %v", token)
+	}
+
 	// _tally provides the eligible tickets snapshot as well as a list of
 	// the votes that have already been cast. We use these to filter out
 	// the tickets that have already voted.
@@ -787,7 +966,7 @@ func (c *ctx) _vote(seed int64, token, voteId string) ([]string, *v1.BallotReply
 		return nil, nil, fmt.Errorf("ticket pool corrupt: %v %v",
 			token, err)
 	}
-	ctres, err := c.wallet.CommittedTickets(c.ctx,
+	ctres, err := c.wallet.CommittedTickets(c.wctx,
 		&pb.CommittedTicketsRequest{
 			Tickets: tix,
 		})
@@ -842,7 +1021,7 @@ func (c *ctx) _vote(seed int64, token, voteId string) ([]string, *v1.BallotReply
 			Message: msg,
 		})
 	}
-	smr, err := c.wallet.SignMessages(c.ctx, sm)
+	smr, err := c.wallet.SignMessages(c.wctx, sm)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -936,6 +1115,23 @@ func (c *ctx) vote(seed int64, args []string) error {
 	}
 
 	return nil
+}
+
+func (c *ctx) _summary(token string) (*v1.BatchVoteSummaryReply, error) {
+	responseBody, err := c.makeRequest("POST", v1.RouteBatchVoteSummary,
+		v1.BatchVoteSummary{Tokens: []string{token}})
+	if err != nil {
+		return nil, err
+	}
+
+	var bvsr v1.BatchVoteSummaryReply
+	err = json.Unmarshal(responseBody, &bvsr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal "+
+			"BatchVoteSummary: %v", err)
+	}
+
+	return &bvsr, nil
 }
 
 func (c *ctx) _tally(token string) (*v1.VoteResultsReply, error) {
@@ -1117,7 +1313,7 @@ func _main() error {
 	defer c.conn.Close()
 
 	// Get block height to validate GRPC creds
-	ar, err := c.wallet.Accounts(c.ctx, &pb.AccountsRequest{})
+	ar, err := c.wallet.Accounts(c.wctx, &pb.AccountsRequest{})
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -860,7 +860,7 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 	for i := 0; ; {
 		if i == 2 {
 			// XXX
-			goto done
+			break
 		}
 
 		verb := "Next vote"
@@ -913,7 +913,7 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 		// Next delay
 		if len(buckets) == i+1 {
 			// And we are done
-			goto done
+			break
 		}
 		delay = buckets[i+1].At
 
@@ -926,7 +926,7 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 		delay = time.Second // XXX
 		time.Sleep(delay)
 	}
-done:
+
 	// Tell retry loop that main loop is done
 	log.Debugf("_voteTrickler: main loop done")
 	c.mainLoopDone <- struct{}{}

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -917,10 +917,6 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 			break
 		}
 
-		var (
-			delay time.Duration
-			err   error
-		)
 		vote := c.voteIntervalPop()
 		if vote == nil {
 			break
@@ -967,10 +963,10 @@ func (c *ctx) _voteTrickler(token, voteBit string, ctres *pb.CommittedTicketsRes
 		}
 
 		fmt.Printf("Next vote at %v (delay %v)\n",
-			time.Now().Add(delay).Format(time.Stamp), delay)
+			time.Now().Add(vote.At).Format(time.Stamp), vote.At)
 
-		delay = time.Second // XXX
-		time.Sleep(delay)
+		vote.At = time.Second // XXX
+		time.Sleep(vote.At)
 
 		// Go to next vote
 		i++

--- a/politeiawww/cmd/politeiavoter/politeiavoter_test.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter_test.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import "testing"
+
+func TestRetryQueue(t *testing.T) {
+}

--- a/politeiawww/cmd/politeiavoter/retry.go
+++ b/politeiawww/cmd/politeiavoter/retry.go
@@ -72,7 +72,7 @@ func (c *ctx) retryLoop() {
 		wait[0] = 30 // XXX
 
 		select {
-		case <-c.forceExit:
+		case <-c.mainLoopForceExit:
 			// Main loop is forcing an exit
 			fmt.Printf("Forced exit retry vote queue.\n")
 			return
@@ -152,7 +152,7 @@ func (c *ctx) retryLoop() {
 			fmt.Printf("Vote has ended; forced exit retry vote queue.\n")
 			if !mainLoopDone {
 				fmt.Printf("Awaiting main vote queue to exit.\n")
-				c.forceExit <- struct{}{}
+				c.retryLoopForceExit <- struct{}{}
 			}
 			return
 		}

--- a/politeiawww/cmd/politeiavoter/retry.go
+++ b/politeiawww/cmd/politeiavoter/retry.go
@@ -69,7 +69,6 @@ func (c *ctx) retryLoop() {
 		} else {
 			wait[0] = wait[0] % 120
 		}
-		wait[0] = 30 // XXX
 
 		select {
 		case <-c.mainLoopForceExit:
@@ -104,16 +103,8 @@ func (c *ctx) retryLoop() {
 		// Vote
 		ticket := e.vote.Ticket
 		b := v1.Ballot{Votes: []v1.CastVote{e.vote}}
-		var (
-			br *v1.CastVoteReply
-		)
-		if e.retries > 1 {
-			log.Debugf("retryLoop: sendVote %v", ticket)
-			br, err = c.sendVote(&b)
-		} else {
-			log.Debugf("retryLoop: sendVoteFail %v", ticket)
-			br, err = c.sendVoteFail(&b)
-		}
+		log.Debugf("retryLoop: sendVote %v", ticket)
+		br, err := c.sendVote(&b)
 		if serr, ok := err.(ErrRetry); ok {
 			// Push to back retry later
 			fmt.Printf("Retry vote rescheduled: %v\n",

--- a/politeiawww/cmd/politeiavoter/retry.go
+++ b/politeiawww/cmd/politeiavoter/retry.go
@@ -115,14 +115,9 @@ func (c *ctx) retryLoop() {
 				e.vote.Ticket)
 			log.Debugf("retryLoop: retry failed vote %v %v",
 				ticket, serr)
-			err := c.jsonLog("failed.json", e.vote.Token, b)
+			err := c.jsonLog("failed.json", e.vote.Token, b, serr)
 			if err != nil {
 				log.Errorf("retryLoop: c.jsonLog 1: %v", err)
-				continue
-			}
-			err = c.jsonLog("failed.json", e.vote.Token, serr)
-			if err != nil {
-				log.Errorf("retryLoop: c.jsonLog 2: %v", err)
 				continue
 			}
 			c.retryPush(e)
@@ -140,7 +135,7 @@ func (c *ctx) retryLoop() {
 		}
 		err = c.jsonLog("success.json", e.vote.Token, result)
 		if err != nil {
-			log.Errorf("retryLoop: c.jsonLog 3: %v", err)
+			log.Errorf("retryLoop: c.jsonLog 2: %v", err)
 			continue
 		}
 

--- a/politeiawww/cmd/politeiavoter/retry.go
+++ b/politeiawww/cmd/politeiavoter/retry.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/util"
+)
+
+type retry struct {
+	retries uint
+	vote    v1.CastVote
+}
+
+func (c *ctx) retryPush(r *retry) {
+	c.Lock()
+	defer c.Unlock()
+	r.retries++
+	c.retryQ.PushBack(r)
+}
+
+func (c *ctx) retryPop() *retry {
+	c.Lock()
+	defer c.Unlock()
+
+	e := c.retryQ.Front()
+	if e == nil {
+		return nil
+	}
+	return c.retryQ.Remove(e).(*retry)
+}
+
+// XXX convert to a print with a signal
+func (c *ctx) dumpQueue() string {
+	c.RLock()
+	defer c.RUnlock()
+
+	var reply string
+	for e := c.retryQ.Front(); e != nil; e = e.Next() {
+		reply += e.Value.(*retry).vote.Ticket + ", "
+	}
+	return reply
+}
+
+func (c *ctx) retryLoop(vr *v1.BallotReply, tickets *[]string) {
+	log.Debug("retryLoop: start of day")
+	defer log.Debugf("retryLoop: end of times")
+	defer c.retryWG.Done()
+
+	mainLoopDone := false
+	for {
+		// Random timeout between 0 and 119 seconds
+		wait, err := util.Random(1)
+		if err != nil {
+			// This really shouldn't happen so just use 33 seconds
+			wait = []byte{33}
+		} else {
+			wait[0] = wait[0] % 120
+		}
+		wait[0] = 10 // XXX
+
+		select {
+		case <-c.c:
+			break
+		case <-c.mainLoopDone:
+			mainLoopDone = true
+		case <-time.After(time.Duration(wait[0]) * time.Second):
+			log.Debugf("retryLoop: tick after %v mainLoopDone %v",
+				time.Duration(wait[0])*time.Second,
+				mainLoopDone)
+		}
+
+		e := c.retryPop()
+		if e == nil {
+			if mainLoopDone {
+				// Main loop has exited
+				log.Debugf("retryLoop: done")
+				log.Debugf("retryLoop: done tickets %v", spew.Sdump(tickets))
+				log.Debugf("retryLoop: done vr %v", spew.Sdump(vr))
+				break
+			}
+			// Nothing to do and main loop has not exited
+			log.Debugf("retryLoop: nothing to do")
+			continue
+		}
+
+		// Vote
+		token := e.vote.Token
+		ticket := e.vote.Ticket
+		b := v1.Ballot{Votes: []v1.CastVote{e.vote}}
+		var (
+			br *v1.CastVoteReply
+		)
+		if e.retries > 1 {
+			log.Debugf("retryLoop: sendVote %v", ticket)
+			br, err = c.sendVote(&b)
+		} else {
+			log.Debugf("retryLoop: sendVoteFail %v", ticket)
+			br, err = c.sendVoteFail(&b)
+		}
+		if serr, ok := err.(ErrRetry); ok {
+			// Push to back retry later
+			log.Debugf("retryLoop: retry failed vote %v %v",
+				ticket, serr)
+			err := c.jsonLog("failed.json", token, b)
+			if err != nil {
+				log.Errorf("retryLoop: c.jsonLog 1: %v", err)
+				continue
+			}
+			err = c.jsonLog("failed.json", token, serr)
+			if err != nil {
+				log.Errorf("retryLoop: c.jsonLog 2: %v", err)
+				continue
+			}
+			c.retryPush(e)
+			continue
+		} else if err != nil {
+			// XXX this may be too rough
+			panic(fmt.Sprintf("permanently failed: %v %v",
+				ticket, err))
+		}
+
+		// journal result
+		err = c.jsonLog("success.json", token, *br)
+		if err != nil {
+			log.Errorf("retryLoop: c.jsonLog 3: %v", err)
+			continue
+		}
+
+		log.Debugf("retryLoop: success %v", spew.Sdump(br))
+
+		// Vote succeeded
+		c.Lock()
+		// Record receipt
+		vr.Receipts = append(vr.Receipts, *br)
+		// Append ticket to return value
+		*tickets = append(*tickets, e.vote.Ticket)
+		c.Unlock()
+	}
+}


### PR DESCRIPTION
The big idea is to make politeiavoter a fire and forget type deal even
when dealing with terrible connections over tor.

When a vote fails move it to a retry queue where the vote will be
retried randomly within 120s. Failed votes are pushed to the end to the
retry list. If a vote fails in the retry loop it is also pushed to the
back of the queue. Votes that error out on the server are not retried;
this only deals with network errors.