### PR TITLE
[cms] Fix util.FetchTx and addresswatcher cleanup

### DIFF
--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -223,7 +223,10 @@ func (p *politeiawww) checkPayments(payment *database.Payments, notifiedTx strin
 		log.Errorf("error FetchTxs for address %s: %v", payment.Address, err)
 		return false
 	}
-
+	if tx == nil {
+		log.Errorf("cannot find txid %v for address %v", notifiedTx, payment.Address)
+		return false
+	}
 	// Calculate amount received
 	amountReceived := dcrutil.Amount(0)
 	log.Debugf("Reviewing transactions for address: %v", payment.Address)

--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -227,10 +227,14 @@ func (p *politeiawww) checkPayments(payment *database.Payments, notifiedTx strin
 	// Calculate amount received
 	amountReceived := dcrutil.Amount(0)
 	log.Debugf("Reviewing transactions for address: %v", payment.Address)
-	// Transaction counter
+
+	// Check to see if running mainnet, if so, only accept transactions
+	// that originate from the Treasury Subsidy.
 	if !p.cfg.TestNet && !p.cfg.SimNet {
 		for _, address := range tx.InputAddresses {
-			if address == mainnetSubsidyAddr {
+			if address != mainnetSubsidyAddr {
+				// All input addresses should be from the subsidy address
+				return false
 			}
 		}
 	}

--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -76,8 +76,13 @@ func (p *politeiawww) setupCMSAddressWatcher() {
 				payment, err := p.cmsDB.PaymentsByAddress(m.Address)
 				if err != nil {
 					log.Errorf("error retreiving payments information from db %v", err)
+					continue
 				}
-				paid := p.checkPayments(payment, m.Address, m.TxHash)
+				if payment.Address != m.Address {
+					log.Errorf("payment address does not match watched address message!")
+					continue
+				}
+				paid := p.checkPayments(payment, m.TxHash)
 				if paid {
 					p.removeWatchAddress(payment.Address)
 				}
@@ -212,50 +217,29 @@ func (p *politeiawww) checkHistoricalPayments(payment *database.Payments) bool {
 // checkPayments checks to see if a given payment has been successfully paid.
 // It will return TRUE if paid, otherwise false.  It utilizes the util
 // FetchTxs which looks for transaction at a given address.
-func (p *politeiawww) checkPayments(payment *database.Payments, watchedAddr, notifiedTx string) bool {
-	txs, err := util.FetchTx(watchedAddr, notifiedTx)
+func (p *politeiawww) checkPayments(payment *database.Payments, notifiedTx string) bool {
+	tx, err := util.FetchTx(payment.Address, notifiedTx)
 	if err != nil {
 		log.Errorf("error FetchTxs for address %s: %v", payment.Address, err)
 		return false
 	}
-	if len(txs) == 0 {
-		return false
-	}
 
-	txIDs := ""
 	// Calculate amount received
 	amountReceived := dcrutil.Amount(0)
 	log.Debugf("Reviewing transactions for address: %v", payment.Address)
 	// Transaction counter
-	i := 0
-	for _, tx := range txs {
-		// Check to see if running mainnet, if so, only accept transactions
-		// that originate from the Treasury Subsidy.
-		if !p.cfg.TestNet && !p.cfg.SimNet {
-			found := false
-			for _, address := range tx.InputAddresses {
-				if address == mainnetSubsidyAddr {
-					found = true
-					break
-				}
-			}
-			if !found {
-				continue
+	if !p.cfg.TestNet && !p.cfg.SimNet {
+		for _, address := range tx.InputAddresses {
+			if address == mainnetSubsidyAddr {
 			}
 		}
-		log.Debugf("Transaction %v with amount %v", tx.TxID, tx.Amount)
-		amountReceived += dcrutil.Amount(tx.Amount)
-		if i == 0 {
-			txIDs = tx.TxID
-		} else {
-			txIDs += ", " + tx.TxID
-		}
-		i++
 	}
+	log.Debugf("Transaction %v with amount %v", tx.TxID, tx.Amount)
+	amountReceived += dcrutil.Amount(tx.Amount)
 	if payment.TxIDs == "" {
-		payment.TxIDs = txIDs
+		payment.TxIDs = tx.TxID
 	} else {
-		payment.TxIDs += ", " + txIDs
+		payment.TxIDs += ", " + tx.TxID
 	}
 
 	log.Debugf("Amount received %v amount needed %v", int64(amountReceived),

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -512,7 +512,7 @@ func FetchTxsForAddressNotBefore(address string, notBefore int64) ([]TxDetails, 
 }
 
 // FetchTx fetches a given transaction based on the provided txid.
-func FetchTx(address, txid string) ([]TxDetails, error) {
+func FetchTx(address, txid string) (*TxDetails, error) {
 	// Get block explorer URLs
 	addr, err := dcrutil.DecodeAddress(address)
 	if err != nil {
@@ -530,15 +530,19 @@ func FetchTx(address, txid string) ([]TxDetails, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch from dcrdata: %v", err)
 	}
-	txs := make([]TxDetails, 0, len(primaryTxs))
+	txDetail := &TxDetails{}
 	for _, tx := range primaryTxs {
-		txDetail, err := convertBETransactionToTxDetails(address, tx)
+		if tx.TxId != txid {
+			continue
+		}
+		txDetail, err = convertBETransactionToTxDetails(address, tx)
 		if err != nil {
 			return nil, fmt.Errorf("convertBETransactionToTxDetails: %v",
 				tx.TxId)
 		}
-		txs = append(txs, *txDetail)
+
+		break
 	}
 
-	return txs, nil
+	return txDetail, nil
 }

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -530,12 +530,11 @@ func FetchTx(address, txid string) (*TxDetails, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch from dcrdata: %v", err)
 	}
-	txDetail := &TxDetails{}
 	for _, tx := range primaryTxs {
 		if strings.TrimSpace(tx.TxId) != strings.TrimSpace(txid) {
 			continue
 		}
-		txDetail, err = convertBETransactionToTxDetails(address, tx)
+		txDetail, err := convertBETransactionToTxDetails(address, tx)
 		if err != nil {
 			return nil, fmt.Errorf("convertBETransactionToTxDetails: %v",
 				tx.TxId)

--- a/util/paywall.go
+++ b/util/paywall.go
@@ -532,7 +532,7 @@ func FetchTx(address, txid string) (*TxDetails, error) {
 	}
 	txDetail := &TxDetails{}
 	for _, tx := range primaryTxs {
-		if tx.TxId != txid {
+		if strings.TrimSpace(tx.TxId) != strings.TrimSpace(txid) {
 			continue
 		}
 		txDetail, err = convertBETransactionToTxDetails(address, tx)
@@ -540,9 +540,8 @@ func FetchTx(address, txid string) (*TxDetails, error) {
 			return nil, fmt.Errorf("convertBETransactionToTxDetails: %v",
 				tx.TxId)
 		}
-
-		break
+		return txDetail, nil
 	}
 
-	return txDetail, nil
+	return nil, nil
 }


### PR DESCRIPTION
This PR fixes util.FetchTx so it properly only returns the requested txid Defails instead 
of all txs related to the provided address.  

Also includes some clean up and improved error handling