### PR TITLE
[cms] Add Sub-Contractor hours type to LineItem

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -21,6 +21,7 @@ server side notifications.  It does not render HTML.
 - [`Invoice exchange rate`](#invoice-exchange-rate)
 - [`Pay invoices`](#pay-invoices)
 - [`Line item payouts`](#line-item-payouts)
+- [`User Sub-Contractors`](#user-sub-contractors)
 
 **Invoice status codes**
 
@@ -1314,6 +1315,106 @@ Reply:
 
 ```json
 {}
+```
+
+### `User sub contractors`
+
+Returns a list of the user's associated subcontractors
+
+**Route:** `GET /v1/user/subcontractors`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| users | array of [`User`](#user)s | The list of subcontractors. |
+
+**Example**
+
+Request:
+
+```json
+{}
+```
+
+Reply:
+
+```json
+{
+  "users": [
+    {
+    "user":
+      {
+        "id": "0",
+        "email": "6b87b6ebb0c80cb7@example.com",
+        "username": "subcontractor1",
+        "isadmin": false,
+        "newuserpaywalladdress": "Tsgs7qb1Gnc43D9EY3xx9ou8Lbo8rB7me6M",
+        "newuserpaywallamount": 10000000,
+        "newuserpaywalltxnotbefore": 1528821554,
+        "newuserpaywalltx": "",
+        "newuserpaywallpollexpiry": 1528821554,
+        "newuserverificationtoken": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+        "newuserverificationexpiry": 1528821554,
+        "updatekeyverificationtoken": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+        "updatekeyverificationexpiry": 1528821554,
+        "numofproposals": 0,
+        "resetpasswordverificationtoken": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+        "resetpasswordverificationexpiry": 1528821554,
+        "identities": [{
+          "pubkey": "5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+          "isactive": true
+        }],
+      },
+    "domain": 1,
+    "githubname": "smobs",
+    "matrixname": "smobs:decred.org",
+    "contractortype": 3,
+    "contractorname": "Steve Mobs",
+    "contractorlocation": "Cupertino, CA",
+    "contractorcontact": "smobs@apple.com",
+    "supervisoruserid": "4",
+  },
+  {
+    "user":
+      {
+        "id": "1",
+        "email": "anotherexample@example.com",
+        "username": "subcontractor2",
+        "isadmin": false,
+        "newuserpaywalladdress": "Tsgs7qb1Gnc43D9EY3xx9ou8Lbo8rB7me6M",
+        "newuserpaywallamount": 10000000,
+        "newuserpaywalltxnotbefore": 1528821554,
+        "newuserpaywalltx": "",
+        "newuserpaywallpollexpiry": 1528821554,
+        "newuserverificationtoken": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+        "newuserverificationexpiry": 1528821554,
+        "updatekeyverificationtoken": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+        "updatekeyverificationexpiry": 1528821554,
+        "numofproposals": 0,
+        "resetpasswordverificationtoken": "337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527",
+        "resetpasswordverificationexpiry": 1528821554,
+        "identities": [{
+          "pubkey": "5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+          "isactive": true
+        }],
+      },
+    "domain": 1,
+    "githubname": "sdobs",
+    "matrixname": "sdobs:decred.org",
+    "contractortype": 3,
+    "contractorname": "Steve Dobs",
+    "contractorlocation": "Cupertino, CA",
+    "contractorcontact": "sdobs@apple.com",
+    "supervisoruserid": "4",
+  },
+  ]
+}
 ```
 
 ### Error codes

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -21,7 +21,7 @@ server side notifications.  It does not render HTML.
 - [`Invoice exchange rate`](#invoice-exchange-rate)
 - [`Pay invoices`](#pay-invoices)
 - [`Line item payouts`](#line-item-payouts)
-- [`User Sub-Contractors`](#user-sub-contractors)
+- [`User sub-contractors`](#user-sub-contractors)
 
 **Invoice status codes**
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -134,7 +134,7 @@ const (
 	// values for each line item in the CSV.
 	PolicyInvoiceFieldDelimiterChar rune = ','
 
-	// PolicySupervisorUserIDSeperator is the character that seperates
+	// PolicySupervisorUserIDSeperator is the character that separates
 	// multiple SupervisorUserIDs for a given cms user.
 	PolicySupervisorUserIDSeperator rune = ','
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -136,7 +136,7 @@ const (
 
 	// PolicyInvoiceLineItemCount is the number of expected fields in the raw
 	// csv line items
-	PolicyInvoiceLineItemCount = 7
+	PolicyInvoiceLineItemCount = 8
 
 	// PolicyMinLineItemColLength is the minimun length for the strings in
 	// each column field of the lineItem structure.
@@ -259,6 +259,8 @@ var (
 		ErrorStatusInvoiceRequireLineItems:        "invoices require at least 1 line item",
 		ErrorStatusInvalidInvoiceMonthYear:        "an invalid month/year was submitted on an invoice",
 		ErrorStatusInvalidExchangeRate:            "exchange rate was invalid or didn't match expected result",
+		ErrorStatusInvalidLineItemType:            "line item has an invalid type",
+		ErrorStatusInvalidLaborExpense:            "line item has an invalid labor or expense field",
 		ErrorStatusDuplicatePaymentAddress:        "a duplicate payment address was used",
 		ErrorStatusInvalidDatesRequested:          "invalid dates were requested",
 		ErrorStatusInvalidInvoiceEditMonthYear:    "invalid attempt to edit invoice month/year",

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -24,6 +24,7 @@ const (
 	RouteInvoiceDetails      = "/invoices/{token:[A-z0-9]{64}}"
 	RouteSetInvoiceStatus    = "/invoices/{token:[A-z0-9]{64}}/status"
 	RouteUserInvoices        = "/user/invoices"
+	RouteUserSubContractors  = "/user/subcontractors"
 	RouteNewDCC              = "/dcc/new"
 	RouteDCCDetails          = "/dcc/{token:[A-z0-9]{64}}"
 	RouteGetDCCs             = "/dcc"
@@ -684,3 +685,13 @@ type SetDCCStatus struct {
 
 // SetDCCStatusReply returns an empty response when successful.
 type SetDCCStatusReply struct{}
+
+// UserSubContractors is a request for a logged in Supervisor to return a
+// list of UserIDs/Usernames
+type UserSubContractors struct{}
+
+// UserSubContractorsReply returns a list of Users that are considered
+// sub contractors of the logged in user making the request.
+type UserSubContractorsReply struct {
+	Users []User `json:"users"`
+}

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -50,10 +50,11 @@ const (
 	InvoiceStatusPaid     InvoiceStatusT = 7 // Invoice has been paid
 
 	// Line item types
-	LineItemTypeInvalid LineItemTypeT = 0 // Invalid type
-	LineItemTypeLabor   LineItemTypeT = 1 // Labor line items
-	LineItemTypeExpense LineItemTypeT = 2 // Expenses incurred line items
-	LineItemTypeMisc    LineItemTypeT = 3 // Catch all for anything else
+	LineItemTypeInvalid  LineItemTypeT = 0 // Invalid type
+	LineItemTypeLabor    LineItemTypeT = 1 // Labor line items
+	LineItemTypeExpense  LineItemTypeT = 2 // Expenses incurred line items
+	LineItemTypeMisc     LineItemTypeT = 3 // Catch all for anything else
+	LineItemTypeSubHours LineItemTypeT = 4 // Line items for subcontractor billing
 
 	// Domain types
 	DomainTypeInvalid       DomainTypeT = 0 // Invalid Domain type
@@ -197,6 +198,9 @@ const (
 	ErrorStatusUserIsAuthor                   www.ErrorStatusT = 1044
 	ErrorStatusInvalidUserDCC                 www.ErrorStatusT = 1045
 	ErrorStatusInvalidDCCContractorType       www.ErrorStatusT = 1046
+	ErrorStatusInvalidTypeSubHoursLineItem    www.ErrorStatusT = 1047
+	ErrorStatusMissingSubUserIDLineItem       www.ErrorStatusT = 1048
+	ErrorStatusInvalidSubUserIDLineItem       www.ErrorStatusT = 1049
 )
 
 var (
@@ -273,6 +277,9 @@ var (
 		ErrorStatusUserIsAuthor:                   "user cannot support or oppose their own sponsored DCC",
 		ErrorStatusInvalidUserDCC:                 "user is not authorized to complete the DCC request",
 		ErrorStatusInvalidDCCContractorType:       "DCC must have a valid contractor type",
+		ErrorStatusInvalidTypeSubHoursLineItem:    "must be a Supervisor Contractor to submit a subcontractor hours line item",
+		ErrorStatusMissingSubUserIDLineItem:       "must supply a userid for a subcontractor hours line item",
+		ErrorStatusInvalidSubUserIDLineItem:       "the userid supplied for the subcontractor hours line item is invalid",
 	}
 )
 
@@ -380,6 +387,7 @@ type LineItemsInput struct {
 	Subdomain     string        `json:"subdomain"`     // Subdomain of work performed
 	Description   string        `json:"description"`   // Description of work performed
 	ProposalToken string        `json:"proposaltoken"` // Link to politeia proposal that work is associated with
+	SubUserID     string        `json:"subuserid"`     // UserID of the associated Subcontractor
 	Labor         uint          `json:"labor"`         // Number of minutes (if labor)
 	Expenses      uint          `json:"expenses"`      // Total cost (in USD cents) of line item (if expense or misc)
 }

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -134,10 +134,6 @@ const (
 	// values for each line item in the CSV.
 	PolicyInvoiceFieldDelimiterChar rune = ','
 
-	// PolicySupervisorUserIDSeperator is the character that separates
-	// multiple SupervisorUserIDs for a given cms user.
-	PolicySupervisorUserIDSeperator rune = ','
-
 	// PolicyInvoiceLineItemCount is the number of expected fields in the raw
 	// csv line items
 	PolicyInvoiceLineItemCount = 8
@@ -571,7 +567,7 @@ type User struct {
 	ContractorName     string          `json:"contractorname"`
 	ContractorLocation string          `json:"contractorlocation"`
 	ContractorContact  string          `json:"contractorcontact"`
-	SupervisorUserID   string          `json:"supervisoruserid"`
+	SupervisorUserIDs  []string        `json:"supervisoruserid"`
 }
 
 // UserDetails fetches a cms user's details by their id.
@@ -598,10 +594,10 @@ type EditUserReply struct{}
 
 // ManageUser performs the given action on a user.
 type ManageUser struct {
-	UserID           string          `json:"userid"`
-	Domain           DomainTypeT     `json:"domain,omitempty"`
-	ContractorType   ContractorTypeT `json:"contractortype,omitempty"`
-	SupervisorUserID string          `json:"supervisoruserid,omitempty"`
+	UserID            string          `json:"userid"`
+	Domain            DomainTypeT     `json:"domain,omitempty"`
+	ContractorType    ContractorTypeT `json:"contractortype,omitempty"`
+	SupervisorUserIDs []string        `json:"supervisoruserids,omitempty"`
 }
 
 // ManageUserReply is the reply for the ManageUserReply command.

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -134,6 +134,10 @@ const (
 	// values for each line item in the CSV.
 	PolicyInvoiceFieldDelimiterChar rune = ','
 
+	// PolicySupervisorUserIDSeperator is the character that seperates
+	// multiple SupervisorUserIDs for a given cms user.
+	PolicySupervisorUserIDSeperator rune = ','
+
 	// PolicyInvoiceLineItemCount is the number of expected fields in the raw
 	// csv line items
 	PolicyInvoiceLineItemCount = 8

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -202,6 +202,7 @@ const (
 	ErrorStatusInvalidTypeSubHoursLineItem    www.ErrorStatusT = 1047
 	ErrorStatusMissingSubUserIDLineItem       www.ErrorStatusT = 1048
 	ErrorStatusInvalidSubUserIDLineItem       www.ErrorStatusT = 1049
+	ErrorStatusInvalidSupervisorUser          www.ErrorStatusT = 1050
 )
 
 var (
@@ -283,6 +284,7 @@ var (
 		ErrorStatusInvalidTypeSubHoursLineItem:    "must be a Supervisor Contractor to submit a subcontractor hours line item",
 		ErrorStatusMissingSubUserIDLineItem:       "must supply a userid for a subcontractor hours line item",
 		ErrorStatusInvalidSubUserIDLineItem:       "the userid supplied for the subcontractor hours line item is invalid",
+		ErrorStatusInvalidSupervisorUser:          "attempted input of an invalid supervisor user id",
 	}
 )
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -567,7 +567,7 @@ type User struct {
 	ContractorName     string          `json:"contractorname"`
 	ContractorLocation string          `json:"contractorlocation"`
 	ContractorContact  string          `json:"contractorcontact"`
-	SupervisorUserIDs  []string        `json:"supervisoruserid"`
+	SupervisorUserIDs  []string        `json:"supervisoruserids"`
 }
 
 // UserDetails fetches a cms user's details by their id.

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -190,6 +190,7 @@ func validateParseCSV(data []byte) (*cms.InvoiceInput, error) {
 		"labor":   cms.LineItemTypeLabor,
 		"expense": cms.LineItemTypeExpense,
 		"misc":    cms.LineItemTypeMisc,
+		"sub":     cms.LineItemTypeSubHours,
 	}
 	invInput := &cms.InvoiceInput{}
 
@@ -236,6 +237,7 @@ func validateParseCSV(data []byte) (*cms.InvoiceInput, error) {
 		lineItem.Subdomain = lineContents[2]
 		lineItem.Description = lineContents[3]
 		lineItem.ProposalToken = lineContents[4]
+		lineItem.SubUserID = lineContents[7]
 		lineItem.Labor = uint(hours * 60)
 		lineItem.Expenses = uint(cost * 100)
 		lineItems = append(lineItems, lineItem)

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -88,6 +88,7 @@ type cmswww struct {
 	UpdateUserKey       shared.UpdateUserKeyCmd  `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
 	UserDetails         UserDetailsCmd           `command:"userdetails" description:"(user)   get current cms user details"`
 	UserInvoices        UserInvoicesCmd          `command:"userinvoices" description:"(user)   get all invoices submitted by a specific user"`
+	UserSubContractors  UserSubContractorsCmd    `command:"usersubcontractors" description:"(user)   get all users that are linked to the user"`
 	Users               shared.UsersCmd          `command:"users" description:"(public) get a list of users"`
 	Secret              shared.SecretCmd         `command:"secret" description:"(user)   ping politeiawww"`
 	Version             shared.VersionCmd        `command:"version" description:"(public) get server info and CSRF token"`

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -43,7 +43,7 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 	}
 
 	userID := cmd.Args.UserID
-	fmt.Println(userID)
+
 	uir, err := client.CMSUserDetails(strings.TrimSpace(userID))
 	if err != nil {
 		return err
@@ -137,7 +137,7 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 			if update {
 				superVisorUserIDs := userInfo.SupervisorUserIDs
 				for {
-					superVisorUserID := ""
+					var superVisorUserID string
 					fmt.Printf("Add another Supervisor User ID: ")
 					superVisorUserID, _ = reader.ReadString('\n')
 					superVisorUserID = strings.TrimSpace(superVisorUserID)

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -234,9 +234,9 @@ Arguments:
 1. userid             (string, required)     ID of the user to manage
 
 Flags:
-  --domain              	(int, optional)     Domain of the contractor
-  --contractortype          (int, optional)     Contractor Type
-  --supervisoruserid        (string, optional)  UserID of the Supervisor
+  --domain             	(int, optional)     Domain of the contractor
+  --contractortype      (int, optional)     Contractor Type
+  --supervisoruserid    (string, optional)  UserID of the Supervisor
 
 Request:
 {

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -251,15 +251,15 @@ Arguments:
 1. userid             (string, required)     ID of the user to manage
 
 Flags:
-  --domain             	(int, optional)     Domain of the contractor
+  --domain              (int, optional)     Domain of the contractor
   --contractortype      (int, optional)     Contractor Type
-  --supervisoruserid    (string, optional)  UserID of the Supervisor
+  --supervisoruserids   (string, optional)  UserID of the Supervisor
 
 Request:
 {
 	"domain": 1,
 	"contractortype": 1,
-	"supervisoruserid": "4",
+	"supervisoruserids": "4",
 }
 
 Response:

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -23,7 +23,7 @@ type ManageUserCmd struct {
 	} `positional-args:"true" optional:"true"`
 	Domain            string `long:"domain" optional:"true" description:"Domain type: Developer, Marketing, Design, Documentation, Research, Community"`
 	ContractorType    string `long:"contractortype" optional:"true" description:"Contractor type: Direct, Sub, Super"`
-	SupervisorUserIDs string `long:"supervisoruserids" optional:"true" description:"Supervisor User ID"`
+	SupervisorUserIDs string `long:"supervisoruserids" optional:"true" description:"Supervisor User IDs"`
 }
 
 // Execute executes the cms manage user command.
@@ -253,7 +253,7 @@ Arguments:
 Flags:
   --domain              (int, optional)     Domain of the contractor
   --contractortype      (int, optional)     Contractor Type
-  --supervisoruserids   (string, optional)  UserID of the Supervisor
+  --supervisoruserids   (string, optional)  UserIDs of the Supervisor
 
 Request:
 {

--- a/politeiawww/cmd/cmswww/usersubcontractors.go
+++ b/politeiawww/cmd/cmswww/usersubcontractors.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// UserSubContractorsCmd gets the subcontractors for the logged in user.
+type UserSubContractorsCmd struct {
+	Args struct{}
+}
+
+// Execute executes the user subcontractors command.
+func (cmd *UserSubContractorsCmd) Execute(args []string) error {
+	// Get user subcontractors
+	uir, err := client.UserSubContractors(
+		&v1.UserSubContractors{})
+	if err != nil {
+		return err
+	}
+
+	// Print user sub contractors
+	return shared.PrintJSON(uir)
+}

--- a/politeiawww/cmd/cmswww/usersubcontractors.go
+++ b/politeiawww/cmd/cmswww/usersubcontractors.go
@@ -11,7 +11,6 @@ import (
 
 // UserSubContractorsCmd gets the subcontractors for the logged in user.
 type UserSubContractorsCmd struct {
-	Args struct{}
 }
 
 // Execute executes the user subcontractors command.

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -1915,6 +1915,29 @@ func (c *Client) SetDCCStatus(sd *cms.SetDCCStatus) (*cms.SetDCCStatusReply, err
 	return &sdr, nil
 }
 
+// UserSubContractors retrieves the subcontractors that are linked to the requesting user
+func (c *Client) UserSubContractors(usc *cms.UserSubContractors) (*cms.UserSubContractorsReply, error) {
+	responseBody, err := c.makeRequest("GET", cms.RouteUserSubContractors, usc)
+	if err != nil {
+		return nil, err
+	}
+
+	var uscr cms.UserSubContractorsReply
+	err = json.Unmarshal(responseBody, &uscr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal UserSubContractorsReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(uscr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &uscr, nil
+}
+
 // WalletAccounts retrieves the walletprc accounts.
 func (c *Client) WalletAccounts() (*walletrpc.AccountsResponse, error) {
 	if c.wallet == nil {

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -597,7 +597,7 @@ func (p *politeiawww) revokeDCCUser(userid string) error {
 	return nil
 }
 
-func (p *politeiawww) processUserSubContractors(u *user.User) ([]cms.UserSubContractors, error) {
+func (p *politeiawww) processUserSubContractors(u *user.User) (*cms.UserSubContractorsReply, error) {
 	usc := user.CMSUserSubContractors{
 		ID: u.ID.String(),
 	}
@@ -614,9 +614,17 @@ func (p *politeiawww) processUserSubContractors(u *user.User) ([]cms.UserSubCont
 	if err != nil {
 		return nil, err
 	}
-	_, err = user.DecodeCMSUserSubContractors([]byte(payloadReply.Payload))
+	cmsUsers, err := user.DecodeCMSUserSubContractorsReply([]byte(payloadReply.Payload))
 	if err != nil {
 		return nil, err
 	}
-	return nil, nil
+	convertedCMSUsers := make([]cms.User, len(cmsUsers.Users))
+	for _, uu := range cmsUsers.Users {
+		converted := convertCMSUserFromDatabaseUser(&uu)
+		convertedCMSUsers = append(convertedCMSUsers, converted)
+	}
+	uscr := &cms.UserSubContractorsReply{
+		Users: convertedCMSUsers,
+	}
+	return uscr, nil
 }

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -352,8 +352,24 @@ func (p *politeiawww) processManageCMSUser(mu cms.ManageUser) (*cms.ManageUserRe
 		uu.ContractorType = int(mu.ContractorType)
 	}
 	if mu.SupervisorUserID != "" {
+		// Validate SupervisorUserID input
+		supUserIDs := strings.Split(mu.SupervisorUserID, ",")
+		for _, super := range supUserIDs {
+			u, err := p.getCMSUserByID(super)
+			if err != nil {
+				return nil, www.UserError{
+					ErrorCode: cms.ErrorStatusInvalidSupervisorUser,
+				}
+			}
+			if u.ContractorType != cms.ContractorTypeSupervisor {
+				return nil, www.UserError{
+					ErrorCode: cms.ErrorStatusInvalidSupervisorUser,
+				}
+			}
+		}
 		uu.SupervisorUserID = mu.SupervisorUserID
 	}
+
 	payload, err := user.EncodeUpdateCMSUser(uu)
 	if err != nil {
 		return nil, err

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -618,7 +618,7 @@ func (p *politeiawww) processUserSubContractors(u *user.User) (*cms.UserSubContr
 	if err != nil {
 		return nil, err
 	}
-	convertedCMSUsers := make([]cms.User, len(cmsUsers.Users))
+	convertedCMSUsers := make([]cms.User, 0, len(cmsUsers.Users))
 	for _, uu := range cmsUsers.Users {
 		converted := convertCMSUserFromDatabaseUser(&uu)
 		convertedCMSUsers = append(convertedCMSUsers, converted)

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -353,7 +353,7 @@ func (p *politeiawww) processManageCMSUser(mu cms.ManageUser) (*cms.ManageUserRe
 	}
 	if mu.SupervisorUserID != "" {
 		// Validate SupervisorUserID input
-		supUserIDs := strings.Split(mu.SupervisorUserID, ",")
+		supUserIDs := strings.Split(mu.SupervisorUserID, string(cms.PolicySupervisorUserIDSeperator))
 		for _, super := range supUserIDs {
 			u, err := p.getCMSUserByID(super)
 			if err != nil {

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -596,3 +596,27 @@ func (p *politeiawww) revokeDCCUser(userid string) error {
 	}
 	return nil
 }
+
+func (p *politeiawww) processUserSubContractors(u *user.User) ([]cms.UserSubContractors, error) {
+	usc := user.CMSUserSubContractors{
+		ID: u.ID.String(),
+	}
+	payload, err := user.EncodeCMSUserSubContractors(usc)
+	if err != nil {
+		return nil, err
+	}
+	pc := user.PluginCommand{
+		ID:      user.CMSPluginID,
+		Command: user.CmdCMSUserSubContractors,
+		Payload: string(payload),
+	}
+	payloadReply, err := p.db.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+	_, err = user.DecodeCMSUserSubContractors([]byte(payloadReply.Payload))
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -359,23 +359,25 @@ func (p *politeiawww) processManageCMSUser(mu cms.ManageUser) (*cms.ManageUserRe
 		for _, super := range mu.SupervisorUserIDs {
 			parseUUID, err := uuid.Parse(super)
 			if err != nil {
-				fmt.Println("Sdfsdf")
+				e := fmt.Sprintf("invalid uuid: %v", super)
 				return nil, www.UserError{
-					ErrorCode: cms.ErrorStatusInvalidSupervisorUser,
+					ErrorCode:    cms.ErrorStatusInvalidSupervisorUser,
+					ErrorContext: []string{e},
 				}
 			}
 			u, err := p.getCMSUserByID(super)
 			if err != nil {
-				fmt.Println("Sdfsdfsadfsdf")
+				e := fmt.Sprintf("user not found: %v", super)
 				return nil, www.UserError{
-					ErrorCode: cms.ErrorStatusInvalidSupervisorUser,
+					ErrorCode:    cms.ErrorStatusInvalidSupervisorUser,
+					ErrorContext: []string{e},
 				}
 			}
 			if u.ContractorType != cms.ContractorTypeSupervisor {
-				fmt.Println(u.ContractorType, u.ID)
-
+				e := fmt.Sprintf("user not a supervisor: %v", super)
 				return nil, www.UserError{
-					ErrorCode: cms.ErrorStatusInvalidSupervisorUser,
+					ErrorCode:    cms.ErrorStatusInvalidSupervisorUser,
+					ErrorContext: []string{e},
 				}
 			}
 			parseSuperUserIds = append(parseSuperUserIds, parseUUID)
@@ -407,7 +409,6 @@ func (p *politeiawww) processCMSUserDetails(ud *cms.UserDetails, isCurrentUser b
 		}
 	}
 	reply := cms.UserDetailsReply{}
-	fmt.Println(ud.UserID)
 	u, err := p.getCMSUserByID(ud.UserID)
 	if err != nil {
 		return nil, err

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -461,6 +461,30 @@ func (p *politeiawww) getCMSUserByID(id string) (*cms.User, error) {
 	return &u, nil
 }
 
+func (p *politeiawww) getCMSUserByIDRaw(id string) (*user.CMSUser, error) {
+	ubi := user.CMSUserByID{
+		ID: id,
+	}
+	payload, err := user.EncodeCMSUserByID(ubi)
+	if err != nil {
+		return nil, err
+	}
+	pc := user.PluginCommand{
+		ID:      user.CMSPluginID,
+		Command: user.CmdCMSUserByID,
+		Payload: string(payload),
+	}
+	payloadReply, err := p.db.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+	ubir, err := user.DecodeCMSUserByIDReply([]byte(payloadReply.Payload))
+	if err != nil {
+		return nil, err
+	}
+	return ubir.User, nil
+}
+
 // convertCMSUserFromDatabaseUser converts a user User to a cms User.
 func convertCMSUserFromDatabaseUser(user *user.CMSUser) cms.User {
 	return cms.User{

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/user"
@@ -352,7 +351,6 @@ func (p *politeiawww) processManageCMSUser(mu cms.ManageUser) (*cms.ManageUserRe
 	if mu.ContractorType != 0 {
 		uu.ContractorType = int(mu.ContractorType)
 	}
-	spew.Dump(mu)
 	if len(mu.SupervisorUserIDs) > 0 {
 		// Validate SupervisorUserID input
 		parseSuperUserIds := make([]uuid.UUID, 0, len(mu.SupervisorUserIDs))
@@ -518,7 +516,6 @@ func (p *politeiawww) getCMSUserByIDRaw(id string) (*user.CMSUser, error) {
 
 // convertCMSUserFromDatabaseUser converts a user User to a cms User.
 func convertCMSUserFromDatabaseUser(user *user.CMSUser) cms.User {
-
 	superUserIDs := make([]string, 0, len(user.SupervisorUserIDs))
 	for _, userIDs := range user.SupervisorUserIDs {
 		superUserIDs = append(superUserIDs, userIDs.String())

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -746,6 +746,26 @@ func (p *politeiawww) handleSetDCCStatus(w http.ResponseWriter, r *http.Request)
 	util.RespondWithJSON(w, http.StatusOK, adr)
 }
 
+func (p *politeiawww) handleUserSubContractors(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleUserSubContractors")
+
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleUserSubContractors: getSessionUser %v", err)
+		return
+	}
+
+	uscr, err := p.processUserSubContractors(u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleUserSubContractors: processUserSubContractors: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, uscr)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -794,6 +814,8 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		p.handleNewCommentDCC, permissionLogin)
 	p.addRoute(http.MethodGet, cms.RouteDCCComments,
 		p.handleDCCComments, permissionLogin)
+	p.addRoute(http.MethodGet, cms.RouteUserSubContractors,
+		p.handleUserSubContractors, permissionLogin)
 
 	// Unauthenticated websocket
 	p.addRoute("", www.RouteUnauthenticatedWebSocket,

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -273,7 +273,8 @@ func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.N
 	}
 
 	// Ensure that the user is not unauthorized to create invoices
-	if _, ok := invalidNewInvoiceContractorType[cms.ContractorTypeT(cmsUser.ContractorType)]; ok {
+	if _, ok := invalidNewInvoiceContractorType[cms.ContractorTypeT(
+		cmsUser.ContractorType)]; ok {
 		return nil, www.UserError{
 			ErrorCode: cms.ErrorStatusInvalidUserNewInvoice,
 		}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -473,13 +473,13 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 	}
 
 	// Verify public key
-	if u.User.PublicKey() != ni.PublicKey {
+	if u.PublicKey() != ni.PublicKey {
 		return www.UserError{
 			ErrorCode: www.ErrorStatusInvalidSigningKey,
 		}
 	}
 
-	pk, err := identity.PublicIdentityFromBytes(u.User.ActiveIdentity().Key[:])
+	pk, err := identity.PublicIdentityFromBytes(u.ActiveIdentity().Key[:])
 	if err != nil {
 		return err
 	}
@@ -702,7 +702,7 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 					if err != nil {
 						return err
 					}
-					if subUser.SupervisorUserID != u.ID.String() {
+					if !strings.Contains(subUser.SupervisorUserID, u.ID.String()) {
 						return www.UserError{
 							ErrorCode: cms.ErrorStatusInvalidSubUserIDLineItem,
 						}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -487,7 +487,6 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 
 	// Check for at least 1 markdown file with a non-empty payload.
 	if len(ni.Files) == 0 || ni.Files[0].Payload == "" {
-		fmt.Println(ni.Files[0].Payload)
 		return www.UserError{
 			ErrorCode: www.ErrorStatusProposalMissingFiles,
 		}
@@ -633,7 +632,6 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 			minRate := 500   // 5 USD (in cents)
 			maxRate := 50000 // 500 USD (in cents)
 			if invInput.ContractorRate < uint(minRate) || invInput.ContractorRate > uint(maxRate) {
-				fmt.Println(invInput.ContractorRate)
 				return www.UserError{
 					ErrorCode: cms.ErrorStatusInvoiceInvalidRate,
 				}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -703,7 +703,14 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 					if err != nil {
 						return err
 					}
-					if !strings.Contains(subUser.SupervisorUserID, u.ID.String()) {
+					found := false
+					for _, superUserIds := range subUser.SupervisorUserIDs {
+						if superUserIds.String() == u.ID.String() {
+							found = true
+							break
+						}
+					}
+					if !found {
 						return www.UserError{
 							ErrorCode: cms.ErrorStatusInvalidSubUserIDLineItem,
 						}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -707,7 +707,7 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 							ErrorCode: cms.ErrorStatusInvalidSubUserIDLineItem,
 						}
 					}
-					if lineInput.Labor != 0 {
+					if lineInput.Labor == 0 {
 						return www.UserError{
 							ErrorCode: cms.ErrorStatusInvalidLaborExpense,
 						}
@@ -1703,7 +1703,7 @@ func (p *politeiawww) calculatePayout(inv database.Invoice) (cms.Payout, error) 
 	var totalExpenses uint
 	for _, lineItem := range inv.LineItems {
 		switch lineItem.Type {
-		case cms.LineItemTypeLabor:
+		case cms.LineItemTypeLabor, cms.LineItemTypeSubHours:
 			totalLaborMinutes += lineItem.Labor
 		case cms.LineItemTypeExpense, cms.LineItemTypeMisc:
 			totalExpenses += lineItem.Expenses

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -224,12 +224,14 @@ type CMSUserSubContractors struct {
 	ID string `json:"id"` // Contractor user id
 }
 
-// EncodeCMSUserSubContractors encodes a CMSUserSubContractors into a JSON byte slice.
+// EncodeCMSUserSubContractors encodes a CMSUserSubContractors into a JSON byte
+// slice.
 func EncodeCMSUserSubContractors(u CMSUserSubContractors) ([]byte, error) {
 	return json.Marshal(u)
 }
 
-// DecodeCMSUserSubContractors decodes JSON byte slice into a CMSUserSubContractors.
+// DecodeCMSUserSubContractors decodes JSON byte slice into a
+// CMSUserSubContractors.
 func DecodeCMSUserSubContractors(b []byte) (*CMSUserSubContractors, error) {
 	var u CMSUserSubContractors
 
@@ -241,13 +243,14 @@ func DecodeCMSUserSubContractors(b []byte) (*CMSUserSubContractors, error) {
 	return &u, nil
 }
 
-// CMSUserSubContractorsReply is the reply to the CMSUserSubContractors command.
+// CMSUserSubContractorsReply is the reply to the CMSUserSubContractors
+// command.
 type CMSUserSubContractorsReply struct {
 	Users []CMSUser `json:"users"`
 }
 
-// EncodeCMSUserSubContractorsReply encodes a CMSUserSubContractorsReply into a JSON
-// byte slice.
+// EncodeCMSUserSubContractorsReply encodes a CMSUserSubContractorsReply into a
+// JSON byte slice.
 func EncodeCMSUserSubContractorsReply(u CMSUserSubContractorsReply) ([]byte, error) {
 	return json.Marshal(u)
 }

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -30,6 +30,11 @@ type CMSUser struct {
 	SupervisorUserIDs  []uuid.UUID `json:"supervisoruserids"`
 }
 
+// EncodeCMSUser encodes a CMSUser into a JSON byte slice.
+func EncodeCMSUser(u CMSUser) ([]byte, error) {
+	return json.Marshal(u)
+}
+
 // DecodeCMSUser decodes a JSON byte slice into a CMSUser.
 func DecodeCMSUser(payload []byte) (*CMSUser, error) {
 	var u CMSUser

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -7,12 +7,13 @@ import (
 )
 
 const (
-	CMSPluginVersion    = "1"
-	CMSPluginID         = "cms"
-	CmdNewCMSUser       = "newcmsuser"
-	CmdCMSUsersByDomain = "cmsusersbydomain"
-	CmdUpdateCMSUser    = "updatecmsuser"
-	CmdCMSUserByID      = "cmsuserbyid"
+	CMSPluginVersion         = "1"
+	CMSPluginID              = "cms"
+	CmdNewCMSUser            = "newcmsuser"
+	CmdCMSUsersByDomain      = "cmsusersbydomain"
+	CmdUpdateCMSUser         = "updatecmsuser"
+	CmdCMSUserByID           = "cmsuserbyid"
+	CmdCMSUserSubContractors = "cmsusersubcontractors"
 )
 
 // CMSUser represents a CMS user. It contains the standard politeiawww user
@@ -208,6 +209,53 @@ func EncodeCMSUserByIDReply(u CMSUserByIDReply) ([]byte, error) {
 // CMSUserByIDReply.
 func DecodeCMSUserByIDReply(b []byte) (*CMSUserByIDReply, error) {
 	var reply CMSUserByIDReply
+
+	err := json.Unmarshal(b, &reply)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reply, nil
+}
+
+// CMSUserSubContractors retrieves all users that are currently have the
+// given ID as their SupervisorID
+type CMSUserSubContractors struct {
+	ID string `json:"id"` // Contractor user id
+}
+
+// EncodeCMSUserSubContractors encodes a CMSUserSubContractors into a JSON byte slice.
+func EncodeCMSUserSubContractors(u CMSUserSubContractors) ([]byte, error) {
+	return json.Marshal(u)
+}
+
+// DecodeCMSUserSubContractors decodes JSON byte slice into a CMSUserSubContractors.
+func DecodeCMSUserSubContractors(b []byte) (*CMSUserSubContractors, error) {
+	var u CMSUserSubContractors
+
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		return nil, err
+	}
+
+	return &u, nil
+}
+
+// CMSUserSubContractorsReply is the reply to the CMSUserSubContractors command.
+type CMSUserSubContractorsReply struct {
+	Users []CMSUser `json:"users"`
+}
+
+// EncodeCMSUserSubContractorsReply encodes a CMSUserSubContractorsReply into a JSON
+// byte slice.
+func EncodeCMSUserSubContractorsReply(u CMSUserSubContractorsReply) ([]byte, error) {
+	return json.Marshal(u)
+}
+
+// DecodeCMSUserSubContractorsReply decodes JSON byte slice into a
+// CMSUserSubContractorsReply.
+func DecodeCMSUserSubContractorsReply(b []byte) (*CMSUserSubContractorsReply, error) {
+	var reply CMSUserSubContractorsReply
 
 	err := json.Unmarshal(b, &reply)
 	if err != nil {

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -20,14 +20,14 @@ const (
 // fields as well as CMS specific user fields.
 type CMSUser struct {
 	User
-	Domain             int    `json:"domain"` // Contractor domain
-	GitHubName         string `json:"githubname"`
-	MatrixName         string `json:"matrixname"`
-	ContractorType     int    `json:"contractortype"`
-	ContractorName     string `json:"contractorname"`
-	ContractorLocation string `json:"contractorlocation"`
-	ContractorContact  string `json:"contractorcontact"`
-	SupervisorUserID   string `json:"supervisoruserid"`
+	Domain             int         `json:"domain"` // Contractor domain
+	GitHubName         string      `json:"githubname"`
+	MatrixName         string      `json:"matrixname"`
+	ContractorType     int         `json:"contractortype"`
+	ContractorName     string      `json:"contractorname"`
+	ContractorLocation string      `json:"contractorlocation"`
+	ContractorContact  string      `json:"contractorcontact"`
+	SupervisorUserIDs  []uuid.UUID `json:"supervisoruserids"`
 }
 
 // DecodeCMSUser decodes a JSON byte slice into a CMSUser.
@@ -136,15 +136,15 @@ func DecodeCMSUsersByDomainReply(b []byte) (*CMSUsersByDomainReply, error) {
 
 // UpdateCMSUser creates a new CMS user record in the user database.
 type UpdateCMSUser struct {
-	ID                 uuid.UUID `json:"id"`
-	Domain             int       `json:"domain"` // Contractor domain
-	GitHubName         string    `json:"githubname"`
-	MatrixName         string    `json:"matrixname"`
-	ContractorType     int       `json:"contractortype"`
-	ContractorName     string    `json:"contractorname"`
-	ContractorLocation string    `json:"contractorlocation"`
-	ContractorContact  string    `json:"contractorcontact"`
-	SupervisorUserID   string    `json:"supervisoruserid"`
+	ID                 uuid.UUID   `json:"id"`
+	Domain             int         `json:"domain"` // Contractor domain
+	GitHubName         string      `json:"githubname"`
+	MatrixName         string      `json:"matrixname"`
+	ContractorType     int         `json:"contractortype"`
+	ContractorName     string      `json:"contractorname"`
+	ContractorLocation string      `json:"contractorlocation"`
+	ContractorContact  string      `json:"contractorcontact"`
+	SupervisorUserIDs  []uuid.UUID `json:"supervisoruserids"`
 }
 
 // EncodeUpdateCMSUser encodes a UpdateCMSUser into a JSON byte slice.

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -30,6 +30,18 @@ type CMSUser struct {
 	SupervisorUserID   string `json:"supervisoruserid"`
 }
 
+// DecodeCMSUser decodes a JSON byte slice into a CMSUser.
+func DecodeCMSUser(payload []byte) (*CMSUser, error) {
+	var u CMSUser
+
+	err := json.Unmarshal(payload, &u)
+	if err != nil {
+		return nil, err
+	}
+
+	return &u, nil
+}
+
 // NewCMSUser creates a new CMS user record in the user database.
 type NewCMSUser struct {
 	Email                     string `json:"email"`

--- a/politeiawww/user/cockroachdb/cms.go
+++ b/politeiawww/user/cockroachdb/cms.go
@@ -284,7 +284,7 @@ func (c *cockroachdb) cmdCMSUserSubContractors(payload string) (string, error) {
 	}
 
 	// Prepare reply
-	subUsers := make([]user.CMSUser, len(cmsUsers))
+	subUsers := make([]user.CMSUser, 0, len(cmsUsers))
 	for _, u := range cmsUsers {
 		convertUser, err := c.convertCMSUserFromDatabase(u)
 		if err != nil {

--- a/politeiawww/user/cockroachdb/cms.go
+++ b/politeiawww/user/cockroachdb/cms.go
@@ -3,6 +3,7 @@ package cockroachdb
 import (
 	"fmt"
 
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	"github.com/decred/politeia/politeiawww/user"
 	"github.com/jinzhu/gorm"
 )
@@ -279,7 +280,8 @@ func (c *cockroachdb) cmdCMSUserSubContractors(payload string) (string, error) {
 	// parse the following:
 	// Where("? = ANY(string_to_array(supervisor_user_id, ','))", p.ID)
 	err = c.userDB.
-		Where("'" + p.ID + "' = ANY(string_to_array(supervisor_user_id, ','))").
+		Where("'" + p.ID + "' = ANY(string_to_array(supervisor_user_id, '" +
+			string(cms.PolicySupervisorUserIDSeperator) + "'))").
 		Preload("User").
 		Find(&cmsUsers).
 		Error

--- a/politeiawww/user/cockroachdb/cms.go
+++ b/politeiawww/user/cockroachdb/cms.go
@@ -129,7 +129,7 @@ func (c *cockroachdb) updateCMSUser(tx *gorm.DB, nu user.UpdateCMSUser) error {
 	cms := CMSUser{
 		ID: nu.ID,
 	}
-	superVisorUserIds := ""
+	var superVisorUserIds string
 	for i, userIds := range nu.SupervisorUserIDs {
 		if i == 0 {
 			superVisorUserIds = userIds.String()

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -57,13 +57,13 @@ type CMSUser struct {
 	ID                 uuid.UUID `gorm:"primary_key"`            // UUID (User foreign key)
 	User               User      `gorm:"not null;foreignkey:ID"` // politeiawww user
 	Domain             int       `gorm:"not null"`               // Contractor domain
-	GitHubName         string
-	MatrixName         string
-	ContractorType     int
-	ContractorName     string
-	ContractorLocation string
-	ContractorContact  string
-	SupervisorUserID   string
+	GitHubName         string    `gorm:"not null"`               // Github Name/ID
+	MatrixName         string    `gorm:"not null"`               // Matrix Name/ID
+	ContractorType     int       `gorm:"not null"`               // Type of Contractor
+	ContractorName     string    `gorm:"not null"`               // IRL Contractor Name or identity
+	ContractorLocation string    `gorm:"not null"`               // General IRL Contractor Location
+	ContractorContact  string    `gorm:"not null"`               // Point of contact outside of matrix
+	SupervisorUserID   string    `gorm:"not null"`               // This is can either be 1 SupervisorUserID or a comma separated string of many supervisor user ids
 
 	// Set by gorm
 	CreatedAt time.Time // Time of record creation

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -53,6 +53,9 @@ func (User) TableName() string {
 // a politeiawww User.
 //
 // This is a CMS plugin model.
+//
+// XXX We need to update SupervisorUserID to SupervisorUserIDs next time we
+// update or do any migration on the userdb.
 type CMSUser struct {
 	ID                 uuid.UUID `gorm:"primary_key"`            // UUID (User foreign key)
 	User               User      `gorm:"not null;foreignkey:ID"` // politeiawww user


### PR DESCRIPTION
This PR adds the ability for a user to include line items that are
associated with their subcontractors.  This will become necessary 
information to populate once we start to tabulate hours work 
for the all-contractor vote capabilities.  

Also included in this PR:
- UserSubContractors request to allow users to get a list of
  users that are currently associated with them.  This will make
  entry much easier on the GUI as users will be offered their
  subcontractors' usernames to select from a dropdown.
- Updates manageuser to include supervisoruserid
- Updates newinvoice to now looks for subcontractor userid CSV field