### PR TITLE
[cms] Filter user details based on requester

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -792,7 +792,9 @@ Reply:
 
 ### `User details`
 
-Returns a logged-in CMS user's information beyond what is stored in the userdb.
+Returns a CMS user's information.  If admin or a user requesting their own
+information everything is returned.  Otherwise, a shorter public user
+information response is provided.
 
 **Route:** `GET /v1/user/details`
 


### PR DESCRIPTION
This implements the same public user information filtering that 
politeia uses.  If a non-admin and not the owner of the userid
requests the UserDetails for a given userID then a shorten list
of information is provided: 
ID, Admin, Username, Identities, ContractorType, GitHubName, MatrixName, Domain