### PR TITLE
multi: Update decredplugin VoteResults command.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -372,7 +372,6 @@ type VoteResults struct {
 }
 
 type VoteResultsReply struct {
-	StartVote StartVote  `json:"startvote"` // Original ballot
 	CastVotes []CastVote `json:"castvotes"` // All votes
 }
 

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -2378,32 +2378,6 @@ func (g *gitBackEnd) pluginProposalVotes(payload string) (string, error) {
 	}
 
 	// Prepare reply
-	var (
-		dd *json.Decoder
-		ff *os.File
-	)
-	// Fill out vote
-	filename := mdFilename(g.vetted, vote.Token,
-		decredplugin.MDStreamVoteBits)
-	ff, err = os.Open(filename)
-	if err != nil {
-		if os.IsNotExist(err) {
-			goto nodata
-		}
-		return "", err
-	}
-	defer ff.Close()
-	dd = json.NewDecoder(ff)
-
-	err = dd.Decode(&vrr.StartVote)
-	if err != nil {
-		if err == io.EOF {
-			goto nodata
-		}
-		return "", err
-	}
-
-nodata:
 	reply, err := decredplugin.EncodeVoteResultsReply(vrr)
 	if err != nil {
 		return "", fmt.Errorf("Could not encode VoteResultsReply: %v",

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -533,20 +533,6 @@ func (d *decred) cmdProposalVotes(payload string) (string, error) {
 		return "", err
 	}
 
-	// Lookup start vote
-	var sv StartVote
-	err = d.recordsdb.
-		Where("token = ?", vr.Token).
-		Preload("Options").
-		Find(&sv).
-		Error
-	if err == gorm.ErrRecordNotFound {
-		// A start vote may note exist if the voting period has not
-		// been started yet. This is ok.
-	} else if err != nil {
-		return "", fmt.Errorf("start vote lookup failed: %v", err)
-	}
-
 	// Lookup all cast votes
 	var cv []CastVote
 	err = d.recordsdb.
@@ -560,14 +546,12 @@ func (d *decred) cmdProposalVotes(payload string) (string, error) {
 	}
 
 	// Prepare reply
-	dsv, _ := convertStartVoteToDecred(sv)
 	dcv := make([]decredplugin.CastVote, 0, len(cv))
 	for _, v := range cv {
 		dcv = append(dcv, convertCastVoteToDecred(v))
 	}
 
 	vrr := decredplugin.VoteResultsReply{
-		StartVote: dsv,
 		CastVotes: dcv,
 	}
 


### PR DESCRIPTION
This diff removes the StartVote from the decredplugin VoteResultsReply.
The StartVote returned by the VoteResults command was never actually being
used by any of the calling functions and the StartVote data is already
returned in the VoteDetails command so having it in the VoteResultsReply
is unnecessarily redundant.