### PR TITLE
multi: Add RFP proposal.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -18,6 +18,7 @@ const (
 	ID                       = "decred"
 	CmdAuthorizeVote         = "authorizevote"
 	CmdStartVote             = "startvote"
+	CmdStartVoteRunoff       = "startvoterunoff"
 	CmdVoteDetails           = "votedetails"
 	CmdVoteSummary           = "votesummary"
 	CmdBatchVoteSummary      = "batchvotesummary"
@@ -35,6 +36,7 @@ const (
 	CmdProposalCommentsLikes = "proposalcommentslikes"
 	CmdInventory             = "inventory"
 	CmdTokenInventory        = "tokeninventory"
+	CmdLinkedFrom            = "linkedfrom"
 	MDStreamAuthorizeVote    = 13 // Vote authorization by proposal author
 	MDStreamVoteBits         = 14 // Vote bits and mask
 	MDStreamVoteSnapshot     = 15 // Vote tickets and start/end parameters
@@ -46,13 +48,29 @@ const (
 	AuthVoteActionAuthorize = "authorize" // Authorize a proposal vote
 	AuthVoteActionRevoke    = "revoke"    // Revoke a proposal vote authorization
 
+	// Vote option IDs
+	VoteOptionIDApprove = "yes"
+	VoteOptionIDReject  = "no"
+
 	// Vote types
 	//
 	// VoteTypeStandard is used to indicate a simple approve or reject
 	// proposal vote where the winner is the voting option that has met
 	// the specified pass and quorum requirements.
+	//
+	// VoteTypeRunoff specifies a runoff vote that multiple proposals compete in.
+	// All proposals are voted on like normal, but there can only be one winner
+	// in a runoff vote. The winner is the proposal that meets the quorum
+	// requirement, meets the pass requirement, and that has the most net yes
+	// votes. The winning proposal is considered approved and all other proposals
+	// are considered rejected. If no proposals meet the quorum and pass
+	// requirements then all proposals are considered rejected.
+	// Note: in a runoff vote it is possible for a proposal to meet the quorum
+	// and pass requirements but still be rejected if it does not have the most
+	// net yes votes.
 	VoteTypeInvalid  VoteT = 0
 	VoteTypeStandard VoteT = 1
+	VoteTypeRunoff   VoteT = 2
 
 	// Versioning
 	VersionStartVoteV1 = 1
@@ -463,6 +481,53 @@ func DecodeStartVoteReply(payload []byte) (*StartVoteReply, error) {
 	return &v, nil
 }
 
+// StartVoteRunoff instructs the plugin to start a runoff vote using the given
+// submissions. Each submission is required to have its own StartVote.
+type StartVoteRunoff struct {
+	Token      string        `json:"token"`      // Token of RFP proposal
+	StartVotes []StartVoteV2 `json:"startvotes"` // StartVotes for each submission
+}
+
+// EncodeStartVoteRunoffencodes StartVoteRunoffinto a JSON byte slice.
+func EncodeStartVoteRunoff(v StartVoteRunoff) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeVotedecodes a JSON byte slice into a StartVoteRunoff.
+func DecodeStartVoteRunoff(payload []byte) (*StartVoteRunoff, error) {
+	var sv StartVoteRunoff
+
+	err := json.Unmarshal(payload, &sv)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sv, nil
+}
+
+// StartVoteRunoffReply is the reply to StartVoteRunoff. The StartVoteReply
+// will be the same for all submissions so only one is returned.
+type StartVoteRunoffReply struct {
+	StartVoteReply StartVoteReply `json:"startvotereply"`
+}
+
+// EncodeStartVoteRunoffReply encodes StartVoteRunoffReply into a JSON byte slice.
+func EncodeStartVoteRunoffReply(v StartVoteRunoffReply) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeVoteReply decodes a JSON byte slice into a StartVoteRunoffReply.
+func DecodeStartVoteRunoffReply(payload []byte) (*StartVoteRunoffReply, error) {
+	var v StartVoteRunoffReply
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
 // VoteDetails is used to retrieve the voting period details for a record.
 type VoteDetails struct {
 	Token string `json:"token"` // Censorship token
@@ -554,7 +619,8 @@ func DecodeVoteResultsReply(payload []byte) (*VoteResultsReply, error) {
 // VoteSummary requests a summary of a proposal vote. This includes certain
 // voting period parameters and a summary of the vote results.
 type VoteSummary struct {
-	Token string `json:"token"` // Censorship token
+	Token     string `json:"token"`     // Censorship token
+	BestBlock uint64 `json:"bestblock"` // Best block
 }
 
 // EncodeVoteSummary encodes VoteSummary into a JSON byte slice.
@@ -587,12 +653,14 @@ type VoteOptionResult struct {
 // voting period parameters as well as a summary of the vote results.
 type VoteSummaryReply struct {
 	Authorized          bool               `json:"authorized"`          // Vote is authorized
+	Type                VoteT              `json:"type"`                // Vote type
 	Duration            uint32             `json:"duration"`            // Vote duration
 	EndHeight           string             `json:"endheight"`           // End block height
 	EligibleTicketCount int                `json:"eligibleticketcount"` // Number of eligible tickets
 	QuorumPercentage    uint32             `json:"quorumpercentage"`    // Percent of eligible votes required for quorum
 	PassPercentage      uint32             `json:"passpercentage"`      // Percent of total votes required to pass
 	Results             []VoteOptionResult `json:"results"`             // Vote results
+	Approved            bool               `json:"approved"`            // Was vote approved
 }
 
 // EncodeVoteSummaryReply encodes VoteSummary into a JSON byte slice.
@@ -616,7 +684,8 @@ func DecodeVoteSummaryReply(payload []byte) (*VoteSummaryReply, error) {
 // includes certain voting period parameters and a summary of the vote
 // results.
 type BatchVoteSummary struct {
-	Tokens []string `json:"token"` // Censorship token
+	Tokens    []string `json:"token"`     // Censorship token
+	BestBlock uint64   `json:"bestblock"` // Best block
 }
 
 // EncodeBatchVoteSummary encodes BatchVoteSummary into a JSON byte slice.
@@ -638,7 +707,9 @@ func DecodeBatchVoteSummary(payload []byte) (*BatchVoteSummary, error) {
 
 // BatchVoteSummaryReply is the reply to the VoteSummary command and returns
 // certain voting period parameters as well as a summary of the vote results.
-// Results will only be returned for tokens of valid vetted proposals.
+// Results are returned for all tokens that correspond to a proposal. This
+// includes both unvetted and vetted proposals. Tokens that do no correspond to
+// a proposal are not included in the returned map.
 type BatchVoteSummaryReply struct {
 	Summaries map[string]VoteSummaryReply `json:"summaries"` // Vote summaries
 }
@@ -1250,6 +1321,53 @@ func EncodeLoadVoteResultsReply(reply LoadVoteResultsReply) ([]byte, error) {
 // DecodeLoadVoteResultsReply decodes a JSON byte slice into a LoadVoteResults.
 func DecodeLoadVoteResultsReply(payload []byte) (*LoadVoteResultsReply, error) {
 	var reply LoadVoteResultsReply
+
+	err := json.Unmarshal(payload, &reply)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reply, nil
+}
+
+// LinkedFrom returns a map[token][]token that contains the linked from list
+// for each of the given proposal tokens. A linked from list is a list of all
+// the proposals that have linked to a given proposal using the LinkTo field
+// in the ProposalGeneral mdstream.
+type LinkedFrom struct {
+	Tokens []string `json:"tokens"`
+}
+
+// EncodeLinkedFrom encodes a LinkedFrom into a JSON byte slice.
+func EncodeLinkedFrom(lf LinkedFrom) ([]byte, error) {
+	return json.Marshal(lf)
+}
+
+// DecodeLinkedFrom decodes a JSON byte slice into a LinkedFrom.
+func DecodeLinkedFrom(payload []byte) (*LinkedFrom, error) {
+	var lf LinkedFrom
+
+	err := json.Unmarshal(payload, &lf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lf, nil
+}
+
+// LinkedFromReply is the reply to the LinkedFrom command.
+type LinkedFromReply struct {
+	LinkedFrom map[string][]string `json:"linkedfrom"`
+}
+
+// EncodeLinkedFromReply encodes a LinkedFromReply into a JSON byte slice.
+func EncodeLinkedFromReply(reply LinkedFromReply) ([]byte, error) {
+	return json.Marshal(reply)
+}
+
+// DecodeLinkedFromReply decodes a JSON byte slice into a LinkedFrom.
+func DecodeLinkedFromReply(payload []byte) (*LinkedFromReply, error) {
+	var reply LinkedFromReply
 
 	err := json.Unmarshal(payload, &reply)
 	if err != nil {

--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -508,9 +508,12 @@ func DecodeStartVoteRunoff(payload []byte) (*StartVoteRunoff, error) {
 }
 
 // StartVoteRunoffReply is the reply to StartVoteRunoff. The StartVoteReply
-// will be the same for all submissions so only one is returned.
+// will be the same for all submissions so only one is returned. The individual
+// AuthorizeVoteReply is returned for each submission where the token is the
+// map key.
 type StartVoteRunoffReply struct {
-	StartVoteReply StartVoteReply `json:"startvotereply"`
+	AuthorizeVoteReplies map[string]AuthorizeVoteReply `json:"authorizevotereply"`
+	StartVoteReply       StartVoteReply                `json:"startvotereply"`
 }
 
 // EncodeStartVoteRunoffReply encodes StartVoteRunoffReply into a JSON byte slice.

--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -1338,7 +1338,7 @@ func DecodeLoadVoteResultsReply(payload []byte) (*LoadVoteResultsReply, error) {
 // LinkedFrom returns a map[token][]token that contains the linked from list
 // for each of the given proposal tokens. A linked from list is a list of all
 // the proposals that have linked to a given proposal using the LinkTo field
-// in the ProposalGeneral mdstream.
+// in the ProposalMetadata mdstream.
 type LinkedFrom struct {
 	Tokens []string `json:"tokens"`
 }

--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -482,10 +482,12 @@ func DecodeStartVoteReply(payload []byte) (*StartVoteReply, error) {
 }
 
 // StartVoteRunoff instructs the plugin to start a runoff vote using the given
-// submissions. Each submission is required to have its own StartVote.
+// submissions. Each submission is required to have its own AuthorizeVote and
+// StartVote.
 type StartVoteRunoff struct {
-	Token      string        `json:"token"`      // Token of RFP proposal
-	StartVotes []StartVoteV2 `json:"startvotes"` // StartVotes for each submission
+	Token          string          `json:"token"`          // Token of RFP proposal
+	AuthorizeVotes []AuthorizeVote `json:"authorizevotes"` // Submission auth votes
+	StartVotes     []StartVoteV2   `json:"startvotes"`     // Submission start votes
 }
 
 // EncodeStartVoteRunoffencodes StartVoteRunoffinto a JSON byte slice.

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -131,6 +131,42 @@ func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 	return &md, nil
 }
 
+// ProposalMetadata contains metadata that is specified by the user on proposal
+// submission. It is attached to a proposal submission as a politeiawww
+// Metadata object and is saved to politeiad as a File, not as a
+// MetadataStream. The filename is defined by FilenameProposalMetadata.
+//
+// The reason it is saved to politeiad as a File is because politeiad only
+// includes Files in the merkle root calculation. This is user defined metadata
+// so it must be included in the proposal signature on submission. If it were
+// saved to politeiad as a MetadataStream then it would not be included in the
+// merkle root, thus causing an error where the client calculated merkle root
+// if different than the politeiad calculated merkle root.
+type ProposalMetadata struct {
+	Name   string `json:"name"`             // Proposal name
+	LinkTo string `json:"linkto,omitempty"` // Token of proposal to link to
+	LinkBy int64  `json:"linkby,omitempty"` // UNIX timestamp of RFP deadline
+}
+
+// EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.
+func EncodeProposalMetadata(md ProposalMetadata) ([]byte, error) {
+	b, err := json.Marshal(md)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// DecodeProposalMetadata decodes a JSON byte slice into a ProposalMetadata.
+func DecodeProposalMetadata(payload []byte) (*ProposalMetadata, error) {
+	var md ProposalMetadata
+	err := json.Unmarshal(payload, &md)
+	if err != nil {
+		return nil, err
+	}
+	return &md, nil
+}
+
 // RecordStatusChangeV1 represents a politeiad record status change and is used
 // to store additional status change metadata that would not otherwise be
 // captured by the politeiad status change routes.

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -45,12 +45,19 @@ const (
 )
 
 // ProposalGeneral represents general metadata for a proposal.
+//
+// LinkBy is set to signify that the proposal is a Request For Proposals (RFP)
+// and serves as the deadline for other proposals to link to the RFP.
+//
+// LinkTo allows a proposal to link to an existing public proposal.
 type ProposalGeneral struct {
-	Version   uint64 `json:"version"`   // Struct version
-	Timestamp int64  `json:"timestamp"` // Last update of proposal
-	Name      string `json:"name"`      // Provided proposal name
-	PublicKey string `json:"publickey"` // Key used for signature
-	Signature string `json:"signature"` // Signature of proposal files merkle root
+	Version   uint64 `json:"version"`          // Struct version
+	Timestamp int64  `json:"timestamp"`        // Last update of proposal
+	Name      string `json:"name"`             // Provided proposal name
+	LinkBy    int64  `json:"linkby,omitempty"` // UNIX timestamp of RFP deadline
+	LinkTo    string `json:"linkto,omitempty"` // Token of proposal to link to
+	PublicKey string `json:"publickey"`        // Key used for signature
+	Signature string `json:"signature"`        // Signature of proposal files merkle root
 }
 
 // EncodeProposalGeneral encodes a ProposalGeneral into a JSON byte slice.

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -1700,13 +1700,13 @@ var (
 // but older records may not. A errProposalMetadata not found error is returned
 // if a ProposalMetadata was not found.
 //
-// This function must be called with the read lock held.
+// This function must be called WITH the lock held.
 func (g *gitBackEnd) vettedProposalMetadata(token string) (*mdstream.ProposalMetadata, error) {
 	tokenb, err := hex.DecodeString(token)
 	if err != nil {
 		return nil, err
 	}
-	r, err := g.GetVetted(tokenb, "")
+	r, err := g.getRecord(tokenb, "", g.vetted, true)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -1736,7 +1736,7 @@ func (g *gitBackEnd) pluginStartVote(payload string) (string, error) {
 
 	// Verify proposal exists
 	token := sv.Vote.Token
-	if !g.propExists(g.vetted, token) {
+	if !g.vettedPropExists(token) {
 		return "", fmt.Errorf("unknown proposal: %v", token)
 	}
 
@@ -1769,11 +1769,15 @@ func (g *gitBackEnd) pluginStartVote(payload string) (string, error) {
 	}
 
 	// Verify proposal state
-	avExists := g.vettedMetadataStreamExists(tokenB,
+	tokenb, err := util.ConvertStringToken(token)
+	if err != nil {
+		return "", err
+	}
+	avExists := g.vettedMetadataStreamExists(tokenb,
 		decredplugin.MDStreamAuthorizeVote)
-	vbExists := g.vettedMetadataStreamExists(tokenB,
+	vbExists := g.vettedMetadataStreamExists(tokenb,
 		decredplugin.MDStreamVoteBits)
-	vsExists := g.vettedMetadataStreamExists(tokenB,
+	vsExists := g.vettedMetadataStreamExists(tokenb,
 		decredplugin.MDStreamVoteSnapshot)
 
 	switch {
@@ -1803,7 +1807,7 @@ func (g *gitBackEnd) pluginStartVote(payload string) (string, error) {
 	}
 
 	// Ensure vote authorization has not been revoked
-	b, err := g.getVettedMetadataStream(tokenB,
+	b, err := g.getVettedMetadataStream(tokenb,
 		decredplugin.MDStreamAuthorizeVote)
 	if err != nil {
 		return "", fmt.Errorf("getVettedMetadataStream %v: %v",
@@ -1828,10 +1832,6 @@ func (g *gitBackEnd) pluginStartVote(payload string) (string, error) {
 	svrb, err := decredplugin.EncodeStartVoteReply(*svr)
 	if err != nil {
 		return "", fmt.Errorf("EncodeStartVoteReply: %v", err)
-	}
-	tokenb, err := util.ConvertStringToken(sv.Vote.Token)
-	if err != nil {
-		return "", fmt.Errorf("ConvertStringToken %v", err)
 	}
 
 	// Store snapshot in metadata
@@ -1928,12 +1928,12 @@ func (g *gitBackEnd) pluginStartVoteRunoff(payload string) (string, error) {
 	}
 
 	// Verify the rfp proposal and all rfp submissions exist
-	if !g.propExists(g.vetted, sv.Token) {
+	if !g.vettedPropExists(sv.Token) {
 		return "", fmt.Errorf("rfp proposal not found: %v",
 			sv.Token)
 	}
 	for _, v := range sv.StartVotes {
-		if !g.propExists(g.vetted, v.Vote.Token) {
+		if !g.vettedPropExists(v.Vote.Token) {
 			return "", fmt.Errorf("rfp submission not found: %v",
 				v.Vote.Token)
 		}

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -1866,13 +1866,20 @@ func (g *gitBackEnd) pluginStartVoteRunoff(payload string) (string, error) {
 		return "", err
 	}
 
-	// Validate the StartVote for each submission
+	if len(sv.StartVotes) == 0 {
+		return "", fmt.Errorf("no startvotes found")
+	}
+
 	var (
-		duration uint32
-		quorum   uint32
-		pass     uint32
+		// Vote params must be the same for all submissions so set
+		// the defaults to be the params of the first submission.
+		duration = sv.StartVotes[0].Vote.Duration
+		quorum   = sv.StartVotes[0].Vote.QuorumPercentage
+		pass     = sv.StartVotes[0].Vote.PassPercentage
 	)
-	for i, v := range sv.StartVotes {
+
+	// Validate the StartVote for each submission
+	for _, v := range sv.StartVotes {
 		err = validateStartVoteV2(v)
 		if err != nil {
 			return "", err
@@ -1884,12 +1891,6 @@ func (g *gitBackEnd) pluginStartVoteRunoff(payload string) (string, error) {
 		}
 
 		// Vote params must be the same for all submissions
-		if i == 0 {
-			duration = v.Vote.Duration
-			quorum = v.Vote.QuorumPercentage
-			pass = v.Vote.PassPercentage
-			continue
-		}
 		switch {
 		case duration != v.Vote.Duration:
 			return "", fmt.Errorf("start votes have different vote durations")

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -1895,23 +1895,23 @@ func (g *gitBackEnd) pluginStartVoteRunoff(payload string) (string, error) {
 	}
 
 	// Ensure start votes and authorize votes match
-	auths := make(map[string]struct{}, len(sv.AuthorizeVotes))
-	starts := make(map[string]struct{}, len(sv.StartVotes))
+	authVotes := make(map[string]struct{}, len(sv.AuthorizeVotes))
+	startVotes := make(map[string]struct{}, len(sv.StartVotes))
 	for _, v := range sv.AuthorizeVotes {
-		auths[v.Token] = struct{}{}
+		authVotes[v.Token] = struct{}{}
 	}
 	for _, v := range sv.StartVotes {
-		starts[v.Vote.Token] = struct{}{}
+		startVotes[v.Vote.Token] = struct{}{}
 	}
 	for _, v := range sv.AuthorizeVotes {
-		_, ok := starts[v.Token]
+		_, ok := startVotes[v.Token]
 		if !ok {
 			return "", fmt.Errorf("authorize vote found without matching"+
 				"start vote %v", v.Token)
 		}
 	}
 	for _, v := range sv.StartVotes {
-		_, ok := auths[v.Vote.Token]
+		_, ok := authVotes[v.Vote.Token]
 		if !ok {
 			return "", fmt.Errorf("start vote found without matching "+
 				"authorize vote %v", v.Vote.Token)

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -460,25 +460,6 @@ func mdFilename(path, id string, mdID int) string {
 		strconv.FormatUint(uint64(mdID), 10)+defaultMDFilenameSuffix)
 }
 
-// loadMDStream loads a specific metadata stream. This function should only be
-// called by plugin commands since gitbe has no knowledge of specific metadata
-// streams.
-//
-// This function must be called with the lock held.
-func loadMDStream(repo, token, version string, mdStreamID int) (*backend.MetadataStream, error) {
-	mdFile := fmt.Sprintf("%02v%v", strconv.Itoa(mdStreamID),
-		defaultMDFilenameSuffix)
-	fn := pijoin(repo, token, version, mdFile)
-	md, err := ioutil.ReadFile(fn)
-	if err != nil {
-		return nil, err
-	}
-	return &backend.MetadataStream{
-		ID:      uint64(mdStreamID),
-		Payload: string(md),
-	}, nil
-}
-
 // loadMDStreams loads all streams of disk.  It returns an array of
 // backend.MetadataStream that is completely filled out.
 //
@@ -1861,7 +1842,7 @@ func (g *gitBackEnd) updateVettedMetadataMulti(um []updateMetadata, idTmp string
 // call. Record itself is not changed. If any parts of the update fail then
 // all work is unwound.
 //
-// This function must be called with the lock held.
+// This function must be called WITH the lock held.
 func (g *gitBackEnd) _updateVettedMetadataMulti(um []updateMetadata, idTmp string) error {
 	if len(um) == 0 {
 		return backend.ErrNoChanges

--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -156,8 +156,14 @@ func convertLikeCommentToDecred(lc LikeComment) decredplugin.LikeComment {
 	}
 }
 
-func convertAuthorizeVoteFromDecred(av decredplugin.AuthorizeVote, avr decredplugin.AuthorizeVoteReply, version uint64) AuthorizeVote {
-	return AuthorizeVote{
+func convertAuthorizeVoteFromDecred(av decredplugin.AuthorizeVote, avr decredplugin.AuthorizeVoteReply) (*AuthorizeVote, error) {
+	version, err := strconv.ParseUint(avr.RecordVersion, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse version '%v' failed: %v",
+			avr.RecordVersion, err)
+	}
+
+	return &AuthorizeVote{
 		Key:       av.Token + avr.RecordVersion,
 		Token:     av.Token,
 		Version:   version,
@@ -166,7 +172,7 @@ func convertAuthorizeVoteFromDecred(av decredplugin.AuthorizeVote, avr decredplu
 		PublicKey: av.PublicKey,
 		Receipt:   avr.Receipt,
 		Timestamp: avr.Timestamp,
-	}
+	}, nil
 }
 
 func convertAuthorizeVoteToDecred(av AuthorizeVote) decredplugin.AuthorizeVote {

--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/decred/politeia/decredplugin"
+	"github.com/decred/politeia/mdstream"
 	"github.com/decred/politeia/politeiad/cache"
 )
 
@@ -400,4 +401,18 @@ func convertVoteOptionResultsToDecred(r []VoteOptionResult) []decredplugin.VoteO
 		results = append(results, convertVoteOptionResultToDecred(v))
 	}
 	return results
+}
+
+func convertProposalGeneralMetadataFromMDStream(pg mdstream.ProposalGeneral, token string, proposalVersion uint64) ProposalGeneralMetadata {
+	return ProposalGeneralMetadata{
+		Token:           token,
+		ProposalVersion: proposalVersion,
+		Version:         pg.Version,
+		Timestamp:       pg.Timestamp,
+		Name:            pg.Name,
+		LinkTo:          pg.LinkTo,
+		LinkBy:          pg.LinkBy,
+		Signature:       pg.Signature,
+		PublicKey:       pg.PublicKey,
+	}
 }

--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/decred/politeia/decredplugin"
-	"github.com/decred/politeia/mdstream"
 	"github.com/decred/politeia/politeiad/cache"
 )
 
@@ -401,18 +400,4 @@ func convertVoteOptionResultsToDecred(r []VoteOptionResult) []decredplugin.VoteO
 		results = append(results, convertVoteOptionResultToDecred(v))
 	}
 	return results
-}
-
-func convertProposalGeneralMetadataFromMDStream(pg mdstream.ProposalGeneral, token string, proposalVersion uint64) ProposalGeneralMetadata {
-	return ProposalGeneralMetadata{
-		Token:           token,
-		ProposalVersion: proposalVersion,
-		Version:         pg.Version,
-		Timestamp:       pg.Timestamp,
-		Name:            pg.Name,
-		LinkTo:          pg.LinkTo,
-		LinkBy:          pg.LinkBy,
-		Signature:       pg.Signature,
-		PublicKey:       pg.PublicKey,
-	}
 }

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -1594,7 +1594,7 @@ func (d *decred) linkedFrom(token string) ([]string, error) {
           WHERE status IN (?)
           AND token IN (
             SELECT token
-            FROM proposal_general_metadata
+            FROM proposal_metadata
             WHERE link_to = ?
           )`
 	rows, err := d.recordsdb.

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -34,9 +34,6 @@ const (
 	tableStartVotes              = "start_votes"
 	tableVoteOptionResults       = "vote_option_results"
 	tableVoteResults             = "vote_results"
-
-	// Vote option IDs
-	voteOptionIDApproved = "yes"
 )
 
 // decred implements the PluginDriver interface.
@@ -54,6 +51,545 @@ func publicStatuses() []int {
 		int(pd.RecordStatusPublic),
 		int(pd.RecordStatusArchived),
 	}
+}
+
+// authorizeVotes returns a map[token]AuthorizeVote for the given records. An
+// entry in the returned map will only exist if an AuthorizeVote is found for
+// the record.
+func (d *decred) authorizeVotes(records []Record) (map[string]AuthorizeVote, error) {
+	authorizeVotes := make(map[string]AuthorizeVote, len(records))
+
+	if len(records) == 0 {
+		return authorizeVotes, nil
+	}
+
+	keys := make([]string, 0, len(records))
+	for _, v := range records {
+		keys = append(keys, v.Token+strconv.FormatUint(v.Version, 10))
+	}
+
+	avs := make([]AuthorizeVote, 0, len(keys))
+	err := d.recordsdb.
+		Where("key IN (?)", keys).
+		Find(&avs).
+		Error
+	if err != nil {
+		return nil, fmt.Errorf("select AuthorizeVotes in %v: %v",
+			keys, err)
+	}
+
+	for _, av := range avs {
+		authorizeVotes[av.Token] = av
+	}
+
+	return authorizeVotes, nil
+}
+
+// startVotes returns a map[token]StartVote for the given tokens. An entry in
+// the returned map will only exist for tokens where a StartVote was found.
+func (d *decred) startVotes(tokens []string) (map[string]StartVote, error) {
+	startVotes := make(map[string]StartVote, len(tokens))
+
+	if len(tokens) == 0 {
+		return startVotes, nil
+	}
+
+	svs := make([]StartVote, 0, len(tokens))
+	err := d.recordsdb.
+		Where("token IN (?)", tokens).
+		Preload("Options").
+		Find(&svs).
+		Error
+	if err != nil {
+		return nil, fmt.Errorf("select StartVotes in %v: %v",
+			tokens, err)
+	}
+
+	for _, v := range svs {
+		startVotes[v.Token] = v
+	}
+
+	return startVotes, nil
+}
+
+// voteOptionResults returns the VoteOptionResult for each of the given
+// VoteOptions. The results are looked up manually from the CastVotes table
+// instead of using the VoteResults table. This allows results to be looked up
+// when a VoteResults entry does not yet exist, such as for ongoing votes.
+func (d *decred) voteOptionResults(options []VoteOption) ([]VoteOptionResult, error) {
+	results := make([]VoteOptionResult, 0, len(options))
+
+	for _, v := range options {
+		var votes uint64
+		tokenVoteBit := v.Token + strconv.FormatUint(v.Bits, 16)
+		err := d.recordsdb.
+			Model(&CastVote{}).
+			Where("token_vote_bit = ?", tokenVoteBit).
+			Count(&votes).
+			Error
+		if err != nil {
+			return nil, fmt.Errorf("select CastVote count for %v: %v",
+				tokenVoteBit, err)
+		}
+
+		results = append(results, VoteOptionResult{
+			Key:   tokenVoteBit,
+			Token: v.Token,
+			Votes: votes,
+			Option: VoteOption{
+				ID:          v.ID,
+				Description: v.Description,
+				Bits:        v.Bits,
+			},
+		})
+	}
+
+	return results, nil
+}
+
+// voteResultsMissing returns the tokens of the standard proposal votes and
+// runoff proposal votes that have finished voting but are missing from the
+// lazy loaded VoteResults table.
+func (d *decred) voteResultsMissing(bestBlock uint64) ([]string, []string, error) {
+	// Find standard vote proposals that have finished voting but
+	// have not yet been added to the VoteResults table.
+	q := `SELECT start_votes.token
+        FROM start_votes
+        LEFT OUTER JOIN vote_results
+          ON start_votes.token = vote_results.token
+          WHERE start_votes.end_height <= ?
+          AND start_votes.Type = ?
+          AND vote_results.token IS NULL`
+	rows, err := d.recordsdb.Raw(q, bestBlock,
+		int(decredplugin.VoteTypeStandard)).Rows()
+	if err != nil {
+		return nil, nil, fmt.Errorf("lookup missing standard vote results: %v",
+			err)
+	}
+	defer rows.Close()
+
+	standard := make([]string, 0, 1024)
+	for rows.Next() {
+		var token string
+		rows.Scan(&token)
+		standard = append(standard, token)
+	}
+
+	// Find runoff vote proposals that have finished voting but
+	// have not yet been added to the VoteResults table.
+	q = `SELECT start_votes.token
+        FROM start_votes
+        LEFT OUTER JOIN vote_results
+          ON start_votes.token = vote_results.token
+          WHERE start_votes.end_height <= ?
+          AND start_votes.Type = ?
+          AND vote_results.token IS NULL`
+	rows, err = d.recordsdb.Raw(q, bestBlock,
+		int(decredplugin.VoteTypeRunoff)).Rows()
+	if err != nil {
+		return nil, nil, fmt.Errorf("lookup missing runoff vote results: %v",
+			err)
+	}
+	defer rows.Close()
+
+	runoff := make([]string, 0, 1024)
+	for rows.Next() {
+		var token string
+		rows.Scan(&token)
+		runoff = append(runoff, token)
+	}
+
+	return standard, runoff, nil
+}
+
+// voteResultsInsertRunoff calculates the results of a runoff vote and inserts
+// a VoteResults record into the cache for each of the runoff vote submissions.
+func (d *decred) voteResultsInsertRunoff(rfpToken string) error {
+	log.Tracef("voteResultsInsertRunoffVote: %v", rfpToken)
+
+	linkedFrom, err := d.linkedFrom(rfpToken)
+	if err != nil {
+		return err
+	}
+
+	// Compile vote results for all RFP submissions
+	results := make([]VoteResults, 0, len(linkedFrom))
+	for _, token := range linkedFrom {
+		// Make sure record hasn't been abandoned
+		var r Record
+		err = d.recordsdb.
+			Where("records.token = ?", token).
+			Order("records.version desc").
+			Limit(1).
+			Preload("Metadata").
+			Find(&r).
+			Error
+		if err != nil {
+			return fmt.Errorf("lookup record %v: %v",
+				token, err)
+		}
+		if r.Status == int(pd.RecordStatusArchived) {
+			// RFP submission has been abandoned
+			continue
+		}
+
+		// Lookup start vote
+		var sv StartVote
+		err := d.recordsdb.
+			Where("token = ?", token).
+			Preload("Options").
+			Find(&sv).
+			Error
+		if err != nil {
+			return fmt.Errorf("find start vote %v: %v",
+				token, err)
+		}
+
+		// Lookup cast votes
+		var cv []CastVote
+		err = d.recordsdb.
+			Where("token = ?", token).
+			Find(&cv).
+			Error
+		if err == gorm.ErrRecordNotFound {
+			// No cast votes exists. In theory, this could
+			// happen if no one were to vote on a proposal.
+			// In practice, this shouldn't happen.
+		} else if err != nil {
+			return fmt.Errorf("lookup cast votes: %v", err)
+		}
+
+		// Prepare vote results. This will mark the vote as
+		// approved if it meets the specified quorum and pass
+		// requirements. The actual runoff vote winner is
+		// determined later in this function.
+		results = append(results, prepareVoteResults(sv, cv))
+	}
+
+	// Determine runoff vote winner. The winner is the vote
+	// that passed the quorum and pass requirments and has
+	// the most net approved votes.
+	var (
+		winnerNetApprove int    // Net number of approve votes of the winner
+		winnerToken      string // Censorship token of the winner
+	)
+	for _, vr := range results {
+		if !vr.Approved {
+			// Vote did not meet quorum and pass requirements
+			continue
+		}
+
+		// Check if this proposal has more net approved votes
+		// then the current highest.
+		var (
+			votesApprove uint64 // Number of approve votes
+			votesReject  uint64 // Number of reject votes
+		)
+		for _, vor := range vr.Results {
+			switch vor.Option.ID {
+			case decredplugin.VoteOptionIDApprove:
+				votesApprove = vor.Votes
+			case decredplugin.VoteOptionIDReject:
+				votesReject = vor.Votes
+			default:
+				// Runoff vote options can only be approve/reject
+				return fmt.Errorf("unknown runoff vote option %v %v",
+					vr.Token, vor.Option.ID)
+			}
+
+			netApprove := int(votesApprove) - int(votesReject)
+			if netApprove > winnerNetApprove {
+				// New winner!
+				winnerToken = vr.Token
+				winnerNetApprove = netApprove
+			}
+
+			// This doesn't handle the unlikely case that the
+			// runoff vote results in a tie. If that happens
+			// we can decide how to handle it and rebuild the
+			// cache with the new rules.
+		}
+	}
+
+	// Now that we know the winner we can update the losers
+	// and insert the results into the cache.
+	for _, vr := range results {
+		// Update runoff vote losers
+		if vr.Token != winnerToken {
+			vr.Approved = false
+		}
+
+		// Insert vote results record
+		err = d.recordsdb.Create(vr).Error
+		if err != nil {
+			return fmt.Errorf("insert vote results %v: %v",
+				vr.Token, err)
+		}
+	}
+
+	return nil
+}
+
+// voteResultsInsertStandard calculates the vote results for a standard
+// proposal vote and inserts a VoteResults record into the cache. A VoteResults
+// record should only be created for proposals once the voting period has
+// ended.
+func (d *decred) voteResultsInsertStandard(token string) error {
+	log.Tracef("insertVoteResults %v", token)
+
+	// Lookup start vote
+	var sv StartVote
+	err := d.recordsdb.
+		Where("token = ?", token).
+		Preload("Options").
+		Find(&sv).
+		Error
+	if err != nil {
+		return fmt.Errorf("lookup start vote %v: %v",
+			token, err)
+	}
+
+	// Lookup cast votes
+	var cv []CastVote
+	err = d.recordsdb.
+		Where("token = ?", token).
+		Find(&cv).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		// No cast votes exists. In theory, this could
+		// happen if no one were to vote on a proposal.
+		// In practice, this shouldn't happen.
+	} else if err != nil {
+		return fmt.Errorf("lookup cast votes: %v", err)
+	}
+
+	// Create a vote results entry
+	vr := prepareVoteResults(sv, cv)
+	err = d.recordsdb.Create(&vr).Error
+	if err != nil {
+		return fmt.Errorf("insert vote results: %v", err)
+	}
+
+	return nil
+}
+
+func (d *decred) voteResultsLoad(bestBlock uint64) error {
+	standard, runoff, err := d.voteResultsMissing(bestBlock)
+	if err != nil {
+		return err
+	}
+
+	// Insert vote results for standard votes proposals.
+	for _, token := range standard {
+		err := d.voteResultsInsertStandard(token)
+		if err != nil {
+			return fmt.Errorf("voteResultsInsertStandard %v: %v",
+				token, err)
+		}
+	}
+
+	// Insert vote results for the runoff vote submissions. Runoff
+	// votes are identitified by the parent RFP proposal token.
+	done := make(map[string]struct{}, len(runoff)) // [rfpToken]struct{}
+	for _, token := range runoff {
+		// Lookup the RFP token for the runoff vote submission
+		var pgm ProposalGeneralMetadata
+		err := d.recordsdb.
+			Where("token = ?", token).
+			Find(&pgm).
+			Error
+		if err != nil {
+			return fmt.Errorf("lookup ProposalGeneralMetadata %v: %v",
+				token, err)
+		}
+		if pgm.LinkTo == "" {
+			return fmt.Errorf("runoff vote linkto not found %v",
+				token)
+		}
+
+		if _, ok := done[pgm.LinkTo]; ok {
+			// Results have already been inserted for this RFP.
+			// This happens because the vote results are built
+			// using the RFP token and all RFP submissions will
+			// list the same RFP token in their LinkTo field.
+			continue
+		}
+
+		// Insert vote results for the full runoff vote
+		err = d.voteResultsInsertRunoff(pgm.LinkTo)
+		if err != nil {
+			return fmt.Errorf("insert runoff vote results %v: %v",
+				pgm.LinkTo, err)
+		}
+
+		done[pgm.LinkTo] = struct{}{}
+	}
+
+	return nil
+}
+
+// voteResults returns a map[token]VoteResults for the given tokens.
+//
+// The VoteResults table is lazy loaded. A cache.ErrRecordNotFound error is
+// returned if the VoteResults table is not up-to-date.
+func (d *decred) voteResults(tokens []string, bestBlock uint64) (map[string]VoteResults, error) {
+	// Check to see if the VoteResults table needs to be updated
+	standard, runoff, err := d.voteResultsMissing(bestBlock)
+	if err != nil {
+		return nil, err
+	}
+	if len(standard) > 0 || len(runoff) > 0 {
+		// Return a ErrRecordNotFound to indicate one
+		// or more vote result records were not found.
+		return nil, cache.ErrRecordNotFound
+	}
+
+	voteResults := make(map[string]VoteResults, len(tokens))
+	if len(tokens) == 0 {
+		return voteResults, nil
+	}
+
+	// Lookup vote results
+	vrs := make([]VoteResults, 0, len(tokens))
+	err = d.recordsdb.
+		Where("token IN (?)", tokens).
+		Preload("Results").
+		Preload("Results.Option").
+		Find(&vrs).
+		Error
+	if err != nil {
+		return nil, fmt.Errorf("select VoteResults in %v: %v",
+			tokens, err)
+	}
+
+	for _, v := range vrs {
+		voteResults[v.Token] = v
+	}
+
+	return voteResults, nil
+}
+
+// voteSummaries returns a map[string]decredplugin.VoteSummaryReply for the
+// given proposal tokens. An entry in the returned map will only exist for
+// tokens where a Record was found.
+//
+// This function pulls data from the the lazy loaded VoteResults table. A
+// cache.ErrRecordNotFound error is returned if the VoteResults table is not
+// up-to-date.
+func (d *decred) voteSummaries(tokens []string, bestBlock uint64) (map[string]decredplugin.VoteSummaryReply, error) {
+	// This query returns the latest version of the given records.
+	query := `SELECT a.* 
+            FROM records a
+            LEFT OUTER JOIN records b
+              ON a.token = b.token 
+              AND a.version < b.version
+              WHERE b.token IS NULL 
+              AND a.token IN (?)`
+	rows, err := d.recordsdb.Raw(query, tokens).Rows()
+	if err != nil {
+		return nil, fmt.Errorf("select records %v: %v",
+			tokens, err)
+	}
+	defer rows.Close()
+
+	records := make([]Record, 0, len(tokens))
+	for rows.Next() {
+		var r Record
+		err := d.recordsdb.ScanRows(rows, &r)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Lookup the AuthorizeVote for each record
+	authVotes, err := d.authorizeVotes(records)
+	if err != nil {
+		return nil, fmt.Errorf("authorizeVotes: %v", err)
+	}
+
+	// Lookup the StartVote for each record that has an AuthorizeVote
+	tokens = make([]string, 0, len(authVotes))
+	for token := range authVotes {
+		tokens = append(tokens, token)
+	}
+	startVotes, err := d.startVotes(tokens)
+	if err != nil {
+		return nil, fmt.Errorf("startVotes: %v", err)
+	}
+
+	// Lookup the VoteResults for each record that has a StartVote
+	tokens = make([]string, 0, len(startVotes))
+	for token := range startVotes {
+		tokens = append(tokens, token)
+	}
+
+	// Check for missing vote results tables
+	voteResults, err := d.voteResults(tokens, bestBlock)
+	if err != nil {
+		if err == cache.ErrRecordNotFound {
+			// The VoteResults table needs to be updated. Return
+			// just the error so the calling function can key off
+			// of it.
+			return nil, err
+		}
+		return nil, fmt.Errorf("voteResults: %v", err)
+	}
+
+	if len(tokens) != len(voteResults) {
+		// There were tokens that do not correspond to a VoteResults
+		// entry. This happens when the proposal vote has either not
+		// begun or is ongoing. We know that these tokens have a
+		// StartVote so the vote must be ongoing. Lookup the results
+		// manually.
+		for _, token := range tokens {
+			_, ok := voteResults[token]
+			if !ok {
+				sv := startVotes[token]
+				results, err := d.voteOptionResults(sv.Options)
+				if err != nil {
+					return nil, fmt.Errorf("voteOptionResults %v: %v",
+						sv.Token, err)
+				}
+				voteResults[token] = VoteResults{
+					Token:    token,
+					Approved: false,
+					Results:  results,
+				}
+			}
+		}
+	}
+
+	// Prepare vote summaries
+	summaries := make(map[string]decredplugin.VoteSummaryReply, len(records))
+	for _, v := range records {
+		av := authVotes[v.Token]
+		sv := startVotes[v.Token]
+		vr := voteResults[v.Token]
+
+		// Return "" not "0" if end height doesn't exist
+		var endHeight string
+		if sv.EndHeight != 0 {
+			endHeight = strconv.FormatUint(uint64(sv.EndHeight), 10)
+		}
+
+		summaries[v.Token] = decredplugin.VoteSummaryReply{
+			Authorized:          av.Action == decredplugin.AuthVoteActionAuthorize,
+			Type:                decredplugin.VoteT(sv.Type),
+			Duration:            sv.Duration,
+			EndHeight:           endHeight,
+			EligibleTicketCount: sv.EligibleTicketCount,
+			QuorumPercentage:    sv.QuorumPercentage,
+			PassPercentage:      sv.PassPercentage,
+			Results:             convertVoteOptionResultsToDecred(vr.Results),
+			Approved:            vr.Approved,
+		}
+	}
+
+	return summaries, nil
 }
 
 // cmdNewComment creates a Comment record using the passed in payloads and
@@ -330,13 +866,13 @@ func (d *decred) cmdProposalCommentsLikes(payload string) (string, error) {
 	return string(clrb), nil
 }
 
-// newAuthorizeVote creates an AuthorizeVote record and inserts it into the
+// insertAuthorizeVote creates an AuthorizeVote record and inserts it into the
 // database.  If a previous AuthorizeVote record exists for the passed in
 // proposal and version, it will be deleted before the new AuthorizeVote record
 // is inserted.
 //
 // This function must be called within a transaction.
-func (d *decred) newAuthorizeVote(tx *gorm.DB, av AuthorizeVote) error {
+func (d *decred) insertAuthorizeVote(tx *gorm.DB, av AuthorizeVote) error {
 	// Delete authorize vote if one exists for this version
 	err := tx.Where("key = ?", av.Key).
 		Delete(AuthorizeVote{}).
@@ -377,10 +913,10 @@ func (d *decred) cmdAuthorizeVote(cmdPayload, replyPayload string) (string, erro
 	// Run update in a transaction
 	a := convertAuthorizeVoteFromDecred(*av, *avr, v)
 	tx := d.recordsdb.Begin()
-	err = d.newAuthorizeVote(tx, a)
+	err = d.insertAuthorizeVote(tx, a)
 	if err != nil {
 		tx.Rollback()
-		return "", fmt.Errorf("newAuthorizeVote: %v", err)
+		return "", fmt.Errorf("insertAuthorizeVote: %v", err)
 	}
 
 	// Commit transaction
@@ -725,274 +1261,6 @@ func prepareVoteResults(sv StartVote, votes []CastVote) VoteResults {
 	}
 }
 
-// insertVoteResultsRunoff calculates the results of a runoff vote and inserts
-// a VoteResults record into the cache for each of the runoff vote submissions.
-func (d *decred) insertVoteResultsRunoff(rfpToken string) error {
-	log.Tracef("insertVoteResultsRunoffVote: %v", rfpToken)
-
-	linkedFrom, err := d.linkedFrom(rfpToken)
-	if err != nil {
-		return err
-	}
-
-	// Compile vote results for all RFP submissions
-	results := make([]VoteResults, 0, len(linkedFrom))
-	for _, token := range linkedFrom {
-		// Make sure record hasn't been abandoned
-		var r Record
-		err = d.recordsdb.
-			Where("records.token = ?", token).
-			Order("records.version desc").
-			Limit(1).
-			Preload("Metadata").
-			Find(&r).
-			Error
-		if err != nil {
-			return fmt.Errorf("lookup record %v: %v",
-				token, err)
-		}
-		if r.Status == int(pd.RecordStatusArchived) {
-			// RFP submission has been abandoned
-			continue
-		}
-
-		// Lookup start vote
-		var sv StartVote
-		err := d.recordsdb.
-			Where("token = ?", token).
-			Preload("Options").
-			Find(&sv).
-			Error
-		if err != nil {
-			return fmt.Errorf("find start vote %v: %v",
-				token, err)
-		}
-
-		// Lookup cast votes
-		var cv []CastVote
-		err = d.recordsdb.
-			Where("token = ?", token).
-			Find(&cv).
-			Error
-		if err == gorm.ErrRecordNotFound {
-			// No cast votes exists. In theory, this could
-			// happen if no one were to vote on a proposal.
-			// In practice, this shouldn't happen.
-		} else if err != nil {
-			return fmt.Errorf("lookup cast votes: %v", err)
-		}
-
-		// Prepare vote results. This will mark the vote as
-		// approved if it meets the specified quorum and pass
-		// requirements. The actual runoff vote winner is
-		// determined later in this function.
-		results = append(results, prepareVoteResults(sv, cv))
-	}
-
-	// Determine runoff vote winner. The winner is the vote
-	// that passed the quorum and pass requirments and has
-	// the most net approved votes.
-	var (
-		winnerNetApprove int    // Net number of approve votes of the winner
-		winnerToken      string // Censorship token of the winner
-	)
-	for _, vr := range results {
-		if !vr.Approved {
-			// Vote did not meet quorum and pass requirements
-			continue
-		}
-
-		// Check if this proposal has more net approved votes
-		// then the current highest.
-		var (
-			votesApprove uint64 // Number of approve votes
-			votesReject  uint64 // Number of reject votes
-		)
-		for _, vor := range vr.Results {
-			switch vor.Option.ID {
-			case decredplugin.VoteOptionIDApprove:
-				votesApprove = vor.Votes
-			case decredplugin.VoteOptionIDReject:
-				votesReject = vor.Votes
-			default:
-				// Runoff vote options can only be approve/reject
-				return fmt.Errorf("unknown runoff vote option %v %v",
-					vr.Token, vor.Option.ID)
-			}
-
-			netApprove := int(votesApprove) - int(votesReject)
-			if netApprove > winnerNetApprove {
-				// New winner!
-				winnerToken = vr.Token
-				winnerNetApprove = netApprove
-			}
-
-			// This doesn't handle the unlikely case that the
-			// runoff vote results in a tie. If that happens
-			// we can decide how to handle it and rebuild the
-			// cache with the new rules.
-		}
-	}
-
-	// Now that we know the winner we can update the losers
-	// and insert the results into the cache.
-	for _, vr := range results {
-		// Update runoff vote losers
-		if vr.Token != winnerToken {
-			vr.Approved = false
-		}
-
-		// Insert vote results record
-		err = d.recordsdb.Create(vr).Error
-		if err != nil {
-			return fmt.Errorf("insert vote results %v: %v",
-				vr.Token, err)
-		}
-	}
-
-	return nil
-}
-
-// insertVoteResultsStandard calculates the vote results for a standard
-// proposal vote and inserts a VoteResults record into the cache. A VoteResults
-// record should only be created for proposals once the voting period has
-// ended.
-func (d *decred) insertVoteResultsStandard(token string) error {
-	log.Tracef("insertVoteResults %v", token)
-
-	// Lookup start vote
-	var sv StartVote
-	err := d.recordsdb.
-		Where("token = ?", token).
-		Preload("Options").
-		Find(&sv).
-		Error
-	if err != nil {
-		return fmt.Errorf("lookup start vote %v: %v",
-			token, err)
-	}
-
-	// Lookup cast votes
-	var cv []CastVote
-	err = d.recordsdb.
-		Where("token = ?", token).
-		Find(&cv).
-		Error
-	if err == gorm.ErrRecordNotFound {
-		// No cast votes exists. In theory, this could
-		// happen if no one were to vote on a proposal.
-		// In practice, this shouldn't happen.
-	} else if err != nil {
-		return fmt.Errorf("lookup cast votes: %v", err)
-	}
-
-	// Create a vote results entry
-	vr := prepareVoteResults(sv, cv)
-	err = d.recordsdb.Create(vr).Error
-	if err != nil {
-		return fmt.Errorf("insert vote results: %v", err)
-	}
-
-	return nil
-}
-
-func (d *decred) loadVoteResults(bestBlock uint64) error {
-	// Find proposals that have a finished voting period but
-	// have not yet been added to the vote results table. Do
-	// not include proposals that were part of a runoff vote.
-	// Those need to be handled separately.
-	q := `SELECT start_votes.token
-        FROM start_votes
-        LEFT OUTER JOIN vote_results
-          ON start_votes.token = vote_results.token
-          WHERE start_votes.end_height <= ?
-          AND start_votes.Type = ?
-          AND vote_results.token IS NULL`
-	rows, err := d.recordsdb.Raw(q, bestBlock,
-		int(decredplugin.VoteTypeStandard)).Rows()
-	if err != nil {
-		return fmt.Errorf("lookup missing standard vote results: %v", err)
-	}
-	defer rows.Close()
-
-	missing := make([]string, 0, 1024)
-	for rows.Next() {
-		var token string
-		rows.Scan(&token)
-		missing = append(missing, token)
-	}
-
-	// Create vote result entries
-	for _, v := range missing {
-		err := d.insertVoteResultsStandard(v)
-		if err != nil {
-			return fmt.Errorf("insertVoteResults %v: %v", v, err)
-		}
-	}
-
-	// Find runoff vote proposals that have a finished voting
-	// period but have not yet been added to the vote results
-	// table.
-	q = `SELECT start_votes.token
-        FROM start_votes
-        LEFT OUTER JOIN vote_results
-          ON start_votes.token = vote_results.token
-          WHERE start_votes.end_height <= ?
-          AND start_votes.Type = ?
-          AND vote_results.token IS NULL`
-	rows, err = d.recordsdb.Raw(q, bestBlock,
-		int(decredplugin.VoteTypeRunoff)).Rows()
-	if err != nil {
-		return fmt.Errorf("lookup missing runoff vote results: %v", err)
-	}
-	defer rows.Close()
-
-	missing = make([]string, 0, 1024)
-	for rows.Next() {
-		var token string
-		rows.Scan(&token)
-		missing = append(missing, token)
-	}
-
-	// Insert vote results for the runoff vote submissions.
-	done := make(map[string]struct{}, len(missing)) // [rfpToken]struct{}
-	for _, token := range missing {
-		// Lookup the RFP token for the runoff vote submission
-		var pgm ProposalGeneralMetadata
-		err := d.recordsdb.
-			Where("token = ?", token).
-			Find(&pgm).
-			Error
-		if err != nil {
-			return fmt.Errorf("lookup ProposalGeneralMetadata %v: %v",
-				token, err)
-		}
-		if pgm.LinkTo == "" {
-			return fmt.Errorf("runoff vote linkto not found %v",
-				token)
-		}
-
-		if _, ok := done[pgm.LinkTo]; ok {
-			// Results have already been inserted for this RFP.
-			// This happens because the vote results are built
-			// using the RFP token and all RFP submissions will
-			// list the same RFP token in their LinkTo field.
-			continue
-		}
-
-		// Insert vote results for the full runoff vote
-		err = d.insertVoteResultsRunoff(pgm.LinkTo)
-		if err != nil {
-			return fmt.Errorf("insert runoff vote results %v: %v",
-				pgm.LinkTo, err)
-		}
-
-		done[pgm.LinkTo] = struct{}{}
-	}
-
-	return nil
-}
-
 // cmdLoadVoteResults creates vote results entries for any proposals that have
 // a finished voting period but have not yet been added to the vote results
 // table. The vote results table is lazy loaded.
@@ -1004,7 +1272,7 @@ func (d *decred) cmdLoadVoteResults(payload string) (string, error) {
 		return "", err
 	}
 
-	err = d.loadVoteResults(lvs.BestBlock)
+	err = d.voteResultsLoad(lvs.BestBlock)
 	if err != nil {
 		return "", err
 	}
@@ -1019,7 +1287,9 @@ func (d *decred) cmdLoadVoteResults(payload string) (string, error) {
 }
 
 // cmdTokenInventory returns the tokens of all records in the cache,
-// categorized by stage of the voting process.
+// categorized by stage of the voting process. This call relies on the lazy
+// loaded VoteResults table. A cache.ErrRecordNotFound is returned if the
+// VoteResults table is not up-to-date.
 func (d *decred) cmdTokenInventory(payload string) (string, error) {
 	log.Tracef("decred cmdTokenInventory")
 
@@ -1028,37 +1298,13 @@ func (d *decred) cmdTokenInventory(payload string) (string, error) {
 		return "", err
 	}
 
-	// The token inventory call cannot be completed if there
-	// are any proposals that have finished voting but that
-	// don't have an entry in the vote results table yet.
-	// Fail here if any are found.
-	// XXX Replace this is loadVoteResults()
-	q := `SELECT start_votes.token
-        FROM start_votes
-        LEFT OUTER JOIN vote_results
-          ON start_votes.token = vote_results.token
-          WHERE start_votes.end_height <= ?
-          AND vote_results.token IS NULL`
-	rows, err := d.recordsdb.Raw(q, ti.BestBlock).Rows()
+	// The VoteResults table is lazy loaded. Check to see if it
+	// needs to be updated.
+	standard, runoff, err := d.voteResultsMissing(ti.BestBlock)
 	if err != nil {
-		return "", fmt.Errorf("no vote results: %v", err)
-	}
-	defer rows.Close()
-
-	var token string
-	missing := make([]string, 0, 1024)
-	for rows.Next() {
-		err = rows.Scan(&token)
-		if err != nil {
-			return "", err
-		}
-		missing = append(missing, token)
-	}
-	if err = rows.Err(); err != nil {
 		return "", err
 	}
-
-	if len(missing) > 0 {
+	if len(standard) > 0 || len(runoff) > 0 {
 		// Return a ErrRecordNotFound to indicate one
 		// or more vote result records were not found.
 		return "", cache.ErrRecordNotFound
@@ -1068,7 +1314,7 @@ func (d *decred) cmdTokenInventory(payload string) (string, error) {
 	// tokens of the most recent version of all records that
 	// are public and do not have an associated StartVote
 	// record, ordered by timestamp in descending order.
-	q = `SELECT a.token
+	q := `SELECT a.token
         FROM records a
         LEFT OUTER JOIN start_votes
           ON a.token = start_votes.token
@@ -1079,12 +1325,13 @@ func (d *decred) cmdTokenInventory(payload string) (string, error) {
           AND start_votes.token IS NULL
           AND a.status = ?
         ORDER BY a.timestamp DESC`
-	rows, err = d.recordsdb.Raw(q, pd.RecordStatusPublic).Rows()
+	rows, err := d.recordsdb.Raw(q, pd.RecordStatusPublic).Rows()
 	if err != nil {
 		return "", fmt.Errorf("pre: %v", err)
 	}
 	defer rows.Close()
 
+	var token string
 	pre := make([]string, 0, 1024)
 	for rows.Next() {
 		err = rows.Scan(&token)
@@ -1270,240 +1517,14 @@ func (d *decred) cmdTokenInventory(payload string) (string, error) {
 	return string(reply), nil
 }
 
-// getAuthorizeVotesForRecords returns a map[token]AuthorizeVote for the given
-// records. An entry in the map will only exist if an AuthorizeVote is found
-// for the record.
-func (d *decred) getAuthorizeVotesForRecords(records map[string]Record) (map[string]AuthorizeVote, error) {
-	authorizeVotes := make(map[string]AuthorizeVote)
-
-	if len(records) == 0 {
-		return authorizeVotes, nil
-	}
-
-	keys := make([]string, 0, len(records))
-	for token, record := range records {
-		keys = append(keys, token+strconv.FormatUint(record.Version, 10))
-	}
-
-	avs := make([]AuthorizeVote, 0, len(keys))
-	err := d.recordsdb.
-		Where("key IN (?)", keys).
-		Find(&avs).
-		Error
-	if err != nil {
-		return nil, err
-	}
-
-	for _, av := range avs {
-		authorizeVotes[av.Token] = av
-	}
-
-	return authorizeVotes, nil
-}
-
-// getStartVotes returns a map[token]StartVote for the given tokens. An entry
-// in the returned map will only exist for tokens where a StartVote was found.
-func (d *decred) getStartVotes(tokens []string) (map[string]StartVote, error) {
-	startVotes := make(map[string]StartVote, len(tokens))
-
-	if len(tokens) == 0 {
-		return startVotes, nil
-	}
-
-	svs := make([]StartVote, 0, len(tokens))
-	err := d.recordsdb.
-		Where("token IN (?)", tokens).
-		Preload("Options").
-		Find(&svs).
-		Error
-	if err != nil {
-		return nil, err
-	}
-
-	for _, v := range svs {
-		startVotes[v.Token] = v
-	}
-
-	return startVotes, nil
-}
-
-// getResultsForVoteOptions returns the VoteOptionResult for each of the given
-// VoteOptions. The results are looked up manually from the CastVotes table
-// instead of using the VoteResults table. This allows results to be looked up
-// when a VoteResults entry does not yet exist, such as for ongoing votes.
-func (d *decred) getResultsForVoteOptions(options []VoteOption) ([]VoteOptionResult, error) {
-	results := make([]VoteOptionResult, 0, len(options))
-
-	for _, v := range options {
-		var votes uint64
-		tokenVoteBit := v.Token + strconv.FormatUint(v.Bits, 16)
-		err := d.recordsdb.
-			Model(&CastVote{}).
-			Where("token_vote_bit = ?", tokenVoteBit).
-			Count(&votes).
-			Error
-		if err != nil {
-			return nil, err
-		}
-
-		results = append(results, VoteOptionResult{
-			Key:   tokenVoteBit,
-			Token: v.Token,
-			Votes: votes,
-			Option: VoteOption{
-				ID:          v.ID,
-				Description: v.Description,
-				Bits:        v.Bits,
-			},
-		})
-	}
-
-	return results, nil
-}
-
-// getVoteResults returns a map[token]VoteResults for the given tokens. The
-// VoteResults table is lazy loaded so results may not exist for some tokens
-// yet. An entry in the returned map will only exist for tokens where a
-// VoteResults was found.
-func (d *decred) getVoteResults(tokens []string, bestBlock uint64) (map[string]VoteResults, error) {
-	voteResults := make(map[string]VoteResults, len(tokens))
-
-	if len(tokens) == 0 {
-		return voteResults, nil
-	}
-
-	// Make sure VoteResults table is up-to-date
-	err := d.loadVoteResults(bestBlock)
-	if err != nil {
-		return nil, fmt.Errorf("loadVoteResults: %v", err)
-	}
-
-	// Lookup vote results
-	vrs := make([]VoteResults, 0, len(tokens))
-	err = d.recordsdb.
-		Where("token IN (?)", tokens).
-		Preload("Results").
-		Preload("Results.Option").
-		Find(&vrs).
-		Error
-	if err != nil {
-		return nil, fmt.Errorf("lookup VoteResults %v: %v", tokens, err)
-	}
-
-	for _, v := range vrs {
-		voteResults[v.Token] = v
-	}
-
-	return voteResults, nil
-}
-
-func (d *decred) voteSummaryBatch(tokens []string, bestBlock uint64) (map[string]decredplugin.VoteSummaryReply, error) {
-	// This query returns the latest version of the given records.
-	query := `SELECT a.* 
-            FROM records a
-            LEFT OUTER JOIN records b
-              ON a.token = b.token 
-              AND a.version < b.version
-              WHERE b.token IS NULL 
-              AND a.token IN (?)`
-	rows, err := d.recordsdb.Raw(query, tokens).Rows()
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	records := make(map[string]Record, len(tokens))
-	for rows.Next() {
-		var r Record
-		err := d.recordsdb.ScanRows(rows, &r)
-		if err != nil {
-			return nil, err
-		}
-		records[r.Token] = r
-	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-
-	// Lookup the AuthorizeVote for each record
-	authVotes, err := d.getAuthorizeVotesForRecords(records)
-	if err != nil {
-		return nil, fmt.Errorf("getAuthorizeVotesForRecords: %v", err)
-	}
-
-	// Lookup the StartVote for each record that has an AuthorizeVote
-	tokens = make([]string, 0, len(authVotes))
-	for token := range authVotes {
-		tokens = append(tokens, token)
-	}
-	startVotes, err := d.getStartVotes(tokens)
-	if err != nil {
-		return nil, fmt.Errorf("getStartVotes: %v", err)
-	}
-
-	// Lookup the VoteResults for each record that has a StartVote
-	tokens = make([]string, 0, len(startVotes))
-	for token := range startVotes {
-		tokens = append(tokens, token)
-	}
-	voteResults, err := d.getVoteResults(tokens, bestBlock)
-	if err != nil {
-		return nil, fmt.Errorf("getVoteResults: %v", err)
-	}
-
-	if len(tokens) != len(voteResults) {
-		// There were tokens that do not correspond to a VoteResults
-		// entry. This happens when the proposal vote has either not
-		// begun or is ongoing. We know that these tokens have a
-		// StartVote so the vote must be ongoing. Lookup the results
-		// manually.
-		for _, token := range tokens {
-			_, ok := voteResults[token]
-			if !ok {
-				sv := startVotes[token]
-				results, err := d.getResultsForVoteOptions(sv.Options)
-				if err != nil {
-					return nil, fmt.Errorf("loadResultsForvVoteOptions %v, %v",
-						sv.Token, err)
-				}
-				voteResults[token] = VoteResults{
-					Token:    token,
-					Approved: false,
-					Results:  results,
-				}
-			}
-		}
-	}
-
-	// Prepare vote summaries
-	summaries := make(map[string]decredplugin.VoteSummaryReply, len(records))
-	for token := range records {
-		av := authVotes[token]
-		sv := startVotes[token]
-		vr := voteResults[token]
-
-		// Return "" not "0" if end height doesn't exist
-		var endHeight string
-		if sv.EndHeight != 0 {
-			endHeight = strconv.FormatUint(uint64(sv.EndHeight), 10)
-		}
-
-		summaries[token] = decredplugin.VoteSummaryReply{
-			Authorized:          av.Action == decredplugin.AuthVoteActionAuthorize,
-			Type:                decredplugin.VoteT(sv.Type),
-			Duration:            sv.Duration,
-			EndHeight:           endHeight,
-			EligibleTicketCount: sv.EligibleTicketCount,
-			QuorumPercentage:    sv.QuorumPercentage,
-			PassPercentage:      sv.PassPercentage,
-			Results:             convertVoteOptionResultsToDecred(vr.Results),
-			Approved:            vr.Approved,
-		}
-	}
-
-	return summaries, nil
-}
-
+// cmdVoteSummary returns a map[string]VoteSummaryReply for the given proposal
+// tokens. Results are returned for all tokens that correspond to a proposal.
+// This includes both unvetted and vetted proposals. Tokens that do no
+// correspond to a proposal are not included in the returned map.
+//
+// This function pulls data from the the lazy loaded VoteResults table. A
+// cache.ErrRecordNotFound error is returned if the VoteResults table is not
+// up-to-date.
 func (d *decred) cmdBatchVoteSummary(payload string) (string, error) {
 	log.Tracef("cmdBatchVoteSummary")
 
@@ -1512,7 +1533,7 @@ func (d *decred) cmdBatchVoteSummary(payload string) (string, error) {
 		return "", err
 	}
 
-	summaries, err := d.voteSummaryBatch(bvs.Tokens, bvs.BestBlock)
+	summaries, err := d.voteSummaries(bvs.Tokens, bvs.BestBlock)
 	if err != nil {
 		return "", err
 	}
@@ -1528,6 +1549,12 @@ func (d *decred) cmdBatchVoteSummary(payload string) (string, error) {
 	return string(reply), nil
 }
 
+// cmdVoteSummary returns a decredplugin.VoteSummaryReply for the given
+// proposal token.
+//
+// This function pulls data from the the lazy loaded VoteResults table. A
+// cache.ErrRecordNotFound error is returned if the VoteResults table is not
+// up-to-date.
 func (d *decred) cmdVoteSummary(payload string) (string, error) {
 	log.Tracef("cmdVoteSummary")
 
@@ -1536,7 +1563,7 @@ func (d *decred) cmdVoteSummary(payload string) (string, error) {
 		return "", err
 	}
 
-	summaries, err := d.voteSummaryBatch([]string{vs.Token}, vs.BestBlock)
+	summaries, err := d.voteSummaries([]string{vs.Token}, vs.BestBlock)
 	if err != nil {
 		return "", err
 	}
@@ -1986,16 +2013,16 @@ func (d *decred) build(ir *decredplugin.InventoryReply) error {
 
 		rv, err := strconv.ParseUint(r.RecordVersion, 10, 64)
 		if err != nil {
-			log.Debugf("newAuthorizeVote failed on '%v'", r)
+			log.Debugf("insertAuthorizeVote failed on '%v'", r)
 			return fmt.Errorf("parse version '%v' failed: %v",
 				r.RecordVersion, err)
 		}
 
 		av := convertAuthorizeVoteFromDecred(v, r, rv)
-		err = d.newAuthorizeVote(d.recordsdb, av)
+		err = d.insertAuthorizeVote(d.recordsdb, av)
 		if err != nil {
-			log.Debugf("newAuthorizeVote failed on '%v'", av)
-			return fmt.Errorf("newAuthorizeVote: %v", err)
+			log.Debugf("insertAuthorizeVote failed on '%v'", av)
+			return fmt.Errorf("insertAuthorizeVote: %v", err)
 		}
 	}
 

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -906,7 +906,7 @@ func (d *decred) loadVoteResults(bestBlock uint64) error {
         LEFT OUTER JOIN vote_results
           ON start_votes.token = vote_results.token
           WHERE start_votes.end_height <= ?
-					AND start_votes.Type = ?
+          AND start_votes.Type = ?
           AND vote_results.token IS NULL`
 	rows, err := d.recordsdb.Raw(q, bestBlock,
 		int(decredplugin.VoteTypeStandard)).Rows()
@@ -938,7 +938,7 @@ func (d *decred) loadVoteResults(bestBlock uint64) error {
         LEFT OUTER JOIN vote_results
           ON start_votes.token = vote_results.token
           WHERE start_votes.end_height <= ?
-					AND start_votes.Type = ?
+          AND start_votes.Type = ?
           AND vote_results.token IS NULL`
 	rows, err = d.recordsdb.Raw(q, bestBlock,
 		int(decredplugin.VoteTypeRunoff)).Rows()

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -423,7 +423,7 @@ func (d *decred) voteResultsInsertRunoff(rfpToken string) error {
 		}
 
 		// Insert vote results record
-		err = d.recordsdb.Create(vr).Error
+		err = d.recordsdb.Create(&vr).Error
 		if err != nil {
 			return fmt.Errorf("insert vote results %v: %v",
 				vr.Token, err)

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -457,21 +457,21 @@ func (d *decred) voteResultsLoad(bestBlock uint64) error {
 	done := make(map[string]struct{}, len(runoff)) // [rfpToken]struct{}
 	for _, token := range runoff {
 		// Lookup the RFP token for the runoff vote submission
-		var pgm ProposalGeneralMetadata
+		var pm ProposalMetadata
 		err := d.recordsdb.
 			Where("token = ?", token).
-			Find(&pgm).
+			Find(&pm).
 			Error
 		if err != nil {
-			return fmt.Errorf("lookup ProposalGeneralMetadata %v: %v",
+			return fmt.Errorf("lookup ProposalMetadata %v: %v",
 				token, err)
 		}
-		if pgm.LinkTo == "" {
+		if pm.LinkTo == "" {
 			return fmt.Errorf("runoff vote linkto not found %v",
 				token)
 		}
 
-		if _, ok := done[pgm.LinkTo]; ok {
+		if _, ok := done[pm.LinkTo]; ok {
 			// Results have already been inserted for this RFP.
 			// This happens because the vote results are built
 			// using the RFP token and all RFP submissions will
@@ -480,13 +480,13 @@ func (d *decred) voteResultsLoad(bestBlock uint64) error {
 		}
 
 		// Insert vote results for the full runoff vote
-		err = d.voteResultsInsertRunoff(pgm.LinkTo)
+		err = d.voteResultsInsertRunoff(pm.LinkTo)
 		if err != nil {
 			return fmt.Errorf("insert runoff vote results %v: %v",
-				pgm.LinkTo, err)
+				pm.LinkTo, err)
 		}
 
-		done[pgm.LinkTo] = struct{}{}
+		done[pm.LinkTo] = struct{}{}
 	}
 
 	return nil

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -74,8 +74,10 @@ func (Record) TableName() string {
 //
 // This is a decred plugin model.
 type ProposalMetadata struct {
-	Token string `gorm:"primary_key"` // Censorship token
-	Name  string `gorm:"not null"`    // Proposal name
+	Token  string `gorm:"primary_key"` // Censorship token
+	Name   string `gorm:"not null"`    // Proposal name
+	LinkTo string `gorm:""`            // Token of proposal to link to
+	LinkBy int64  `gorm:""`            // UNIX timestamp of RFP deadline
 }
 
 // Comment represents a record comment, including all of the server side

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -80,6 +80,8 @@ type ProposalGeneralMetadata struct {
 	Version         uint64 `gorm:"not null"`            // Struct version
 	Timestamp       int64  `gorm:"not null"`            // Last update of proposal
 	Name            string `gorm:"not null"`            // Proposal name
+	LinkTo          string `gorm:"size:64"`             // Token of proposal to link to
+	LinkBy          int64  `gorm:""`                    // UNIX timestamp of RFP deadline
 	Signature       string `gorm:"not null;size:128"`   // Client signature
 	PublicKey       string `gorm:"not null;size:64"`    // Pubkey used for Signature
 }

--- a/politeiad/cache/testcache/decred.go
+++ b/politeiad/cache/testcache/decred.go
@@ -157,6 +157,7 @@ func (c *testcache) voteSummaryReply(token string) (*decred.VoteSummaryReply, er
 
 	vsr := decred.VoteSummaryReply{
 		Authorized:          av.Action == decred.AuthVoteActionAuthorize,
+		Type:                sv.Vote.Type,
 		Duration:            duration,
 		EndHeight:           svr.EndHeight,
 		EligibleTicketCount: 0,

--- a/politeiad/cache/testcache/testcache.go
+++ b/politeiad/cache/testcache/testcache.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	decred "github.com/decred/politeia/decredplugin"
-	"github.com/decred/politeia/mdstream"
 	"github.com/decred/politeia/politeiad/cache"
 )
 
@@ -25,8 +24,6 @@ type testcache struct {
 	authorizeVotes   map[string]map[string]decred.AuthorizeVote // [token][version]AuthorizeVote
 	startVotes       map[string]decred.StartVoteV2              // [token]StartVote
 	startVoteReplies map[string]decred.StartVoteReply           // [token]StartVoteReply
-
-	proposalGeneralMetadata map[string]mdstream.ProposalGeneral // [token]ProposalGeneral
 }
 
 // NewRecords adds a record to the cache.

--- a/politeiad/cache/testcache/testcache.go
+++ b/politeiad/cache/testcache/testcache.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	decred "github.com/decred/politeia/decredplugin"
+	"github.com/decred/politeia/mdstream"
 	"github.com/decred/politeia/politeiad/cache"
 )
 
@@ -24,6 +25,8 @@ type testcache struct {
 	authorizeVotes   map[string]map[string]decred.AuthorizeVote // [token][version]AuthorizeVote
 	startVotes       map[string]decred.StartVoteV2              // [token]StartVote
 	startVoteReplies map[string]decred.StartVoteReply           // [token]StartVoteReply
+
+	proposalGeneralMetadata map[string]mdstream.ProposalGeneral // [token]ProposalGeneral
 }
 
 // NewRecords adds a record to the cache.

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -1006,7 +1006,7 @@ func (p *politeia) pluginCommand(w http.ResponseWriter, r *http.Request) {
 		ReplyPayload:   payload,
 	})
 	if err != nil {
-		log.Criticalf("Cache plugin exec failed: command:%v"+
+		log.Criticalf("Cache plugin exec failed: command:%v "+
 			"commandPayload:%v replyPayload:%v error:%v",
 			pc.Command, pc.Payload, payload, err)
 	}

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -2845,15 +2845,14 @@ This is a shortened representation of a user, used for lists.
 | | Type | Description |
 |-|-|-|
 | status | int | Status identifier |
-| approved | bool | Has the proposal vote passed. |
-| type | [`VoteT`](#vote-types)| Vote type. |
-| eligibletickets | int | Total number of eligible tickets |
-| duration | uint32 | Duration of the vote in blocks |
-| endheight | uint64 | The chain height in which the vote will end |
-| bestblock | uint64 | The current chain height |
-| quorumpercentage | uint32 | Percent of eligible votes required for quorum |
-| passpercentage | uint32 | Percent of total votes required to pass |
-| optionsresult | array of VoteOptionResult | Option description along with the number of votes it has received |
+| approved | bool | Has the proposal vote passed |
+| type | [`VoteT`](#vote-types)| Vote type (omitempty) |
+| eligibletickets | int | Total number of eligible tickets (omitempty) |
+| duration | uint32 | Duration of the vote in blocks (omitempty) |
+| endheight | uint64 | The chain height in which the vote will end (omitempty) |
+| quorumpercentage | uint32 | Percent of eligible votes required for quorum (omitempty) |
+| passpercentage | uint32 | Percent of total votes required to pass (omitempty) |
+| optionsresult | array of VoteOptionResult | Option description along with the number of votes it has received (omitempty) |
 
 ### `Censorship record`
 

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -117,6 +117,18 @@ notifications.  It does not render HTML.
 - [`ErrorStatusDuplicateComment`](#ErrorStatusDuplicateComment)
 - [`ErrorStatusInvalidLogin`](#ErrorStatusInvalidLogin)
 - [`ErrorStatusCommentIsCensored`](#ErrorStatusCommentIsCensored)
+- [`ErrorStatusInvalidProposalVersion`](#ErrorStatusInvalidProposalVersion)
+- [`ErrorStatusMetadataInvalid`](#ErrorStatusMetadataInvalid)
+- [`ErrorStatusMetadataMissing`](#ErrorStatusMetadataMissing)
+- [`ErrorStatusMetadataDigestInvalid`](#ErrorStatusMetadataDigestInvalid)
+- [`ErrorStatusInvalidVoteType`](#ErrorStatusInvalidVoteType)
+- [`ErrorStatusInvalidVoteOptions`](#ErrorStatusInvalidVoteOptions)
+- [`ErrorStatusLinkByDeadlineNotMet`](#ErrorStatusLinkByDeadlineNotMet)
+- [`ErrorStatusNoLinkedProposals`](#ErrorStatusNoLinkedProposals)
+- [`ErrorStatusInvalidLinkTo`](#ErrorStatusInvalidLinkTo)
+- [`ErrorStatusInvalidLinkBy`](#ErrorStatusInvalidLinkBy)
+- [`ErrorStatusInvalidRunoffVote`](#ErrorStatusInvalidRunoffVote)
+- [`ErrorStatusWrongProposalType`](#ErrorStatusWrongProposalType)
 
 **Websockets**
 
@@ -1353,8 +1365,8 @@ Reply:
 
 ### `Policy`
 
-Retrieve server policy.  The returned values contain various maxima that the client
-SHALL observe.
+Retrieve server policy.  The returned values contain various maxima that the
+client SHALL observe.
 
 **Route:** `GET /v1/policy`
 
@@ -1364,29 +1376,26 @@ SHALL observe.
 
 | | Type | Description |
 |-|-|-|
-| minpasswordlength | integer | minimum number of characters accepted for user passwords |
-| minusernamelength | integer | minimum number of characters accepted for username |
-| maxusernamelength | integer | maximum number of characters accepted for username |
+| minpasswordlength | number | minimum number of characters accepted for user passwords |
+| minusernamelength | number | minimum number of characters accepted for username |
+| maxusernamelength | number | maximum number of characters accepted for username |
 | usernamesupportedchars | array of strings | the regular expression of a valid username |
-| proposallistpagesize | integer | maximum number of proposals returned for the routes that return lists of proposals |
-| userlistpagesize | integer | maximum number of users returned for the routes that return lists of users |
-| maximages | integer | maximum number of images accepted when creating a new proposal |
-| maximagesize | integer | maximum image file size (in bytes) accepted when creating a new proposal |
-| maxmds | integer | maximum number of markdown files accepted when creating a new proposal |
-| maxmdsize | integer | maximum markdown file size (in bytes) accepted when creating a new proposal |
+| proposallistpagesize | number | maximum number of proposals returned for the routes that return lists of proposals |
+| userlistpagesize | number | maximum number of users returned for the routes that return lists of users |
+| maximages | number | maximum number of images accepted when creating a new proposal |
+| maximagesize | number | maximum image file size (in bytes) accepted when creating a new proposal |
+| maxmds | number | maximum number of markdown files accepted when creating a new proposal |
+| maxmdsize | number | maximum markdown file size (in bytes) accepted when creating a new proposal |
 | validmimetypes | array of strings | list of all acceptable MIME types that can be communicated between client and server. |
-| maxproposalnamelength | integer | max length of a proposal name |
-| minproposalnamelength | integer | min length of a proposal name |
+| maxproposalnamelength | number | max length of a proposal name |
+| minproposalnamelength | number | min length of a proposal name |
 | proposalnamesupportedchars | array of strings | the regular expression of a valid proposal name |
-| maxcommentlength | integer | maximum number of characters accepted for comments |
+| maxcommentlength | number | maximum number of characters accepted for comments |
 | backendpublickey | string |  |
-| maxnamelength | integer | maximum contractor name length (cmswww)
-| minnamelength | integer | mininum contractor name length (cmswww)
-| maxlocationlength | integer | maximum contractor location length (cmswww)
-| minlocationlength | integer | minimum contractor location length (cmswww)
-| invoicecommentchar | char | character for comments on invoices (cmswww)
-| invoicefielddelimiterchar | char | character for invoice csv field separation (cmswww)
-| invoicelineitemcount | integer | expected count for line item fields (cmswww)
+| buildinformation | []string | build information including module commit hashes |
+| IndexFilename | string | required filename for the proposal index.md file |
+| MinLinkbyPeriod | number | Minimum required period, in seconds, for the proposal linkby period |
+| MaxLinkByPeriod | number | Maximum allowed period, in seconds, for the proposal linkby period |
 
 
 **Example**
@@ -2674,8 +2683,20 @@ Reply:
 | <a name="ErrorStatusNoProposalChanges">ErrorStatusNoProposalChanges</a> | 60 | No changes found in proposal. |
 | <a name="ErrorStatusMaxProposalsExceedsPolicy">ErrorStatusMaxProposalsExceededPolicy</a> | 61 | Number of proposals requested exceeded the ProposalListPageSize. |
 | <a name="ErrorStatusDuplicateComment">ErrorStatusDuplicateComment</a> | 62 | Duplicate comment. |
-| <a name="ErrorStatusInvalidLogin">ErrorStatusInvalidLogin</a> | 62 | Invalid login credentials. |
-| <a name="ErrorStatusCommentIsCensored">ErrorStatusCommentIsCensored</a> | 62 | Comment is censored. |
+| <a name="ErrorStatusInvalidLogin">ErrorStatusInvalidLogin</a> | 63 | Invalid login credentials. |
+| <a name="ErrorStatusCommentIsCensored">ErrorStatusCommentIsCensored</a> | 64 | Comment is censored. |
+| <a name="ErrorStatusInvalidProposalVersion">ErrorStatusInvalidProposalVersion</a> | 65 | Invalid proposal version.  |
+| <a name="ErrorStatusMetadataInvalid">ErrorStatusMetadataInvalid</a> | 66 | Invalid proposal metadata.  |
+| <a name="ErrorStatusMetadataMissing">ErrorStatusMetadataMissing</a> | 67 | Missing proposal metadata. |
+| <a name="ErrorStatusMetadataDigestInvalid">ErrorStatusMetadataDigestInvalid</a> | 68 | Proposal metadata digest invalid.  |
+| <a name="ErrorStatusInvalidVoteType">ErrorStatusInvalidVoteType</a> | 69 | Invalid vote type. |
+| <a name="ErrorStatusInvalidVoteOptions">ErrorStatusInvalidVoteOptions</a> | 70 | Invalid vote option.  |
+| <a name="ErrorStatusLinkByDeadlineNotMet">ErrorStatusLinkByDeadlineNotMet</a> | 71 | Linkby not met yet.  |
+| <a name="ErrorStatusNoLinkedProposals">ErrorStatusNoLinkedProposals</a> | 72 | No linked proposals.  |
+| <a name="ErrorStatusInvalidLinkTo">ErrorStatusInvalidLinkTo</a> | 73 | Invalid propsoal linkto. |
+| <a name="ErrorStatusInvalidLinkBy">ErrorStatusInvalidLinkBy</a> | 74 | Invalid proposal linkby.  |
+| <a name="ErrorStatusInvalidRunoffVote">ErrorStatusInvalidRunoffVote</a> | 75 | Invalid runoff vote. |
+| <a name="ErrorStatusWrongProposalType">ErrorStatusWrongProposalType</a> | 76 | Wrong proposal type. |
 
 
 ### `Proposal status codes`
@@ -2689,6 +2710,13 @@ Reply:
 | <a name="PropStatusPublic">PropStatusPublic</a> | 4 | The proposal has been published by an admin. |
 | <a name="PropStatusUnreviewedChanges">PropStatusUnreviewedChanges</a> | 5 | The proposal has not been rewieved by an admin yet and has been edited by the author. |
 | <a name="PropStatusAbandoned">PropStatusAbandoned</a> | 6 | The proposal is public and has been deemed abandoned by an admin. |
+
+### `Vote types`
+| Status | Value | Description |
+|-|-|-|
+| <a name="VoteTypeInvalid">VoteTypeInvalid</a>| 0 | An invalid vote type. This shall be considered a bug. |
+| <a name="VoteTypeStandard">VoteTypeStandard</a>| 1 | A simple approve or reject proposal vote where the winner is the voting option that has met the specified pass and quorum requirements. |
+| <a name="VoteTypeRunoff">VoteType</a>| 2 | A runoff vote that multiple proposals compete in. All proposals are voted on like normal, but there can only be one winner in a runoff vote. The winner is the proposal that meets the quorum requirement, meets the pass requirement, and that has the most net yes votes. The winning proposal is considered approved and all other proposals are considered rejected. If no proposals meet the quorum and pass requirements then all proposals are considered rejected. Note: in a runoff vote it is possible for a proposal to meet the quorum and pass requirements but still be rejected if it does not have the most net yes votes. |
 
 ### `User edit actions`
 
@@ -2766,17 +2794,21 @@ This is a shortened representation of a user, used for lists.
 | status | number | Current status of the proposal. |
 | timestamp | number | The unix time of the last update of the proposal. |
 | userid | string | The ID of the user who created the proposal. |
+| username | string | Proposal author's username. | 
 | publickey | string | The public key of the user who created the proposal. |
 | signature | string | The signature of the merkle root, signed by the user who created the proposal. |
-| version | string | The proposal version. |
-| censorshiprecord | [`censorshiprecord`](#censorship-record) | The censorship record that was created when the proposal was submitted. |
-| files | array of [`File`](#file)s | This property will only be populated for the [`Proposal details`](#proposal-details) call. |
 | numcomments | number | The number of comments on the proposal. This should be ignored for proposals which are not public. |
-| statatuschangemessage | Message associated to the status change. |
-| pubishedat | The timestamp of when the proposal has been published. If the proposals has not been pubished, this field will not be present. |
-| censoredat | The timestamp of when the proposal has been censored. If the proposals has not been censored, this field will not be present. |
-| abandonedat | The timestamp of when the proposal has been abandoned. If the proposals has not been abandoned, this field will not be present. |
- 
+| version | string | The proposal version. |
+| statatuschangemessage | string | Message associated to the status change (omitempty). |
+| pubishedat | number | The timestamp of when the proposal was published (omitempty). |
+| censoredat | number | The timestamp of when the proposal was censored (omitempty). |
+| abandonedat | The timestamp of when the proposal was abandoned (omitempty). |
+| linkto | string | Censorship token of proposal to link to (omitempty). |
+| linkby | number | Unix timestamp of RFP link by deadline (omitempty). | 
+| files | [][`File`](#file)s | Proposal files. This property will only be populated for the [`Proposal details`](#proposal-details) call. |
+| metadata | [][`Metadata`](#metadata) | Proposal metadata. This will contain a [`ProposalMetadata`](#proposal-metadata). | 
+| censorshiprecord | [`CensorshipRecord`](#censorship-record) | The censorship record that was created when the proposal was submitted. |
+
 ### `Identity`
 
 | | Type | Description |
@@ -2801,16 +2833,20 @@ This is a shortened representation of a user, used for lists.
 | Hint | string | Hint that describes the payload |
 | Payload | string | Base64 encoded metadata content where the metadata content is JSON encoded. |
 
-### `Proposal Metadata`
+### `Proposal metadata`
 | | Type | Description |
 |-|-|-|
 | Name | string | Proposal name. |
+| LinkTo | string | Censorship token of the proposal to link to (optional). |
+| LinkBy | int64 | Unix timestamp of the RFP deadline (optional). |
 
-### `Vote Summary`
+### `Vote summary`
 
 | | Type | Description |
 |-|-|-|
 | status | int | Status identifier |
+| approved | bool | Has the proposal vote passed. |
+| type | [`VoteT`](#vote-types)| Vote type. |
 | eligibletickets | int | Total number of eligible tickets |
 | duration | uint32 | Duration of the vote in blocks |
 | endheight | uint64 | The chain height in which the vote will end |

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -924,7 +924,7 @@ type PolicyReply struct {
 	BackendPublicKey           string   `json:"backendpublickey"`
 	IndexFileName              string   `json:"indexfilename"`
 	DataFileName               string   `json:"datafilename"`
-	MinLinkByPeriod            int64    `json:"mixlinkbyperiod"`
+	MinLinkByPeriod            int64    `json:"minlinkbyperiod"`
 	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
 }
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -135,7 +135,7 @@ const (
 
 	// PolicyMaxLinkByPeriod is the maximum amount of time into the
 	// future that the proposal LinkBy field can be set to
-	PolicyMaxLinkByPeriod = 1209600 // Three months in seconds
+	PolicyMaxLinkByPeriod = 7776000 // Three months in seconds
 
 	// ProposalListPageSize is the maximum number of proposals returned
 	// for the routes that return lists of proposals

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -79,16 +79,16 @@ const (
 	// verification token expires
 	VerificationExpiryHours = 24
 
-	// PolicyIdexFileName is the file name of the proposal markdown
+	// PolicyIdexFilename is the file name of the proposal markdown
 	// file. Every proposal is required to have a index file. The index
 	// file should contain the proposal content.
-	PolicyIndexFileName = "index.md"
+	PolicyIndexFilename = "index.md"
 
-	// PolicyDataFileName is the name of the proposal data json file.
+	// PolicyDataFilename is the name of the proposal data json file.
 	// The data file allows certain proposal fields, such as LinkTo,
 	// to be specified using json instead of having to parse them out
 	// of the index markdown file.
-	PolicyDataFileName = "data.json"
+	PolicyDataFilename = "data.json"
 
 	// PolicyMaxImages is the maximum number of images accepted
 	// when creating a new proposal
@@ -922,8 +922,8 @@ type PolicyReply struct {
 	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
 	MaxCommentLength           uint     `json:"maxcommentlength"`
 	BackendPublicKey           string   `json:"backendpublickey"`
-	IndexFileName              string   `json:"indexfilename"`
-	DataFileName               string   `json:"datafilename"`
+	IndexFilename              string   `json:"indexfilename"`
+	DataFilename               string   `json:"datafilename"`
 	MinLinkByPeriod            int64    `json:"minlinkbyperiod"`
 	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
 }

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -99,7 +99,8 @@ const (
 	PolicyMaxImageSize = 512 * 1024
 
 	// PolicyMaxMDs is the maximum number of markdown files accepted
-	// when creating a new proposal
+	// when creating a new proposal. This currently allows for the
+	// index file and the data file.
 	PolicyMaxMDs = 2
 
 	// PolicyMaxMDSize is the maximum markdown file size (in bytes)
@@ -131,6 +132,10 @@ const (
 	// for a one week voting period of the RFP and a minimum of one
 	// week to accept RFP submissions.
 	PolicyMinLinkByPeriod = 1209600 // Two weeks in seconds
+
+	// PolicyMaxLinkByPeriod is the maximum amount of time into the
+	// future that the proposal LinkBy field can be set to
+	PolicyMaxLinkByPeriod = 1209600 // Three months in seconds
 
 	// ProposalListPageSize is the maximum number of proposals returned
 	// for the routes that return lists of proposals
@@ -917,6 +922,10 @@ type PolicyReply struct {
 	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
 	MaxCommentLength           uint     `json:"maxcommentlength"`
 	BackendPublicKey           string   `json:"backendpublickey"`
+	IndexFileName              string   `json:"indexfilename"`
+	DataFileName               string   `json:"datafilename"`
+	MinLinkByPeriod            int64    `json:"mixlinkbyperiod"`
+	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -262,11 +262,15 @@ const (
 	// the specified pass and quorum requirements.
 	//
 	// VoteTypeRunoff specifies a runoff vote that multiple proposals compete in.
-	// There can only be one winner of a runoff vote. The winner is the proposal
-	// that meets the quorum requirement, meets the pass requirement, and that
-	// has the most net yes votes. The winning proposal is considered approved
-	// and all other proposals are considered rejected. If no proposals meet the
-	// quorum and pass requirements then all proposals are considered rejected.
+	// All proposals are voted on like normal, but there can only be one winner
+	// in a runoff vote. The winner is the proposal that meets the quorum
+	// requirement, meets the pass requirement, and that has the most net yes
+	// votes. The winning proposal is considered approved and all other proposals
+	// are considered rejected. If no proposals meet the quorum and pass
+	// requirements then all proposals are considered rejected.
+	// Note: in a runoff vote it is possible for a proposal to meet the quorum
+	// and pass requirements but still be rejected if it does not have the most
+	// net yes votes.
 	VoteTypeInvalid  VoteT = 0
 	VoteTypeStandard VoteT = 1
 	VoteTypeRunoff   VoteT = 2
@@ -378,6 +382,16 @@ var (
 		ErrorStatusInvalidLogin:                "invalid login credentials",
 		ErrorStatusCommentIsCensored:           "comment is censored",
 		ErrorStatusInvalidProposalVersion:      "invalid proposal version",
+		ErrorStatusInvalidVoteType:             "invalid vote type",
+		ErrorStatusInvalidVoteOptions:          "invalid vote options",
+		ErrorStatusWrongVoteResult:             "invalid vote results",
+		ErrorStatusLinkByDeadlineNotMet:        "linkby deadline note met",
+		ErrorStatusNoLinkedProposals:           "no linked proposals",
+		ErrorStatusInvalidProposalData:         "invalid proposal data",
+		ErrorStatusInvalidLinkTo:               "invalid linkto",
+		ErrorStatusInvalidLinkBy:               "invalid linkby",
+		ErrorStatusInvalidRunoffVote:           "invalid runoff vote",
+		ErrorStatusWrongProposalType:           "wrong proposal type",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -84,12 +84,6 @@ const (
 	// file should contain the proposal content.
 	PolicyIndexFilename = "index.md"
 
-	// PolicyDataFilename is the name of the proposal data json file.
-	// The data file allows certain proposal fields, such as LinkTo,
-	// to be specified using json instead of having to parse them out
-	// of the index markdown file.
-	PolicyDataFilename = "data.json"
-
 	// PolicyMaxImages is the maximum number of images accepted
 	// when creating a new proposal
 	PolicyMaxImages = 5
@@ -99,9 +93,8 @@ const (
 	PolicyMaxImageSize = 512 * 1024
 
 	// PolicyMaxMDs is the maximum number of markdown files accepted
-	// when creating a new proposal. This currently allows for the
-	// index file and the data file.
-	PolicyMaxMDs = 2
+	// when creating a new proposal.
+	PolicyMaxMDs = 1
 
 	// PolicyMaxMDSize is the maximum markdown file size (in bytes)
 	// accepted when creating a new proposal
@@ -454,7 +447,9 @@ const (
 // ProposalMetadata contains metadata that is specified by the user on proposal
 // submission. It is attached to a proposal submission as a Metadata object.
 type ProposalMetadata struct {
-	Name string `json:"name"`
+	Name   string `json:"name"`             // Proposal name
+	LinkTo string `json:"linkto,omitempty"` // Token of proposal to link to
+	LinkBy int64  `json:"linkby,omitempty"` // UNIX timestamp of RFP deadline
 }
 
 // Metadata describes user specified metadata.
@@ -962,7 +957,6 @@ type PolicyReply struct {
 	BackendPublicKey           string   `json:"backendpublickey"`
 	BuildInformation           []string `json:"buildinformation"`
 	IndexFilename              string   `json:"indexfilename"`
-	DataFilename               string   `json:"datafilename"`
 	MinLinkByPeriod            int64    `json:"minlinkbyperiod"`
 	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
 }

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -120,16 +120,6 @@ const (
 	// accepted for comments
 	PolicyMaxCommentLength = 8000
 
-	// PolicyLinkByMinPeriod is the minimum amount of time required for
-	// the proposal LinkBy deadline. It is set for two weeks to allow
-	// for a one week voting period of the RFP and a minimum of one
-	// week to accept RFP submissions.
-	PolicyLinkByMinPeriod = 1209600 // Two weeks in seconds
-
-	// PolicyLinkByMaxPeriod is the maximum amount of time into the
-	// future that the proposal LinkBy field can be set to
-	PolicyLinkByMaxPeriod = 7776000 // Three months in seconds
-
 	// ProposalListPageSize is the maximum number of proposals returned
 	// for the routes that return lists of proposals
 	ProposalListPageSize = 20
@@ -442,6 +432,11 @@ const (
 
 // ProposalMetadata contains metadata that is specified by the user on proposal
 // submission. It is attached to a proposal submission as a Metadata object.
+//
+// LinkBy must allow for a minimum of one week after the proposal vote ends for
+// RFP submissions to be submitted. The LinkBy field is validated on both
+// proposal submission and before the proposal vote is started to ensure that
+// the RFP submissions have sufficient time to be submitted.
 type ProposalMetadata struct {
 	Name   string `json:"name"`             // Proposal name
 	LinkTo string `json:"linkto,omitempty"` // Token of proposal to link to

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -504,11 +504,6 @@ type ProposalRecord struct {
 	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
 }
 
-// IsRFP returns whether the proposal is a Request For Proposals (RFP).
-func (p *ProposalRecord) IsRFP() bool {
-	return p.LinkBy != 0
-}
-
 // ProposalCredit contains the details of a proposal credit that has been
 // purchased by the user.
 type ProposalCredit struct {

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -211,11 +211,10 @@ const (
 	ErrorStatusInvalidVoteOptions          ErrorStatusT = 70
 	ErrorStatusLinkByDeadlineNotMet        ErrorStatusT = 71
 	ErrorStatusNoLinkedProposals           ErrorStatusT = 72
-	ErrorStatusInvalidProposalData         ErrorStatusT = 73
-	ErrorStatusInvalidLinkTo               ErrorStatusT = 74
-	ErrorStatusInvalidLinkBy               ErrorStatusT = 75
-	ErrorStatusInvalidRunoffVote           ErrorStatusT = 76
-	ErrorStatusWrongProposalType           ErrorStatusT = 77
+	ErrorStatusInvalidLinkTo               ErrorStatusT = 73
+	ErrorStatusInvalidLinkBy               ErrorStatusT = 74
+	ErrorStatusInvalidRunoffVote           ErrorStatusT = 75
+	ErrorStatusWrongProposalType           ErrorStatusT = 76
 
 	// Proposal state codes
 	//
@@ -382,11 +381,10 @@ var (
 		ErrorStatusMetadataDigestInvalid:       "metadata digest invalid",
 		ErrorStatusInvalidVoteType:             "invalid vote type",
 		ErrorStatusInvalidVoteOptions:          "invalid vote options",
-		ErrorStatusLinkByDeadlineNotMet:        "linkby deadline note met",
+		ErrorStatusLinkByDeadlineNotMet:        "linkby deadline note met yet",
 		ErrorStatusNoLinkedProposals:           "no linked proposals",
-		ErrorStatusInvalidProposalData:         "invalid proposal data",
-		ErrorStatusInvalidLinkTo:               "invalid linkto",
-		ErrorStatusInvalidLinkBy:               "invalid linkby",
+		ErrorStatusInvalidLinkTo:               "invalid proposal linkto",
+		ErrorStatusInvalidLinkBy:               "invalid proposal linkby",
 		ErrorStatusInvalidRunoffVote:           "invalid runoff vote",
 		ErrorStatusWrongProposalType:           "wrong proposal type",
 	}

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -209,14 +209,13 @@ const (
 	ErrorStatusMetadataDigestInvalid       ErrorStatusT = 68
 	ErrorStatusInvalidVoteType             ErrorStatusT = 69
 	ErrorStatusInvalidVoteOptions          ErrorStatusT = 70
-	ErrorStatusWrongVoteResult             ErrorStatusT = 71
-	ErrorStatusLinkByDeadlineNotMet        ErrorStatusT = 72
-	ErrorStatusNoLinkedProposals           ErrorStatusT = 73
-	ErrorStatusInvalidProposalData         ErrorStatusT = 74
-	ErrorStatusInvalidLinkTo               ErrorStatusT = 75
-	ErrorStatusInvalidLinkBy               ErrorStatusT = 76
-	ErrorStatusInvalidRunoffVote           ErrorStatusT = 77
-	ErrorStatusWrongProposalType           ErrorStatusT = 78
+	ErrorStatusLinkByDeadlineNotMet        ErrorStatusT = 71
+	ErrorStatusNoLinkedProposals           ErrorStatusT = 72
+	ErrorStatusInvalidProposalData         ErrorStatusT = 73
+	ErrorStatusInvalidLinkTo               ErrorStatusT = 74
+	ErrorStatusInvalidLinkBy               ErrorStatusT = 75
+	ErrorStatusInvalidRunoffVote           ErrorStatusT = 76
+	ErrorStatusWrongProposalType           ErrorStatusT = 77
 
 	// Proposal state codes
 	//
@@ -383,7 +382,6 @@ var (
 		ErrorStatusMetadataDigestInvalid:       "metadata digest invalid",
 		ErrorStatusInvalidVoteType:             "invalid vote type",
 		ErrorStatusInvalidVoteOptions:          "invalid vote options",
-		ErrorStatusWrongVoteResult:             "invalid vote results",
 		ErrorStatusLinkByDeadlineNotMet:        "linkby deadline note met",
 		ErrorStatusNoLinkedProposals:           "no linked proposals",
 		ErrorStatusInvalidProposalData:         "invalid proposal data",

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -127,15 +127,15 @@ const (
 	// accepted for comments
 	PolicyMaxCommentLength = 8000
 
-	// PolicyMinLinkByPeriod is the minimum amount of time required for
+	// PolicyLinkByMinPeriod is the minimum amount of time required for
 	// the proposal LinkBy deadline. It is set for two weeks to allow
 	// for a one week voting period of the RFP and a minimum of one
 	// week to accept RFP submissions.
-	PolicyMinLinkByPeriod = 1209600 // Two weeks in seconds
+	PolicyLinkByMinPeriod = 1209600 // Two weeks in seconds
 
-	// PolicyMaxLinkByPeriod is the maximum amount of time into the
+	// PolicyLinkByMaxPeriod is the maximum amount of time into the
 	// future that the proposal LinkBy field can be set to
-	PolicyMaxLinkByPeriod = 7776000 // Three months in seconds
+	PolicyLinkByMaxPeriod = 7776000 // Three months in seconds
 
 	// ProposalListPageSize is the maximum number of proposals returned
 	// for the routes that return lists of proposals
@@ -456,13 +456,13 @@ type CensorshipRecord struct {
 // when the full ticket snapshot or the full cast vote data is not needed.
 type VoteSummary struct {
 	Status           PropVoteStatusT    `json:"status"`                     // Vote status
+	Approved         bool               `json:"approved"`                   // Was the vote approved
 	Type             VoteT              `json:"type,omitempty"`             // Vote type
 	EligibleTickets  uint32             `json:"eligibletickets,omitempty"`  // Number of eligible tickets
 	Duration         uint32             `json:"duration,omitempty"`         // Duration of vote
 	EndHeight        uint64             `json:"endheight,omitempty"`        // Vote end height
 	QuorumPercentage uint32             `json:"quorumpercentage,omitempty"` // Percent of eligible votes required for quorum
 	PassPercentage   uint32             `json:"passpercentage,omitempty"`   // Percent of total votes required to pass
-	Approved         bool               `json:"approved,omitempty"`         // Was the vote approved
 	Results          []VoteOptionResult `json:"results,omitempty"`          // Vote results
 }
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -423,7 +423,7 @@ type File struct {
 
 // ProposalData is the data that is parsed from the data.json file. The
 // data.json file is part of the proposal files bundle and includes specifc
-// fields that are needed by politeiawww. They are included in a seperate json
+// fields that are needed by politeiawww. They are included in a separate json
 // file instead of the index markdown file to make parsing easier.
 //
 // The proposal name is not included in the ProposalData due to backwards

--- a/politeiawww/api/www/v2/api.md
+++ b/politeiawww/api/www/v2/api.md
@@ -9,6 +9,7 @@ using a JSON REST API.
 **Vote Routes**
 
 - [`Start vote`](#start-vote)
+- [`Start vote runoff`](#start-vote-runoff)
 - [`Vote details`](#vote-details)
 
 ### `Start vote`
@@ -41,48 +42,33 @@ Differences between v1 and v2 StartVoteReply:
 | Parameter | Type | Description | Required |
 |-|-|-|-|
 | publickey | string | Public key used to sign the vote | Yes |
-| vote | Vote | Vote details | Yes |
+| vote | [`Vote`](#vote) | Vote details | Yes |
 | signature | string | Signature of the Vote digest | Yes |
 
 **Results (StartVoteReply):**
 
 | | Type | Description |
 | - | - | - |
-| startblockheight | uint32 | Start block height of the vote |
+| startblockheight | number | Start block height of the vote |
 | startblockhash | string | Start block hash of the vote |
-| endblockheight | uint32 | End block height of the vote |
+| endblockheight | number | End block height of the vote |
 | eligibletickets | []string | All ticket hashes that are eligible to vote |
-
-**Vote:**
-
-| | Type | Description |
-| - | - | - |
-| token | string | Censorship token |
-| proposalversion | uint32 | Proposal version being voted on |
-| type | int | Type of proposal vote | 
-| mask | uint64 | Mask for valid vote bits |
-| duration | uint32 | Duration of the vote in blocks |
-| quorumpercentage | uint32 | Percent of eligible votes required for a quorum |
-| pass percentage | uint32 | Percent of total votes required for the proposal to considered approved | 
-| options | []VoteOption | Vote options |
-
-**VoteOption:**
-
-| | Type | Description |
-| - | - | - |
-| Id | string | Single unique word that identifies this option, e.g. "yes" |
-| Description | string | Human readable description of this option |
-| Bits | uint64 | Bits that make up this choice, e.g. 0x01 |
 
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
+- [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
+- [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
 - [`ErrorStatusInvalidPropVoteBits`](#ErrorStatusInvalidPropVoteBits)
+- [`ErrorStatusInvalidVoteOptions`](#ErrorStatusInvalidVoteOptions)
 - [`ErrorStatusInvalidPropVoteParams`](#ErrorStatusInvalidPropVoteParams)
 - [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
 - [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
-- [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
+- [`ErrorStatusInvalidProposalVersion`](#ErrorStatusInvalidProposalVersion)
 - [`ErrorStatusWrongStatus`](#ErrorStatusWrongStatus)
 - [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
+- [`ErrorStatusInvalidVoteType`] (#ErrorStatusInvalidVoteType)
+- [`ErrorStatusWrongProposalType`](#ErrorStatusWrongProposalType)
+- [`ErrorStatusInvalidLinkBy`](#ErrorStatusInvalidLinkBy)
 
 **Example**
 
@@ -128,6 +114,187 @@ Reply:
 
 Note: eligibletickets is abbreviated for readability.
 
+
+### `Start vote runoff`
+Start the runoff voting process on all public, non-abandoned RFP submissions
+for the provided RFP token.
+
+`AuthorizeVotes` must contain a vote authorization for each RFP submission that
+is participating in the runoff vote. Unlike standard votes, these vote
+authorizations are not signed by the submission author. They are signed by the
+admin starting the runoff vote.
+
+StartVotes must contain a StartVote for each RFP submission that is
+participating in the runoff vote. The runoff vote can only be started once the
+RFP proposal itself has been approved by a vote and once the LinkBy submission
+deadline has expired. Once the LinkBy deadline has expired, the runoff vote can
+be started at any point by an admin. It is not required that RFP submission
+authors authorize the start of the vote.
+
+**Route:** `POST /v2/vote/startrunoff`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| token | string | RFP proposal censorship token | Yes |
+| authorizevotes | [][`AuthorizeVote`](#authorize-vote) | Authorize votes for rfp submissions | Yes |
+| startvotes | [][`StartVote`](#start-vote) | Start votes for rfp submissions | Yes |
+
+**Results (StartVoteRunoffReply):**
+
+| | Type | Description |
+| - | - | - |
+| startblockheight | number | Start block height of the vote |
+| startblockhash | string | Start block hash of the vote |
+| endblockheight | number | End block height of the vote |
+| eligibletickets | []string | All ticket hashes that are eligible to vote |
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusInvalidRunoffVote`](#ErrorStatusInvalidRunoffVote)
+- [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
+- [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
+- [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
+- [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
+- [`ErrorStatusWrongStatus`](#ErrorStatusWrongStatus)
+- [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
+- [`ErrorStatusInvalidAuthVoteAction`](#ErrorStatusInvalidAuthVoteAction)
+- [`ErrorStatusInvalidPropVoteBits`](#ErrorStatusInvalidPropVoteBits)
+- [`ErrorStatusInvalidVoteOptions`](#ErrorStatusInvalidVoteOptions)
+- [`ErrorStatusInvalidPropVoteParams`](#ErrorStatusInvalidPropVoteParams)
+- [`ErrorStatusInvalidProposalVersion`](#ErrorStatusInvalidProposalVersion)
+- [`ErrorStatusInvalidVoteType`] (#ErrorStatusInvalidVoteType)
+- [`ErrorStatusWrongProposalType`](#ErrorStatusWrongProposalType)
+- [`ErrorStatusLinkByDeadlineNotMet`](#ErrorStatusLinkByDeadlineNotMet)
+- [`ErrorStatusNoLinkedProposals`](#ErrorStatusNoLinkedProposals)
+
+**Example**
+
+Request:
+
+``` json
+{
+  "token": "b1052a4e099aa3b58edb4ad174fee88bc2ef52eb5d052b97ca062f043233a23b",
+  "authorizevote": [
+    {
+      "token": "6ec6c28c350013873e15a37c16ffcea90dd08043ed55c44194008e167527999a",
+      "action": "authorize",
+      "publickey": "d8fa97b2ce42fb279938b9918b3bf5a7fb68ba6a3296159f237be27cda92435d",
+      "signature": "904439a08211c36c894cde928eaae1b75b5dc1e12dc0d9c62d38ba2cc8ea5df4f9ca6774634ef1a95594edfff25b0493b5054c652d93f9037e2edad6fc0ee30b"
+    },
+    {
+      "token": "abb8f4e498227ee9c58765820cd6137a76bb261e8f8d34b4b44f49d4208e37a9",
+      "action": "authorize",
+      "publickey": "d8fa97b2ce42fb279938b9918b3bf5a7fb68ba6a3296159f237be27cda92435d",
+      "signature": "a154563161efd5fedfbc13728af0cc61995ffb3984accb102bcecf2b56e48069e66e32285aea01f0333c46a4610e6fcb86c93bad063cf39567f31b664dcdd60d"
+    },
+    {
+      "token": "cfd2a55ef902c7fe5dc35da66c578283f4aeebbd58917e771e4e567d84d28363",
+      "action": "authorize",
+      "publickey": "d8fa97b2ce42fb279938b9918b3bf5a7fb68ba6a3296159f237be27cda92435d",
+      "signature": "99b7a544dd9c910fa48c653a9e8ff14aa9b083227baeebd81ef35288f388c575cd65870e0cf68d5c692c6c9e4d9063e7f425601b19ad507164b8cdf1031ed90f"
+    }
+  ],
+  "startvotes": [
+    {
+      "vote": {
+        "token": "6ec6c28c350013873e15a37c16ffcea90dd08043ed55c44194008e167527999a",
+        "proposalversion": 1,
+        "type": 2,
+        "mask": 3,
+        "duration": 2,
+        "quorumpercentage": 1,
+        "passpercentage": 1,
+        "options": [
+          {
+            "id": "yes",
+            "description": "Don't approve proposal",
+            "bits": 1
+          },
+          {
+            "id": "no",
+            "description": "Approve proposal",
+            "bits": 2
+          }
+        ]
+      },
+      "publickey": "d8fa97b2ce42fb279938b9918b3bf5a7fb68ba6a3296159f237be27cda92435d",
+      "signature": "d5c909dfa755a777d8f8678e10d955faf5c53d00b1e21c744faadbf15328ff48550b76ff8f9136ecb40b6614ebfe7ca9ee8280c4b0141fd6399a37d0705f7a0d"
+    },
+    {
+      "vote": {
+        "token": "abb8f4e498227ee9c58765820cd6137a76bb261e8f8d34b4b44f49d4208e37a9",
+        "proposalversion": 1,
+        "type": 2,
+        "mask": 3,
+        "duration": 2,
+        "quorumpercentage": 1,
+        "passpercentage": 1,
+        "options": [
+          {
+            "id": "yes",
+            "description": "Don't approve proposal",
+            "bits": 1
+          },
+          {
+            "id": "no",
+            "description": "Approve proposal",
+            "bits": 2
+          }
+        ]
+      },
+      "publickey": "d8fa97b2ce42fb279938b9918b3bf5a7fb68ba6a3296159f237be27cda92435d",
+      "signature": "08f9e9669f3d40b69046b162046c1485c8d0eb32fc1a815101ba7ab25d0feb543d1dcd9825ebea8bd593d935d176ba3099987cd96564810734b0c5a01cd97501"
+    },
+    {
+      "vote": {
+        "token": "cfd2a55ef902c7fe5dc35da66c578283f4aeebbd58917e771e4e567d84d28363",
+        "proposalversion": 1,
+        "type": 2,
+        "mask": 3,
+        "duration": 2,
+        "quorumpercentage": 1,
+        "passpercentage": 1,
+        "options": [
+          {
+            "id": "yes",
+            "description": "Don't approve proposal",
+            "bits": 1
+          },
+          {
+            "id": "no",
+            "description": "Approve proposal",
+            "bits": 2
+          }
+        ]
+      },
+      "publickey": "d8fa97b2ce42fb279938b9918b3bf5a7fb68ba6a3296159f237be27cda92435d",
+      "signature": "166b210404e0968e300f23961d6e5db6e253ac1b821501c3f8f6fbd7fbf07596e02c3be7114bc8387a7efc14a9a95c56b3dc0b0bea3609ecb6119ff32d60850b"
+    }
+  ]
+}
+
+```
+
+Reply:
+
+```json
+{
+  "startblockheight": 417842,
+  "startblockhash": "00000058ff98f9f4a859ab30e81fc66cb1dabefd6a597000dd252716514bd57f",
+  "endblockheight": 417860,
+  "eligibletickets": [
+    "000011e329fe0359ea1d2070d927c93971232c1118502dddf0b7f1014bf38d97",
+    "0004b0f8b2883a2150749b2c8ba05652b02220e98895999fd96df790384888f9",
+    "00107166c5fc5c322ecda3748a1896f4a2de6672aae25014123d2cedc83e8f42",
+    "002272cf4788c3f726c30472f9c97d2ce66b997b5762ff4df6a05c4761272413"
+  ]
+}
+```
+
+Note: eligibletickets is abbreviated for readability.
+
 ### `Vote details`
 
 Vote details returns all of the relevant proposal vote information for the
@@ -152,13 +319,13 @@ between the Vote versions.
 
 | | Type | Description |
 | - | - | - |
-| version | uint32 | Start vote version |
+| version | number | Start vote version |
 | vote | string | JSON encoded Vote |
 | publickey | string | Key used for signature |
 | signature | string | Start vote signature |
-| startblockheight | uint32 | Start block height of the vote |
+| startblockheight | number | Start block height of the vote |
 | startblockhash | string | Start block hash of the vote |
-| endblockheight | uint32 | End block height of the vote |
+| endblockheight | number | End block height of the vote |
 | eligibletickets | []string | All ticket hashes that are eligible to vote |
 
 On failure the call shall return `400 Bad Request` and one of the following
@@ -189,3 +356,53 @@ Reply:
 ```
 
 Note: eligibletickets is abbreviated for readability.
+
+### `Authorize vote actions`
+| Action | Value | Description |
+|-|-|-|
+| Authorize | authorize | Authorize a proposal vote |
+| Revoke | revoke | Revoke a previous authorization | 
+
+### `Authorize vote`
+| Parameter | Value | Description |
+|-|-|-|
+| token | string | Proposal token of vote that is being authorized |
+| action | [`AuthVoteAction`](#authorize-vote-actions) | Authorize or revoke | 
+| publickey | string | Public key used for signature |
+| signature | string | Signature of `token+version+action` |
+
+### `Vote types`
+| Type | Value | Description |
+|-|-|-|
+| <a name="VoteTypeInvalid">VoteTypeInvalid</a>| 0 | An invalid vote type. This shall be considered a bug. |
+| <a name="VoteTypeStandard">VoteTypeStandard</a>| 1 | A simple approve or reject proposal vote where the winner is the voting option that has met the specified pass and quorum requirements. |
+| <a name="VoteTypeRunoff">VoteTypeRunoff</a>| 2 | A runoff vote that multiple proposals compete in. All proposals are voted on like normal, but there can only be one winner in a runoff vote. The winner is the proposal that meets the quorum requirement, meets the pass requirement, and that has the most net yes votes. The winning proposal is considered approved and all other proposals are considered rejected. If no proposals meet the quorum and pass requirements then all proposals are considered rejected. Note: in a runoff vote it is possible for a proposal to meet the quorum and pass requirements but still be rejected if it does not have the most net yes votes. |
+
+### `Vote option`
+
+| Parameter | Type | Description |
+| - | - | - |
+| id | string | Single unique word that identifies this option, e.g. "yes" |
+| description | string | Human readable description of this option |
+| bits | number | Bits that make up this choice, e.g. 0x01 |
+
+### `Vote`
+
+| Parameter | Type | Description |
+| - | - | - |
+| token | string | Censorship token |
+| proposalversion | number | Proposal version being voted on |
+| type | [`VoteT`](#vote-types) | Type of proposal vote | 
+| mask | number | Mask for valid vote bits |
+| duration | number | Duration of the vote in blocks |
+| quorumpercentage | number | Percent of eligible votes required for a quorum |
+| pass percentage | number | Percent of total votes required for the proposal to considered approved | 
+| options | [][`VoteOption`](#vote-option) | Vote options |
+
+### `Start vote`
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| publickey | string | Public key used to sign the vote | Yes |
+| vote | [`Vote`](#vote) | Vote details | Yes |
+| signature | string | Signature of the Vote digest | Yes |

--- a/politeiawww/api/www/v2/v2.go
+++ b/politeiawww/api/www/v2/v2.go
@@ -37,8 +37,6 @@ const (
 	VoteTypeInvalid  VoteT = 0
 	VoteTypeStandard VoteT = 1
 	VoteTypeRunoff   VoteT = 2
-
-	// TODO should error statuses be in v1 or v2?
 )
 
 var (

--- a/politeiawww/api/www/v2/v2.go
+++ b/politeiawww/api/www/v2/v2.go
@@ -120,7 +120,7 @@ type StartVoteReply struct {
 // AuthorizeVotes must contain a vote authorization for each RFP submission
 // that is participating in the runoff vote. Unlike standard votes, these vote
 // authorizations are not signed by the submission author. They are signed by
-// the admin.
+// the admin starting the runoff vote.
 //
 // StartVotes must contain a StartVote for each RFP submission that is
 // participating in the runoff vote. The runoff vote can only be started once

--- a/politeiawww/api/www/v2/v2.go
+++ b/politeiawww/api/www/v2/v2.go
@@ -102,15 +102,23 @@ type StartVoteReply struct {
 }
 
 // StartVoteRunoff starts the runoff voting process on all public,
-// non-abandoned RFP submissions for the provided RFP token. The StartVotes
-// array must contain a StartVote for each of the RFP submissions that is
+// non-abandoned RFP submissions for the provided RFP token.
+//
+// AuthorizeVotes must contain a vote authorization for each RFP submission
+// that is participating in the runoff vote. Unlike standard votes, these vote
+// authorizations are not signed by the submission author. They are signed by
+// the admin.
+//
+// StartVotes must contain a StartVote for each RFP submission that is
 // participating in the runoff vote. The runoff vote can only be started once
-// the RFP proposal has been approved by a vote and once the LinkBy RFP
+// the RFP proposal itself has been approved by a vote and once the LinkBy
 // submission deadline has expired. Once the LinkBy deadline has expired, the
 // runoff vote can be started at any point by an admin. It is not required that
 // RFP submission authors authorize the start of the vote.
 type StartVoteRunoff struct {
-	Token      string      `json:"token"`      // RFP censorship token
+	Token string `json:"token"` // RFP censorship token
+	// TODO
+	// AuthorizeVotes []AuthorizeVote `json:"authorizevote"` // AuthorizeVote for each RFP submission
 	StartVotes []StartVote `json:"startvotes"` // StartVote for each RFP submission
 }
 

--- a/politeiawww/api/www/v2/v2.go
+++ b/politeiawww/api/www/v2/v2.go
@@ -37,6 +37,10 @@ const (
 	VoteTypeInvalid  VoteT = 0
 	VoteTypeStandard VoteT = 1
 	VoteTypeRunoff   VoteT = 2
+
+	// AuthorizeVote actions
+	AuthVoteActionAuthorize = "authorize"
+	AuthVoteActionRevoke    = "revoke"
 )
 
 var (
@@ -49,6 +53,15 @@ type VoteOption struct {
 	Id          string `json:"id"`          // Single unique word identifying vote (e.g. yes)
 	Description string `json:"description"` // Longer description of the vote.
 	Bits        uint64 `json:"bits"`        // Bits used for this option
+}
+
+// AuthorizeVote is used to indicate that a proposal has been finalized and is
+// ready to be voted on.
+type AuthorizeVote struct {
+	Token     string `json:"token"`     // Proposal token
+	Action    string `json:"action"`    // Authorize or revoke
+	PublicKey string `json:"publickey"` // Key used for signature
+	Signature string `json:"signature"` // Signature of token+version+action
 }
 
 // Vote represents the vote params and vote options for a proposal vote.
@@ -116,10 +129,9 @@ type StartVoteReply struct {
 // runoff vote can be started at any point by an admin. It is not required that
 // RFP submission authors authorize the start of the vote.
 type StartVoteRunoff struct {
-	Token string `json:"token"` // RFP censorship token
-	// TODO
-	// AuthorizeVotes []AuthorizeVote `json:"authorizevote"` // AuthorizeVote for each RFP submission
-	StartVotes []StartVote `json:"startvotes"` // StartVote for each RFP submission
+	Token          string          `json:"token"`
+	AuthorizeVotes []AuthorizeVote `json:"authorizevote"`
+	StartVotes     []StartVote     `json:"startvotes"`
 }
 
 // The StartVoteRunoffReply is the reply to the StartVoteRunoff command. The

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -120,9 +120,8 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		Name: cmd.Name,
 	}
 	if cmd.RFP {
-		// Double the minimum LinkBy period to give a buffer
-		t := time.Second * v1.PolicyLinkByMinPeriod * 2
-		pm.LinkBy = time.Now().Add(t).Unix()
+		// Set linkby to a month from now
+		pm.LinkBy = time.Now().Add(time.Hour * 24 * 30).Unix()
 	}
 	if cmd.LinkTo != "" {
 		pm.LinkTo = cmd.LinkTo

--- a/politeiawww/cmd/piwww/help.go
+++ b/politeiawww/cmd/piwww/help.go
@@ -91,6 +91,8 @@ func (cmd *HelpCmd) Execute(args []string) error {
 		fmt.Printf("%s\n", verifyUserPaymentHelpMsg)
 	case "startvote":
 		fmt.Printf("%s\n", startVoteHelpMsg)
+	case "startvoterunoff":
+		fmt.Printf("%s\n", startVoteRunoffHelpMsg)
 	case "voteresults":
 		fmt.Printf("%s\n", voteResultsHelpMsg)
 	case "inventory":

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -121,9 +121,8 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		Name: cmd.Name,
 	}
 	if cmd.RFP {
-		// Double the minimum LinkBy period to give a buffer
-		t := time.Second * v1.PolicyLinkByMinPeriod * 2
-		pm.LinkBy = time.Now().Add(t).Unix()
+		// Set linkby to a month from now
+		pm.LinkBy = time.Now().Add(time.Hour * 24 * 30).Unix()
 	}
 	if cmd.LinkTo != "" {
 		pm.LinkTo = cmd.LinkTo

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -111,7 +111,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 	var pd v1.ProposalData
 	if cmd.RFP {
 		// Double the minimum LinkBy period to give a buffer
-		t := time.Second * v1.PolicyMinLinkByPeriod * 2
+		t := time.Second * v1.PolicyLinkByMinPeriod * 2
 		pd.LinkBy = time.Now().Add(t).Unix()
 	}
 	if cmd.LinkTo != "" {

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"time"
 
 	"github.com/decred/politeia/politeiad/api/v1/mime"
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
@@ -108,39 +109,20 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		files = append(files, f)
 	}
 
-	/*
-		TODO
-		// Create proposal data json file if one or more of the proposal
-		// data fields has been specified.
-		var pd v1.ProposalData
-		if cmd.RFP {
-			// Double the minimum LinkBy period to give a buffer
-			t := time.Second * v1.PolicyLinkByMinPeriod * 2
-			pd.LinkBy = time.Now().Add(t).Unix()
-		}
-		if cmd.LinkTo != "" {
-			pd.LinkTo = cmd.LinkTo
-		}
-		b, err := json.Marshal(pd)
-		if err != nil {
-			return err
-		}
-		if len(b) > 2 {
-			// At least one of the fields has been filled in if len(b) > 2.
-			files = append(files, v1.File{
-				Name:    v1.PolicyDataFilename,
-				MIME:    mime.DetectMimeType(b),
-				Digest:  hex.EncodeToString(util.Digest(b)),
-				Payload: base64.StdEncoding.EncodeToString(b),
-			})
-	*/
-
 	// Setup metadata
 	if cmd.Name == "" {
 		cmd.Name = "Some proposal title"
 	}
 	pm := v1.ProposalMetadata{
 		Name: cmd.Name,
+	}
+	if cmd.RFP {
+		// Double the minimum LinkBy period to give a buffer
+		t := time.Second * v1.PolicyLinkByMinPeriod * 2
+		pm.LinkBy = time.Now().Add(t).Unix()
+	}
+	if cmd.LinkTo != "" {
+		pm.LinkTo = cmd.LinkTo
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -111,7 +111,11 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 
 	// Setup metadata
 	if cmd.Name == "" {
-		cmd.Name = "Some proposal title"
+		r, err := util.Random(v1.PolicyMinProposalNameLength)
+		if err != nil {
+			return err
+		}
+		cmd.Name = hex.EncodeToString(r)
 	}
 	pm := v1.ProposalMetadata{
 		Name: cmd.Name,
@@ -193,7 +197,7 @@ Flags:
   --random   (bool, optional)    Generate a random proposal.
   --rfp      (bool, optional)    Make the proposal an RFP by inserting a LinkBy timestamp into the
                                  proposal data JSON file. The LinkBy timestamp is set to be one
-																 week from the current time.
+                                 week from the current time.
   --linkto   (string, optional)  Token of an existing public proposal to link to. The token is
                                  used to populate the LinkTo field in the proposal data JSON file.
 

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -80,7 +80,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 	}
 
 	f := v1.File{
-		Name:    v1.PolicyIndexFileName,
+		Name:    v1.PolicyIndexFilename,
 		MIME:    mime.DetectMimeType(md),
 		Digest:  hex.EncodeToString(util.Digest(md)),
 		Payload: base64.StdEncoding.EncodeToString(md),
@@ -124,7 +124,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 	if len(b) > 2 {
 		// At least one of the fields has been filled in if len(b) > 2.
 		files = append(files, v1.File{
-			Name:    v1.PolicyDataFileName,
+			Name:    v1.PolicyDataFilename,
 			MIME:    mime.DetectMimeType(b),
 			Digest:  hex.EncodeToString(util.Digest(b)),
 			Payload: base64.StdEncoding.EncodeToString(b),

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -110,7 +110,9 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 	// data fields has been specified.
 	var pd v1.ProposalData
 	if cmd.RFP {
-		pd.LinkBy = time.Now().Add(time.Hour * 24 * 14).Unix()
+		// Double the minimum LinkBy period to give a buffer
+		t := time.Second * v1.PolicyMinLinkByPeriod * 2
+		pd.LinkBy = time.Now().Add(t).Unix()
 	}
 	if cmd.LinkTo != "" {
 		pd.LinkTo = cmd.LinkTo

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -82,6 +82,7 @@ type piwww struct {
 	SendFaucetTx       SendFaucetTxCmd          `command:"sendfaucettx" description:"         send a DCR transaction using the Decred testnet faucet"`
 	SetProposalStatus  SetProposalStatusCmd     `command:"setproposalstatus" description:"(admin)  set the status of a proposal"`
 	StartVote          StartVoteCmd             `command:"startvote" description:"(admin)  start the voting period on a proposal"`
+	StartVoteRunoff    StartVoteRunoffCmd       `command:"startvoterunoff" description:"(admin)  start a runoff using the submissions to an RFP"`
 	Subscribe          SubscribeCmd             `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`
 	Tally              TallyCmd                 `command:"tally" description:"(public) get the vote tally for a proposal"`
 	TestRun            TestRunCmd               `command:"testrun" description:"         run a series of tests on the politeiawww routes (dev use only)"`

--- a/politeiawww/cmd/piwww/startvote.go
+++ b/politeiawww/cmd/piwww/startvote.go
@@ -16,12 +16,16 @@ import (
 )
 
 // StartVoteCmd starts the voting period on the specified proposal.
+//
+// The QuorumPercentage and PassPercentage are strings and not uint32 so that a
+// value of 0 can be passed in and not be overwritten by the defaults. This is
+// sometimes desirable when testing.
 type StartVoteCmd struct {
 	Args struct {
 		Token            string `positional-arg-name:"token" required:"true"`
 		Duration         uint32 `positional-arg-name:"duration"`
-		QuorumPercentage uint32 `positional-arg-name:"quorumpercentage"`
-		PassPercentage   uint32 `positional-arg-name:"passpercentage"`
+		QuorumPercentage string `positional-arg-name:"quorumpercentage"`
+		PassPercentage   string `positional-arg-name:"passpercentage"`
 	} `positional-args:"true"`
 }
 
@@ -52,11 +56,19 @@ func (cmd *StartVoteCmd) Execute(args []string) error {
 	if cmd.Args.Duration != 0 {
 		duration = cmd.Args.Duration
 	}
-	if cmd.Args.QuorumPercentage != 0 {
-		quorum = cmd.Args.QuorumPercentage
+	if cmd.Args.QuorumPercentage != "" {
+		i, err := strconv.ParseUint(cmd.Args.QuorumPercentage, 10, 32)
+		if err != nil {
+			return err
+		}
+		quorum = uint32(i)
 	}
-	if cmd.Args.PassPercentage != 0 {
-		pass = cmd.Args.PassPercentage
+	if cmd.Args.PassPercentage != "" {
+		i, err := strconv.ParseUint(cmd.Args.PassPercentage, 10, 32)
+		if err != nil {
+			return err
+		}
+		pass = uint32(i)
 	}
 
 	// Create StartVote
@@ -117,14 +129,17 @@ func (cmd *StartVoteCmd) Execute(args []string) error {
 // specified.
 var startVoteHelpMsg = `startvote <token> <duration> <quorumpercentage> <passpercentage>
 
-Start voting period for a proposal. Requires admin privileges.  The optional
-arguments must either all be used or none be used.
+Start voting period for a proposal. Requires admin privileges.
+
+The quorumpercentage and passpercentage are strings and not uint32 so that a
+value of 0 can be passed in and not be overwritten by the defaults. This is
+sometimes desirable when testing.
 
 Arguments:
 1. token              (string, required)  Proposal censorship token
 2. duration           (uint32, optional)  Duration of vote in blocks (default: 2016)
-3. quorumpercentage   (uint32, optional)  Percent of votes required for quorum (default: 10)
-4. passpercentage     (uint32, optional)  Percent of votes required to pass (default: 60)
+3. quorumpercentage   (string, optional)  Percent of votes required for quorum (default: 10)
+4. passpercentage     (string, optional)  Percent of votes required to pass (default: 60)
 
 Result:
 

--- a/politeiawww/cmd/piwww/startvote.go
+++ b/politeiawww/cmd/piwww/startvote.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/decred/politeia/decredplugin"
 	v2 "github.com/decred/politeia/politeiawww/api/www/v2"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 	"github.com/decred/politeia/util"
@@ -69,12 +70,12 @@ func (cmd *StartVoteCmd) Execute(args []string) error {
 		PassPercentage:   pass,
 		Options: []v2.VoteOption{
 			{
-				Id:          "no",
+				Id:          decredplugin.VoteOptionIDApprove,
 				Description: "Don't approve proposal",
 				Bits:        0x01,
 			},
 			{
-				Id:          "yes",
+				Id:          decredplugin.VoteOptionIDReject,
 				Description: "Approve proposal",
 				Bits:        0x02,
 			},

--- a/politeiawww/cmd/piwww/startvoterunoff.go
+++ b/politeiawww/cmd/piwww/startvoterunoff.go
@@ -18,12 +18,16 @@ import (
 
 // StartVoteRunoffCmd starts the voting period on all public submissions to a
 // request for proposals (RFP).
+//
+// The QuorumPercentage and PassPercentage are strings and not uint32 so that a
+// value of 0 can be passed in and not be overwritten by the defaults. This is
+// sometimes desirable when testing.
 type StartVoteRunoffCmd struct {
 	Args struct {
 		TokenRFP         string `positional-arg-name:"token" required:"true"` // RFP censorship token
-		Duration         uint32 `positional-arg-name:"duration"`              // Vote duration
-		QuorumPercentage uint32 `positional-arg-name:"quorumpercentage"`      // Quorum percentage
-		PassPercentage   uint32 `positional-arg-name:"passpercentage"`        // Pass percentage
+		Duration         uint32 `positional-arg-name:"duration"`              // Duration in blocks
+		QuorumPercentage string `positional-arg-name:"quorumpercentage"`
+		PassPercentage   string `positional-arg-name:"passpercentage"`
 	} `positional-args:"true"`
 }
 
@@ -44,11 +48,19 @@ func (cmd *StartVoteRunoffCmd) Execute(args []string) error {
 	if cmd.Args.Duration != 0 {
 		duration = cmd.Args.Duration
 	}
-	if cmd.Args.QuorumPercentage != 0 {
-		quorum = cmd.Args.QuorumPercentage
+	if cmd.Args.QuorumPercentage != "" {
+		i, err := strconv.ParseUint(cmd.Args.QuorumPercentage, 10, 32)
+		if err != nil {
+			return err
+		}
+		quorum = uint32(i)
 	}
-	if cmd.Args.PassPercentage != 0 {
-		pass = cmd.Args.PassPercentage
+	if cmd.Args.PassPercentage != "" {
+		i, err := strconv.ParseUint(cmd.Args.PassPercentage, 10, 32)
+		if err != nil {
+			return err
+		}
+		pass = uint32(i)
 	}
 
 	// Fetch RFP proposal and RFP submissions
@@ -148,6 +160,10 @@ var startVoteRunoffHelpMsg = `startvoterunoff <token> <duration> <quorumpercenta
 
 Start the voting period on all public submissions to an RFP proposal. The
 optional arguments must either all be used or none be used.
+
+The quorumpercentage and passpercentage are strings and not uint32 so that a
+value of 0 can be passed in and not be overwritten by the defaults. This is
+sometimes desirable when testing.
 
 Arguments:
 1. token              (string, required)  Proposal censorship token

--- a/politeiawww/cmd/piwww/startvoterunoff.go
+++ b/politeiawww/cmd/piwww/startvoterunoff.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+
+	"github.com/decred/politeia/decredplugin"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
+	v2 "github.com/decred/politeia/politeiawww/api/www/v2"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+	"github.com/decred/politeia/util"
+)
+
+// StartVoteRunoffCmd starts the voting period on all public submissions to a
+// request for proposals (RFP).
+type StartVoteRunoffCmd struct {
+	Args struct {
+		TokenRFP         string `positional-arg-name:"token" required:"true"` // RFP censorship token
+		Duration         uint32 `positional-arg-name:"duration"`              // Vote duration
+		QuorumPercentage uint32 `positional-arg-name:"quorumpercentage"`      // Quorum percentage
+		PassPercentage   uint32 `positional-arg-name:"passpercentage"`        // Pass percentage
+	} `positional-args:"true"`
+}
+
+// Execute executes the StartVoteRunoff command.
+func (cmd *StartVoteRunoffCmd) Execute(args []string) error {
+	// Check for user identity
+	if cfg.Identity == nil {
+		return shared.ErrUserIdentityNotFound
+	}
+
+	// Setup vote params
+	var (
+		// Default values
+		duration uint32 = 2016
+		quorum   uint32 = 10
+		pass     uint32 = 60
+	)
+	if cmd.Args.Duration != 0 {
+		duration = cmd.Args.Duration
+	}
+	if cmd.Args.QuorumPercentage != 0 {
+		quorum = cmd.Args.QuorumPercentage
+	}
+	if cmd.Args.PassPercentage != 0 {
+		pass = cmd.Args.PassPercentage
+	}
+
+	// Fetch RFP proposal and RFP submissions
+	pdr, err := client.ProposalDetails(cmd.Args.TokenRFP,
+		&v1.ProposalsDetails{})
+	if err != nil {
+		return err
+	}
+	bpr, err := client.BatchProposals(&v1.BatchProposals{
+		Tokens: pdr.Proposal.LinkedFrom,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Only include submissions that are public. This will
+	// filter out any submissions that have been abandoned.
+	submissions := make([]v1.ProposalRecord, 0, len(bpr.Proposals))
+	for _, v := range bpr.Proposals {
+		if v.Status == v1.PropStatusPublic {
+			submissions = append(submissions, v)
+		}
+	}
+
+	// Prepare StartVote for each public RFP submission
+	startVotes := make([]v2.StartVote, 0, len(submissions))
+	for _, v := range submissions {
+		version, err := strconv.ParseUint(v.Version, 10, 32)
+		if err != nil {
+			return err
+		}
+
+		vote := v2.Vote{
+			Token:            v.CensorshipRecord.Token,
+			ProposalVersion:  uint32(version),
+			Type:             v2.VoteTypeRunoff,
+			Mask:             0x03, // bit 0 no, bit 1 yes
+			Duration:         duration,
+			QuorumPercentage: quorum,
+			PassPercentage:   pass,
+			Options: []v2.VoteOption{
+				{
+					Id:          decredplugin.VoteOptionIDApprove,
+					Description: "Don't approve proposal",
+					Bits:        0x01,
+				},
+				{
+					Id:          decredplugin.VoteOptionIDReject,
+					Description: "Approve proposal",
+					Bits:        0x02,
+				},
+			},
+		}
+		vb, err := json.Marshal(vote)
+		if err != nil {
+			return err
+		}
+		msg := hex.EncodeToString(util.Digest(vb))
+		sig := cfg.Identity.SignMessage([]byte(msg))
+
+		startVotes = append(startVotes, v2.StartVote{
+			Vote:      vote,
+			PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+			Signature: hex.EncodeToString(sig[:]),
+		})
+	}
+
+	// Prepare and send request
+	svr := v2.StartVoteRunoff{
+		Token:      cmd.Args.TokenRFP,
+		StartVotes: startVotes,
+	}
+	err = shared.PrintJSON(svr)
+	if err != nil {
+		return err
+	}
+	svrr, err := client.StartVoteRunoffV2(svr)
+	if err != nil {
+		return err
+	}
+
+	// Print response details. Remove ticket snapshot from
+	// the response before printing so that the output is
+	// legible.
+	m := "removed by politeiawwwcli for readability"
+	svrr.EligibleTickets = []string{m}
+	err = shared.PrintJSON(svrr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// startVoteRunoffHelpMsg is the help command output for 'startvoterunoff'.
+var startVoteRunoffHelpMsg = `startvoterunoff <token> <duration> <quorumpercentage> <passpercentage>
+
+Start the voting period on all public submissions to an RFP proposal. The
+optional arguments must either all be used or none be used.
+
+Arguments:
+1. token              (string, required)  Proposal censorship token
+2. duration           (uint32, optional)  Duration of vote in blocks (default: 2016)
+3. quorumpercentage   (uint32, optional)  Percent of votes required for quorum (default: 10)
+4. passpercentage     (uint32, optional)  Percent of votes required to pass (default: 60)
+`

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -1213,6 +1213,32 @@ func (c *Client) StartVoteV2(sv www2.StartVote) (*www2.StartVoteReply, error) {
 	return &svr, nil
 }
 
+// StartVoteRunoffV2 sends the given StartVoteRunoff to the politeiawww v2
+// StartVoteRunoffRoute and returns the reply.
+func (c *Client) StartVoteRunoffV2(svr www2.StartVoteRunoff) (*www2.StartVoteRunoffReply, error) {
+	responseBody, err := c.makeRequest(http.MethodPost,
+		www2.APIRoute, www2.RouteStartVoteRunoff, svr)
+	if err != nil {
+		return nil, err
+	}
+
+	var svrr www2.StartVoteRunoffReply
+	err = json.Unmarshal(responseBody, &svrr)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.cfg.Verbose {
+		svrr.EligibleTickets = []string{"removed by piwww for readability"}
+		err := prettyPrintJSON(svr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &svrr, nil
+}
+
 // VerifyUserPayment checks whether the logged in user has paid their user
 // registration fee.
 func (c *Client) VerifyUserPayment() (*www.VerifyUserPaymentReply, error) {

--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -186,7 +186,7 @@ func validateComment(c www.NewComment) error {
 		}
 	}
 	// validate token
-	if !tokenIsValid(c.Token) {
+	if !isTokenValid(c.Token) {
 		return www.UserError{
 			ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 		}

--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -249,12 +249,11 @@ func (p *politeiawww) processNewComment(nc www.NewComment, u *user.User) (*www.N
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
 	}
-	vsr, err := p.decredVoteSummary(nc.Token, bb)
+	vs, err := p.voteSummaryGet(nc.Token, bb)
 	if err != nil {
-		return nil, fmt.Errorf("decredVoteSummary: %v", err)
+		return nil, fmt.Errorf("voteSummaryGet: %v", err)
 	}
-	s := voteStatusFromVoteSummary(*vsr, bb)
-	if s == www.PropVoteStatusFinished {
+	if vs.Status == www.PropVoteStatusFinished {
 		return nil, www.UserError{
 			ErrorCode:    www.ErrorStatusWrongVoteStatus,
 			ErrorContext: []string{"vote is finished"},
@@ -514,12 +513,11 @@ func (p *politeiawww) processLikeComment(lc www.LikeComment, u *user.User) (*www
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
 	}
-	vsr, err := p.decredVoteSummary(pr.CensorshipRecord.Token, bb)
+	vs, err := p.voteSummaryGet(pr.CensorshipRecord.Token, bb)
 	if err != nil {
 		return nil, err
 	}
-	s := voteStatusFromVoteSummary(*vsr, bb)
-	if s == www.PropVoteStatusFinished {
+	if vs.Status == www.PropVoteStatusFinished {
 		return nil, www.UserError{
 			ErrorCode:    www.ErrorStatusWrongVoteStatus,
 			ErrorContext: []string{"vote has ended"},
@@ -658,12 +656,11 @@ func (p *politeiawww) processCensorComment(cc www.CensorComment, u *user.User) (
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
 	}
-	vsr, err := p.decredVoteSummary(cc.Token, bb)
+	vs, err := p.voteSummaryGet(cc.Token, bb)
 	if err != nil {
 		return nil, err
 	}
-	s := voteStatusFromVoteSummary(*vsr, bb)
-	if s == www.PropVoteStatusFinished {
+	if vs.Status == www.PropVoteStatusFinished {
 		return nil, www.UserError{
 			ErrorCode:    www.ErrorStatusWrongVoteStatus,
 			ErrorContext: []string{"vote has ended"},

--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -245,13 +245,13 @@ func (p *politeiawww) processNewComment(nc www.NewComment, u *user.User) (*www.N
 	}
 
 	// Ensure proposal voting has not ended
-	vsr, err := p.decredVoteSummary(nc.Token)
-	if err != nil {
-		return nil, fmt.Errorf("decredVoteSummary: %v", err)
-	}
 	bb, err := p.getBestBlock()
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
+	}
+	vsr, err := p.decredVoteSummary(nc.Token, bb)
+	if err != nil {
+		return nil, fmt.Errorf("decredVoteSummary: %v", err)
 	}
 	s := voteStatusFromVoteSummary(*vsr, bb)
 	if s == www.PropVoteStatusFinished {
@@ -510,13 +510,13 @@ func (p *politeiawww) processLikeComment(lc www.LikeComment, u *user.User) (*www
 	}
 
 	// Ensure proposal voting has not ended
-	vsr, err := p.decredVoteSummary(pr.CensorshipRecord.Token)
-	if err != nil {
-		return nil, err
-	}
 	bb, err := p.getBestBlock()
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
+	}
+	vsr, err := p.decredVoteSummary(pr.CensorshipRecord.Token, bb)
+	if err != nil {
+		return nil, err
 	}
 	s := voteStatusFromVoteSummary(*vsr, bb)
 	if s == www.PropVoteStatusFinished {
@@ -654,13 +654,13 @@ func (p *politeiawww) processCensorComment(cc www.CensorComment, u *user.User) (
 	}
 
 	// Ensure proposal voting has not ended
-	vsr, err := p.decredVoteSummary(cc.Token)
-	if err != nil {
-		return nil, err
-	}
 	bb, err := p.getBestBlock()
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
+	}
+	vsr, err := p.decredVoteSummary(cc.Token, bb)
+	if err != nil {
+		return nil, err
 	}
 	s := voteStatusFromVoteSummary(*vsr, bb)
 	if s == www.PropVoteStatusFinished {

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -103,12 +103,13 @@ func convertVoteOptionsV2ToDecred(vo []www2.VoteOption) []decredplugin.VoteOptio
 }
 
 func convertVoteTypeV2ToDecred(v www2.VoteT) decredplugin.VoteT {
-	var dv decredplugin.VoteT
 	switch v {
 	case www2.VoteTypeStandard:
-		dv = decredplugin.VoteTypeStandard
+		return decredplugin.VoteTypeStandard
+	case www2.VoteTypeRunoff:
+		return decredplugin.VoteTypeRunoff
 	}
-	return dv
+	return decredplugin.VoteTypeInvalid
 }
 
 func convertVoteV2ToDecred(v www2.Vote) decredplugin.VoteV2 {
@@ -130,6 +131,14 @@ func convertStartVoteV2ToDecred(sv www2.StartVote) decredplugin.StartVoteV2 {
 		Vote:      convertVoteV2ToDecred(sv.Vote),
 		Signature: sv.Signature,
 	}
+}
+
+func convertStartVotesV2ToDecred(sv []www2.StartVote) []decredplugin.StartVoteV2 {
+	dsv := make([]decredplugin.StartVoteV2, 0, len(sv))
+	for _, v := range sv {
+		dsv = append(dsv, convertStartVoteV2ToDecred(v))
+	}
+	return dsv
 }
 
 func convertDecredStartVoteV1ToVoteDetailsReplyV2(sv decredplugin.StartVoteV1, svr decredplugin.StartVoteReply) (*www2.VoteDetailsReply, error) {
@@ -441,6 +450,9 @@ func convertPropFromCache(r cache.Record) www.ProposalRecord {
 		PublishedAt:         publishedAt,
 		CensoredAt:          censoredAt,
 		AbandonedAt:         abandonedAt,
+		LinkTo:              pg.LinkTo,
+		LinkBy:              pg.LinkBy,
+		LinkedFrom:          []string{},
 		CensorshipRecord: www.CensorshipRecord{
 			Token:     r.CensorshipRecord.Token,
 			Merkle:    r.CensorshipRecord.Merkle,
@@ -576,6 +588,8 @@ func convertVoteTypeFromDecred(v decredplugin.VoteT) www2.VoteT {
 	switch v {
 	case decredplugin.VoteTypeStandard:
 		return www2.VoteTypeStandard
+	case decredplugin.VoteTypeRunoff:
+		return www2.VoteTypeRunoff
 	}
 	return www2.VoteTypeInvalid
 }

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -61,13 +61,30 @@ func convertBallotReplyFromDecredPlugin(b decredplugin.BallotReply) www.BallotRe
 	return br
 }
 
-func convertAuthorizeVoteFromWWW(av www.AuthorizeVote) decredplugin.AuthorizeVote {
+func convertAuthorizeVoteToDecred(av www.AuthorizeVote) decredplugin.AuthorizeVote {
 	return decredplugin.AuthorizeVote{
 		Action:    av.Action,
 		Token:     av.Token,
 		PublicKey: av.PublicKey,
 		Signature: av.Signature,
 	}
+}
+
+func convertAuthorizeVoteV2ToDecred(av www2.AuthorizeVote) decredplugin.AuthorizeVote {
+	return decredplugin.AuthorizeVote{
+		Action:    av.Action,
+		Token:     av.Token,
+		PublicKey: av.PublicKey,
+		Signature: av.Signature,
+	}
+}
+
+func convertAuthorizeVotesV2ToDecred(av []www2.AuthorizeVote) []decredplugin.AuthorizeVote {
+	dav := make([]decredplugin.AuthorizeVote, 0, len(av))
+	for _, v := range av {
+		dav = append(dav, convertAuthorizeVoteV2ToDecred(v))
+	}
+	return dav
 }
 
 func convertVoteOptionFromWWW(vo www.VoteOption) decredplugin.VoteOption {

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -427,7 +427,7 @@ func (p *politeiawww) decredBatchVoteSummary(tokens []string, bestBlock uint64) 
 //
 // This function should not be called directly in most circumstances due to its
 // reliance on the lazy loaded VoteResults cache table. The politeiawww method
-// getVoteSummary() should be called instead.
+// voteSummaryGet() should be called instead.
 func (p *politeiawww) decredVoteSummary(token string, bestBlock uint64) (*decredplugin.VoteSummaryReply, error) {
 	v := decredplugin.VoteSummary{
 		Token:     token,

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/politeia/decredplugin"
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/cache"
@@ -303,6 +302,10 @@ func (p *politeiawww) decredInventory() (*decredplugin.InventoryReply, error) {
 
 // decredTokenInventory sends the decred plugin tokeninventory command to the
 // cache.
+//
+// This function should not be called directly in most circumstances due to its
+// reliance on the lazy loaded VoteResults cache table. The politeiawww method
+// tokenInventory() should be called instead.
 func (p *politeiawww) decredTokenInventory(bestBlock uint64, includeUnvetted bool) (*decredplugin.TokenInventoryReply, error) {
 	payload, err := decredplugin.EncodeTokenInventory(
 		decredplugin.TokenInventory{
@@ -378,7 +381,6 @@ func (p *politeiawww) decredLoadVoteResults(bestBlock uint64) (*decredplugin.Loa
 	b := []byte(pcr.Payload)
 	reply, err := decredplugin.DecodeLoadVoteResultsReply(b)
 	if err != nil {
-		spew.Dump("here")
 		return nil, err
 	}
 
@@ -387,6 +389,10 @@ func (p *politeiawww) decredLoadVoteResults(bestBlock uint64) (*decredplugin.Loa
 
 // decredBatchVoteSummary uses the decred plugin batch vote summary command to
 // request a vote summary for a set of proposals from the cache.
+//
+// This function should not be called directly in most circumstances due to its
+// reliance on the lazy loaded VoteResults cache table. The politeiawww method
+// getVoteSummaries() should be called instead.
 func (p *politeiawww) decredBatchVoteSummary(tokens []string, bestBlock uint64) (*decredplugin.BatchVoteSummaryReply, error) {
 	bvs := decredplugin.BatchVoteSummary{
 		Tokens:    tokens,
@@ -418,6 +424,10 @@ func (p *politeiawww) decredBatchVoteSummary(tokens []string, bestBlock uint64) 
 
 // decredVoteSummary uses the decred plugin vote summary command to request a
 // vote summary for a specific proposal from the cache.
+//
+// This function should not be called directly in most circumstances due to its
+// reliance on the lazy loaded VoteResults cache table. The politeiawww method
+// getVoteSummary() should be called instead.
 func (p *politeiawww) decredVoteSummary(token string, bestBlock uint64) (*decredplugin.VoteSummaryReply, error) {
 	v := decredplugin.VoteSummary{
 		Token:     token,

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -387,9 +387,10 @@ func (p *politeiawww) decredLoadVoteResults(bestBlock uint64) (*decredplugin.Loa
 
 // decredBatchVoteSummary uses the decred plugin batch vote summary command to
 // request a vote summary for a set of proposals from the cache.
-func (p *politeiawww) decredBatchVoteSummary(tokens []string) (*decredplugin.BatchVoteSummaryReply, error) {
+func (p *politeiawww) decredBatchVoteSummary(tokens []string, bestBlock uint64) (*decredplugin.BatchVoteSummaryReply, error) {
 	bvs := decredplugin.BatchVoteSummary{
-		Tokens: tokens,
+		Tokens:    tokens,
+		BestBlock: bestBlock,
 	}
 	payload, err := decredplugin.EncodeBatchVoteSummary(bvs)
 	if err != nil {
@@ -417,9 +418,10 @@ func (p *politeiawww) decredBatchVoteSummary(tokens []string) (*decredplugin.Bat
 
 // decredVoteSummary uses the decred plugin vote summary command to request a
 // vote summary for a specific proposal from the cache.
-func (p *politeiawww) decredVoteSummary(token string) (*decredplugin.VoteSummaryReply, error) {
+func (p *politeiawww) decredVoteSummary(token string, bestBlock uint64) (*decredplugin.VoteSummaryReply, error) {
 	v := decredplugin.VoteSummary{
-		Token: token,
+		Token:     token,
+		BestBlock: bestBlock,
 	}
 	payload, err := decredplugin.EncodeVoteSummary(v)
 	if err != nil {
@@ -438,6 +440,34 @@ func (p *politeiawww) decredVoteSummary(token string) (*decredplugin.VoteSummary
 	}
 
 	reply, err := decredplugin.DecodeVoteSummaryReply([]byte(resp.Payload))
+	if err != nil {
+		return nil, err
+	}
+
+	return reply, nil
+}
+
+func (p *politeiawww) decredLinkedFrom(tokens []string) (*decredplugin.LinkedFromReply, error) {
+	lf := decredplugin.LinkedFrom{
+		Tokens: tokens,
+	}
+	payload, err := decredplugin.EncodeLinkedFrom(lf)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := cache.PluginCommand{
+		ID:             decredplugin.ID,
+		Command:        decredplugin.CmdLinkedFrom,
+		CommandPayload: string(payload),
+	}
+
+	resp, err := p.cache.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+
+	reply, err := decredplugin.DecodeLinkedFromReply([]byte(resp.Payload))
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/events.go
+++ b/politeiawww/events.go
@@ -55,7 +55,7 @@ type EventDataProposalEdited struct {
 
 type EventDataProposalVoteStarted struct {
 	AdminUser *user.User
-	StartVote *www2.StartVote
+	StartVote www2.StartVote
 }
 
 type EventDataProposalVoteAuthorized struct {

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -750,7 +750,7 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 	if numInvoiceFiles == 0 {
 		return www.UserError{
 			ErrorCode:    www.ErrorStatusProposalMissingFiles,
-			ErrorContext: []string{www.PolicyIndexFileName},
+			ErrorContext: []string{www.PolicyIndexFilename},
 		}
 	}
 

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -750,7 +750,7 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 	if numInvoiceFiles == 0 {
 		return www.UserError{
 			ErrorCode:    www.ErrorStatusProposalMissingFiles,
-			ErrorContext: []string{indexFile},
+			ErrorContext: []string{www.PolicyIndexFileName},
 		}
 	}
 

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -360,7 +360,6 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		MaxCommentLength:           www.PolicyMaxCommentLength,
 		BuildInformation:           version.BuildInformation(),
 		IndexFilename:              www.PolicyIndexFilename,
-		DataFilename:               www.PolicyDataFilename,
 		MinLinkByPeriod:            www.PolicyLinkByMinPeriod,
 		MaxLinkByPeriod:            www.PolicyLinkByMaxPeriod,
 	}

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -361,8 +361,8 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		BuildInformation:           version.BuildInformation(),
 		IndexFilename:              www.PolicyIndexFilename,
 		DataFilename:               www.PolicyDataFilename,
-		MinLinkByPeriod:            www.PolicyMinLinkByPeriod,
-		MaxLinkByPeriod:            www.PolicyMaxLinkByPeriod,
+		MinLinkByPeriod:            www.PolicyLinkByMinPeriod,
+		MaxLinkByPeriod:            www.PolicyLinkByMaxPeriod,
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -119,7 +119,7 @@ type politeiawww struct {
 	userPaywallPool map[uuid.UUID]paywallPoolMember // [userid][paywallPoolMember]
 	commentVotes    map[string]counters             // [token+commentID]counters
 
-	// voteSummaries is a lazy loaded cache of the votes summaries of
+	// voteSummaries is a lazy loaded cache of votes summaries for
 	// proposals whose voting period has ended.
 	voteSummaries map[string]www.VoteSummary // [token]VoteSummary
 

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package main
 
 import (
@@ -1166,6 +1170,45 @@ func (p *politeiawww) handleStartVoteV2(w http.ResponseWriter, r *http.Request) 
 	util.RespondWithJSON(w, http.StatusOK, svr)
 }
 
+// handleStartVoteRunoffV2 handles starting a runoff vote for RFP proposal
+// submissions.
+func (p *politeiawww) handleStartVoteRunoffV2(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleStartVoteRunoffV2")
+
+	var sv www2.StartVoteRunoff
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&sv); err != nil {
+		RespondWithError(w, r, 0, "handleStartVoteRunoffV2: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	user, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleStartVoteRunoffV2: getSessionUser %v", err)
+		return
+	}
+
+	// Sanity
+	if !user.Admin {
+		RespondWithError(w, r, 0,
+			"handleStartVoteRunoffV2: admin %v", user.Admin)
+		return
+	}
+
+	svr, err := p.processStartVoteRunoffV2(sv, user)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleStartVoteRunoffV2: processStartVoteRunoff %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, svr)
+}
+
 // handleCensorComment handles the censoring of a comment by an admin.
 func (p *politeiawww) handleCensorComment(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleCensorComment")
@@ -1298,6 +1341,9 @@ func (p *politeiawww) setPoliteiaWWWRoutes() {
 		permissionAdmin)
 	p.addRoute(http.MethodPost, www2.APIRoute,
 		www2.RouteStartVote, p.handleStartVoteV2,
+		permissionAdmin)
+	p.addRoute(http.MethodPost, www2.APIRoute,
+		www2.RouteStartVoteRunoff, p.handleStartVoteRunoffV2,
 		permissionAdmin)
 	p.addRoute(http.MethodPost, www.PoliteiaWWWAPIRoute,
 		www.RouteCensorComment, p.handleCensorComment,

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -355,8 +355,8 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		MaxProposalNameLength:      www.PolicyMaxProposalNameLength,
 		ProposalNameSupportedChars: www.PolicyProposalNameSupportedChars,
 		MaxCommentLength:           www.PolicyMaxCommentLength,
-		IndexFileName:              www.PolicyIndexFileName,
-		DataFileName:               www.PolicyDataFileName,
+		IndexFilename:              www.PolicyIndexFilename,
+		DataFilename:               www.PolicyDataFilename,
 		MinLinkByPeriod:            www.PolicyMinLinkByPeriod,
 		MaxLinkByPeriod:            www.PolicyMaxLinkByPeriod,
 	}

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -360,8 +360,8 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		MaxCommentLength:           www.PolicyMaxCommentLength,
 		BuildInformation:           version.BuildInformation(),
 		IndexFilename:              www.PolicyIndexFilename,
-		MinLinkByPeriod:            www.PolicyLinkByMinPeriod,
-		MaxLinkByPeriod:            www.PolicyLinkByMaxPeriod,
+		MinLinkByPeriod:            p.linkByPeriodMin(),
+		MaxLinkByPeriod:            p.linkByPeriodMax(),
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -355,6 +355,10 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		MaxProposalNameLength:      www.PolicyMaxProposalNameLength,
 		ProposalNameSupportedChars: www.PolicyProposalNameSupportedChars,
 		MaxCommentLength:           www.PolicyMaxCommentLength,
+		IndexFileName:              www.PolicyIndexFileName,
+		DataFileName:               www.PolicyDataFileName,
+		MinLinkByPeriod:            www.PolicyMinLinkByPeriod,
+		MaxLinkByPeriod:            www.PolicyMaxLinkByPeriod,
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)

--- a/politeiawww/politeiawww_test.go
+++ b/politeiawww/politeiawww_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -315,9 +314,10 @@ func TestHandleProposalDetails(t *testing.T) {
 			}
 
 			// Validate expected proposal with received proposal
-			if !reflect.DeepEqual(gotReply.Proposal, v.wantReply) {
-				t.Errorf("got proposal %v, want %v",
-					gotReply.Proposal, v.wantReply)
+			diff := deep.Equal(gotReply.Proposal, v.wantReply)
+			if diff != nil {
+				t.Errorf("got/want diff:\n%v",
+					spew.Sdump(diff))
 			}
 
 			// Validate http status code

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -343,13 +343,13 @@ func (p *politeiawww) validateProposal(np www.NewProposal, u *user.User) (*www.P
 			// The only text files that are allowed are the index markdown
 			// file and the data json file.
 			switch v.Name {
-			case www.PolicyIndexFileName:
+			case www.PolicyIndexFilename:
 				// Index markdown file
 
 				// Only one index file is allowed
 				if foundIndexFile {
 					e := fmt.Sprintf("more than one %v file found",
-						www.PolicyIndexFileName)
+						www.PolicyIndexFilename)
 					return nil, www.UserError{
 						ErrorCode:    www.ErrorStatusMaxMDsExceededPolicy,
 						ErrorContext: []string{e},
@@ -369,13 +369,13 @@ func (p *politeiawww) validateProposal(np www.NewProposal, u *user.User) (*www.P
 					}
 				}
 
-			case www.PolicyDataFileName:
+			case www.PolicyDataFilename:
 				// Data json file
 
 				// Only one data file is allowed
 				if foundDataFile {
 					e := fmt.Sprintf("more than one %v file found",
-						www.PolicyDataFileName)
+						www.PolicyDataFilename)
 					return nil, www.UserError{
 						ErrorCode:    www.ErrorStatusMaxMDsExceededPolicy,
 						ErrorContext: []string{e},
@@ -436,7 +436,7 @@ func (p *politeiawww) validateProposal(np www.NewProposal, u *user.User) (*www.P
 	// Verify that an index file is present. The data file is
 	// currently optional.
 	if !foundIndexFile {
-		e := fmt.Sprintf("%v file not found", www.PolicyIndexFileName)
+		e := fmt.Sprintf("%v file not found", www.PolicyIndexFilename)
 		return nil, www.UserError{
 			ErrorCode:    www.ErrorStatusProposalMissingFiles,
 			ErrorContext: []string{e},
@@ -517,7 +517,7 @@ func voteStatusFromVoteSummary(r decredplugin.VoteSummaryReply, bestBlock uint64
 // getProposalName returns the proposal name based on the index markdown file.
 func getProposalName(files []www.File) (string, error) {
 	for _, file := range files {
-		if file.Name == www.PolicyIndexFileName {
+		if file.Name == www.PolicyIndexFilename {
 			return parseProposalName(file.Payload)
 		}
 	}
@@ -1689,17 +1689,17 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 	)
 	for _, v := range cachedProp.Files {
 		switch v.Name {
-		case www.PolicyIndexFileName:
+		case www.PolicyIndexFilename:
 			indexFileOld = v
-		case www.PolicyDataFileName:
+		case www.PolicyDataFilename:
 			dataFileOld = v
 		}
 	}
 	for _, v := range ep.Files {
 		switch v.Name {
-		case www.PolicyIndexFileName:
+		case www.PolicyIndexFilename:
 			indexFileNew = v
-		case www.PolicyDataFileName:
+		case www.PolicyDataFilename:
 			dataFileNew = v
 		}
 	}

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -2854,7 +2854,7 @@ func (p *politeiawww) processStartVoteRunoffV2(sv www2.StartVoteRunoff, u *user.
 			ErrorCode:    www.ErrorStatusWrongVoteResult,
 			ErrorContext: []string{"rfp proposal vote did not pass"},
 		}
-	case rfp.LinkBy < time.Now().Unix():
+	case rfp.LinkBy > time.Now().Unix():
 		// Vote cannot start on RFP submissions until the RFP
 		// linkby deadline has been met.
 		return nil, www.UserError{

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1680,25 +1680,33 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		}
 	}
 
-	// Check for changes in the index.md file
-	var newMDFile www.File
-	for _, v := range ep.Files {
-		if v.Name == www.PolicyIndexFileName {
-			newMDFile = v
-		}
-	}
-
-	var oldMDFile www.File
-	for _, v := range cachedProp.Files {
-		if v.Name == www.PolicyIndexFileName {
-			oldMDFile = v
-		}
-	}
-
-	mdChanges := newMDFile.Payload != oldMDFile.Payload
-
 	// Check that the proposal has been changed
-	if !mdChanges && len(delFiles) == 0 &&
+	var (
+		indexFileOld www.File
+		indexFileNew www.File
+		dataFileOld  www.File
+		dataFileNew  www.File
+	)
+	for _, v := range cachedProp.Files {
+		switch v.Name {
+		case www.PolicyIndexFileName:
+			indexFileOld = v
+		case www.PolicyDataFileName:
+			dataFileOld = v
+		}
+	}
+	for _, v := range ep.Files {
+		switch v.Name {
+		case www.PolicyIndexFileName:
+			indexFileNew = v
+		case www.PolicyDataFileName:
+			dataFileNew = v
+		}
+	}
+
+	if indexFileOld.Payload == indexFileNew.Payload &&
+		dataFileOld.Payload == dataFileNew.Payload &&
+		len(delFiles) == 0 &&
 		len(cachedProp.Files) == len(ep.Files) {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusNoProposalChanges,

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -217,10 +217,19 @@ func (p *politeiawww) validateProposalData(pd www.ProposalData) error {
 
 	// Validate LinkBy
 	if pd.LinkBy != 0 {
-		ts := time.Now().Unix() + www.PolicyMinLinkByPeriod
-		if pd.LinkBy < ts {
+		min := time.Now().Unix() + www.PolicyLinkByMinPeriod
+		max := time.Now().Unix() + www.PolicyLinkByMaxPeriod
+		switch {
+		case pd.LinkBy < min:
 			e := fmt.Sprintf("linkby period cannot be shorter than %v seconds",
-				www.PolicyMinLinkByPeriod)
+				www.PolicyLinkByMinPeriod)
+			return www.UserError{
+				ErrorCode:    www.ErrorStatusInvalidLinkBy,
+				ErrorContext: []string{e},
+			}
+		case pd.LinkBy > max:
+			e := fmt.Sprintf("linkby period cannot be greater than %v seconds",
+				www.PolicyLinkByMaxPeriod)
 			return www.UserError{
 				ErrorCode:    www.ErrorStatusInvalidLinkBy,
 				ErrorContext: []string{e},
@@ -2628,10 +2637,19 @@ func (p *politeiawww) processStartVoteV2(sv www2.StartVote, u *user.User) (*www2
 
 	// Verify the LinkBy deadline for RFP proposals
 	if pr.IsRFP() {
-		ts := time.Now().Unix() + www.PolicyMinLinkByPeriod
-		if pr.LinkBy < ts {
+		min := time.Now().Unix() + www.PolicyLinkByMinPeriod
+		max := time.Now().Unix() + www.PolicyLinkByMaxPeriod
+		switch {
+		case pr.LinkBy < min:
 			e := fmt.Sprintf("linkby period must be at least %v seconds from "+
-				"the start of the proposal vote", www.PolicyMinLinkByPeriod)
+				"the start of the proposal vote", www.PolicyLinkByMinPeriod)
+			return nil, www.UserError{
+				ErrorCode:    www.ErrorStatusInvalidLinkBy,
+				ErrorContext: []string{e},
+			}
+		case pr.LinkBy > max:
+			e := fmt.Sprintf("linkby period cannot be more than %v seconds from "+
+				"the start of the proposal vote", www.PolicyLinkByMaxPeriod)
 			return nil, www.UserError{
 				ErrorCode:    www.ErrorStatusInvalidLinkBy,
 				ErrorContext: []string{e},

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -538,7 +538,7 @@ func voteStatusFromVoteSummary(r decredplugin.VoteSummaryReply, endHeight, bestB
 	switch {
 	case !r.Authorized:
 		return www.PropVoteStatusNotAuthorized
-	case r.Authorized:
+	case r.Authorized && endHeight == 0:
 		return www.PropVoteStatusAuthorized
 	case bestBlock < endHeight:
 		return www.PropVoteStatusStarted
@@ -1722,7 +1722,7 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		Signature: ep.Signature,
 	}
 
-	_, err = p.validateProposal(np, u)
+	pm, err := p.validateProposal(np, u)
 	if err != nil {
 		return nil, err
 	}
@@ -1731,17 +1731,13 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 			ErrorCode: www.ErrorStatusNoProposalChanges,
 		}
 	}
-
-	/*
-		// TODO
-		if cachedProp.State == www.PropStateVetted &&
-			cachedProp.LinkTo != proposalData.LinkTo {
-			return nil, www.UserError{
-				ErrorCode:    www.ErrorStatusInvalidLinkTo,
-				ErrorContext: []string{"linkto cannot change once public"},
-			}
+	if cachedProp.State == www.PropStateVetted &&
+		cachedProp.LinkTo != pm.LinkTo {
+		return nil, www.UserError{
+			ErrorCode:    www.ErrorStatusInvalidLinkTo,
+			ErrorContext: []string{"linkto cannot change once public"},
 		}
-	*/
+	}
 
 	// politeiad only includes files in its merkle root calc, not the
 	// metadata streams. This is why we include the ProposalMetadata

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1019,28 +1019,31 @@ func (p *politeiawww) getVoteSummaries(tokens []string, bestBlock uint64) (map[s
 		done = true
 	}
 
-	for token, summary := range reply.Summaries {
-		results := convertVoteOptionResultsFromDecred(summary.Results)
+	for token, v := range reply.Summaries {
+		results := convertVoteOptionResultsFromDecred(v.Results)
+		votet := convertVoteTypeFromDecred(v.Type)
 
 		// An endHeight will not exist if the proposal has not gone
 		// up for vote yet.
 		var endHeight uint64
-		if summary.EndHeight != "" {
-			i, err := strconv.ParseUint(summary.EndHeight, 10, 64)
+		if v.EndHeight != "" {
+			i, err := strconv.ParseUint(v.EndHeight, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse end height "+
-					"'%v' for %v: %v", summary.EndHeight, token, err)
+					"'%v' for %v: %v", v.EndHeight, token, err)
 			}
 			endHeight = i
 		}
 
 		vs := www.VoteSummary{
-			Status:           voteStatusFromVoteSummary(summary, bestBlock),
-			EligibleTickets:  uint32(summary.EligibleTicketCount),
-			Duration:         summary.Duration,
+			Status:           voteStatusFromVoteSummary(v, bestBlock),
+			Type:             www.VoteT(int(votet)),
+			Approved:         v.Approved,
+			EligibleTickets:  uint32(v.EligibleTicketCount),
+			Duration:         v.Duration,
 			EndHeight:        endHeight,
-			QuorumPercentage: summary.QuorumPercentage,
-			PassPercentage:   summary.PassPercentage,
+			QuorumPercentage: v.QuorumPercentage,
+			PassPercentage:   v.PassPercentage,
 			Results:          results,
 		}
 
@@ -1057,8 +1060,8 @@ func (p *politeiawww) getVoteSummaries(tokens []string, bestBlock uint64) (map[s
 	return voteSummaries, nil
 }
 
-// getVoteSummary returns the VoteSummary for the given token. A
-// cache.ErrRecordNotFound error is returned if the token does actually not
+// getVoteSummary returns the VoteSummary for the given token. A cache
+// ErrRecordNotFound error is returned if the token does actually not
 // correspond to a proposal.
 func (p *politeiawww) getVoteSummary(token string, bestBlock uint64) (*www.VoteSummary, error) {
 	s, err := p.getVoteSummaries([]string{token}, bestBlock)

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -89,7 +89,7 @@ func createFileMD(t *testing.T, size int, title string) *www.File {
 	b.WriteString(base64.StdEncoding.EncodeToString(r) + "\n")
 
 	return &www.File{
-		Name:    www.PolicyIndexFileName,
+		Name:    www.PolicyIndexFilename,
 		MIME:    mime.DetectMimeType(b.Bytes()),
 		Digest:  hex.EncodeToString(util.Digest(b.Bytes())),
 		Payload: base64.StdEncoding.EncodeToString(b.Bytes()),

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -89,7 +89,7 @@ func createFileMD(t *testing.T, size int, title string) *www.File {
 	b.WriteString(base64.StdEncoding.EncodeToString(r) + "\n")
 
 	return &www.File{
-		Name:    indexFile,
+		Name:    www.PolicyIndexFileName,
 		MIME:    mime.DetectMimeType(b.Bytes()),
 		Digest:  hex.EncodeToString(util.Digest(b.Bytes())),
 		Payload: base64.StdEncoding.EncodeToString(b.Bytes()),
@@ -586,7 +586,7 @@ func TestValidateProposal(t *testing.T) {
 
 		{"bad md filename", *propBadFilename, usr,
 			www.UserError{
-				ErrorCode: www.ErrorStatusProposalMissingFiles,
+				ErrorCode: www.ErrorStatusMaxMDsExceededPolicy,
 			}},
 
 		{"duplicate filenames", *propDupFiles, usr,
@@ -623,7 +623,7 @@ func TestValidateProposal(t *testing.T) {
 	// Run test cases
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateProposal(test.newProposal, test.user)
+			_, err := p.validateProposal(test.newProposal, test.user)
 			got := errToStr(err)
 			want := errToStr(test.want)
 			if got != want {

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -292,7 +292,7 @@ func newAuthorizeVote(token, version, action string, id *identity.FullIdentity) 
 
 func newAuthorizeVoteCmd(t *testing.T, token, version, action string, id *identity.FullIdentity) pd.PluginCommand {
 	av := newAuthorizeVote(token, version, action, id)
-	dav := convertAuthorizeVoteFromWWW(av)
+	dav := convertAuthorizeVoteToDecred(av)
 	payload, err := decredplugin.EncodeAuthorizeVote(dav)
 	if err != nil {
 		t.Fatal(err)

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -213,6 +213,7 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 		userEmails:      make(map[string]uuid.UUID),
 		userPaywallPool: make(map[uuid.UUID]paywallPoolMember),
 		commentVotes:    make(map[string]counters),
+		voteSummaries:   make(map[string]www.VoteSummary),
 	}
 
 	// Setup routes

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -234,7 +234,9 @@ func validateSignature(pubKey string, signature string, elements ...string) erro
 	}
 	b, err := hex.DecodeString(pubKey)
 	if err != nil {
-		return err
+		return www.UserError{
+			ErrorCode: www.ErrorStatusInvalidPublicKey,
+		}
 	}
 	pk, err := identity.PublicIdentityFromBytes(b)
 	if err != nil {


### PR DESCRIPTION
Closes #966

This diff adds a new type of proposal called a Request For Proposals
(RFP) and a new type of proposal vote called a runoff vote.

# Overview of the RFP process

1. Any politeia user can submit an RFP proposal. An RFP proposal must
   first be voted on and approved by the stakeholders before RFP
   submissions are allowed. The RFP proposal is essentially asking the
   stakeholders the question, "Do the stakeholders want to open up an
   RFP process and solicit proposals for this topic?"

2. If approved, new proposal submissions are allowed to link to the RFP
   proposal. These linked proposals are considered to be RFP
   submissions. A link is not official until the RFP submission is made
   public, leaving this decision in the hands of the admins. A deadline
   exists for RFP submissions to be accepted. This deadline is set by
   the RFP author when they orginally submit the RFP and can be updated
   at any point before the start of the RFP proposal vote (step 1). Once
   the RFP proposal goes up for vote in step 1, this deadline becomes
   final. RFP submissions are not accepted once this deadline expires.

3. Once the RFP submission deadline expires, an admin can start the
   voting process on the RFP submissions at any time. This is a new type
   of vote called a runoff vote. Whe an admin starts the runoff vote,
   the voting period on all public, non-abandoned RFP submissions will
   begin simultaneously. Unlike a normal proposal vote, no vote
   authorization is required from the submission author. Each submission
   is voted on like a normal proposal vote.

4. The results of the runoff vote are calculated as follows:
   - Only one proposal can be approved.
   - The winning proposal is the proposal that meets the quorum %
     requirement, meets the pass % requirement, and that has the most
     net yes votes.
     Note: this means that it will be possible for a proposal to meet
     the quorum and pass requirements but still be rejected if it does
     not have the most net yes votes.
   - If no proposals meet the quorum and pass requirements then all of
     the proposals will be considered rejected.

# Data changes
Added to the user defined `ProposalMetdata`:
- `LinkBy`: A UNIX timestamp of the RFP submission deadline. We
  determine if a proposal is an RFP by checking if this field is set.
- `LinkTo`: Censorship token of an existing public proposal to link to.
  This is only used for RFP submissions at the moment, but can be used
	for other types of links in the future such as proposal updates.

# API changes

Routes added:
- `StartVoteRunoff`: start the voting process on all public,
  non-abandoned RFP submissions simultaneously.

Routes with API changes:
- `VoteSummary`: a `Type` field and a `Approved` field were added to the
  `VoteSummaryReply`. A runoff vote makes it much harder for the client
  to calculate the vote results, it needs the results from all of the
  proposals in the runoff vote to do so, so the backend now does it and
  returns whether the vote for any single proposal was approved.

Routes with code changes:
- `NewProposal`
- `EditProposal`
- `AuthorizeVote`
- `StartVote`
- `TokenInventory`

# Testing with piwww CLI

The following commands can be used to test this diff. Manually editing
the allowable quorum percentage, pass percentage, and minimum duration
in politeiad is required if you want to test this in a reasonable manner.

```bash
# Submit an RFP proposal, make it public, and start the voting process
# on it. The RFP must first pass a vote before RFP submissions can link
# to it. The following vote params are used for testing purposes:
# duration = 1 block
# quorum = 0%
# pass = 0%
$ piwww newproposal --random --rfp
$ piwww setproposalstatus [rfp_token] public
$ piwww authorizevote [rfp_token]
$ piwww startvote [rfp_token] 1 0 0

# Vote on the RFP proposal.
$ piwww vote [rfp_token] yes

# Wait for the vote to end...

# Submit four RFP submissions. Abandon one of them.
$ piwww newproposal --random --linkto=[rfp_token]
$ piwww setproposalstatus [submission1_token] public

$ piwww newproposal --random --linkto=[rfp_token]
$ piwww setproposalstatus [submission2_token] public

$ piwww newproposal --random --linkto=[rfp_token]
$ piwww setproposalstatus [submission3_token] public

$ piwww newproposal --random --linkto=[rfp_token]
$ piwww setproposalstatus [submission4_token] public
$ piwww setproposalstatus [submission4_token] abandoned

# Start the runoff vote on the RFP submissions. The same vote params are
# used as before.
$ piwww startvoterunoff [rfp_token] 1 0 0

# Vote on the submissions so that submission1 wins.
piwww vote [submission1_token] yes
piwww vote [submission2_token] no
piwww vote [submission3_token] no

# Wait for the vote to end...

# Fetch the token inventory so that the vote results get calculated and
# added to the cache.
piwww tokeninventory
```

