### PR TITLE
[cms] Minor fixes on api docs and cmd instructions

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1006,7 +1006,7 @@ Reply:
 
 Retrieve DCCs by status.
 
-**Routes:** `POST /v1/dcc/status`
+**Routes:** `POST /v1/dcc`
 
 **Params:**
 

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -89,7 +89,7 @@ type cmswww struct {
 	UserDetails         UserDetailsCmd           `command:"userdetails" description:"(user)   get current cms user details"`
 	UserInvoices        UserInvoicesCmd          `command:"userinvoices" description:"(user)   get all invoices submitted by a specific user"`
 	UserSubContractors  UserSubContractorsCmd    `command:"usersubcontractors" description:"(user)   get all users that are linked to the user"`
-	Users               shared.UsersCmd          `command:"users" description:"(public) get a list of users"`
+	Users               shared.UsersCmd          `command:"users" description:"(admin) get a list of users"`
 	Secret              shared.SecretCmd         `command:"secret" description:"(user)   ping politeiawww"`
 	Version             shared.VersionCmd        `command:"version" description:"(public) get server info and CSRF token"`
 }

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -89,7 +89,7 @@ type cmswww struct {
 	UserDetails         UserDetailsCmd           `command:"userdetails" description:"(user)   get current cms user details"`
 	UserInvoices        UserInvoicesCmd          `command:"userinvoices" description:"(user)   get all invoices submitted by a specific user"`
 	UserSubContractors  UserSubContractorsCmd    `command:"usersubcontractors" description:"(user)   get all users that are linked to the user"`
-	Users               shared.UsersCmd          `command:"users" description:"(admin) get a list of users"`
+	Users               shared.UsersCmd          `command:"users" description:"(user) get a list of users"`
 	Secret              shared.SecretCmd         `command:"secret" description:"(user)   ping politeiawww"`
 	Version             shared.VersionCmd        `command:"version" description:"(public) get server info and CSRF token"`
 }


### PR DESCRIPTION
1. Get DCC route: https://github.com/decred/politeia/blob/9a6d7c62c1d0f51f4fafa22bf14d9dd3b598a02b/politeiawww/api/cms/v1/v1.go#L30


2. `users` command:
https://github.com/decred/politeia/blob/9a6d7c62c1d0f51f4fafa22bf14d9dd3b598a02b/politeiawww/userwww.go#L842-L843