### PR TITLE
[cms] Obtain userid for invoice rebuild

### DIFF
--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -549,6 +549,13 @@ func _main() error {
 							log.Errorf("convertCacheToDatabaseInvoice: %v", err)
 							break
 						}
+						u, err := p.db.UserGetByPubKey(i.PublicKey)
+						if err != nil {
+							log.Errorf("usergetbypubkey: %v %v", err, i.PublicKey)
+							break
+						}
+						i.UserID = u.ID.String()
+						i.Username = u.Username
 						dbInvs = append(dbInvs, *i)
 					case mdstream.IDDCCGeneral:
 						d, err := convertCacheToDatabaseDCC(r)


### PR DESCRIPTION
This fixes an issue with invoices after rebuilding of not having user id information (which is used for db queries) with the invoices.  

This caused users not to be able to see their invoices, or admins seeing user invoice lists.