### PR TITLE
politeiavoter: Use context client for best block.

### DIFF
--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -1063,7 +1063,7 @@ func (c *ctx) bestBlock() (uint32, error) {
 		url = "https://explorer.dcrdata.org:443/api/block/best"
 	}
 
-	r, err := http.Get(url)
+	r, err := c.client.Get(url)
 	if err != nil {
 		return 0, err
 	}

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"net/http"
@@ -1071,23 +1070,19 @@ func (c *ctx) bestBlock() (uint32, error) {
 	}
 	defer r.Body.Close()
 
+	responseBody := util.ConvertBodyToByteArray(r.Body, false)
+	log.Tracef("Response: %v %v", r.StatusCode, string(responseBody))
+
 	if r.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			return 0, fmt.Errorf("dcrdata error: %v %v %v",
-				r.StatusCode, url, err)
-		}
 		return 0, fmt.Errorf("dcrdata error: %v %v %s",
-			r.StatusCode, url, body)
+			r.StatusCode, url, string(responseBody))
 	}
 
 	var bdb dcrdataapi.BlockDataBasic
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&bdb); err != nil {
+	err = json.Unmarshal(responseBody, &bdb)
+	if err != nil {
 		return 0, err
 	}
-
-	log.Debugf("%+v", bdb)
 
 	return bdb.Height, nil
 }

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -1063,6 +1063,8 @@ func (c *ctx) bestBlock() (uint32, error) {
 		url = "https://explorer.dcrdata.org:443/api/block/best"
 	}
 
+	log.Debugf("Request: GET %v", url)
+
 	r, err := c.client.Get(url)
 	if err != nil {
 		return 0, err
@@ -1084,6 +1086,8 @@ func (c *ctx) bestBlock() (uint32, error) {
 	if err := decoder.Decode(&bdb); err != nil {
 		return 0, err
 	}
+
+	log.Debugf("%+v", bdb)
 
 	return bdb.Height, nil
 }


### PR DESCRIPTION
The best block call was not using the context client, which means the call was not being routed through the proxy.  This diff fixes that.  It also adds in logging for the best block call.

```
2019-10-22 09:54:28.189 [DBG] POLV: Request: GET https://explorer.dcrdata.org:443/api/block/best
2019-10-22 09:54:30.089 [TRC] POLV: Response: 200 {"height":390491,"size":33119,"hash":"00000000000000000bcfa2fa22d9e9f50e57b42cc5e2a09cf0010afd20a83c78","diff":27788681028.69406,"sdiff":129.79952598,"time":1571759072,"txlength":0,"ticket_pool":{"height":390491,"size":40838,"value":5333850.00654643,"valavg":130.6099712656455,"winners":["eb4ff11b6d97b47b7f1736205539927556d9f7c8fe72511f3f85bb2bb8d5c495","746d44a3d47fa2f7492a7dcb25e3cab053150c6d35530c7aa4e1a300bc3e4d5c","4c371ab49516ba33ee1f25383a6356d0012c6197ff1ce42a25ba6cac2bd11606","425c091326aa45ba75bc57dec181943034aa51d7b2cd8e301cb3476f5d745640","604ddf0cfd01f758170ae6fb624ab515c50c63477cf316cc3d74689411ceb477"]}}
```