### PR TITLE
multi: Rename mdstream to RecordStatusChange.

### DIFF
--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -17,7 +17,7 @@ import (
 const (
 	// mdstream IDs
 	IDProposalGeneral      = 0
-	IDProposalStatusChange = 2
+	IDRecordStatusChange   = 2
 	IDInvoiceGeneral       = 3
 	IDInvoiceStatusChange  = 4
 	IDInvoicePayment       = 5
@@ -31,7 +31,7 @@ const (
 
 	// mdstream current supported versions
 	VersionProposalGeneral      = 1
-	VersionProposalStatusChange = 1
+	VersionRecordStatusChange   = 1
 	VersionInvoiceGeneral       = 1
 	VersionInvoiceStatusChange  = 1
 	VersionInvoicePayment       = 1
@@ -68,9 +68,13 @@ func DecodeProposalGeneral(payload []byte) (*ProposalGeneral, error) {
 	return &md, nil
 }
 
-// ProposalStatusChange represents a proposal status change.
+// RecordStatusChange represents a politeiad record status change and is used
+// to store additional status change metadata that would not otherwise be
+// captured by the politeiad status change routes.
+//
+// This mdstream is used by both pi and cms.
 // XXX this is missing the admin signature
-type ProposalStatusChange struct {
+type RecordStatusChange struct {
 	Version             uint             `json:"version"`                       // Version of the struct
 	AdminPubKey         string           `json:"adminpubkey"`                   // Identity of the administrator
 	NewStatus           pd.RecordStatusT `json:"newstatus"`                     // New status
@@ -78,33 +82,33 @@ type ProposalStatusChange struct {
 	Timestamp           int64            `json:"timestamp"`                     // Timestamp of the change
 }
 
-// EncodeProposalStatusChange encodes an ProposalStatusChange into a JSON byte
+// EncodeRecordStatusChange encodes an RecordStatusChange into a JSON byte
 // slice.
-func EncodeProposalStatusChange(m ProposalStatusChange) ([]byte, error) {
-	b, err := json.Marshal(m)
+func EncodeRecordStatusChange(rsc RecordStatusChange) ([]byte, error) {
+	b, err := json.Marshal(rsc)
 	if err != nil {
 		return nil, err
 	}
 	return b, nil
 }
 
-// DecodeProposalStatusChange decodes a JSON byte slice into a slice of
-// ProposalStatusChange.
-func DecodeProposalStatusChange(payload []byte) ([]ProposalStatusChange, error) {
-	var psc []ProposalStatusChange
+// DecodeRecordStatusChange decodes a JSON byte slice into a slice of
+// RecordStatusChange.
+func DecodeRecordStatusChange(payload []byte) ([]RecordStatusChange, error) {
+	var changes []RecordStatusChange
 	d := json.NewDecoder(strings.NewReader(string(payload)))
 	for {
-		var p ProposalStatusChange
-		err := d.Decode(&p)
+		var rsc RecordStatusChange
+		err := d.Decode(&rsc)
 		if err == io.EOF {
 			break
 		} else if err != nil {
 			return nil, err
 		}
 
-		psc = append(psc, p)
+		changes = append(changes, rsc)
 	}
-	return psc, nil
+	return changes, nil
 }
 
 // InvoiceGeneral represents the general metadata for an invoice and is

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -227,7 +227,7 @@ func convertPropStatusFromCache(s cache.RecordStatusT) www.PropStatusT {
 func convertPropFromCache(r cache.Record) www.ProposalRecord {
 	// Decode markdown stream payloads
 	var bpm *mdstream.ProposalGeneral
-	var msc []mdstream.ProposalStatusChange
+	var msc []mdstream.RecordStatusChange
 	for _, ms := range r.Metadata {
 		// General metadata
 		if ms.ID == mdstream.IDProposalGeneral {
@@ -240,10 +240,10 @@ func convertPropFromCache(r cache.Record) www.ProposalRecord {
 		}
 
 		// Status change metatdata
-		if ms.ID == mdstream.IDProposalStatusChange {
-			md, err := mdstream.DecodeProposalStatusChange([]byte(ms.Payload))
+		if ms.ID == mdstream.IDRecordStatusChange {
+			md, err := mdstream.DecodeRecordStatusChange([]byte(ms.Payload))
 			if err != nil {
-				log.Errorf("convertPropFromCache: DecodeProposalStatusChange "+
+				log.Errorf("convertPropFromCache: DecodeRecordStatusChange "+
 					"'%v' token '%v': %v", ms, r.CensorshipRecord.Token, err)
 			}
 			msc = md

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -173,12 +173,12 @@ func (p *politeiawww) processNewDCC(nd cms.NewDCC, u *user.User) (*cms.NewDCCRep
 	// Change politeiad record status to public. DCCs
 	// do not need to be reviewed before becoming public.
 	// An admin signature is not included for this reason.
-	c := mdstream.ProposalStatusChange{
-		Version:   mdstream.VersionProposalStatusChange,
+	c := mdstream.RecordStatusChange{
+		Version:   mdstream.VersionRecordStatusChange,
 		Timestamp: time.Now().Unix(),
 		NewStatus: pd.RecordStatusPublic,
 	}
-	blob, err := mdstream.EncodeProposalStatusChange(c)
+	blob, err := mdstream.EncodeRecordStatusChange(c)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (p *politeiawww) processNewDCC(nd cms.NewDCC, u *user.User) (*cms.NewDCCRep
 		Challenge: hex.EncodeToString(challenge),
 		MDAppend: []pd.MetadataStream{
 			{
-				ID:      mdstream.IDProposalStatusChange,
+				ID:      mdstream.IDRecordStatusChange,
 				Payload: string(blob),
 			},
 		},

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -383,12 +383,12 @@ func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.N
 	// Change politeiad record status to public. Invoices
 	// do not need to be reviewed before becoming public.
 	// An admin signature is not included for this reason.
-	c := mdstream.ProposalStatusChange{
-		Version:   mdstream.VersionProposalStatusChange,
+	c := mdstream.RecordStatusChange{
+		Version:   mdstream.VersionRecordStatusChange,
 		Timestamp: time.Now().Unix(),
 		NewStatus: pd.RecordStatusPublic,
 	}
-	blob, err := mdstream.EncodeProposalStatusChange(c)
+	blob, err := mdstream.EncodeRecordStatusChange(c)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +404,7 @@ func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.N
 		Challenge: hex.EncodeToString(challenge),
 		MDAppend: []pd.MetadataStream{
 			{
-				ID:      mdstream.IDProposalStatusChange,
+				ID:      mdstream.IDRecordStatusChange,
 				Payload: string(blob),
 			},
 		},

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1136,8 +1136,8 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 
 	// Create change record
 	newStatus := convertPropStatusFromWWW(sps.ProposalStatus)
-	blob, err := json.Marshal(mdstream.ProposalStatusChange{
-		Version:             mdstream.VersionProposalStatusChange,
+	blob, err := json.Marshal(mdstream.RecordStatusChange{
+		Version:             mdstream.VersionRecordStatusChange,
 		Timestamp:           time.Now().Unix(),
 		NewStatus:           newStatus,
 		AdminPubKey:         u.PublicKey(),
@@ -1171,7 +1171,7 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 			Challenge: hex.EncodeToString(challenge),
 			MDAppend: []pd.MetadataStream{
 				{
-					ID:      mdstream.IDProposalStatusChange,
+					ID:      mdstream.IDRecordStatusChange,
 					Payload: string(blob),
 				},
 			},
@@ -1220,7 +1220,7 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 			Challenge: hex.EncodeToString(challenge),
 			MDAppend: []pd.MetadataStream{
 				{
-					ID:      mdstream.IDProposalStatusChange,
+					ID:      mdstream.IDRecordStatusChange,
 					Payload: string(blob),
 				},
 			},


### PR DESCRIPTION
This diff renames the ProposalStatusChange mdstream to
RecordStatusChange. The name ProposalStatusChange did not make sense
since this mdstream is used by both pi and cms to store additional
status change metadata for general record status changes.