### PR TITLE
tlog: Create a tlog util package.

### DIFF
--- a/tlog/tclient/tclient.go
+++ b/tlog/tclient/tclient.go
@@ -22,6 +22,7 @@ import (
 	dcrtime "github.com/decred/dcrtime/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	v1 "github.com/decred/politeia/tlog/api/v1"
+	tlogutil "github.com/decred/politeia/tlog/util"
 	"github.com/decred/politeia/util"
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
@@ -115,7 +116,7 @@ func handleFile(filename string) (*v1.RecordEntry, error) {
 		return nil, err
 	}
 
-	re := util.RecordEntryNew(myID, dd, data)
+	re := tlogutil.RecordEntryNew(myID, dd, data)
 	return &re, nil
 }
 
@@ -360,7 +361,7 @@ func recordParse(index int) ([]v1.RecordEntry, error) {
 			if err != nil {
 				return nil, err
 			}
-			re = append(re, util.RecordEntryNew(myID, dd, kv))
+			re = append(re, tlogutil.RecordEntryNew(myID, dd, kv))
 			continue
 		}
 		r, err := handleFile(v)
@@ -429,7 +430,7 @@ func recordNew() error {
 		return err
 	}
 	for _, v := range rnr.Proofs {
-		err := util.QueuedLeafProofVerify(publicKey, lrSTH, v)
+		err := tlogutil.QueuedLeafProofVerify(publicKey, lrSTH, v)
 		if err != nil {
 			return err
 		}
@@ -521,7 +522,7 @@ func recordAppend() error {
 		return fmt.Errorf("VerifySignedLogRoot: %v", err)
 	}
 	for _, v := range rar.Proofs {
-		err := util.QueuedLeafProofVerify(publicKey, lrv1, v)
+		err := tlogutil.QueuedLeafProofVerify(publicKey, lrv1, v)
 		if err != nil {
 			return err
 		}
@@ -613,7 +614,7 @@ func recordGet() error {
 			continue
 		}
 
-		err = util.RecordEntryProofVerify(publicKey, v)
+		err = tlogutil.RecordEntryProofVerify(publicKey, v)
 		if err != nil {
 			return err
 		}
@@ -703,7 +704,7 @@ func recordEntriesGet() error {
 
 	// Verify record entry proofs
 	for _, v := range rgr.Proofs {
-		err := util.RecordEntryProofVerify(publicKey, v)
+		err := tlogutil.RecordEntryProofVerify(publicKey, v)
 		if err != nil {
 			return err
 		}

--- a/tlog/tserver/anchor.go
+++ b/tlog/tserver/anchor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	v1 "github.com/decred/politeia/tlog/api/v1"
+	tlogutil "github.com/decred/politeia/tlog/util"
 	"github.com/decred/politeia/util"
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
@@ -386,7 +387,7 @@ func (t *tserver) waitForAchor(trees []*trillian.Tree, anchors []v1.DataAnchor, 
 					err)
 				continue
 			}
-			re := util.RecordEntryNew(nil, dd, data)
+			re := tlogutil.RecordEntryNew(nil, dd, data)
 
 			treeID := trees[k].TreeId
 			proofs, sth, err := t.appendRecord(trees[k], &v.STH,

--- a/tlog/tserver/tserver.go
+++ b/tlog/tserver/tserver.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "github.com/decred/politeia/tlog/api/v1"
+	tlogutil "github.com/decred/politeia/tlog/util"
 	"github.com/decred/politeia/util"
 	"github.com/decred/politeia/util/version"
 	"github.com/golang/protobuf/ptypes"
@@ -564,7 +565,7 @@ func (t *tserver) recordNew(w http.ResponseWriter, r *http.Request) {
 
 	// Verify individual record entries
 	for k := range rn.RecordEntries {
-		err := util.RecordEntryVerify(rn.RecordEntries[k])
+		err := tlogutil.RecordEntryVerify(rn.RecordEntries[k])
 		if err != nil {
 			// Abort entire thing if any RecordEntry is invalid
 			e := fmt.Sprintf("recordNew RecordEntryVerify(%v): %v",
@@ -636,7 +637,7 @@ func (t *tserver) recordAppend(w http.ResponseWriter, r *http.Request) {
 
 	// Verify individual record entries
 	for k := range ra.RecordEntries {
-		err := util.RecordEntryVerify(ra.RecordEntries[k])
+		err := tlogutil.RecordEntryVerify(ra.RecordEntries[k])
 		if err != nil {
 			// Abort entire thing if any RecordEntry is invalid
 			e := fmt.Sprintf("recordAppend RecordEntryVerify(%v): %v",

--- a/tlog/util/util.go
+++ b/tlog/util/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 The Decred developers
+// Copyright (c) 2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrtime/merkle"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	v1 "github.com/decred/politeia/tlog/api/v1"
+	"github.com/decred/politeia/util"
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
 	tcrypto "github.com/google/trillian/crypto"
@@ -53,7 +54,7 @@ func RecordEntryNew(myId *identity.FullIdentity, dataHint, data []byte) v1.Recor
 // RecordEntryVerify ensures that a tlog RecordEntry is valid.
 func RecordEntryVerify(record v1.RecordEntry) error {
 	// Decode identity
-	id, err := IdentityFromString(record.PublicKey)
+	id, err := util.IdentityFromString(record.PublicKey)
 	if err != nil {
 		return fmt.Errorf("invalid pubkey: %v", err)
 	}
@@ -173,7 +174,7 @@ func RecordEntryProofVerify(pk crypto.PublicKey, rep v1.RecordEntryProof) error 
 
 	// Verify that the log root hash is included in the anchor
 	var found bool
-	h := Hash(rep.STH.LogRoot)
+	h := util.Hash(rep.STH.LogRoot)
 	for _, v := range rep.Anchor.MerklePath.Hashes {
 		if bytes.Equal(h[:], v[:]) {
 			found = true


### PR DESCRIPTION
This diff moves tlog specific util functions into a tlog util package.
The is necessary because our CLI tools that used any functions from the
global util package, such as the politeia tool, could no longer use the
-v flag. Trying to use the -v flag would cause a runtime panic due to
the glog package already declaring it. The depenecy tree to get to the
glog package was as follows:

github.com/decred/politeia/util
github.com/decred/politeia/tlog/api/v1
github.com/google/trillian
github.com/golang/glog

Moving the tlog util functions into a tlog util package fixes this.