### PR TITLE
[cms] Add SubRate to Invoice line items

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -393,6 +393,7 @@ type LineItemsInput struct {
 	Description   string        `json:"description"`   // Description of work performed
 	ProposalToken string        `json:"proposaltoken"` // Link to politeia proposal that work is associated with
 	SubUserID     string        `json:"subuserid"`     // UserID of the associated Subcontractor
+	SubRate       uint          `json:"subrate"`       // The payrate of the subcontractor
 	Labor         uint          `json:"labor"`         // Number of minutes (if labor)
 	Expenses      uint          `json:"expenses"`      // Total cost (in USD cents) of line item (if expense or misc)
 }

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -136,7 +136,7 @@ const (
 
 	// PolicyInvoiceLineItemCount is the number of expected fields in the raw
 	// csv line items
-	PolicyInvoiceLineItemCount = 8
+	PolicyInvoiceLineItemCount = 9
 
 	// PolicyMinLineItemColLength is the minimun length for the strings in
 	// each column field of the lineItem structure.

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -225,7 +225,11 @@ func validateParseCSV(data []byte) (*cms.InvoiceInput, error) {
 			return invInput,
 				fmt.Errorf("invalid cost entered on line: %v", i)
 		}
-
+		rate, err := strconv.Atoi(lineContents[8])
+		if err != nil {
+			return invInput,
+				fmt.Errorf("invalid subrate hours entered on line: %v", i)
+		}
 		lineItemType, ok := LineItemType[strings.ToLower(lineContents[0])]
 		if !ok {
 			return invInput,
@@ -238,6 +242,7 @@ func validateParseCSV(data []byte) (*cms.InvoiceInput, error) {
 		lineItem.Description = lineContents[3]
 		lineItem.ProposalToken = lineContents[4]
 		lineItem.SubUserID = lineContents[7]
+		lineItem.SubRate = uint(rate * 100)
 		lineItem.Labor = uint(hours * 60)
 		lineItem.Expenses = uint(cost * 100)
 		lineItems = append(lineItems, lineItem)

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	cacheID    = "cms"
-	cmsVersion = "1"
+	cmsVersion = "2"
 
 	// Database table names
 	tableNameVersions      = "versions"

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -109,6 +109,7 @@ func EncodeInvoiceLineItem(dbLineItem *database.LineItem) LineItem {
 	lineItem.ProposalURL = dbLineItem.ProposalURL
 	lineItem.Labor = dbLineItem.Labor
 	lineItem.Expenses = dbLineItem.Expenses
+	lineItem.ContractorRate = dbLineItem.ContractorRate
 	return lineItem
 }
 
@@ -123,6 +124,7 @@ func DecodeInvoiceLineItem(lineItem *LineItem) *database.LineItem {
 	dbLineItem.ProposalURL = lineItem.ProposalURL
 	dbLineItem.Labor = lineItem.Labor
 	dbLineItem.Expenses = lineItem.Expenses
+	dbLineItem.ContractorRate = lineItem.ContractorRate
 
 	return dbLineItem
 }

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -56,15 +56,16 @@ func (Invoice) TableName() string {
 
 // LineItem is the database model for the database.LineItem type
 type LineItem struct {
-	LineItemKey  string `gorm:"primary_key"` // Token of the Invoice + array index
-	InvoiceToken string `gorm:"not null"`    // Censorship token of the invoice
-	Type         uint   `gorm:"not null"`    // Type of line item
-	Domain       string `gorm:"not null"`    // Domain of the work performed (dev, marketing etc)
-	Subdomain    string `gorm:"not null"`    // Subdomain of the work performed (decrediton, event X etc)
-	Description  string `gorm:"not null"`    // Description of work performed
-	ProposalURL  string `gorm:"not null"`    // Link to politeia proposal that work is associated with
-	Labor        uint   `gorm:"not null"`    // Number of minutes worked
-	Expenses     uint   `gorm:"not null"`    // Total cost of line item (in USD cents)
+	LineItemKey    string `gorm:"primary_key"` // Token of the Invoice + array index
+	InvoiceToken   string `gorm:"not null"`    // Censorship token of the invoice
+	Type           uint   `gorm:"not null"`    // Type of line item
+	Domain         string `gorm:"not null"`    // Domain of the work performed (dev, marketing etc)
+	Subdomain      string `gorm:"not null"`    // Subdomain of the work performed (decrediton, event X etc)
+	Description    string `gorm:"not null"`    // Description of work performed
+	ProposalURL    string `gorm:"not null"`    // Link to politeia proposal that work is associated with
+	Labor          uint   `gorm:"not null"`    // Number of minutes worked
+	Expenses       uint   `gorm:"not null"`    // Total cost of line item (in USD cents)
+	ContractorRate uint   `gorm:"not null"`    // Optional contractor rate for line item, typically used for Sub Contractors
 }
 
 // TableName returns the table name of the line items table.

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -606,6 +606,7 @@ func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) *cms.I
 			ProposalToken: dbLineItem.ProposalURL,
 			Labor:         dbLineItem.Labor,
 			Expenses:      dbLineItem.Expenses,
+			SubRate:       dbLineItem.ContractorRate,
 		}
 		invInputLineItems = append(invInputLineItems, lineItem)
 	}
@@ -636,13 +637,14 @@ func convertInvoiceRecordToDatabaseInvoice(invRec *cms.InvoiceRecord) *cmsdataba
 	dbInvoice.LineItems = make([]cmsdatabase.LineItem, 0, len(invRec.Input.LineItems))
 	for _, lineItem := range invRec.Input.LineItems {
 		dbLineItem := cmsdatabase.LineItem{
-			Type:        lineItem.Type,
-			Domain:      lineItem.Domain,
-			Subdomain:   lineItem.Subdomain,
-			Description: lineItem.Description,
-			ProposalURL: lineItem.ProposalToken,
-			Labor:       lineItem.Labor,
-			Expenses:    lineItem.Expenses,
+			Type:           lineItem.Type,
+			Domain:         lineItem.Domain,
+			Subdomain:      lineItem.Subdomain,
+			Description:    lineItem.Description,
+			ProposalURL:    lineItem.ProposalToken,
+			Labor:          lineItem.Labor,
+			Expenses:       lineItem.Expenses,
+			ContractorRate: lineItem.SubRate,
 		}
 		dbInvoice.LineItems = append(dbInvoice.LineItems, dbLineItem)
 	}
@@ -661,6 +663,8 @@ func convertLineItemsToDatabase(token string, l []cms.LineItemsInput) []cmsdatab
 			ProposalURL:  v.ProposalToken,
 			Labor:        v.Labor,
 			Expenses:     v.Expenses,
+			// If subrate is populated, use the existing contractor rate field.
+			ContractorRate: v.SubRate,
 		})
 	}
 	return dl


### PR DESCRIPTION
Because subcontractors may have different rates than the supervisor or other subcontractors within the same group we needed to add the ability to have differing subrates per lineitem.

This was pretty minor change.  Just added a new field to the line item database table and updated the various conversions and payout calculations.