### PR TITLE
[cms] Add payment backend stream

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -344,18 +344,18 @@ type EditInvoiceReply struct {
 
 // InvoiceRecord is an entire invoice and its content.
 type InvoiceRecord struct {
-	Status             InvoiceStatusT `json:"status"`                       // Current status of invoice
-	StatusChangeReason string         `json:"statuschangereason,omitempty"` // Reason (if any) for the current status
-	Timestamp          int64          `json:"timestamp"`                    // Last update of invoice
-	UserID             string         `json:"userid"`                       // ID of user who submitted invoice
-	Username           string         `json:"username"`                     // Username of user who submitted invoice
-	PublicKey          string         `json:"publickey"`                    // User's public key, used to verify signature.
-	Signature          string         `json:"signature"`                    // Signature of file digest
-	Files              []www.File     `json:"file"`                         // Actual invoice file
-	Version            string         `json:"version"`                      // Record version
-	Input              InvoiceInput   `json:"input"`                        // Decoded invoice from invoice.json file
-
-	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
+	Status             InvoiceStatusT       `json:"status"`                       // Current status of invoice
+	StatusChangeReason string               `json:"statuschangereason,omitempty"` // Reason (if any) for the current status
+	Timestamp          int64                `json:"timestamp"`                    // Last update of invoice
+	UserID             string               `json:"userid"`                       // ID of user who submitted invoice
+	Username           string               `json:"username"`                     // Username of user who submitted invoice
+	PublicKey          string               `json:"publickey"`                    // User's public key, used to verify signature.
+	Signature          string               `json:"signature"`                    // Signature of file digest
+	Files              []www.File           `json:"file"`                         // Actual invoice file
+	Version            string               `json:"version"`                      // Record version
+	Input              InvoiceInput         `json:"input"`                        // Decoded invoice from invoice.json file
+	Payment            PaymentInformation   `json:"payment"`                      // Payment information for the Invoice
+	CensorshipRecord   www.CensorshipRecord `json:"censorshiprecord"`
 }
 
 // InvoiceDetails is used to retrieve a invoice by it's token.
@@ -531,7 +531,7 @@ type InvoicePayoutsReply struct {
 type PaymentInformation struct {
 	Token           string         `json:"token"`
 	Address         string         `json:"address"`
-	TxIDs           []string       `json:"txids"`
+	TxIDs           string         `json:"txids"`
 	TimeStarted     int64          `json:"timestarted"`
 	TimeLastUpdated int64          `json:"timelastupdated"`
 	AmountNeeded    dcrutil.Amount `json:"amountneeded"`

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -531,7 +531,7 @@ type InvoicePayoutsReply struct {
 type PaymentInformation struct {
 	Token           string         `json:"token"`
 	Address         string         `json:"address"`
-	TxIDs           string         `json:"txids"`
+	TxIDs           []string       `json:"txids"`
 	TimeStarted     int64          `json:"timestarted"`
 	TimeLastUpdated int64          `json:"timelastupdated"`
 	AmountNeeded    dcrutil.Amount `json:"amountneeded"`

--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -292,6 +292,7 @@ func (p *politeiawww) updateInvoicePayment(payment *database.Payments) error {
 		Token:          payment.InvoiceToken,
 		Address:        payment.Address,
 		TxIDs:          payment.TxIDs,
+		TimeStarted:    payment.TimeStarted,
 		TimeUpdated:    payment.TimeLastUpdated,
 		Status:         payment.Status,
 		AmountReceived: payment.AmountReceived,

--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -98,7 +98,7 @@ func (p *politeiawww) restartCMSAddressesWatching() error {
 		_, err := p.cmsDB.PaymentsByAddress(invoice.PaymentAddress)
 		if err != nil {
 			if err == database.ErrInvoiceNotFound {
-				payout, err := p.calculatePayout(invoice)
+				payout, err := calculatePayout(invoice)
 				if err != nil {
 					return err
 				}
@@ -289,14 +289,9 @@ func (p *politeiawww) updateInvoicePayment(payment *database.Payments) error {
 	// Create new backend invoice payment metadata
 	c := backendInvoicePayment{
 		Version:        backendInvoicePaymentVersion,
-		Token:          payment.InvoiceToken,
-		Address:        payment.Address,
 		TxIDs:          payment.TxIDs,
-		TimeStarted:    payment.TimeStarted,
-		TimeUpdated:    payment.TimeLastUpdated,
-		Status:         payment.Status,
+		Timestamp:      payment.TimeLastUpdated,
 		AmountReceived: payment.AmountReceived,
-		AmountNeeded:   payment.AmountNeeded,
 	}
 
 	blob, err := encodeBackendInvoicePayment(c)

--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -267,10 +267,10 @@ func (p *politeiawww) checkPayments(payment *database.Payments, watchedAddr, not
 	payment.AmountReceived = int64(amountReceived)
 	payment.TimeLastUpdated = time.Now().Unix()
 
-	err = p.cmsDB.UpdatePayments(payment)
+	err = p.updateInvoicePayment(payment)
 	if err != nil {
-		log.Errorf("Error updating payments information for: %v %v",
-			payment.Address, err)
+		log.Errorf("error updateInvoicePayment %v", err)
+		return false
 	}
 
 	if payment.Status == cms.PaymentStatusPaid {
@@ -285,6 +285,65 @@ func (p *politeiawww) checkPayments(payment *database.Payments, watchedAddr, not
 	return false
 }
 
+func (p *politeiawww) updateInvoicePayment(payment *database.Payments) error {
+	// Create new backend invoice payment metadata
+	c := backendInvoicePayment{
+		Version:        backendInvoicePaymentVersion,
+		Token:          payment.InvoiceToken,
+		Address:        payment.Address,
+		TxIDs:          payment.TxIDs,
+		TimeUpdated:    payment.TimeLastUpdated,
+		Status:         payment.Status,
+		AmountReceived: payment.AmountReceived,
+		AmountNeeded:   payment.AmountNeeded,
+	}
+
+	blob, err := encodeBackendInvoicePayment(c)
+	if err != nil {
+		return err
+	}
+
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return err
+	}
+
+	pdCommand := pd.UpdateVettedMetadata{
+		Challenge: hex.EncodeToString(challenge),
+		Token:     payment.InvoiceToken,
+		MDAppend: []pd.MetadataStream{
+			{
+				ID:      mdStreamInvoicePayment,
+				Payload: string(blob),
+			},
+		},
+	}
+	responseBody, err := p.makeRequest(http.MethodPost,
+		pd.UpdateVettedMetadataRoute, pdCommand)
+	if err != nil {
+		return err
+	}
+
+	var pdReply pd.UpdateVettedMetadataReply
+	err = json.Unmarshal(responseBody, &pdReply)
+	if err != nil {
+		return fmt.Errorf("Could not unmarshal UpdateVettedMetadataReply: %v",
+			err)
+	}
+
+	// Verify the UpdateVettedMetadata challenge.
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, pdReply.Response)
+	if err != nil {
+		return err
+	}
+
+	err = p.cmsDB.UpdatePayments(payment)
+	if err != nil {
+		log.Errorf("Error updating payments information for: %v %v",
+			payment.Address, err)
+	}
+	return nil
+}
 func (p *politeiawww) invoiceStatusPaid(token string) error {
 	dbInvoice, err := p.cmsDB.InvoiceByToken(token)
 	if err != nil {

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -857,7 +857,7 @@ func convertInvoiceFromCache(r cache.Record) cms.InvoiceRecord {
 	payment.TimeLastUpdated = p.Timestamp
 	payment.AmountReceived = dcrutil.Amount(p.AmountReceived)
 	payment.Address = ii.PaymentAddress
-	payment.AmountNeeded = dcrutil.Amount(payout.DCRTotal)
+	payment.AmountNeeded = payout.DCRTotal
 
 	invRec.Payment = payment
 

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -852,7 +852,8 @@ func convertInvoiceFromCache(r cache.Record) cms.InvoiceRecord {
 	if err != nil {
 		log.Errorf("unable to calculate payout for %v", r.CensorshipRecord.Token)
 	}
-	payment.TxIDs = p.TxIDs
+	txIDs := strings.Split(p.TxIDs, ",")
+	payment.TxIDs = txIDs
 	payment.TimeLastUpdated = p.Timestamp
 	payment.AmountReceived = dcrutil.Amount(p.AmountReceived)
 	payment.Address = ii.PaymentAddress

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -812,10 +812,12 @@ func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails, user 
 
 	// Calculate the payout from the invoice record
 	dbInv := convertInvoiceRecordToDatabaseInvoice(invRec)
-	payout, err := p.calculatePayout(*dbInv)
+	payout, err := calculatePayout(*dbInv)
 	if err != nil {
 		return nil, err
 	}
+
+	payout.Username = user.Username
 
 	// Setup reply
 	reply := cms.InvoiceDetailsReply{
@@ -927,10 +929,11 @@ func (p *politeiawww) processSetInvoiceStatus(sis cms.SetInvoiceStatus, u *user.
 	dbInvoice.Status = c.NewStatus
 
 	// Calculate amount of DCR needed
-	payout, err := p.calculatePayout(*dbInvoice)
+	payout, err := calculatePayout(*dbInvoice)
 	if err != nil {
 		return nil, err
 	}
+	payout.Username = u.Username
 	// If approved then update Invoice's Payment table in DB
 	if c.NewStatus == cms.InvoiceStatusApproved {
 		dbInvoice.Payments = database.Payments{
@@ -1255,10 +1258,11 @@ func (p *politeiawww) processGeneratePayouts(gp cms.GeneratePayouts, u *user.Use
 	reply := &cms.GeneratePayoutsReply{}
 	payouts := make([]cms.Payout, 0, len(dbInvs))
 	for _, inv := range dbInvs {
-		payout, err := p.calculatePayout(inv)
+		payout, err := calculatePayout(inv)
 		if err != nil {
 			return nil, err
 		}
+		payout.Username = u.Username
 		payouts = append(payouts, payout)
 	}
 	sort.Slice(payouts, func(i, j int) bool {
@@ -1597,15 +1601,10 @@ type backendInvoiceStatusChange struct {
 // backendInvoicePayment represents an invoice payment and is stored
 // in the metadata stream mdStreamInvoicePayment in politeiad.
 type backendInvoicePayment struct {
-	Version        uint               `json:"version"`        // Version of the struct
-	Token          string             `json:"token"`          // Token of the associated invoice
-	Address        string             `json:"address"`        // Payment address of the invoice
-	TxIDs          string             `json:"txids"`          // TxIDs captured from the payment
-	TimeStarted    int64              `json:"timestarted"`    // Time of when payment first began watching
-	TimeUpdated    int64              `json:"timeupdated"`    // Time of last payment update
-	Status         cms.PaymentStatusT `json:"status"`         // Current status of the payment
-	AmountReceived int64              `json:"amountreceived"` // Amount of DCR payment currently received
-	AmountNeeded   int64              `json:"amountneeded"`   // Amount of DCR payment needed to pay invoice
+	Version        uint   `json:"version"`        // Version of the struct
+	TxIDs          string `json:"txids"`          // TxIDs captured from the payment, separated by commas
+	Timestamp      int64  `json:"timeupdated"`    // Time of last payment update
+	AmountReceived int64  `json:"amountreceived"` // Amount of DCR payment currently received
 }
 
 // encodeBackendInvoiceMetadata encodes a backendInvoiceMetadata into a JSON
@@ -1741,20 +1740,12 @@ func getInvoiceMonthYear(files []www.File) (uint, uint) {
 	return 0, 0
 }
 
-func (p *politeiawww) calculatePayout(inv database.Invoice) (cms.Payout, error) {
+func calculatePayout(inv database.Invoice) (cms.Payout, error) {
 	payout := cms.Payout{}
-
-	var username string
-	u, err := p.db.UserGetByPubKey(inv.PublicKey)
-	if err != nil {
-		log.Errorf("calculatePayout: UserGetByPubKey: token:%v "+
-			"pubkey:%v err:%v", inv.Token, inv.PublicKey, err)
-	} else {
-		username = u.Username
-	}
-
+	var err error
 	var totalLaborMinutes uint
 	var totalExpenses uint
+
 	for _, lineItem := range inv.LineItems {
 		switch lineItem.Type {
 		case cms.LineItemTypeLabor, cms.LineItemTypeSubHours:
@@ -1772,7 +1763,6 @@ func (p *politeiawww) calculatePayout(inv database.Invoice) (cms.Payout, error) 
 	payout.Token = inv.Token
 	payout.ContractorName = inv.ContractorName
 
-	payout.Username = username
 	payout.Month = inv.Month
 	payout.Year = inv.Year
 	payout.Total = payout.LaborTotal + payout.ExpenseTotal


### PR DESCRIPTION
Adding payment information to the backend was overlooked in the initial implementation.
Upon receipt of any new payment by the address watcher a new backendInvoicePayment mdstream
is appended to the existing invoice record in politeiad.

With this, we will be able to fully recover cmsdb information pertaining to invoices from the backend anchored information on politeiad.