### PR TITLE
[cms] Update manageuser command.

### DIFF
--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -5,14 +5,13 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
+	"github.com/google/uuid"
 )
 
 // ManageUserCmd allows an administrator to update Domain, ContractorType
@@ -21,245 +20,146 @@ type ManageUserCmd struct {
 	Args struct {
 		UserID string `positional-arg-name:"userid" required:"true"`
 	} `positional-args:"true" optional:"true"`
-	Domain            string `long:"domain" optional:"true" description:"Domain type: Developer, Marketing, Design, Documentation, Research, Community"`
-	ContractorType    string `long:"contractortype" optional:"true" description:"Contractor type: Direct, Sub, Super"`
-	SupervisorUserIDs string `long:"supervisoruserids" optional:"true" description:"Supervisor User IDs"`
+	Domain            string `long:"domain" optional:"true"`
+	ContractorType    string `long:"contractortype" optional:"true"`
+	SupervisorUserIDs string `long:"supervisoruserids" optional:"true"`
 }
 
 // Execute executes the cms manage user command.
 func (cmd *ManageUserCmd) Execute(args []string) error {
-	// Check for user identity
-	if cfg.Identity == nil {
-		return shared.ErrUserIdentityNotFound
+	domains := map[string]cms.DomainTypeT{
+		"developer":     cms.DomainTypeDeveloper,
+		"marketing":     cms.DomainTypeMarketing,
+		"community":     cms.DomainTypeCommunity,
+		"research":      cms.DomainTypeResearch,
+		"design":        cms.DomainTypeDesign,
+		"documentation": cms.DomainTypeDocumentation,
 	}
-	lr, err := client.Me()
+	contractorTypes := map[string]cms.ContractorTypeT{
+		"direct":     cms.ContractorTypeDirect,
+		"supervisor": cms.ContractorTypeSupervisor,
+		"contractor": cms.ContractorTypeSubContractor,
+		"nominee":    cms.ContractorTypeNominee,
+		"revoked":    cms.ContractorTypeRevoked,
+	}
+
+	// Validate user ID
+	_, err := uuid.Parse(cmd.Args.UserID)
 	if err != nil {
-		return err
-	}
-	// If it's an admin requesting, get the userID from the options or
-	// commandline entry.  Otherwise just request with the current user's ID.
-	if !lr.IsAdmin {
-		return fmt.Errorf("must be an administrator to complete this request")
+		return fmt.Errorf("invalid user ID: %v", err)
 	}
 
-	userID := cmd.Args.UserID
-
-	uir, err := client.CMSUserDetails(strings.TrimSpace(userID))
-	if err != nil {
-		return err
-	}
-
-	userInfo := cms.User{}
-	if uir != nil {
-		userInfo = uir.User
-	}
-	var domainType, contractorType int
-	if cmd.Domain != "" || cmd.ContractorType != "" ||
-		cmd.SupervisorUserIDs == "" {
-		reader := bufio.NewReader(os.Stdin)
-		if cmd.Domain == "" {
-			str := fmt.Sprintf("The current Domain setting is: \"%v\" Update?",
-				userInfo.Domain)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("Domain Type: (1) Developer, (2) Marketing, (3) " +
-						"Community, (4) Research, (5) Design, (6) Documentation:  ")
-					cmd.Domain, _ = reader.ReadString('\n')
-					domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
-					if err != nil {
-						fmt.Println("Invalid entry, please try again.")
-						continue
-					}
-					if domainType < 1 || domainType > 6 {
-						fmt.Println("Invalid domain type entered, please try again.")
-						continue
-					}
-					str := fmt.Sprintf(
-						"Your current Domain setting is: \"%v\" Keep this?",
-						domainType)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						break
-					}
-				}
-			} else {
-				domainType = int(userInfo.Domain)
-			}
-		}
-		if cmd.ContractorType == "" {
-			str := fmt.Sprintf("Your current Contractor Type setting is: \"%v\" Update?",
-				userInfo.ContractorType)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				for {
-					fmt.Printf("(1) Direct, (2) Supervisor, (3) Sub contractor:  ")
-					cmd.ContractorType, _ = reader.ReadString('\n')
-					contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
-					if err != nil {
-						fmt.Println("Invalid entry, please try again.")
-						continue
-					}
-					if contractorType < 1 || contractorType > 3 {
-						fmt.Println("Invalid contractor type entered, please try again.")
-						continue
-					}
-					str := fmt.Sprintf(
-						"Your current Contractor Type setting is: \"%v\" Keep this?",
-						contractorType)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						break
-					}
-				}
-			} else {
-				contractorType = int(userInfo.ContractorType)
-			}
-		}
-		if cmd.SupervisorUserIDs == "" {
-			str := fmt.Sprintf("The current Supervisor IDs are: %v Update?", userInfo.SupervisorUserIDs)
-			update, err := promptListBool(reader, str, "no")
-			if err != nil {
-				return err
-			}
-			if update {
-				superVisorUserIDs := userInfo.SupervisorUserIDs
-				for {
-					var superVisorUserID string
-					fmt.Printf("Add another Supervisor User ID: ")
-					superVisorUserID, _ = reader.ReadString('\n')
-					superVisorUserID = strings.TrimSpace(superVisorUserID)
-					str := fmt.Sprintf(
-						"The Supervisor User ID is: \"%v\" Add this?",
-						superVisorUserID)
-					update, err := promptListBool(reader, str, "yes")
-					if err != nil {
-						return err
-					}
-					if update {
-						superVisorUserIDs = append(superVisorUserIDs, superVisorUserID)
-						str := fmt.Sprintf("The current Supervisor IDs are: %v Keep This?", superVisorUserIDs)
-						update, err := promptListBool(reader, str, "yes")
-						if err != nil {
-							return err
-						}
-						if update {
-							break
-						}
-					}
-				}
-				userInfo.SupervisorUserIDs = superVisorUserIDs
-			}
-			fmt.Print("\nPlease carefully review your information and ensure it's " +
-				"correct. If not, press Ctrl + C to exit. Or, press Enter to continue " +
-				"your request.")
-			reader.ReadString('\n')
+	// Validate domain. The domain can be either the numeric code
+	// or the human readable equivalent.
+	var domain cms.DomainTypeT
+	if cmd.Domain != "" {
+		d, err := strconv.ParseUint(cmd.Domain, 10, 32)
+		if err == nil {
+			// Numeric code found
+			domain = cms.DomainTypeT(d)
+		} else if d, ok := domains[cmd.Domain]; ok {
+			// Human readable domain found
+			domain = d
+		} else {
+			// Invalid domain
+			return fmt.Errorf("invalid domain; use the command " +
+				"'cmswww help manageuser' for list of valid domains")
 		}
 	}
 
-	if domainType == 0 {
-		domainType, err = strconv.Atoi(strings.TrimSpace(cmd.Domain))
-		if err != nil {
-			return fmt.Errorf("invalid domain attempted, please try again")
+	// Validate contractor type. The contractor type can be either
+	// a numeric code or the human readable equivalent.
+	var contractorType cms.ContractorTypeT
+	if cmd.ContractorType != "" {
+		ct, err := strconv.ParseUint(cmd.ContractorType, 10, 32)
+		if err == nil {
+			// Numeric code found
+			contractorType = cms.ContractorTypeT(ct)
+		} else if ct, ok := contractorTypes[cmd.ContractorType]; ok {
+			// Human readable contractor type found
+			contractorType = ct
+		} else {
+			// Invalid contrator type
+			return fmt.Errorf("invalid contractor type; use the command " +
+				"'cmswww help manageuser' for list of valid contractor types")
 		}
 	}
-	userInfo.Domain = cms.DomainTypeT(domainType)
 
-	if contractorType == 0 {
-		contractorType, err = strconv.Atoi(strings.TrimSpace(cmd.ContractorType))
-		if err != nil {
-			return fmt.Errorf("invalid domain attempted, please try again")
-		}
-	}
-	userInfo.ContractorType = cms.ContractorTypeT(contractorType)
-
+	// Validate supervisor user IDs
+	supervisorIDs := make([]string, 0, 16)
 	if cmd.SupervisorUserIDs != "" {
-		superVisorUserIDs := strings.Split(cmd.SupervisorUserIDs, ",")
-		if len(superVisorUserIDs) < 1 {
-			return fmt.Errorf("invalid supervisor user ids attempted, please try again with a list separated by commas")
+		supervisorIDs = strings.Split(cmd.SupervisorUserIDs, ",")
+		for _, v := range supervisorIDs {
+			_, err := uuid.Parse(v)
+			if err != nil {
+				return fmt.Errorf("invalid supervisor ID '%v': %v", v, err)
+			}
 		}
-		userInfo.SupervisorUserIDs = superVisorUserIDs
 	}
 
-	updateInfo := cms.ManageUser{
-		UserID:            userID,
-		Domain:            userInfo.Domain,
-		ContractorType:    userInfo.ContractorType,
-		SupervisorUserIDs: userInfo.SupervisorUserIDs,
+	// Send request
+	mu := cms.ManageUser{
+		UserID:            cmd.Args.UserID,
+		Domain:            domain,
+		ContractorType:    contractorType,
+		SupervisorUserIDs: supervisorIDs,
 	}
-
-	ecur, err := client.CMSManageUser(updateInfo)
+	err = shared.PrintJSON(mu)
+	if err != nil {
+		return err
+	}
+	mur, err := client.CMSManageUser(mu)
+	if err != nil {
+		return err
+	}
+	err = shared.PrintJSON(mur)
 	if err != nil {
 		return err
 	}
 
-	// Print update user information reply. (should be empty)
-	return shared.PrintJSON(ecur)
-}
-
-func parseDomain(domain string) (cms.DomainTypeT, error) {
-	domain = strings.ToLower(strings.TrimSpace(domain))
-	switch domain {
-	case "developer":
-		return cms.DomainTypeDeveloper, nil
-	case "marketing":
-		return cms.DomainTypeMarketing, nil
-	case "community":
-		return cms.DomainTypeCommunity, nil
-	case "documentation":
-		return cms.DomainTypeDocumentation, nil
-	case "research":
-		return cms.DomainTypeResearch, nil
-	case "design":
-		return cms.DomainTypeDesign, nil
-	default:
-		return cms.DomainTypeInvalid, fmt.Errorf("invalid domain type")
-	}
-}
-
-func parseContractorType(contractorType string) (cms.ContractorTypeT, error) {
-	contractorType = strings.ToLower(strings.TrimSpace(contractorType))
-	switch contractorType {
-	case "direct":
-		return cms.ContractorTypeDirect, nil
-	case "sub":
-		return cms.ContractorTypeSubContractor, nil
-	case "super":
-		return cms.ContractorTypeSupervisor, nil
-	default:
-		return cms.ContractorTypeInvalid, fmt.Errorf("invalid domain type")
-	}
+	return nil
 }
 
 const manageUserHelpMsg = `manageuser [flags] "userid"
 
-Edit a invoice.
+Update the Domain, ContractorType and SupervisorID of the specified user. This
+command requires admin privileges.
+
+Numeric codes or their human readable equivalents can be used to specify the
+domain and contractory type. See below for the available options.
 
 Arguments:
-1. userid             (string, required)     ID of the user to manage
+1. userid               (string, required)     ID of the user to manage
 
 Flags:
-  --domain              (int, optional)     Domain of the contractor
-  --contractortype      (int, optional)     Contractor Type
-  --supervisoruserids   (string, optional)  UserIDs of the Supervisor
+  --domain              (string, optional)  Domain of the contractor
+  --contractortype      (string, optional)  Contractor Type
+  --supervisoruserids   (string, optional)  Supervisor user IDs (comma separated)
+
+Domain types:
+1. developer
+2. marketing
+3. community
+4. research
+5. design
+6. documentation
+
+Contractor types:
+1. direct
+2. supervisor
+3. subcontractor
+4. nominee
+5. revoked
 
 Request:
 {
-	"domain": 1,
-	"contractortype": 1,
-	"supervisoruserids": "4",
+  "userid": "c1261442-dc61-4861-9d6c-f104fd0b076b",
+  "domain": 1,
+  "contractortype": 1,
+  "supervisoruserids": [
+    "f43a040c-585c-4431-a9dd-6dbdde885bb5",
+    "914de514-f861-41e3-8fcb-e3ebbb26a333"
+  ]
 }
 
 Response:

--- a/politeiawww/cmd/cmswww/newinvoice.go
+++ b/politeiawww/cmd/cmswww/newinvoice.go
@@ -216,18 +216,26 @@ const newInvoiceHelpMsg = `newinvoice [flags] "csvFile" "attachmentFiles"
 Submit a new invoice to Politeia. Invoice must be a csv file. Accepted
 attachment filetypes: png or plain text.
 
+An invoice csv line item should use the following format:
+
+type,domain,subdomain,description,proposalToken,labor,expenses,subUserID
+
+Valid types   : labor, expense, misc, sub
+Labor units   : hours
+Expenses units: USD
+
 Arguments:
-1. month			 (string, required)   Month (MM, 01-12)
-2. year				 (string, required)   Year (YYYY)
-3. csvFile			 (string, required)   Invoice CSV file
-4. attachmentFiles	 (string, optional)   Attachments
+1. month             (string, required)   Month (MM, 01-12)
+2. year              (string, required)   Year (YYYY)
+3. csvFile           (string, required)   Invoice CSV file
+4. attachmentFiles   (string, optional)   Attachments
 
 Flags:
   --name              (string, optional)   Fill in contractor name
   --contact           (string, optional)   Fill in email address or contact of the contractor
   --location          (string, optional)   Fill in contractor location (e.g. Dallas, TX, USA) of the contractor
   --paymentaddress    (string, optional)   Fill in payment address for this invoice.
-  --rate              (string, optional)   Fill in contractor pay rate for labor.
+  --rate              (string, optional)   Fill in contractor pay rate for labor (USD).
 
 Result:
 {


### PR DESCRIPTION
This diff makes the following changes to the cmswww manageuser command:

- Removes the CLI prompts that would occur when optional arguments were
  left out. This allows the command to be used in scripts.
- Accepts both numeric codes or their human readable equivalents for the
  domain and contractor type arguments.
- Updates the help command to list the available domain types and
  contractor types.

Example usage:
```
$ cmswww manageuser b89c8363-ae41-4e4f-b574-3ef8963671dc --domain=developer
{
  "userid": "b89c8363-ae41-4e4f-b574-3ef8963671dc",
  "domain": 1,
}
{}

$ cmswww manageuser b89c8363-ae41-4e4f-b574-3ef8963671dc --domain=1
{
  "userid": "b89c8363-ae41-4e4f-b574-3ef8963671dc",
  "domain": 1,
}
{}
```

I also snuck in a update to newinvoice help message that adds
documentation for the expected csv format.