### PR TITLE
[cms] Add CMS Users Request

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -16,6 +16,7 @@ server side notifications.  It does not render HTML.
 - [`Edit invoice`](#edit-invoice)
 - [`Set invoice status`](#set-invoice-status)
 - [`Set DCC status`](#set-dcc-status)
+- [`CMS Users`](#cms-users)
 - [`Generate payouts`](#generate-payouts)
 - [`Invoice comments`](#invoice-comments)
 - [`Invoice exchange rate`](#invoice-exchange-rate)
@@ -1421,6 +1422,48 @@ Reply:
     "supervisoruserid": "4",
   },
   ]
+}
+```
+
+### `CMS Users`
+
+Returns a list of cms users given optional filters. 
+
+**Route:** `GET /v1/cmsusers`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+| domain | int | A query int to match against user's domain. | |
+| contractortype | int | A query string to match user's contractor type. | |
+
+**Results:**
+
+| Parameter | Type | Description |
+|-|-|-|
+| users | array of [CMS Abridged User](#cms-abridged-user) | The list of cms users that match the query. 
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusInvalidInput`](#ErrorStatusInvalidInput)
+
+**Example**
+
+Request:
+
+```json
+{
+  "domain": "1",
+  "username": "1"
+}
+```
+
+Reply:
+
+```json
+{
+  "users": []
 }
 ```
 

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1442,7 +1442,7 @@ Returns a list of cms users given optional filters.
 
 | Parameter | Type | Description |
 |-|-|-|
-| users | array of [CMS Abridged User](#cms-abridged-user) | The list of cms users that match the query. 
+| users | array of [Abridged CMS User](#abridged-cms-user) | The list of cms users that match the query. 
 
 On failure the call shall return `400 Bad Request` and one of the following
 error codes:
@@ -1590,3 +1590,13 @@ Reply:
 | <a name="DCCStatusRejected">DCCStatusRejected</a>| 4 | Rejected issuance/revocation |
 | <a name="DCCStatusDebate">DCCStatusDebate</a>| 5 | If a issuance/revocation receives enough comments, it would enter a "debate" status that would require a full contractor vote (to be added later).  |
 
+### `Abridged CMS User`
+
+This is a shortened representation of a user, used for lists.
+
+| | Type | Description |
+|-|-|-|
+| id | string | The unique id of the user. |
+| username | string | Unique username. |
+| contractortype | string | CMS Domain of the user. |
+| domain | string | CMS contractor type of the user. |

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -19,6 +19,7 @@ const (
 	// Contractor Management Routes
 	RouteInviteNewUser       = "/invite"
 	RouteRegisterUser        = "/register"
+	RouteCMSUsers            = "/cmsusers"
 	RouteNewInvoice          = "/invoices/new"
 	RouteEditInvoice         = "/invoices/edit"
 	RouteInvoiceDetails      = "/invoices/{token:[A-z0-9]{64}}"
@@ -708,6 +709,12 @@ type AbridgedCMSUser struct {
 	Domain         DomainTypeT     `json:"domain"`
 	ContractorType ContractorTypeT `json:"contractortype"`
 	Username       string          `json:"username"`
+}
+
+// CMSUsers is used to request a list of CMS users given a filter.
+type CMSUsers struct {
+	Domain         DomainTypeT     `json:"domain"`
+	ContractorType ContractorTypeT `json:"contractortype"`
 }
 
 // CMSUsersReply returns a list of Users that are currently

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -703,7 +703,8 @@ type UserSubContractorsReply struct {
 	Users []User `json:"users"`
 }
 
-// AbridgedCMSUser is a shortened version of User that's used for the admin list.
+// AbridgedCMSUser is a shortened version of CMS User that's used for the
+// CMSUsers reply.
 type AbridgedCMSUser struct {
 	ID             string          `json:"id"`
 	Domain         DomainTypeT     `json:"domain"`

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -701,3 +701,16 @@ type UserSubContractors struct{}
 type UserSubContractorsReply struct {
 	Users []User `json:"users"`
 }
+
+// AbridgedCMSUser is a shortened version of User that's used for the admin list.
+type AbridgedCMSUser struct {
+	ID             string          `json:"id"`
+	Domain         DomainTypeT     `json:"domain"`
+	ContractorType ContractorTypeT `json:"contractortype"`
+	Username       string          `json:"username"`
+}
+
+// CMSUsersReply returns a list of Users that are currently
+type CMSUsersReply struct {
+	Users []AbridgedCMSUser `json:"users"`
+}

--- a/politeiawww/cmd/cmswww/cmsusers.go
+++ b/politeiawww/cmd/cmswww/cmsusers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 The Decred developers
+// Copyright (c) 2017-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/politeiawww/cmd/cmswww/cmsusers.go
+++ b/politeiawww/cmd/cmswww/cmsusers.go
@@ -38,7 +38,7 @@ Fetch a list of cms users based on filters provided.
 Arguments: None
 
 Flags:
-  --domain       (int, optional)   Email filter
+  --domain            (int, optional)      Email filter
   --contractortype    (string, optional)   Username filter
 
 

--- a/politeiawww/cmd/cmswww/cmsusers.go
+++ b/politeiawww/cmd/cmswww/cmsusers.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// CMSUsersCmd retreives a list of users that have been filtered using the
+// specified filtering params.
+type CMSUsersCmd struct {
+	Domain         int `long:"domain"`         // Domain filter
+	ContractorType int `long:"contractortype"` // Contractor Type filter
+}
+
+// Execute executes the cmsusers command.
+func (cmd *CMSUsersCmd) Execute(args []string) error {
+	u := v1.CMSUsers{
+		Domain:         v1.DomainTypeT(cmd.Domain),
+		ContractorType: v1.ContractorTypeT(cmd.ContractorType),
+	}
+
+	ur, err := client.CMSUsers(&u)
+	if err != nil {
+		return err
+	}
+	return shared.PrintJSON(ur)
+}
+
+// CMSUsersHelpMsg is the output of the help command when 'cmsusers' is specified.
+const CMSUsersHelpMsg = `cmsusers [flags]
+
+Fetch a list of cms users based on filters provided.
+
+Arguments: None
+
+Flags:
+  --domain       (int, optional)   Email filter
+  --contractortype    (string, optional)   Username filter
+
+
+Example (Admin):
+cmsusers --domain=1 --contractortype=1
+
+Result  :
+{
+  "users": [
+    {
+      "id":             (string)  User id
+      "domain":         (string)  Domaint Type
+      "username":       (string)  Username
+      "contractortype": (string)  Contractor Type 
+    }
+  ]
+}
+`

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -58,6 +58,7 @@ type cmswww struct {
 	CensorComment       shared.CensorCommentCmd  `command:"censorcomment" description:"(admin)  censor a comment"`
 	ChangePassword      shared.ChangePasswordCmd `command:"changepassword" description:"(user)   change the password for the logged in user"`
 	ChangeUsername      shared.ChangeUsernameCmd `command:"changeusername" description:"(user)   change the username for the logged in user"`
+	CMSUsers            CMSUsersCmd          	 `command:"cmsusers" description:"(user) get a list of users"`
 	DCCComments         DCCCommentsCmd           `command:"dcccomments" description:"(user)   get the comments for a dcc proposal"`
 	DCCDetails          DCCDetailsCmd            `command:"dccdetails" description:"(user)   get the details of a dcc"`
 	EditInvoice         EditInvoiceCmd           `command:"editinvoice" description:"(user)   edit a invoice"`

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -58,7 +58,7 @@ type cmswww struct {
 	CensorComment       shared.CensorCommentCmd  `command:"censorcomment" description:"(admin)  censor a comment"`
 	ChangePassword      shared.ChangePasswordCmd `command:"changepassword" description:"(user)   change the password for the logged in user"`
 	ChangeUsername      shared.ChangeUsernameCmd `command:"changeusername" description:"(user)   change the username for the logged in user"`
-	CMSUsers            CMSUsersCmd          	 `command:"cmsusers" description:"(user) get a list of users"`
+	CMSUsers            CMSUsersCmd              `command:"cmsusers" description:"(user) get a list of cms users"`
 	DCCComments         DCCCommentsCmd           `command:"dcccomments" description:"(user)   get the comments for a dcc proposal"`
 	DCCDetails          DCCDetailsCmd            `command:"dccdetails" description:"(user)   get the details of a dcc"`
 	EditInvoice         EditInvoiceCmd           `command:"editinvoice" description:"(user)   edit a invoice"`

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -58,7 +58,7 @@ type cmswww struct {
 	CensorComment       shared.CensorCommentCmd  `command:"censorcomment" description:"(admin)  censor a comment"`
 	ChangePassword      shared.ChangePasswordCmd `command:"changepassword" description:"(user)   change the password for the logged in user"`
 	ChangeUsername      shared.ChangeUsernameCmd `command:"changeusername" description:"(user)   change the username for the logged in user"`
-	CMSUsers            CMSUsersCmd              `command:"cmsusers" description:"(user) get a list of cms users"`
+	CMSUsers            CMSUsersCmd              `command:"cmsusers" description:"(user)   get a list of cms users"`
 	DCCComments         DCCCommentsCmd           `command:"dcccomments" description:"(user)   get the comments for a dcc proposal"`
 	DCCDetails          DCCDetailsCmd            `command:"dccdetails" description:"(user)   get the details of a dcc"`
 	EditInvoice         EditInvoiceCmd           `command:"editinvoice" description:"(user)   edit a invoice"`

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -1255,6 +1255,30 @@ func (c *Client) Users(u *v1.Users) (*v1.UsersReply, error) {
 	return &ur, nil
 }
 
+// CMSUsers retrieves a list of cms users that adhere to the specified filtering
+// parameters.
+func (c *Client) CMSUsers(cu *cms.CMSUsers) (*cms.CMSUsersReply, error) {
+	responseBody, err := c.makeRequest("GET", cms.RouteCMSUsers, cu)
+	if err != nil {
+		return nil, err
+	}
+
+	var cur cms.CMSUsersReply
+	err = json.Unmarshal(responseBody, &cur)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal CMSUsersReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(cur)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &cur, nil
+}
+
 // ManageUser allows an admin to edit certain attributes of the specified user.
 func (c *Client) ManageUser(mu *v1.ManageUser) (*v1.ManageUserReply, error) {
 	responseBody, err := c.makeRequest("POST", v1.RouteManageUser, mu)

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -715,14 +715,12 @@ func (p *politeiawww) processCMSUsers(users *cms.CMSUsers) (*cms.CMSUsersReply, 
 		// Execute plugin command
 		pcr, err := p.db.PluginExec(pc)
 		if err != nil {
-			log.Error(err)
 			return nil, err
 		}
 
 		// Decode reply
 		reply, err := user.DecodeCMSUsersByDomainReply([]byte(pcr.Payload))
 		if err != nil {
-			log.Error(err)
 			return nil, err
 		}
 		for _, u := range reply.Users {
@@ -756,7 +754,6 @@ func (p *politeiawww) processCMSUsers(users *cms.CMSUsers) (*cms.CMSUsersReply, 
 		// Execute plugin command
 		pcr, err := p.db.PluginExec(pc)
 		if err != nil {
-			log.Error(err)
 			return nil, err
 		}
 
@@ -764,7 +761,6 @@ func (p *politeiawww) processCMSUsers(users *cms.CMSUsers) (*cms.CMSUsersReply, 
 		reply, err := user.DecodeCMSUsersByContractorTypeReply(
 			[]byte(pcr.Payload))
 		if err != nil {
-			log.Error(err)
 			return nil, err
 		}
 		for _, u := range reply.Users {

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -686,9 +686,9 @@ func (p *politeiawww) processUserSubContractors(u *user.User) (*cms.UserSubContr
 	return uscr, nil
 }
 
-// processUsers returns a list of users given a set of filters. Username and
-// email searches will return partial matches. Pubkey searches must be an exact
-// match. Non admins can search by pubkey or username.
+// processCMSUsers returns a list of cms users given a set of filters. If
+// either domain or contractor is non-zero then they are used as matching
+// criteria, otherwise the full list will be returned.
 func (p *politeiawww) processCMSUsers(users *cms.CMSUsers) (*cms.CMSUsersReply, error) {
 	log.Tracef("processCMSUsers")
 
@@ -739,7 +739,6 @@ func (p *politeiawww) processCMSUsers(users *cms.CMSUsers) (*cms.CMSUsersReply, 
 			}
 		}
 	} else if contractortype != 0 {
-
 		// Setup plugin command
 		cu := user.CMSUsersByContractorType{
 			ContractorType: contractortype,
@@ -762,7 +761,8 @@ func (p *politeiawww) processCMSUsers(users *cms.CMSUsers) (*cms.CMSUsersReply, 
 		}
 
 		// Decode reply
-		reply, err := user.DecodeCMSUsersByContractorTypeReply([]byte(pcr.Payload))
+		reply, err := user.DecodeCMSUsersByContractorTypeReply(
+			[]byte(pcr.Payload))
 		if err != nil {
 			log.Error(err)
 			return nil, err

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -7,13 +7,14 @@ import (
 )
 
 const (
-	CMSPluginVersion         = "1"
-	CMSPluginID              = "cms"
-	CmdNewCMSUser            = "newcmsuser"
-	CmdCMSUsersByDomain      = "cmsusersbydomain"
-	CmdUpdateCMSUser         = "updatecmsuser"
-	CmdCMSUserByID           = "cmsuserbyid"
-	CmdCMSUserSubContractors = "cmsusersubcontractors"
+	CMSPluginVersion            = "1"
+	CMSPluginID                 = "cms"
+	CmdNewCMSUser               = "newcmsuser"
+	CmdCMSUsersByDomain         = "cmsusersbydomain"
+	CmdCMSUsersByContractorType = "cmsusersbycontractortype"
+	CmdUpdateCMSUser            = "updatecmsuser"
+	CmdCMSUserByID              = "cmsuserbyid"
+	CmdCMSUserSubContractors    = "cmsusersubcontractors"
 )
 
 // CMSUser represents a CMS user. It contains the standard politeiawww user
@@ -130,6 +131,52 @@ func EncodeCMSUsersByDomainReply(u CMSUsersByDomainReply) ([]byte, error) {
 // CMSUsersByDomainReply.
 func DecodeCMSUsersByDomainReply(b []byte) (*CMSUsersByDomainReply, error) {
 	var reply CMSUsersByDomainReply
+
+	err := json.Unmarshal(b, &reply)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reply, nil
+}
+
+// CMSUsersByContractorType returns all CMS users within the provided domain.
+type CMSUsersByContractorType struct {
+	ContractorType int `json:"contractortype"` // Contractor type
+}
+
+// EncodeCMSUsersByContractorType encodes a CMSUsersByContractorType into a JSON byte slice.
+func EncodeCMSUsersByContractorType(u CMSUsersByContractorType) ([]byte, error) {
+	return json.Marshal(u)
+}
+
+// DecodeCMSUsersByContractorType decodes JSON byte slice into a CMSUsersByContractorType.
+func DecodeCMSUsersByContractorType(b []byte) (*CMSUsersByContractorType, error) {
+	var u CMSUsersByContractorType
+
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		return nil, err
+	}
+
+	return &u, nil
+}
+
+// CMSUsersByContractorTypeReply is the reply to the CMSUsersByContractorType command.
+type CMSUsersByContractorTypeReply struct {
+	Users []CMSUser `json:"users"`
+}
+
+// EncodeCMSUsersByContractorTypeReply encodes a CMSUsersByContractorTypeReply into a JSON
+// byte slice.
+func EncodeCMSUsersByContractorTypeReply(u CMSUsersByContractorTypeReply) ([]byte, error) {
+	return json.Marshal(u)
+}
+
+// DecodeCMSUsersByContractorTypeReply decodes JSON byte slice into a
+// CMSUsersByContractorTypeReply.
+func DecodeCMSUsersByContractorTypeReply(b []byte) (*CMSUsersByContractorTypeReply, error) {
+	var reply CMSUsersByContractorTypeReply
 
 	err := json.Unmarshal(b, &reply)
 	if err != nil {

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -140,17 +140,20 @@ func DecodeCMSUsersByDomainReply(b []byte) (*CMSUsersByDomainReply, error) {
 	return &reply, nil
 }
 
-// CMSUsersByContractorType returns all CMS users within the provided domain.
+// CMSUsersByContractorType returns all CMS users within the provided
+// contractor type.
 type CMSUsersByContractorType struct {
 	ContractorType int `json:"contractortype"` // Contractor type
 }
 
-// EncodeCMSUsersByContractorType encodes a CMSUsersByContractorType into a JSON byte slice.
+// EncodeCMSUsersByContractorType encodes a CMSUsersByContractorType into a
+// JSON byte slice.
 func EncodeCMSUsersByContractorType(u CMSUsersByContractorType) ([]byte, error) {
 	return json.Marshal(u)
 }
 
-// DecodeCMSUsersByContractorType decodes JSON byte slice into a CMSUsersByContractorType.
+// DecodeCMSUsersByContractorType decodes JSON byte slice into a
+// CMSUsersByContractorType.
 func DecodeCMSUsersByContractorType(b []byte) (*CMSUsersByContractorType, error) {
 	var u CMSUsersByContractorType
 
@@ -162,12 +165,14 @@ func DecodeCMSUsersByContractorType(b []byte) (*CMSUsersByContractorType, error)
 	return &u, nil
 }
 
-// CMSUsersByContractorTypeReply is the reply to the CMSUsersByContractorType command.
+// CMSUsersByContractorTypeReply is the reply to the CMSUsersByContractorType
+// command.
 type CMSUsersByContractorTypeReply struct {
 	Users []CMSUser `json:"users"`
 }
 
-// EncodeCMSUsersByContractorTypeReply encodes a CMSUsersByContractorTypeReply into a JSON
+// EncodeCMSUsersByContractorTypeReply encodes a CMSUsersByContractorTypeReply
+// into a JSON
 // byte slice.
 func EncodeCMSUsersByContractorTypeReply(u CMSUsersByContractorTypeReply) ([]byte, error) {
 	return json.Marshal(u)

--- a/politeiawww/user/cockroachdb/cms.go
+++ b/politeiawww/user/cockroachdb/cms.go
@@ -238,6 +238,41 @@ func (c *cockroachdb) cmdCMSUsersByDomain(payload string) (string, error) {
 	return string(reply), nil
 }
 
+// cmdCMSUsersByContractorType returns all CMS users within the provided domain.
+func (c *cockroachdb) cmdCMSUsersByContractorType(payload string) (string, error) {
+	// Decode payload
+	p, err := user.DecodeCMSUsersByContractorType([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	// Lookup cms users
+	var users []CMSUser
+	err = c.userDB.
+		Where("contractor_type = ?", p.ContractorType).
+		Preload("User").
+		Find(&users).
+		Error
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare reply
+	u, err := c.convertCMSUsersFromDatabase(users)
+	if err != nil {
+		return "", err
+	}
+	r := user.CMSUsersByContractorTypeReply{
+		Users: u,
+	}
+	reply, err := user.EncodeCMSUsersByContractorTypeReply(r)
+	if err != nil {
+		return "", err
+	}
+
+	return string(reply), nil
+}
+
 // cmdCMSUserByID returns the user information for a given user ID.
 func (c *cockroachdb) cmdCMSUserByID(payload string) (string, error) {
 	// Decode payload
@@ -335,6 +370,8 @@ func (c *cockroachdb) cmsPluginExec(cmd, payload string) (string, error) {
 		return c.cmdNewCMSUser(payload)
 	case user.CmdCMSUsersByDomain:
 		return c.cmdCMSUsersByDomain(payload)
+	case user.CmdCMSUsersByContractorType:
+		return c.cmdCMSUsersByContractorType(payload)
 	case user.CmdUpdateCMSUser:
 		return c.cmdUpdateCMSUser(payload)
 	case user.CmdCMSUserByID:

--- a/politeiawww/user/cockroachdb/cms.go
+++ b/politeiawww/user/cockroachdb/cms.go
@@ -238,7 +238,8 @@ func (c *cockroachdb) cmdCMSUsersByDomain(payload string) (string, error) {
 	return string(reply), nil
 }
 
-// cmdCMSUsersByContractorType returns all CMS users within the provided domain.
+// cmdCMSUsersByContractorType returns all CMS users within the provided
+// contractor type.
 func (c *cockroachdb) cmdCMSUsersByContractorType(payload string) (string, error) {
 	// Decode payload
 	p, err := user.DecodeCMSUsersByContractorType([]byte(payload))

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -633,8 +633,8 @@ func (p *politeiawww) handleUsers(w http.ResponseWriter, r *http.Request) {
 func (p *politeiawww) handleCMSUsers(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleCMSUsers")
 
-	var u www.Users
-	err := util.ParseGetParams(r, &u)
+	var cu cms.CMSUsers
+	err := util.ParseGetParams(r, &cu)
 	if err != nil {
 		RespondWithError(w, r, 0, "handleCMSUsers: ParseGetParams",
 			www.UserError{
@@ -643,15 +643,14 @@ func (p *politeiawww) handleCMSUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ur, err := p.processCMSUsers(&u)
-
+	cur, err := p.processCMSUsers(&cu)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleCMSUsers: processCMSUsers %v", err)
 		return
 	}
 
-	util.RespondWithJSON(w, http.StatusOK, ur)
+	util.RespondWithJSON(w, http.StatusOK, cur)
 }
 
 // handleUserPaymentsRescan allows an admin to rescan a user's paywall address
@@ -863,6 +862,8 @@ func (p *politeiawww) setCMSUserWWWRoutes() {
 	p.addRoute(http.MethodPost, www.RouteEditUser,
 		p.handleEditCMSUser, permissionLogin)
 	p.addRoute(http.MethodGet, www.RouteUsers,
+		p.handleUsers, permissionLogin)
+	p.addRoute(http.MethodGet, cms.RouteCMSUsers,
 		p.handleCMSUsers, permissionLogin)
 
 	// Routes that require being logged in as an admin user.

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -629,6 +629,31 @@ func (p *politeiawww) handleUsers(w http.ResponseWriter, r *http.Request) {
 	util.RespondWithJSON(w, http.StatusOK, ur)
 }
 
+// handleCMSUsers handles fetching a list of cms users.
+func (p *politeiawww) handleCMSUsers(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleCMSUsers")
+
+	var u www.Users
+	err := util.ParseGetParams(r, &u)
+	if err != nil {
+		RespondWithError(w, r, 0, "handleCMSUsers: ParseGetParams",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	ur, err := p.processCMSUsers(&u)
+
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleCMSUsers: processCMSUsers %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, ur)
+}
+
 // handleUserPaymentsRescan allows an admin to rescan a user's paywall address
 // to check for any payments that may have been missed by paywall polling.
 func (p *politeiawww) handleUserPaymentsRescan(w http.ResponseWriter, r *http.Request) {
@@ -837,10 +862,10 @@ func (p *politeiawww) setCMSUserWWWRoutes() {
 		p.handleCMSUserDetails, permissionLogin)
 	p.addRoute(http.MethodPost, www.RouteEditUser,
 		p.handleEditCMSUser, permissionLogin)
+	p.addRoute(http.MethodGet, www.RouteUsers,
+		p.handleCMSUsers, permissionLogin)
 
 	// Routes that require being logged in as an admin user.
-	p.addRoute(http.MethodGet, www.RouteUsers,
-		p.handleUsers, permissionAdmin)
 	p.addRoute(http.MethodPost, www.RouteManageUser,
 		p.handleManageCMSUser, permissionAdmin)
 }


### PR DESCRIPTION
This PR adds a new authenticated route to all users to request a list of users in various domains and/or contractor types.   If no domain or contractor type is given then the full list of contractors is provided.  I don't believe any of the returned information should be considered private.

This is required for things like dropdowns and other UX improvements for DCC submissions.