### PR TITLE
[cms] Add payment backend stream

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -344,18 +344,18 @@ type EditInvoiceReply struct {
 
 // InvoiceRecord is an entire invoice and its content.
 type InvoiceRecord struct {
-	Status             InvoiceStatusT `json:"status"`                       // Current status of invoice
-	StatusChangeReason string         `json:"statuschangereason,omitempty"` // Reason (if any) for the current status
-	Timestamp          int64          `json:"timestamp"`                    // Last update of invoice
-	UserID             string         `json:"userid"`                       // ID of user who submitted invoice
-	Username           string         `json:"username"`                     // Username of user who submitted invoice
-	PublicKey          string         `json:"publickey"`                    // User's public key, used to verify signature.
-	Signature          string         `json:"signature"`                    // Signature of file digest
-	Files              []www.File     `json:"file"`                         // Actual invoice file
-	Version            string         `json:"version"`                      // Record version
-	Input              InvoiceInput   `json:"input"`                        // Decoded invoice from invoice.json file
-
-	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
+	Status             InvoiceStatusT       `json:"status"`                       // Current status of invoice
+	StatusChangeReason string               `json:"statuschangereason,omitempty"` // Reason (if any) for the current status
+	Timestamp          int64                `json:"timestamp"`                    // Last update of invoice
+	UserID             string               `json:"userid"`                       // ID of user who submitted invoice
+	Username           string               `json:"username"`                     // Username of user who submitted invoice
+	PublicKey          string               `json:"publickey"`                    // User's public key, used to verify signature.
+	Signature          string               `json:"signature"`                    // Signature of file digest
+	Files              []www.File           `json:"file"`                         // Actual invoice file
+	Version            string               `json:"version"`                      // Record version
+	Input              InvoiceInput         `json:"input"`                        // Decoded invoice from invoice.json file
+	Payment            PaymentInformation   `json:"payment"`                      // Payment information for the Invoice
+	CensorshipRecord   www.CensorshipRecord `json:"censorshiprecord"`
 }
 
 // InvoiceDetails is used to retrieve a invoice by it's token.
@@ -531,7 +531,7 @@ type InvoicePayoutsReply struct {
 type PaymentInformation struct {
 	Token           string         `json:"token"`
 	Address         string         `json:"address"`
-	TxIDs           []string       `json:"txids"`
+	TxIDs           string         `json:"txids"`
 	TimeStarted     int64          `json:"timestarted"`
 	TimeLastUpdated int64          `json:"timelastupdated"`
 	AmountNeeded    dcrutil.Amount `json:"amountneeded"`

--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -292,6 +292,7 @@ func (p *politeiawww) updateInvoicePayment(payment *database.Payments) error {
 		Token:          payment.InvoiceToken,
 		Address:        payment.Address,
 		TxIDs:          payment.TxIDs,
+		TimeStarted:    payment.TimeStarted,
 		TimeUpdated:    payment.TimeLastUpdated,
 		Status:         payment.Status,
 		AmountReceived: payment.AmountReceived,

--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -267,10 +267,10 @@ func (p *politeiawww) checkPayments(payment *database.Payments, watchedAddr, not
 	payment.AmountReceived = int64(amountReceived)
 	payment.TimeLastUpdated = time.Now().Unix()
 
-	err = p.cmsDB.UpdatePayments(payment)
+	err = p.updateInvoicePayment(payment)
 	if err != nil {
-		log.Errorf("Error updating payments information for: %v %v",
-			payment.Address, err)
+		log.Errorf("error updateInvoicePayment %v", err)
+		return false
 	}
 
 	if payment.Status == cms.PaymentStatusPaid {
@@ -285,6 +285,65 @@ func (p *politeiawww) checkPayments(payment *database.Payments, watchedAddr, not
 	return false
 }
 
+func (p *politeiawww) updateInvoicePayment(payment *database.Payments) error {
+	// Create new backend invoice payment metadata
+	c := backendInvoicePayment{
+		Version:        backendInvoicePaymentVersion,
+		Token:          payment.InvoiceToken,
+		Address:        payment.Address,
+		TxIDs:          payment.TxIDs,
+		TimeUpdated:    payment.TimeLastUpdated,
+		Status:         payment.Status,
+		AmountReceived: payment.AmountReceived,
+		AmountNeeded:   payment.AmountNeeded,
+	}
+
+	blob, err := encodeBackendInvoicePayment(c)
+	if err != nil {
+		return err
+	}
+
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return err
+	}
+
+	pdCommand := pd.UpdateVettedMetadata{
+		Challenge: hex.EncodeToString(challenge),
+		Token:     payment.InvoiceToken,
+		MDAppend: []pd.MetadataStream{
+			{
+				ID:      mdStreamInvoicePayment,
+				Payload: string(blob),
+			},
+		},
+	}
+	responseBody, err := p.makeRequest(http.MethodPost,
+		pd.UpdateVettedMetadataRoute, pdCommand)
+	if err != nil {
+		return err
+	}
+
+	var pdReply pd.UpdateVettedMetadataReply
+	err = json.Unmarshal(responseBody, &pdReply)
+	if err != nil {
+		return fmt.Errorf("Could not unmarshal UpdateVettedMetadataReply: %v",
+			err)
+	}
+
+	// Verify the UpdateVettedMetadata challenge.
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, pdReply.Response)
+	if err != nil {
+		return err
+	}
+
+	err = p.cmsDB.UpdatePayments(payment)
+	if err != nil {
+		log.Errorf("Error updating payments information for: %v %v",
+			payment.Address, err)
+	}
+	return nil
+}
 func (p *politeiawww) invoiceStatusPaid(token string) error {
 	dbInvoice, err := p.cmsDB.InvoiceByToken(token)
 	if err != nil {


### PR DESCRIPTION
Adding payment information to the backend was overlooked in the initial implementation.
Upon receipt of any new payment by the address watcher a new backendInvoicePayment mdstream
is appended to the existing invoice record in politeiad.

With this, we will be able to fully recover cmsdb information pertaining to invoices from the backend anchored information on politeiad.