### PR TITLE
[cms] Add nominated username to DCC Record

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -624,6 +624,7 @@ type DCCRecord struct {
 	PublicKey          string     `json:"publickey"`          // Sponsoring user's public key, used to verify signature.
 	Signature          string     `json:"signature"`          // Signature of file digest
 
+	NomineeUsername string `json:"nomineeusername"` // The username of the nominated user.
 	SponsorUserID   string `json:"sponsoruserid"`   // The userid of the sponsoring user.
 	SponsorUsername string `json:"sponsorusername"` // The username of the sponsoring user.
 

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -554,7 +554,7 @@ func (p *politeiawww) getDCC(token string) (*cms.DCCRecord, error) {
 	i.SupportUserIDs = supportUserIDs
 	i.OppositionUserIDs = opposeUserIDs
 
-	// Fill in userID and username fields
+	// Fill in sponsoring userID and username fields
 	u, err := p.db.UserGetByPubKey(i.PublicKey)
 	if err != nil {
 		log.Errorf("getDCC: getUserByPubKey: token:%v "+
@@ -563,6 +563,17 @@ func (p *politeiawww) getDCC(token string) (*cms.DCCRecord, error) {
 		i.SponsorUserID = u.ID.String()
 		i.SponsorUsername = u.Username
 	}
+
+	// Fill in nominee username
+
+	nomineeUser, err := p.getCMSUserByID(i.DCC.NomineeUserID)
+	if err != nil {
+		log.Errorf("getDCC: getCMSUserByID: token:%v "+
+			"userid:%v err:%v", token, i.DCC.NomineeUserID, err)
+	} else {
+		i.NomineeUsername = nomineeUser.Username
+	}
+
 	return &i, nil
 }
 


### PR DESCRIPTION
Adding this now allows for better information to be displayed in 
DCC listings and details without have to perform subsequent requests
to retrieve that information.