### PR TITLE
[cms] Rebuild cmsDB from records cache

### DIFF
--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -438,6 +438,7 @@ func createCmsTables(tx *gorm.DB) error {
 				Version:   cmsVersion,
 				Timestamp: time.Now().Unix(),
 			}).Error
+		return err
 	}
 
 	return nil
@@ -467,8 +468,6 @@ func (c *cockroachdb) dropTables(tx *gorm.DB) error {
 	return tx.Delete(&Version{
 		ID: cacheID,
 	}).Error
-
-	return nil
 }
 
 // build the records cache using the passed in records.

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -533,15 +533,6 @@ func (c *cockroachdb) Build(dbInvs []database.Invoice, dbDCCs []database.DCC) er
 	}
 
 	log.Infof("Building records cache")
-	/*
-		for _, cr := range records {
-			_, err := strconv.ParseUint(cr.Version, 10, 64)
-			if err != nil {
-				return fmt.Errorf("parse version '%v' failed %v: %v",
-					cr.Version, cr.CensorshipRecord.Token, err)
-			}
-		}
-	*/
 	invoices := make([]Invoice, 0, len(dbInvs))
 	for _, dbInv := range dbInvs {
 		inv := EncodeInvoice(&dbInv)

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/decred/politeia/decredplugin"
 	database "github.com/decred/politeia/politeiawww/cmsdatabase"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
@@ -22,6 +21,7 @@ const (
 	cmsVersion = "1"
 
 	// Database table names
+	tableNameVersions      = "versions"
 	tableNameInvoice       = "invoices"
 	tableNameLineItem      = "line_items"
 	tableNameInvoiceChange = "invoice_changes"
@@ -420,51 +420,27 @@ func createCmsTables(tx *gorm.DB) error {
 			return err
 		}
 	}
+	if !tx.HasTable(tableNameVersions) {
+		err := tx.CreateTable(&Version{}).Error
+		if err != nil {
+			return err
+		}
+	}
+
+	var v Version
+	err := tx.Where("id = ?", cacheID).
+		Find(&v).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		err = tx.Create(
+			&Version{
+				ID:        cacheID,
+				Version:   cmsVersion,
+				Timestamp: time.Now().Unix(),
+			}).Error
+	}
+
 	return nil
-}
-
-//
-// This function must be called within a transaction.
-func (c *cockroachdb) build(tx *gorm.DB, ir *decredplugin.InventoryReply) error {
-	log.Tracef("cms build")
-
-	// Create the database tables
-	err := createCmsTables(tx)
-	if err != nil {
-		return fmt.Errorf("createCmsTables: %v", err)
-	}
-
-	// pull Inventory from d then rebuild invoice database
-	return nil
-}
-
-// Build drops all existing decred plugin tables from the database, recreates
-// them, then uses the passed in inventory payload to build the decred plugin
-// cache.
-func (c *cockroachdb) Build(payload string) error {
-	log.Tracef("invoice Build")
-
-	// Decode the payload
-	ir, err := decredplugin.DecodeInventoryReply([]byte(payload))
-	if err != nil {
-		return fmt.Errorf("DecodeInventoryReply: %v", err)
-	}
-
-	// Drop all decred plugin tables
-	err = c.recordsdb.DropTableIfExists(tableNameInvoice, tableNameLineItem).Error
-	if err != nil {
-		return fmt.Errorf("drop invoice tables failed: %v", err)
-	}
-
-	// Build the decred plugin cache from scratch
-	tx := c.recordsdb.Begin()
-	err = c.build(tx, ir)
-	if err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	return tx.Commit().Error
 }
 
 // Setup calls the tables creation function to ensure the database is prepared for use.
@@ -477,6 +453,123 @@ func (c *cockroachdb) Setup() error {
 	}
 
 	return tx.Commit().Error
+}
+
+func (c *cockroachdb) dropTables(tx *gorm.DB) error {
+	// Drop record tables
+	err := tx.DropTableIfExists(tableNameInvoice, tableNameInvoiceChange,
+		tableNameLineItem, tableNamePayments, tableNameDCC).Error
+	if err != nil {
+		return err
+	}
+
+	// Remove cms version record
+	return tx.Delete(&Version{
+		ID: cacheID,
+	}).Error
+
+	return nil
+}
+
+// build the records cache using the passed in records.
+//
+// This function cannot be called using a transaction because it could
+// potentially exceed cockroachdb's transaction size limit.
+func (c *cockroachdb) build(invoices []Invoice, dccs []DCC) error {
+	log.Tracef("build")
+
+	// Drop record tables
+	tx := c.recordsdb.Begin()
+	err := c.dropTables(tx)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("drop tables: %v", err)
+	}
+	err = tx.Commit().Error
+	if err != nil {
+		return err
+	}
+
+	// Create record tables
+	tx = c.recordsdb.Begin()
+	err = createCmsTables(tx)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("create tables: %v", err)
+	}
+	err = tx.Commit().Error
+	if err != nil {
+		return err
+	}
+
+	for _, i := range invoices {
+		err := c.recordsdb.Create(&i).Error
+		if err != nil {
+			log.Debugf("create invoice failed on '%v'", i)
+			return fmt.Errorf("create invoice: %v", err)
+		}
+	}
+
+	for _, d := range dccs {
+		err := c.recordsdb.Create(&d).Error
+		if err != nil {
+			log.Debugf("create dcc failed on '%v'", d)
+			return fmt.Errorf("create dcc: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Build drops all existing tables from the records cache, recreates them, then
+// builds the records cache using the passed in records.
+func (c *cockroachdb) Build(dbInvs []database.Invoice, dbDCCs []database.DCC) error {
+	log.Tracef("Build")
+
+	c.Lock()
+	defer c.Unlock()
+
+	if c.shutdown {
+		return database.ErrShutdown
+	}
+
+	log.Infof("Building records cache")
+	/*
+		for _, cr := range records {
+			_, err := strconv.ParseUint(cr.Version, 10, 64)
+			if err != nil {
+				return fmt.Errorf("parse version '%v' failed %v: %v",
+					cr.Version, cr.CensorshipRecord.Token, err)
+			}
+		}
+	*/
+	invoices := make([]Invoice, 0, len(dbInvs))
+	for _, dbInv := range dbInvs {
+		inv := EncodeInvoice(&dbInv)
+		invoices = append(invoices, *inv)
+	}
+	dccs := make([]DCC, 0, len(dbDCCs))
+	for _, dbDCC := range dbDCCs {
+		dcc := encodeDCC(&dbDCC)
+		dccs = append(dccs, *dcc)
+	}
+	// Build the records cache. This is not run using a
+	// transaction because it could potentially exceed
+	// cockroachdb's transaction size limit.
+	err := c.build(invoices, dccs)
+	if err != nil {
+		// Remove the version record. This will
+		// force a rebuild on the next start up.
+		err1 := c.recordsdb.Delete(&Version{
+			ID: cacheID,
+		}).Error
+		if err1 != nil {
+			panic("the cache is out of sync and will not rebuild" +
+				"automatically; a rebuild must be forced")
+		}
+	}
+
+	return err
 }
 
 func buildQueryString(user, rootCert, cert, key string) string {
@@ -521,6 +614,28 @@ func New(host, net, rootCert, cert, key string) (*cockroachdb, error) {
 	// Disable automatic table name pluralization. We set table
 	// names manually.
 	c.recordsdb.SingularTable(true)
+
+	// Return an error if the version record is not found or
+	// if there is a version mismatch, but also return the
+	// cache context so that the cache can be built/rebuilt.
+	if !c.recordsdb.HasTable(tableNameVersions) {
+		log.Debugf("table '%v' does not exist", tableNameVersions)
+		return c, database.ErrNoVersionRecord
+	}
+
+	var v Version
+	err = c.recordsdb.
+		Where("id = ?", cacheID).
+		Find(&v).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		log.Debugf("version record not found for ID '%v'", cacheID)
+		err = database.ErrNoVersionRecord
+	} else if v.Version != cmsVersion {
+		log.Debugf("version mismatch for ID '%v': got %v, want %v",
+			cacheID, v.Version, cmsVersion)
+		err = database.ErrWrongVersion
+	}
 
 	return c, err
 }

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -48,7 +48,7 @@ func EncodeInvoice(dbInvoice *database.Invoice) *Invoice {
 
 	for i, dbInvoiceLineItem := range dbInvoice.LineItems {
 		invoiceLineItem := EncodeInvoiceLineItem(&dbInvoiceLineItem)
-		invoiceLineItem.LineItemKey = dbInvoiceLineItem.InvoiceToken + strconv.Itoa(i)
+		invoiceLineItem.LineItemKey = dbInvoice.Token + strconv.Itoa(i)
 		invoice.LineItems = append(invoice.LineItems, invoiceLineItem)
 	}
 

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -10,6 +10,19 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
 
+// Version describes the version of a record or plugin that the database is
+// currently using.
+type Version struct {
+	ID        string `gorm:"primary_key"` // Primary key
+	Version   string `gorm:"not null"`    // Version
+	Timestamp int64  `gorm:"not null"`    // UNIX timestamp of record creation
+}
+
+// TableName returns the table name of the invoices table.
+func (Version) TableName() string {
+	return tableNameVersions
+}
+
 // Invoice is the database model for the database.Invoice type
 type Invoice struct {
 	Token              string    `gorm:"primary_key"`

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -12,6 +12,16 @@ import (
 )
 
 var (
+	// ErrNoVersionRecord is emitted when no version record exists.
+	ErrNoVersionRecord = errors.New("no version record")
+
+	// ErrWrongVersion is emitted when the version record does not
+	// match the implementation version.
+	ErrWrongVersion = errors.New("wrong version")
+
+	// ErrShutdown is emitted when the cache is shutting down.
+	ErrShutdown = errors.New("cache is shutting down")
+
 	// ErrUserNotFound indicates that a user name was not found in the
 	// database.
 	ErrUserNotFound = errors.New("user not found")
@@ -63,8 +73,8 @@ type Database interface {
 	// Setup the invoice tables
 	Setup() error
 
-	// Build the invoice tables from scratch (from inventory of d)
-	Build(string) error
+	// Build the relevant tables of cmsdb from scratch
+	Build([]Invoice, []DCC) error
 
 	// Close performs cleanup of the backend.
 	Close() error

--- a/politeiawww/config.go
+++ b/politeiawww/config.go
@@ -121,6 +121,7 @@ type config struct {
 	DBRootCert               string `long:"dbrootcert" description:"File containing the CA certificate for the database"`
 	DBCert                   string `long:"dbcert" description:"File containing the politeiawww client certificate for the database"`
 	DBKey                    string `long:"dbkey" description:"File containing the politeiawww client certificate key for the database"`
+	BuildCMSDB               bool   `long:"buildcmsdb" description:"Build the cmsdb from scratch"`
 	UserDB                   string `long:"userdb" description:"Database choice for the user database"`
 	EncryptionKey            string `long:"encryptionkey" description:"File containing encryption key used for encrypting user data at rest"`
 	OldEncryptionKey         string `long:"oldencryptionkey" description:"File containing old encryption key (only set when rotating keys)"`

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -558,7 +558,6 @@ func _main() error {
 							break
 						}
 						dbDCCs = append(dbDCCs, *d)
-						break
 					}
 				}
 			}

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -550,7 +550,6 @@ func _main() error {
 							break
 						}
 						dbInvs = append(dbInvs, *i)
-						break
 					case mdstream.IDDCCGeneral:
 						d, err := convertCacheToDatabaseDCC(r)
 						if err != nil {


### PR DESCRIPTION
This PR now allows for rebuilding of the cmsdb based on db version 
changes.  

Adding the `--buildcmsdb` option to politeiawww will no drop relevant tables
in cmsDB (invoices, line items, payments, invoice changes and dccs).  Then 
it will take all of the records and metadata currently stored in the backend's cache
and rebuild the tables from that information.