### PR TITLE
multi: Cleanup batched calls in cache and userdb.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -782,9 +782,13 @@ func DecodeGetCommentsReply(payload []byte) (*GetCommentsReply, error) {
 	return &gcr, nil
 }
 
-// GetNumComments retrieve the number of comments for a list of proposals.
+// GetNumComments returns a map that contains the number of comments for the
+// provided list of censorship tokens. If a provided token does not corresond
+// to an actual proposal then the token will not be included in the returned
+// map. It is the responsibility of the caller to ensure that results are
+// returned for all of the provided tokens.
 type GetNumComments struct {
-	Tokens []string `json:"tokens"` // Proposal ID
+	Tokens []string `json:"tokens"` // List of censorship tokens
 }
 
 // EncodeGetNumComments encodes GetBatchComments into a JSON byte slice.
@@ -804,9 +808,9 @@ func DecodeGetNumComments(payload []byte) (*GetNumComments, error) {
 	return &gnc, nil
 }
 
-// GetNumCommentsReply returns a map from proposal token to int
+// GetNumCommentsReply is the reply to the GetNumComments command.
 type GetNumCommentsReply struct {
-	CommentsMap map[string]int `json:"commentsmap"`
+	NumComments map[string]int `json:"numcomments"` // [token]numComments
 }
 
 // EncodeGetNumCommentsReply encodes GetNumCommentsReply into a

--- a/politeiad/cache/cache.go
+++ b/politeiad/cache/cache.go
@@ -173,7 +173,7 @@ type Cache interface {
 	UpdateRecordMetadata(string, []MetadataStream) error
 
 	// Get the latest version of a set of records
-	Records([]string, bool) ([]Record, error)
+	Records([]string, bool) (map[string]Record, error)
 
 	// Get the latest version of all records
 	Inventory() ([]Record, error)

--- a/politeiad/cache/cachestub/cachestub.go
+++ b/politeiad/cache/cachestub/cachestub.go
@@ -20,8 +20,8 @@ func (c *cachestub) Record(token string) (*cache.Record, error) {
 }
 
 // Records is a stub to satisfy the cache interface.
-func (c *cachestub) Records(token []string, fetchFiles bool) ([]cache.Record, error) {
-	records := make([]cache.Record, 0)
+func (c *cachestub) Records(token []string, fetchFiles bool) (map[string]cache.Record, error) {
+	records := make(map[string]cache.Record, 0)
 	return records, nil
 }
 

--- a/politeiad/cache/cachestub/cachestub.go
+++ b/politeiad/cache/cachestub/cachestub.go
@@ -21,7 +21,7 @@ func (c *cachestub) Record(token string) (*cache.Record, error) {
 
 // Records is a stub to satisfy the cache interface.
 func (c *cachestub) Records(token []string, fetchFiles bool) (map[string]cache.Record, error) {
-	records := make(map[string]cache.Record, 0)
+	records := make(map[string]cache.Record)
 	return records, nil
 }
 

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -201,6 +201,10 @@ func (d *decred) cmdGetComments(payload string) (string, error) {
 	return string(gcrb), nil
 }
 
+// cmdGetNumComments returns an encoded plugin reply that contains a
+// [token]numComments map for the provided list of censorship tokens. If a
+// provided token does not correspond to an actual proposal then it will not
+// be included in the returned map.
 func (d *decred) cmdGetNumComments(payload string) (string, error) {
 	log.Tracef("decred cmdGetNumComments")
 
@@ -209,13 +213,12 @@ func (d *decred) cmdGetNumComments(payload string) (string, error) {
 		return "", err
 	}
 
+	// Lookup number of comments for provided tokens
 	type Result struct {
 		Token  string
 		Counts int
 	}
-
-	results := make([]Result, 0, 1024)
-
+	results := make([]Result, 0, len(gnc.Tokens))
 	err = d.recordsdb.
 		Table("comments").
 		Select("count(*) as counts, token").
@@ -223,18 +226,19 @@ func (d *decred) cmdGetNumComments(payload string) (string, error) {
 		Where("token IN (?)", gnc.Tokens).
 		Find(&results).
 		Error
-
 	if err != nil {
 		return "", err
 	}
 
-	commentMap := make(map[string]int)
+	// Put results into a map
+	numComments := make(map[string]int) // [token]numComments
 	for _, c := range results {
-		commentMap[c.Token] = c.Counts
+		numComments[c.Token] = c.Counts
 	}
 
+	// Encode reply
 	gncr := decredplugin.GetNumCommentsReply{
-		CommentsMap: commentMap,
+		NumComments: numComments,
 	}
 	gncre, err := decredplugin.EncodeGetNumCommentsReply(gncr)
 	if err != nil {

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -231,7 +231,7 @@ func (d *decred) cmdGetNumComments(payload string) (string, error) {
 	}
 
 	// Put results into a map
-	numComments := make(map[string]int) // [token]numComments
+	numComments := make(map[string]int, len(results)) // [token]numComments
 	for _, c := range results {
 		numComments[c.Token] = c.Counts
 	}

--- a/politeiad/cache/testcache/testcache.go
+++ b/politeiad/cache/testcache/testcache.go
@@ -81,18 +81,17 @@ func (c *testcache) Record(token string) (*cache.Record, error) {
 }
 
 // Records returns the most recent version of a set of records.
-func (c *testcache) Records(tokens []string, fetchFiles bool) ([]cache.Record, error) {
+func (c *testcache) Records(tokens []string, fetchFiles bool) (map[string]cache.Record, error) {
 	c.RLock()
 	defer c.RUnlock()
 
-	records := make([]cache.Record, 0, len(tokens))
-
+	records := make(map[string]cache.Record, len(tokens)) // [token]Record
 	for _, token := range tokens {
 		r, err := c.record(token)
 		if err != nil {
 			return nil, err
 		}
-		records = append(records, *r)
+		records[token] = *r
 	}
 
 	return records, nil

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -1574,6 +1574,7 @@ limited by the `ProposalListPageSize` property, which is provided via
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
 - [`ErrorStatusMaxProposalsExceededPolicy`](#ErrorStatusMaxProposalsExceededPolicy)
+- [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
 - [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
 
 **Example**

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -99,8 +99,11 @@ func (p *politeiawww) decredGetComments(token string) ([]decredplugin.Comment, e
 	return gcr.Comments, nil
 }
 
-// decredGetBatchComments sends the decred plugin GetBachComments command to the
-// cache and returns all of the comments for each of the tokens passed in.
+// decredGetNumComments sends the decred plugin command GetNumComments to the
+// cache and returns the number of comments for each of the specified
+// proposals. If a provided token does not correspond to an actual proposal
+// then it will not be included in the returned map. It is the responability
+// of the caller to ensure results are returned for all of the provided tokens.
 func (p *politeiawww) decredGetNumComments(tokens []string) (map[string]int, error) {
 	// Setup plugin command
 	gnc := decredplugin.GetNumComments{
@@ -118,7 +121,7 @@ func (p *politeiawww) decredGetNumComments(tokens []string) (map[string]int, err
 		CommandPayload: string(payload),
 	}
 
-	// Get comments from the cache
+	// Send plugin comand
 	reply, err := p.cache.PluginExec(pc)
 	if err != nil {
 		return nil, fmt.Errorf("PluginExec: %v", err)
@@ -130,7 +133,7 @@ func (p *politeiawww) decredGetNumComments(tokens []string) (map[string]int, err
 		return nil, err
 	}
 
-	return gncr.CommentsMap, nil
+	return gncr.NumComments, nil
 }
 
 // decredCommentLikes sends the decred plugin commentlikes command to the cache


### PR DESCRIPTION
This diff standardizes how batched called are handled in the cache and
the userdb. Before this diff, some batched calls where returning a slice
of results and some were returning a map of results. Having all batched
calls perform the same way makes the code easier to reason about.

All batched calls in the cache and the userdb now return a map of the
results. If an output is not found for one of the input values, such as
if a passed in proposal token doesn't actually correspond to a proposal,
the input value will not be included in the returned map. This makes it
easy for the calling function to check if results where found for all
input values and leaves it up to the calling function to decide how to
deal with values that were not found.