### PR TITLE
multi: Add RecordStatusChangeV2 mdstream.

### DIFF
--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -151,7 +151,7 @@ func DecodeRecordStatusChanges(payload []byte) ([]RecordStatusChangeV1, []Record
 
 	d := json.NewDecoder(strings.NewReader(string(payload)))
 	for {
-		// Decode json into a generic map to determine the version.
+		// Decode json into a map so we can determine the version.
 		statusChange := make(map[string]interface{}, 6)
 		err := d.Decode(&statusChange)
 		if err == io.EOF {

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -1424,8 +1424,20 @@ Reply:
 
 ### `Set proposal status`
 
-Set status of proposal to `PropStatusPublic`, `PropStatusCensored` or
-`PropStatusAbandoned`.  This call requires admin privileges.
+Update the [status](#proposal-status-codes) of a proposal.  This call requires
+admin privileges.
+
+Unvetted proposals can have their status updated to:  
+`PropStatusPublic`  
+`PropStatusCensored`
+
+Vetted proposals can have their status updated to:  
+`PropStatusAbandoned`
+
+A status change message detailing the reason for the status change is required
+for the following statuses:  
+`PropStatusCensored`  
+`PropStatusAbandoned`
 
 **Route:** `POST /v1/proposals/{token}/status`
 
@@ -1434,26 +1446,25 @@ Set status of proposal to `PropStatusPublic`, `PropStatusCensored` or
 | Parameter | Type | Description | Required |
 |-|-|-|-|
 | token | string | Token is the unique censorship token that identifies a specific proposal. | Yes |
-| proposalstatus | number | Status indicates the new status for the proposal. Valid statuses are: [PropStatusCensored](#PropStatusCensored), [PropStatusPublic](#PropStatusPublic), [PropStatusAbandoned](#PropStatusAbandoned). | Yes |
-| signature | string | Signature of token+string(status). | Yes |
-| publickey | string | Public key from the client side, sent to politeiawww for verification | Yes |
+| proposalstatus | [`proposal status`](#proposal-status-codes) | New proposal status.| Yes |
+| statuschangemessage | string |  Reason for status change. | No |
+| signature | string | Signature of (token + proposalstatus + statuschangemessage). | Yes |
+| publickey | string | Public key that corresponds to the signature. | Yes |
 
 **Results:**
 
 | Parameter | Type | Description |
 |-|-|-|
-| proposal | [`Proposal`](#proposal) | an entire proposal and it's content |
+| proposal | [`Proposal`](#proposal) | An entire proposal and it's contents. |
 
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
-- [`ErrorStatusNoPublicKey`](#ErrorStatusNoPublicKey)
+- [`ErrorStatusChangeMessageCannotBeBlank`](#ErrorStatusChangeMessageCannotBeBlank)
 - [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
 - [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
-- [`ErrorStatusChangeMessageCannotBeBlank`](#ErrorStatusChangeMessageCannotBeBlank)
 - [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
 - [`ErrorStatusReviewerAdminEqualsAuthor`](#ErrorStatusReviewerAdminEqualsAuthor)
 - [`ErrorStatusInvalidPropStatusTransition`](#ErrorStatusInvalidPropStatusTransition)
-- [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
 
 **Example**
 
@@ -2683,7 +2694,7 @@ Reply:
 }
 ```
 
-### Error codes
+### `Error codes`
 
 | Status | Value | Description |
 |-|-|-|
@@ -2753,7 +2764,7 @@ Reply:
 | <a name="ErrorStatusCommentIsCensored">ErrorStatusCommentIsCensored</a> | 62 | Comment is censored. |
 
 
-### Proposal status codes
+### `Proposal status codes`
 
 | Status | Value | Description |
 |-|-|-|
@@ -2765,7 +2776,7 @@ Reply:
 | <a name="PropStatusUnreviewedChanges">PropStatusUnreviewedChanges</a> | 5 | The proposal has not been rewieved by an admin yet and has been edited by the author. |
 | <a name="PropStatusAbandoned">PropStatusAbandoned</a> | 6 | The proposal is public and has been deemed abandoned by an admin. |
 
-### User edit actions
+### `User edit actions`
 
 | Status | Value | Description |
 |-|-|-|
@@ -2805,7 +2816,7 @@ Reply:
 | proposalcredits | uint64 | The number of available proposal credits the user has. |
 | emailnotifications | uint64 | A flag storing the user's preferences for email notifications. Individual notification preferences are stored in bits of the number, and are [documented below](#emailnotifications). |
 
-### Email notifications
+### `Email notifications`
 
 These are the available email notifications that can be sent.
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -781,13 +781,16 @@ type BatchVoteSummaryReply struct {
 	Summaries map[string]VoteSummary `json:"summaries"` // [token]VoteSummary
 }
 
-// SetProposalStatus is used to publish or censor an unreviewed proposal.
+// SetProposalStatus is used to change the status of a proposal. Only admins
+// have the ability to change a proposal's status. Some status changes, such
+// as censoring a proposal, require the StatusChangeMessage to be populated
+// with the reason for the status change.
 type SetProposalStatus struct {
-	Token               string      `json:"token"`
-	ProposalStatus      PropStatusT `json:"proposalstatus"`
+	Token               string      `json:"token"`                         // Proposal token
+	ProposalStatus      PropStatusT `json:"proposalstatus"`                // New status
 	StatusChangeMessage string      `json:"statuschangemessage,omitempty"` // Message associated to the status change
 	Signature           string      `json:"signature"`                     // Signature of Token+string(ProposalStatus)+StatusChangeMessage
-	PublicKey           string      `json:"publickey"`
+	PublicKey           string      `json:"publickey"`                     // Signature pubkey
 }
 
 // SetProposalStatusReply is used to reply to a SetProposalStatus command.

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -226,44 +226,78 @@ func convertPropStatusFromCache(s cache.RecordStatusT) www.PropStatusT {
 
 func convertPropFromCache(r cache.Record) www.ProposalRecord {
 	// Decode markdown stream payloads
-	var bpm *mdstream.ProposalGeneral
-	var msc []mdstream.RecordStatusChangeV1
-	for _, ms := range r.Metadata {
-		// General metadata
-		if ms.ID == mdstream.IDProposalGeneral {
-			md, err := mdstream.DecodeProposalGeneral([]byte(ms.Payload))
-			if err != nil {
-				log.Errorf("convertPropFromCache: DecodeProposalGeneral "+
-					"'%v' token '%v': %v", ms, r.CensorshipRecord.Token, err)
-			}
-			bpm = md
-		}
+	var (
+		pg         *mdstream.ProposalGeneral
+		statusesV1 []mdstream.RecordStatusChangeV1
+		statusesV2 []mdstream.RecordStatusChangeV2
+		err        error
 
-		// Decode status change metatdata. The status changes are always
-		// decoded as V1 since the only difference between V1 and V2 is
-		// the addition of the signature, which is not needed to create
-		// the ProposalRecord.
-		if ms.ID == mdstream.IDRecordStatusChange {
-			md, err := mdstream.DecodeRecordStatusChangeV1([]byte(ms.Payload))
+		token = r.CensorshipRecord.Token
+	)
+	for _, ms := range r.Metadata {
+		switch ms.ID {
+		case mdstream.IDProposalGeneral:
+			// General metadata
+			pg, err = mdstream.DecodeProposalGeneral([]byte(ms.Payload))
 			if err != nil {
-				log.Errorf("convertPropFromCache: DecodeRecordStatusChangeV1 "+
-					"'%v' token '%v': %v", ms, r.CensorshipRecord.Token, err)
+				log.Errorf("convertPropFromCache: DecodeProposalGeneral: "+
+					"err:%v token:%v mdstream:%v", err, token, ms)
 			}
-			msc = md
+		case mdstream.IDRecordStatusChange:
+			// Status changes
+			b := []byte(ms.Payload)
+			statusesV1, statusesV2, err = mdstream.DecodeRecordStatusChanges(b)
+			if err != nil {
+				log.Errorf("convertPropFromCache: DecodeRecordStatusChanges: "+
+					"err:%v token:%v mdstream:%v", err, token, ms)
+			}
+		default:
+			log.Errorf("convertPropFromCache: invalid mdstream ID: "+
+				"token:%v mdstream:%v", token, ms)
 		}
 	}
 
 	// Compile proposal status change metadata
 	var (
-		changeMsg   string
-		publishedAt int64
-		censoredAt  int64
-		abandonedAt int64
+		changeMsg          string
+		changeMsgTimestamp int64
+		publishedAt        int64
+		censoredAt         int64
+		abandonedAt        int64
 	)
-	for _, v := range msc {
-		// Overwrite change message because we only need to keep
-		// the most recent one.
-		changeMsg = v.StatusChangeMessage
+	for _, v := range statusesV1 {
+		// Keep the most recent status change message. This is what
+		// will be returned as part of the ProposalRecord.
+		if v.Timestamp > changeMsgTimestamp {
+			changeMsg = v.StatusChangeMessage
+			changeMsgTimestamp = v.Timestamp
+		}
+
+		switch convertPropStatusFromPD(v.NewStatus) {
+		case www.PropStatusPublic:
+			publishedAt = v.Timestamp
+		case www.PropStatusCensored:
+			censoredAt = v.Timestamp
+		case www.PropStatusAbandoned:
+			abandonedAt = v.Timestamp
+		}
+	}
+	for _, v := range statusesV2 {
+		// Verify the signature
+		err := v.VerifySignature(token)
+		if err != nil {
+			// This is not good!
+			e := fmt.Sprintf("invalid status change signature: "+
+				"token:%v status:%v", token, v)
+			panic(e)
+		}
+
+		// Keep the most recent status change message. This is what
+		// will be returned as part of the ProposalRecord.
+		if v.Timestamp > changeMsgTimestamp {
+			changeMsg = v.StatusChangeMessage
+			changeMsgTimestamp = v.Timestamp
+		}
 
 		switch convertPropStatusFromPD(v.NewStatus) {
 		case www.PropStatusPublic:
@@ -293,14 +327,14 @@ func convertPropFromCache(r cache.Record) www.ProposalRecord {
 	// as zero values since a cache record does not contain that
 	// data.
 	return www.ProposalRecord{
-		Name:                bpm.Name,
+		Name:                pg.Name,
 		State:               convertPropStatusToState(status),
 		Status:              status,
 		Timestamp:           r.Timestamp,
 		UserId:              "",
 		Username:            "",
-		PublicKey:           bpm.PublicKey,
-		Signature:           bpm.Signature,
+		PublicKey:           pg.PublicKey,
+		Signature:           pg.Signature,
 		Files:               files,
 		NumComments:         0,
 		Version:             r.Version,

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -227,7 +227,7 @@ func convertPropStatusFromCache(s cache.RecordStatusT) www.PropStatusT {
 func convertPropFromCache(r cache.Record) www.ProposalRecord {
 	// Decode markdown stream payloads
 	var bpm *mdstream.ProposalGeneral
-	var msc []mdstream.RecordStatusChange
+	var msc []mdstream.RecordStatusChangeV1
 	for _, ms := range r.Metadata {
 		// General metadata
 		if ms.ID == mdstream.IDProposalGeneral {
@@ -239,11 +239,14 @@ func convertPropFromCache(r cache.Record) www.ProposalRecord {
 			bpm = md
 		}
 
-		// Status change metatdata
+		// Decode status change metatdata. The status changes are always
+		// decoded as V1 since the only difference between V1 and V2 is
+		// the addition of the signature, which is not needed to create
+		// the ProposalRecord.
 		if ms.ID == mdstream.IDRecordStatusChange {
-			md, err := mdstream.DecodeRecordStatusChange([]byte(ms.Payload))
+			md, err := mdstream.DecodeRecordStatusChangeV1([]byte(ms.Payload))
 			if err != nil {
-				log.Errorf("convertPropFromCache: DecodeRecordStatusChange "+
+				log.Errorf("convertPropFromCache: DecodeRecordStatusChangeV1 "+
 					"'%v' token '%v': %v", ms, r.CensorshipRecord.Token, err)
 			}
 			msc = md

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -172,13 +172,14 @@ func (p *politeiawww) processNewDCC(nd cms.NewDCC, u *user.User) (*cms.NewDCCRep
 
 	// Change politeiad record status to public. DCCs
 	// do not need to be reviewed before becoming public.
-	// An admin signature is not included for this reason.
-	c := mdstream.RecordStatusChange{
+	// An admin pubkey and signature are not included for
+	// this reason.
+	c := mdstream.RecordStatusChangeV2{
 		Version:   mdstream.VersionRecordStatusChange,
 		Timestamp: time.Now().Unix(),
 		NewStatus: pd.RecordStatusPublic,
 	}
-	blob, err := mdstream.EncodeRecordStatusChange(c)
+	blob, err := mdstream.EncodeRecordStatusChangeV2(c)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -382,13 +382,14 @@ func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.N
 
 	// Change politeiad record status to public. Invoices
 	// do not need to be reviewed before becoming public.
-	// An admin signature is not included for this reason.
-	c := mdstream.RecordStatusChange{
+	// An admin pubkey and signature are not included for
+	// this reason.
+	c := mdstream.RecordStatusChangeV2{
 		Version:   mdstream.VersionRecordStatusChange,
 		Timestamp: time.Now().Unix(),
 		NewStatus: pd.RecordStatusPublic,
 	}
-	blob, err := mdstream.EncodeRecordStatusChange(c)
+	blob, err := mdstream.EncodeRecordStatusChangeV2(c)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1136,13 +1136,15 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 
 	// Create change record
 	newStatus := convertPropStatusFromWWW(sps.ProposalStatus)
-	blob, err := json.Marshal(mdstream.RecordStatusChange{
-		Version:             mdstream.VersionRecordStatusChange,
-		Timestamp:           time.Now().Unix(),
-		NewStatus:           newStatus,
-		AdminPubKey:         u.PublicKey(),
-		StatusChangeMessage: sps.StatusChangeMessage,
-	})
+	blob, err := mdstream.EncodeRecordStatusChangeV2(
+		mdstream.RecordStatusChangeV2{
+			Version:             mdstream.VersionRecordStatusChange,
+			Timestamp:           time.Now().Unix(),
+			NewStatus:           newStatus,
+			Signature:           sps.Signature,
+			AdminPubKey:         u.PublicKey(),
+			StatusChangeMessage: sps.StatusChangeMessage,
+		})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This diff adds a RecordStatusChangeV2 to the mdstream package and
updates politeiawww to use the RecordStatusChangeV2 mdstream.

RecordStatusChangeV2 adds a Signature field, which was erroneously left
out of V1. The status change signature was being included in the
politeiawww API call correctly and was being validated by politeiawww
correctly, but was not being saved to gitbe since it was missing from
the V1 mdstream. This diff fixes that.

No politeiawww API changes were required since the API was already
including the signature correctly.