### PR TITLE
[cms] Add All Contractor Vote for contentious DCCs

### DIFF
--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -164,15 +164,15 @@ func EncodeStartVote(v StartVote) ([]byte, error) {
 }
 
 // DecodeStartVote a JSON byte slice into a StartVote.
-func DecodeStartVote(payload []byte) (*StartVote, error) {
+func DecodeStartVote(payload []byte) (StartVote, error) {
 	var sv StartVote
 
 	err := json.Unmarshal(payload, &sv)
 	if err != nil {
-		return nil, err
+		return sv, err
 	}
 
-	return &sv, nil
+	return sv, nil
 }
 
 const VersionStartVoteReply = 1
@@ -194,16 +194,16 @@ func EncodeStartVoteReply(v StartVoteReply) ([]byte, error) {
 	return json.Marshal(v)
 }
 
-// DecodeVoteReply decodes a JSON byte slice into a StartVoteReply.
-func DecodeStartVoteReply(payload []byte) (*StartVoteReply, error) {
+// DecodeStartVoteReply decodes a JSON byte slice into a StartVoteReply.
+func DecodeStartVoteReply(payload []byte) (StartVoteReply, error) {
 	var v StartVoteReply
 
 	err := json.Unmarshal(payload, &v)
 	if err != nil {
-		return nil, err
+		return v, err
 	}
 
-	return &v, nil
+	return v, nil
 }
 
 // VoteDetails is used to retrieve the voting period details for a record.

--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -1,0 +1,447 @@
+package cmsplugin
+
+import (
+	"encoding/json"
+)
+
+type ErrorStatusT int
+
+// Plugin settings, kinda doesn;t go here but for now it is fine
+const (
+	Version               = "1"
+	ID                    = "cms"
+	CmdVoteDetails        = "votedccdetails"
+	CmdStartVote          = "startdccvote"
+	CmdCastVote           = "castdccvote"
+	CmdDCCVotes           = "dccvotes"
+	CmdInventory          = "cmsinventory"
+	CmdTokenInventory     = "dccinventory"
+	CmdVoteSummary        = "votedccsummary"
+	CmdLoadDCCVoteResults = "loaddccvoteresults"
+	MDStreamVoteBits      = 16 // Vote bits and mask
+	MDStreamVoteSnapshot  = 17 // Vote tickets and start/end parameters
+
+	VoteDurationMin = 2016 // Minimum vote duration (in blocks)
+	VoteDurationMax = 4032 // Maximum vote duration (in blocks)
+
+	// Error status codes
+	ErrorStatusInvalid          ErrorStatusT = 0
+	ErrorStatusInternalError    ErrorStatusT = 1
+	ErrorStatusDCCNotFound      ErrorStatusT = 2
+	ErrorStatusInvalidVoteBit   ErrorStatusT = 3
+	ErrorStatusVoteHasEnded     ErrorStatusT = 4
+	ErrorStatusDuplicateVote    ErrorStatusT = 5
+	ErrorStatusIneligibleUserID ErrorStatusT = 6
+)
+
+var (
+	// ErrorStatus converts error status codes to human readable text.
+	ErrorStatus = map[ErrorStatusT]string{
+		ErrorStatusInvalid:          "invalid error status",
+		ErrorStatusInternalError:    "internal error",
+		ErrorStatusDCCNotFound:      "dcc not found",
+		ErrorStatusInvalidVoteBit:   "invalid vote bit",
+		ErrorStatusVoteHasEnded:     "vote has ended",
+		ErrorStatusDuplicateVote:    "duplicate vote",
+		ErrorStatusIneligibleUserID: "inegligible user id",
+	}
+)
+
+// VoteOption describes a single vote option.
+type VoteOption struct {
+	Id          string `json:"id"`          // Single unique word identifying vote (e.g. yes)
+	Description string `json:"description"` // Longer description of the vote.
+	Bits        uint64 `json:"bits"`        // Bits used for this option
+}
+
+// Vote represents the vote options for vote that is identified by its token.
+type Vote struct {
+	Token            string       `json:"token"`            // Token that identifies vote
+	Mask             uint64       `json:"mask"`             // Valid votebits
+	Duration         uint32       `json:"duration"`         // Duration in blocks
+	QuorumPercentage uint32       `json:"quorumpercentage"` // Percent of eligible votes required for quorum
+	PassPercentage   uint32       `json:"passpercentage"`   // Percent of total votes required to pass
+	Options          []VoteOption `json:"options"`          // Vote option
+}
+
+// EncodeVote encodes Vote into a JSON byte slice.
+func EncodeVote(v Vote) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeVote decodes a JSON byte slice into a Vote.
+func DecodeVote(payload []byte) (*Vote, error) {
+	var v Vote
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// CastVote is a signed vote.
+type CastVote struct {
+	Token     string `json:"token"`     // DCC ID
+	UserID    string `json:"publickey"` // User ID provided by cmswww
+	VoteBit   string `json:"votebit"`   // Vote bit that was selected, this is encode in hex
+	Signature string `json:"signature"` // Signature of Token+Ticket+VoteBit
+}
+
+// EncodeCastVote encodes CastVotes into a JSON byte slice.
+func EncodeCastVote(cv CastVote) ([]byte, error) {
+	return json.Marshal(cv)
+}
+
+// DecodeCastVote decodes a JSON byte slice into a CastVote.
+func DecodeCastVote(payload []byte) (*CastVote, error) {
+	var cv CastVote
+
+	err := json.Unmarshal(payload, &cv)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cv, nil
+}
+
+// CastVoteReply contains the signature or error to a cast vote command. The
+// Error and ErrorStatus fields will only be populated if something went wrong
+// while attempting to cast the vote.
+type CastVoteReply struct {
+	ClientSignature string       `json:"clientsignature"`       // Signature that was sent in
+	Signature       string       `json:"signature"`             // Signature of the ClientSignature
+	Error           string       `json:"error"`                 // Error status message
+	ErrorStatus     ErrorStatusT `json:"errorstatus,omitempty"` // Error status code
+}
+
+// EncodeCastVoteReply encodes CastVoteReply into a JSON byte slice.
+func EncodeCastVoteReply(cvr CastVoteReply) ([]byte, error) {
+	return json.Marshal(cvr)
+}
+
+// DecodeCastVoteReply decodes a JSON byte slice into a CastVote.
+func DecodeCastVoteReply(payload []byte) (*CastVoteReply, error) {
+	var cvr CastVoteReply
+
+	err := json.Unmarshal(payload, &cvr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cvr, nil
+}
+
+// UserWeight describes a single vote option.
+type UserWeight struct {
+	UserID string `json:"userid"` // Unique user id from cmswww.
+	Weight int64  `json:"weight"` // Calculated user voted weight, provided by cmswww.
+}
+
+const VersionStartVote = 1
+
+// StartVote instructs the plugin to commence voting on a proposal with the
+// provided vote bits.
+type StartVote struct {
+	// decred plugin only data
+	Version uint   `json:"version"` // Version of this structure
+	Payload string `json:"payload"` // JSON encoded StartVote
+	Token   string `json:"token"`   // Token
+
+	PublicKey   string       `json:"publickey"`   // Key used for signature.
+	UserWeights []UserWeight `json:"userweights"` // Array of User ID + weight
+	Vote        Vote         `json:"vote"`        // Vote + options
+	Signature   string       `json:"signature"`   // Signature of Votehash
+}
+
+// EncodeStartVote a JSON byte slice.
+func EncodeStartVote(v StartVote) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeStartVote a JSON byte slice into a StartVote.
+func DecodeStartVote(payload []byte) (*StartVote, error) {
+	var sv StartVote
+
+	err := json.Unmarshal(payload, &sv)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sv, nil
+}
+
+const VersionStartVoteReply = 1
+
+// StartVoteReply is the reply to StartVote.
+type StartVoteReply struct {
+	// cms plugin only data
+	Version uint `json:"version"` // Version of this structure
+
+	// Shared data
+	StartBlockHeight string   `json:"startblockheight"` // Block height
+	StartBlockHash   string   `json:"startblockhash"`   // Block hash
+	EligibleUsers    []string `json:"userweights"`      // Array of User ID + weight
+	EndHeight        string   `json:"endheight"`        // Height of vote end
+}
+
+// EncodeStartVoteReply encodes StartVoteReply into a JSON byte slice.
+func EncodeStartVoteReply(v StartVoteReply) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeVoteReply decodes a JSON byte slice into a StartVoteReply.
+func DecodeStartVoteReply(payload []byte) (*StartVoteReply, error) {
+	var v StartVoteReply
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// VoteDetails is used to retrieve the voting period details for a record.
+type VoteDetails struct {
+	Token string `json:"token"` // Censorship token
+}
+
+// EncodeVoteDetails encodes VoteDetails into a JSON byte slice.
+func EncodeVoteDetails(vd VoteDetails) ([]byte, error) {
+	return json.Marshal(vd)
+}
+
+// DecodeVoteDetails decodes a JSON byte slice into a VoteDetails.
+func DecodeVoteDetails(payload []byte) (*VoteDetails, error) {
+	var vd VoteDetails
+
+	err := json.Unmarshal(payload, &vd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vd, nil
+}
+
+// VoteDetailsReply is the reply to VoteDetails.
+type VoteDetailsReply struct {
+	StartVote      StartVote      `json:"startvote"`      // Vote ballot
+	StartVoteReply StartVoteReply `json:"startvotereply"` // Start vote snapshot
+}
+
+// EncodeVoteDetailsReply encodes VoteDetailsReply into a JSON byte slice.
+func EncodeVoteDetailsReply(vdr VoteDetailsReply) ([]byte, error) {
+	return json.Marshal(vdr)
+}
+
+// DecodeVoteReply decodes a JSON byte slice into a VoteDetailsReply.
+func DecodeVoteDetailsReply(payload []byte) (*VoteDetailsReply, error) {
+	var vdr VoteDetailsReply
+
+	err := json.Unmarshal(payload, &vdr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vdr, nil
+}
+
+type VoteResults struct {
+	Token string `json:"token"` // Censorship token
+}
+
+type VoteResultsReply struct {
+	StartVote StartVote  `json:"startvote"` // Original ballot
+	CastVotes []CastVote `json:"castvotes"` // All votes
+}
+
+// EncodeVoteResults encodes VoteResults into a JSON byte slice.
+func EncodeVoteResults(v VoteResults) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeVoteResults decodes a JSON byte slice into a VoteResults.
+func DecodeVoteResults(payload []byte) (*VoteResults, error) {
+	var v VoteResults
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// EncodeVoteResultsReply encodes VoteResults into a JSON byte slice.
+func EncodeVoteResultsReply(v VoteResultsReply) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeVoteResultsReply decodes a JSON byte slice into a VoteResults.
+func DecodeVoteResultsReply(payload []byte) (*VoteResultsReply, error) {
+	var v VoteResultsReply
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// VoteSummary requests a summary of a proposal vote. This includes certain
+// voting period parameters and a summary of the vote results.
+type VoteSummary struct {
+	Token string `json:"token"` // Censorship token
+}
+
+// EncodeVoteSummary encodes VoteSummary into a JSON byte slice.
+func EncodeVoteSummary(v VoteSummary) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeVoteSummary decodes a JSON byte slice into a VoteSummary.
+func DecodeVoteSummary(payload []byte) (*VoteSummary, error) {
+	var v VoteSummary
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// VoteOptionResult describes a vote option and the total number of votes that
+// have been cast for this option.
+type VoteOptionResult struct {
+	ID          string `json:"id"`          // Single unique word identifying vote (e.g. yes)
+	Description string `json:"description"` // Longer description of the vote.
+	Bits        uint64 `json:"bits"`        // Bits used for this option
+	Votes       uint64 `json:"votes"`       // Number of votes cast for this option
+}
+
+// VoteSummaryReply is the reply to the VoteSummary command and returns certain
+// voting period parameters as well as a summary of the vote results.
+type VoteSummaryReply struct {
+	Duration       uint32             `json:"duration"`       // Vote duration
+	EndHeight      string             `json:"endheight"`      // End block height
+	PassPercentage uint32             `json:"passpercentage"` // Percent of total votes required to pass
+	Results        []VoteOptionResult `json:"results"`        // Vote results
+}
+
+// EncodeVoteSummaryReply encodes VoteSummary into a JSON byte slice.
+func EncodeVoteSummaryReply(v VoteSummaryReply) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// DecodeVoteSummaryReply decodes a JSON byte slice into a VoteSummaryReply.
+func DecodeVoteSummaryReply(payload []byte) (*VoteSummaryReply, error) {
+	var v VoteSummaryReply
+
+	err := json.Unmarshal(payload, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Inventory is used to retrieve the decred plugin inventory.
+type Inventory struct{}
+
+// EncodeInventory encodes Inventory into a JSON byte slice.
+func EncodeInventory(i Inventory) ([]byte, error) {
+	return json.Marshal(i)
+}
+
+// DecodeInventory decodes a JSON byte slice into a Inventory.
+func DecodeInventory(payload []byte) (*Inventory, error) {
+	var i Inventory
+
+	err := json.Unmarshal(payload, &i)
+	if err != nil {
+		return nil, err
+	}
+
+	return &i, nil
+}
+
+// StartVoteTuple is used to return the StartVote and StartVoteReply for a
+// record. StartVoteReply does not contain any record identifying data so it
+// must be returned with the StartVote in order to know what record it belongs
+// to.
+type StartVoteTuple struct {
+	StartVote      StartVote      `json:"startvote"`      // Start vote
+	StartVoteReply StartVoteReply `json:"startvotereply"` // Start vote reply
+}
+
+// InventoryReply returns the cms plugin inventory.
+type InventoryReply struct {
+	StartVoteTuples []StartVoteTuple `json:"startvotetuples"` // Start vote tuples
+	CastVotes       []CastVote       `json:"castvotes"`       // Cast votes
+}
+
+// EncodeInventoryReply encodes a InventoryReply into a JSON byte slice.
+func EncodeInventoryReply(ir InventoryReply) ([]byte, error) {
+	return json.Marshal(ir)
+}
+
+// DecodeInventoryReply decodes a JSON byte slice into a inventory.
+func DecodeInventoryReply(payload []byte) (*InventoryReply, error) {
+	var ir InventoryReply
+
+	err := json.Unmarshal(payload, &ir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ir, nil
+}
+
+// LoadVoteResults creates a vote results entry in the cache for any proposals
+// that have finsished voting but have not yet been added to the lazy loaded
+// vote results table.
+type LoadVoteResults struct {
+	BestBlock uint64 `json:"bestblock"` // Best block height
+}
+
+// EncodeLoadVoteResults encodes a LoadVoteResults into a JSON byte slice.
+func EncodeLoadVoteResults(lvr LoadVoteResults) ([]byte, error) {
+	return json.Marshal(lvr)
+}
+
+// DecodeLoadVoteResults decodes a JSON byte slice into a LoadVoteResults.
+func DecodeLoadVoteResults(payload []byte) (*LoadVoteResults, error) {
+	var lvr LoadVoteResults
+
+	err := json.Unmarshal(payload, &lvr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lvr, nil
+}
+
+// LoadVoteResultsReply is the reply to the LoadVoteResults command.
+type LoadVoteResultsReply struct{}
+
+// EncodeLoadVoteResultsReply encodes a LoadVoteResultsReply into a JSON
+// byte slice.
+func EncodeLoadVoteResultsReply(reply LoadVoteResultsReply) ([]byte, error) {
+	return json.Marshal(reply)
+}
+
+// DecodeLoadVoteResultsReply decodes a JSON byte slice into a LoadVoteResults.
+func DecodeLoadVoteResultsReply(payload []byte) (*LoadVoteResultsReply, error) {
+	var reply LoadVoteResultsReply
+
+	err := json.Unmarshal(payload, &reply)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reply, nil
+}

--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -154,7 +154,6 @@ const VersionStartVote = 1
 type StartVote struct {
 	// decred plugin only data
 	Version uint   `json:"version"` // Version of this structure
-	Payload string `json:"payload"` // JSON encoded StartVote
 	Token   string `json:"token"`   // Token
 
 	PublicKey   string       `json:"publickey"`   // Key used for signature.
@@ -188,10 +187,9 @@ type StartVoteReply struct {
 	Version uint `json:"version"` // Version of this structure
 
 	// Shared data
-	StartBlockHeight uint32   `json:"startblockheight"` // Block height
-	StartBlockHash   string   `json:"startblockhash"`   // Block hash
-	EligibleUsers    []string `json:"userweights"`      // Array of User ID + weight
-	EndHeight        uint32   `json:"endheight"`        // Height of vote end
+	StartBlockHeight uint32 `json:"startblockheight"` // Block height
+	StartBlockHash   string `json:"startblockhash"`   // Block hash
+	EndHeight        uint32 `json:"endheight"`        // Height of vote end
 }
 
 // EncodeStartVoteReply encodes StartVoteReply into a JSON byte slice.

--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -454,7 +454,7 @@ func DecodeLoadVoteResultsReply(payload []byte) (*LoadVoteResultsReply, error) {
 	return &reply, nil
 }
 
-// VerifySignature verifies that the StartVoteV1 signature is correct.
+// VerifySignature verifies that the StartVoteV2 signature is correct.
 func (s *StartVote) VerifySignature() error {
 	sig, err := util.ConvertSignature(s.Signature)
 	if err != nil {
@@ -468,7 +468,12 @@ func (s *StartVote) VerifySignature() error {
 	if err != nil {
 		return err
 	}
-	if !pk.VerifyMessage([]byte(s.Vote.Token), sig) {
+	vb, err := json.Marshal(s.Vote)
+	if err != nil {
+		return err
+	}
+	msg := hex.EncodeToString(util.Digest(vb))
+	if !pk.VerifyMessage([]byte(msg), sig) {
 		return fmt.Errorf("invalid signature")
 	}
 	return nil

--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -37,8 +37,9 @@ const (
 	ErrorStatusIneligibleUserID ErrorStatusT = 6
 
 	// String constant to ensure that the observed dcc vote option is tabulated
-	// as "approved".
-	DCCApprovalString = "yes"
+	// as "approved" or "disapproved".
+	DCCApprovalString    = "yes"
+	DCCDisapprovalString = "yes"
 )
 
 var (

--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -36,10 +36,9 @@ const (
 	ErrorStatusDuplicateVote    ErrorStatusT = 5
 	ErrorStatusIneligibleUserID ErrorStatusT = 6
 
-	// String constants to ensure that provided options are only one of these
-	// two.
-	DCCApprovalString    = "yes"
-	DCCDisapprovalString = "no"
+	// String constant to ensure that the observed dcc vote option is tabulated
+	// as "approved".
+	DCCApprovalString = "yes"
 )
 
 var (

--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -89,7 +89,7 @@ type CastVote struct {
 	Token     string `json:"token"`     // DCC ID
 	UserID    string `json:"publickey"` // User ID provided by cmswww
 	VoteBit   string `json:"votebit"`   // Vote bit that was selected, this is encode in hex
-	Signature string `json:"signature"` // Signature of Token+Ticket+VoteBit
+	Signature string `json:"signature"` // Signature of the Token+VoteBit+UserID by the submitting user.
 }
 
 // EncodeCastVote encodes CastVotes into a JSON byte slice.

--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -6,20 +6,18 @@ import (
 
 type ErrorStatusT int
 
-// Plugin settings, kinda doesn;t go here but for now it is fine
+// Plugin settings, kinda doesn't go here but for now it is fine
 const (
-	Version               = "1"
-	ID                    = "cms"
-	CmdVoteDetails        = "votedccdetails"
-	CmdStartVote          = "startdccvote"
-	CmdCastVote           = "castdccvote"
-	CmdDCCVotes           = "dccvotes"
-	CmdInventory          = "cmsinventory"
-	CmdTokenInventory     = "dccinventory"
-	CmdVoteSummary        = "votedccsummary"
-	CmdLoadDCCVoteResults = "loaddccvoteresults"
-	MDStreamVoteBits      = 16 // Vote bits and mask
-	MDStreamVoteSnapshot  = 17 // Vote tickets and start/end parameters
+	Version              = "1"
+	ID                   = "cms"
+	CmdVoteDetails       = "votedccdetails"
+	CmdStartVote         = "startdccvote"
+	CmdCastVote          = "castdccvote"
+	CmdInventory         = "cmsinventory"
+	CmdVoteSummary       = "votedccsummary"
+	CmdLoadVoteResults   = "loaddccvoteresults"
+	MDStreamVoteBits     = 16 // Vote bits and mask
+	MDStreamVoteSnapshot = 17 // Vote tickets and start/end parameters
 
 	VoteDurationMin = 2016 // Minimum vote duration (in blocks)
 	VoteDurationMax = 4032 // Maximum vote duration (in blocks)
@@ -32,6 +30,11 @@ const (
 	ErrorStatusVoteHasEnded     ErrorStatusT = 4
 	ErrorStatusDuplicateVote    ErrorStatusT = 5
 	ErrorStatusIneligibleUserID ErrorStatusT = 6
+
+	// String constants to ensure that provided options are only one of these
+	// two.
+	DCCApprovalString    = "yes"
+	DCCDisapprovalString = "no"
 )
 
 var (
@@ -180,10 +183,10 @@ type StartVoteReply struct {
 	Version uint `json:"version"` // Version of this structure
 
 	// Shared data
-	StartBlockHeight string   `json:"startblockheight"` // Block height
+	StartBlockHeight uint32   `json:"startblockheight"` // Block height
 	StartBlockHash   string   `json:"startblockhash"`   // Block hash
 	EligibleUsers    []string `json:"userweights"`      // Array of User ID + weight
-	EndHeight        string   `json:"endheight"`        // Height of vote end
+	EndHeight        uint32   `json:"endheight"`        // Height of vote end
 }
 
 // EncodeStartVoteReply encodes StartVoteReply into a JSON byte slice.
@@ -327,7 +330,7 @@ type VoteOptionResult struct {
 // voting period parameters as well as a summary of the vote results.
 type VoteSummaryReply struct {
 	Duration       uint32             `json:"duration"`       // Vote duration
-	EndHeight      string             `json:"endheight"`      // End block height
+	EndHeight      uint32             `json:"endheight"`      // End block height
 	PassPercentage uint32             `json:"passpercentage"` // Percent of total votes required to pass
 	Results        []VoteOptionResult `json:"results"`        // Vote results
 }

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -1,0 +1,1192 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gitbe
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/decred/politeia/cmsplugin"
+	"github.com/decred/politeia/politeiad/api/v1/identity"
+	"github.com/decred/politeia/politeiad/backend"
+	"github.com/decred/politeia/util"
+)
+
+const (
+	cmsPluginIdentity  = "cmsfullidentity"
+	cmsPluginJournals  = "cmssjournals"
+	cmsPluginInventory = "cmsinventory"
+)
+
+type CastDCCVoteJournal struct {
+	CastVote cmsplugin.CastVote `json:"castvote"` // Client side vote
+	Receipt  string             `json:"receipt"`  // Signature of CastVote.Signature
+}
+
+func encodeCastDCCVoteJournal(cvj CastDCCVoteJournal) ([]byte, error) {
+	b, err := json.Marshal(cvj)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func decodeCastDCCVoteJournal(payload []byte) (*CastDCCVoteJournal, error) {
+	var cvj CastDCCVoteJournal
+
+	err := json.Unmarshal(payload, &cvj)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cvj, nil
+}
+
+var (
+	cmsPluginSettings map[string]string             // [key]setting
+	cmsPluginHooks    map[string]func(string) error // [key]func(token) error
+
+	// Cached values, requires lock. These caches are lazy loaded.
+	// XXX why is this a pointer? Convert if possible after investigating
+	cmsPluginVoteCache         = make(map[string]*cmsplugin.StartVote)     // [token]startvote
+	cmsPluginVoteSnapshotCache = make(map[string]cmsplugin.StartVoteReply) // [token]StartVoteReply
+
+	// Plugin specific data that CANNOT be treated as metadata
+	cmsDataDir = filepath.Join("plugins", "cms")
+
+	// Cached values, requires lock. These caches are built on startup.
+	cmsPluginVotesCache = make(map[string]map[string]struct{}) // [token][ticket]struct{}
+
+	// errIneligibleUserID is emitted when a vote is cast using an
+	// ineligible userid.
+	errIneligibleUserID = errors.New("ineligible userid")
+)
+
+// init is used to pregenerate the JSON journal actions.
+func init() {
+	var err error
+
+	journalAdd, err = json.Marshal(JournalAction{
+		Version: journalVersion,
+		Action:  journalActionAdd,
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+	journalDel, err = json.Marshal(JournalAction{
+		Version: journalVersion,
+		Action:  journalActionDel,
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+	journalAddLike, err = json.Marshal(JournalAction{
+		Version: journalVersion,
+		Action:  journalActionAddLike,
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
+func getCMSPlugin(testnet bool) backend.Plugin {
+	cmsPlugin := backend.Plugin{
+		ID:       cmsplugin.ID,
+		Version:  cmsplugin.Version,
+		Settings: []backend.PluginSetting{},
+	}
+
+	if testnet {
+		cmsPlugin.Settings = append(cmsPlugin.Settings,
+			backend.PluginSetting{
+				Key:   "dcrdata",
+				Value: "https://testnet.dcrdata.org:443/",
+			},
+		)
+	} else {
+		cmsPlugin.Settings = append(cmsPlugin.Settings,
+			backend.PluginSetting{
+				Key:   "dcrdata",
+				Value: "https://explorer.dcrdata.org:443/",
+			})
+	}
+
+	// This setting is used to tell politeiad how to retrieve the
+	// decred plugin data that is required to build the external
+	// politeiad cache.
+	cmsPlugin.Settings = append(cmsPlugin.Settings,
+		backend.PluginSetting{
+			Key:   cmsPluginInventory,
+			Value: cmsplugin.CmdInventory,
+		})
+
+	// Initialize hooks
+	cmsPluginHooks = make(map[string]func(string) error)
+
+	// Initialize settings map
+	cmsPluginSettings = make(map[string]string)
+	for _, v := range cmsPlugin.Settings {
+		cmsPluginSettings[v.Key] = v.Value
+	}
+	return cmsPlugin
+}
+
+// initDecredPluginJournals is called externally to run initial procedures
+// such as replaying journals
+func (g *gitBackEnd) initCMSPluginJournals() error {
+	log.Infof("initCMSPluginJournals")
+
+	// check if backend journal is initialized
+	if g.journal == nil {
+		return fmt.Errorf("initCMSPlugin backend journal isn't initialized")
+	}
+
+	err := g.replayAllJournals()
+	if err != nil {
+		log.Infof("initCMSPlugin replay all journals %v", err)
+	}
+	return nil
+}
+
+//SetCMSPluginSetting removes a setting if the value is "" and adds a setting otherwise.
+func setCMSPluginSetting(key, value string) {
+	if value == "" {
+		delete(cmsPluginSettings, key)
+		return
+	}
+
+	cmsPluginSettings[key] = value
+}
+
+func setCMSPluginHook(name string, f func(string) error) {
+	cmsPluginHooks[name] = f
+}
+
+// flushDCCVotes flushes votes journal to cms plugin directory in git. It
+// returns the filename that was coppied into git repo.
+//
+// Must be called WITH the mutex held.
+func (g *gitBackEnd) flushDCCVotes(token string) (string, error) {
+	if !g.unvettedPropExists(token) {
+		return "", fmt.Errorf("unknown dcc: %v", token)
+	}
+
+	// Setup source filenames and verify they actually exist
+	srcDir := pijoin(g.journals, token)
+	srcVotes := pijoin(srcDir, defaultBallotFilename)
+	if !util.FileExists(srcVotes) {
+		return "", nil
+	}
+
+	// Setup destination filenames
+	version, err := getLatest(pijoin(g.unvetted, token))
+	if err != nil {
+		return "", err
+	}
+	dir := pijoin(g.unvetted, token, version, pluginDataDir)
+	votes := pijoin(dir, defaultBallotFilename)
+
+	// Create the destination container dir
+	_ = os.MkdirAll(dir, 0764)
+
+	// Move journal into place
+	err = g.journal.Copy(srcVotes, votes)
+	if err != nil {
+		return "", err
+	}
+
+	// Return filename that is relative to git dir.
+	return pijoin(token, version, pluginDataDir, defaultBallotFilename), nil
+}
+
+// _flushDCCVotesJournals walks all votes journal directories and copies
+// modified journals into the unvetted repo. It returns an array of filenames
+// that need to be added to the git repo and subsequently rebased into the
+// vetted repo .
+//
+// Must be called WITH the mutex held.
+func (g *gitBackEnd) _flushDCCVotesJournals() ([]string, error) {
+	dirs, err := ioutil.ReadDir(g.journals)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]string, 0, len(dirs))
+	for _, v := range dirs {
+		filename := pijoin(g.journals, v.Name(),
+			defaultBallotFlushed)
+		log.Tracef("Checking: %v", v.Name())
+		if util.FileExists(filename) {
+			continue
+		}
+
+		log.Infof("Flushing votes: %v", v.Name())
+
+		// We simply copy the journal into git
+		destination, err := g.flushDCCVotes(v.Name())
+		if err != nil {
+			log.Errorf("Could not flush %v: %v", v.Name(), err)
+			continue
+		}
+
+		// Create flush record
+		err = createFlushFile(filename)
+		if err != nil {
+			log.Errorf("Could not mark flushed %v: %v", v.Name(),
+				err)
+			continue
+		}
+
+		// Add filename to work
+		files = append(files, destination)
+	}
+
+	return files, nil
+}
+
+// flushDCCVoteJournals wraps _flushDCCVoteJournals in git magic to revert
+// flush in case of errors.
+//
+// Must be called WITHOUT the mutex held.
+func (g *gitBackEnd) flushDCCVoteJournals() error {
+	log.Tracef("flushDCCVoteJournals")
+
+	// We may have to make this more granular
+	g.Lock()
+	defer g.Unlock()
+
+	// git checkout master
+	err := g.gitCheckout(g.unvetted, "master")
+	if err != nil {
+		return err
+	}
+
+	// git pull --ff-only --rebase
+	err = g.gitPull(g.unvetted, true)
+	if err != nil {
+		return err
+	}
+
+	// git checkout -b timestamp_flushvotes
+	branch := strconv.FormatInt(time.Now().Unix(), 10) + "_flushvotes"
+	_ = g.gitBranchDelete(g.unvetted, branch) // Just in case
+	err = g.gitNewBranch(g.unvetted, branch)
+	if err != nil {
+		return err
+	}
+
+	// closure to handle unwind if needed
+	var errUnwind error
+	defer func() {
+		if errUnwind == nil {
+			return
+		}
+		err := g.flushJournalsUnwind(branch)
+		if err != nil {
+			log.Errorf("flushJournalsUnwind: %v", err)
+		}
+	}()
+
+	// Flush journals
+	files, err := g._flushDCCVotesJournals()
+	if err != nil {
+		errUnwind = err
+		return err
+	}
+
+	if len(files) == 0 {
+		log.Info("flushVotesJournals: nothing to do")
+		err = g.flushJournalsUnwind(branch)
+		if err != nil {
+			log.Errorf("flushJournalsUnwind: %v", err)
+		}
+		return nil
+	}
+
+	// git add journals
+	commitMessage := "Flush vote journals.\n\n"
+	for _, v := range files {
+		err = g.gitAdd(g.unvetted, v)
+		if err != nil {
+			errUnwind = err
+			return err
+		}
+
+		s := strings.Split(v, string(os.PathSeparator))
+		if len(s) == 0 {
+			commitMessage += "ERROR: " + v + "\n"
+		} else {
+			commitMessage += s[0] + "\n"
+		}
+	}
+
+	// git commit
+	err = g.gitCommit(g.unvetted, commitMessage)
+	if err != nil {
+		errUnwind = err
+		return err
+	}
+
+	// git rebase master
+	err = g.rebasePR(branch)
+	if err != nil {
+		errUnwind = err
+		return err
+	}
+
+	return nil
+}
+func (g *gitBackEnd) cmsPluginJournalFlusher() {
+	// XXX make this a single PR instead of 2 to save some git time
+	err := g.flushDCCVoteJournals()
+	if err != nil {
+		log.Errorf("cmsPluginVoteFlusher: %v", err)
+	}
+}
+
+func (g *gitBackEnd) pluginStartDCCVote(payload string) (string, error) {
+	vote, err := cmsplugin.DecodeStartVote([]byte(payload))
+	if err != nil {
+		return "", fmt.Errorf("DecodeStartVote %v", err)
+	}
+
+	// Verify vote bits are somewhat sane
+	for _, v := range vote.Vote.Options {
+		err = _validateCMSVoteBit(vote.Vote.Options, vote.Vote.Mask, v.Bits)
+		if err != nil {
+			return "", fmt.Errorf("invalid vote bits: %v", err)
+		}
+	}
+
+	// Verify dcc exists
+	tokenB, err := util.ConvertStringToken(vote.Vote.Token)
+	if err != nil {
+		return "", fmt.Errorf("ConvertStringToken %v", err)
+	}
+	token := vote.Vote.Token
+
+	if !g.vettedPropExists(token) {
+		return "", fmt.Errorf("unknown proposal: %v", token)
+	}
+
+	// Make sure vote duration is within min/max range
+	// XXX calculate this value for testnet instead of using hard coded values.
+	if vote.Vote.Duration < cmsplugin.VoteDurationMin ||
+		vote.Vote.Duration > cmsplugin.VoteDurationMax {
+		// XXX return a user error instead of an internal error
+		return "", fmt.Errorf("invalid duration: %v (%v - %v)",
+			vote.Vote.Duration, cmsplugin.VoteDurationMin,
+			cmsplugin.VoteDurationMax)
+	}
+
+	// 1. Get best block
+	bb, err := bestBlock()
+	if err != nil {
+		return "", fmt.Errorf("bestBlock %v", err)
+	}
+	if bb.Height < uint32(g.activeNetParams.TicketMaturity) {
+		return "", fmt.Errorf("invalid height")
+	}
+	// 2. Subtract TicketMaturity from block height to get into
+	// unforkable teritory
+	startVoteBlock, err := block(bb.Height)
+	if err != nil {
+		return "", fmt.Errorf("bestBlock %v", err)
+	}
+
+	// Convert the user weights array into a []string array.
+	// This will become the format "userid+weight"
+	eligbleUsers := make([]string, len(vote.UserWeights))
+	for i, uw := range vote.UserWeights {
+		fmt.Println(i, uw, len(vote.UserWeights))
+		eligbleUsers[i] = uw.UserID + "," + strconv.Itoa(int(uw.Weight))
+	}
+
+	svr := cmsplugin.StartVoteReply{
+		Version: cmsplugin.VersionStartVoteReply,
+		StartBlockHeight: strconv.FormatUint(uint64(startVoteBlock.Height),
+			10),
+		StartBlockHash: startVoteBlock.Hash,
+		// On EndHeight: we start in the past, add maturity to correct
+		EndHeight: strconv.FormatUint(uint64(startVoteBlock.Height+
+			vote.Vote.Duration+
+			uint32(g.activeNetParams.TicketMaturity)), 10),
+		EligibleUsers: eligbleUsers,
+	}
+	svrb, err := cmsplugin.EncodeStartVoteReply(svr)
+	if err != nil {
+		return "", fmt.Errorf("EncodeStartVoteReply: %v", err)
+	}
+
+	// Add version to on disk structure
+	vote.Version = cmsplugin.VersionStartVote
+	voteb, err := cmsplugin.EncodeStartVote(*vote)
+	if err != nil {
+		return "", fmt.Errorf("EncodeStartVote: %v", err)
+	}
+
+	// Verify proposal state
+	g.Lock()
+	defer g.Unlock()
+	if g.shutdown {
+		// Make sure we are not shutting down
+		return "", backend.ErrShutdown
+	}
+	_, err1 := os.Stat(pijoin(joinLatest(g.vetted, token),
+		fmt.Sprintf("%02v%v", cmsplugin.MDStreamVoteBits,
+			defaultMDFilenameSuffix)))
+	_, err2 := os.Stat(pijoin(joinLatest(g.vetted, token),
+		fmt.Sprintf("%02v%v", cmsplugin.MDStreamVoteSnapshot,
+			defaultMDFilenameSuffix)))
+
+	if err1 != nil && err2 != nil {
+		// Vote has not started, continue
+	} else if err1 == nil && err2 == nil {
+		// Vote has started
+		return "", fmt.Errorf("dcc vote already started: %v",
+			token)
+	} else {
+		// This is bad, both files should exist or not exist
+		return "", fmt.Errorf("dcc is unknown vote state: %v",
+			token)
+	}
+
+	// Store snapshot in metadata
+	err = g._updateVettedMetadata(tokenB, nil, []backend.MetadataStream{
+		{
+			ID:      cmsplugin.MDStreamVoteBits,
+			Payload: string(voteb),
+		},
+		{
+			ID:      cmsplugin.MDStreamVoteSnapshot,
+			Payload: string(svrb),
+		}})
+	if err != nil {
+		return "", fmt.Errorf("_updateVettedMetadata: %v", err)
+	}
+
+	// Add vote snapshot to in-memory cache
+	cmsPluginVoteSnapshotCache[token] = svr
+
+	log.Infof("Vote started for: %v snapshot %v start %v end %v",
+		token, svr.StartBlockHash, svr.StartBlockHeight,
+		svr.EndHeight)
+
+	// return success and encoded answer
+	return string(svrb), nil
+}
+
+// validateCMSVoteBits ensures that the passed in bit is a valid vote option.
+// This function is expensive due to it's filesystem touches and therefore is
+// lazily cached. This could stand a rewrite.
+func (g *gitBackEnd) validateCMSVoteBit(token, bit string) error {
+	b, err := strconv.ParseUint(bit, 16, 64)
+	if err != nil {
+		return err
+	}
+
+	g.Lock()
+	defer g.Unlock()
+	if g.shutdown {
+		return backend.ErrShutdown
+	}
+
+	sv, ok := cmsPluginVoteCache[token]
+	if !ok {
+		// StartVote is not in the cache. Load it from disk.
+
+		// git checkout master
+		err = g.gitCheckout(g.unvetted, "master")
+		if err != nil {
+			return err
+		}
+
+		// git pull --ff-only --rebase
+		err = g.gitPull(g.unvetted, true)
+		if err != nil {
+			return err
+		}
+		// Load md stream
+		svb, err := ioutil.ReadFile(mdFilename(g.vetted, token,
+			cmsplugin.MDStreamVoteBits))
+		if err != nil {
+			return err
+		}
+		svp, err := cmsplugin.DecodeStartVote(svb)
+		if err != nil {
+			return err
+		}
+		sv = svp
+
+		// Update cache
+		cmsPluginVoteCache[token] = sv
+	}
+
+	// Handle StartVote versioning
+	var (
+		mask    uint64
+		options []cmsplugin.VoteOption
+	)
+	switch sv.Version {
+	case cmsplugin.VersionStartVote:
+		mask = sv.Vote.Mask
+		options = sv.Vote.Options
+	default:
+		return fmt.Errorf("invalid start vote version %v %v",
+			sv.Version, sv.Token)
+	}
+
+	return _validateCMSVoteBit(options, mask, b)
+}
+
+// _validateVoteBit iterates over all vote bits and ensure the sent in vote bit
+// exists.
+func _validateCMSVoteBit(options []cmsplugin.VoteOption, mask uint64, bit uint64) error {
+	if len(options) == 0 {
+		return fmt.Errorf("_validateVoteBit vote corrupt")
+	}
+	if bit == 0 {
+		return invalidVoteBitError{
+			err: fmt.Errorf("invalid bit 0x%x", bit),
+		}
+	}
+	if mask&bit != bit {
+		return invalidVoteBitError{
+			err: fmt.Errorf("invalid mask 0x%x bit 0x%x",
+				mask, bit),
+		}
+	}
+	for _, v := range options {
+		if v.Bits == bit {
+			return nil
+		}
+	}
+	return invalidVoteBitError{
+		err: fmt.Errorf("bit not found 0x%x", bit),
+	}
+}
+
+// replayDCCBallot replays voting journal for given dcc.
+//
+// Functions must be called WITH the lock held.
+func (g *gitBackEnd) replayDCCBallot(token string) error {
+	// Verify proposal exists, we can run this lockless
+	if !g.vettedPropExists(token) {
+		return nil
+	}
+
+	// Do some cheap things before expensive calls
+	bfilename := pijoin(g.journals, token,
+		defaultBallotFilename)
+
+	// Replay journal
+	err := g.journal.Open(bfilename)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("journal.Open: %v", err)
+		}
+		return nil
+	}
+	defer func() {
+		err = g.journal.Close(bfilename)
+		if err != nil {
+			log.Errorf("journal.Close: %v", err)
+		}
+	}()
+
+	for {
+		err = g.journal.Replay(bfilename, func(s string) error {
+			ss := bytes.NewReader([]byte(s))
+			d := json.NewDecoder(ss)
+
+			// Decode action
+			var action JournalAction
+			err = d.Decode(&action)
+			if err != nil {
+				return fmt.Errorf("journal action: %v", err)
+			}
+
+			switch action.Action {
+			case journalActionAdd:
+				var cvj CastDCCVoteJournal
+				err = d.Decode(&cvj)
+				if err != nil {
+					return fmt.Errorf("journal add: %v",
+						err)
+				}
+
+				token := cvj.CastVote.Token
+				userid := cvj.CastVote.UserID
+				// See if the prop already exists
+				if _, ok := cmsPluginVotesCache[token]; !ok {
+					// Create map to track tickets
+					cmsPluginVotesCache[token] = make(map[string]struct{})
+				}
+				// See if we have a duplicate vote
+				if _, ok := cmsPluginVotesCache[token][userid]; ok {
+					log.Errorf("duplicate cast vote %v %v",
+						token, userid)
+				}
+				// All good, record vote in cache
+				cmsPluginVotesCache[token][userid] = struct{}{}
+
+			default:
+				return fmt.Errorf("invalid action: %v",
+					action.Action)
+			}
+			return nil
+		})
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// loadDCCVoteSnapshotCache loads the cmsplugin.StartVoteReply from disk for the provided
+// token and adds it to the cmsPluginVoteSnapshotCache.
+//
+// This function must be called WITH the lock held.
+func (g *gitBackEnd) loadDCCVoteSnapshotCache(token string) (*cmsplugin.StartVoteReply, error) {
+	// git checkout master
+	err := g.gitCheckout(g.unvetted, "master")
+	if err != nil {
+		return nil, err
+	}
+
+	// git pull --ff-only --rebase
+	err = g.gitPull(g.unvetted, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the vote snapshot from disk
+	f, err := os.Open(mdFilename(g.vetted, token,
+		cmsplugin.MDStreamVoteSnapshot))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var svr cmsplugin.StartVoteReply
+	d := json.NewDecoder(f)
+	err = d.Decode(&svr)
+	if err != nil {
+		return nil, err
+	}
+
+	cmsPluginVoteSnapshotCache[token] = svr
+
+	return &svr, nil
+}
+
+// dccVoteEndHeight returns the voting period end height for the provided token.
+func (g *gitBackEnd) dccVoteEndHeight(token string) (uint32, error) {
+	g.Lock()
+	defer g.Unlock()
+	if g.shutdown {
+		return 0, backend.ErrShutdown
+	}
+
+	svr, ok := cmsPluginVoteSnapshotCache[token]
+	if !ok {
+		s, err := g.loadDCCVoteSnapshotCache(token)
+		if err != nil {
+			return 0, err
+		}
+		svr = *s
+	}
+
+	endHeight, err := strconv.ParseUint(svr.EndHeight, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(endHeight), nil
+}
+
+// writeVote writes the provided vote to the provided journal file path, if the
+// vote does not already exist. Once successfully written to the journal, the
+// vote is added to the cast vote memory cache.
+//
+// This function must be called WITHOUT the lock held.
+func (g *gitBackEnd) writeDCCVote(v cmsplugin.CastVote, receipt, journalPath string) error {
+	g.Lock()
+	defer g.Unlock()
+
+	// Ensure ticket is eligible to vote.
+	// This cache should have already been loaded when the
+	// vote end height was validated, but lets be sure.
+	svr, ok := cmsPluginVoteSnapshotCache[v.Token]
+	if !ok {
+		s, err := g.loadDCCVoteSnapshotCache(v.Token)
+		if err != nil {
+			return fmt.Errorf("loadDCCVoteSnapshotCache: %v",
+				err)
+		}
+		svr = *s
+	}
+	var found bool
+	for _, t := range svr.EligibleUsers {
+		if strings.Contains(t, v.UserID) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return errIneligibleUserID
+	}
+
+	// Ensure vote is not a duplicate
+	_, ok = cmsPluginVotesCache[v.Token]
+	if !ok {
+		cmsPluginVotesCache[v.Token] = make(map[string]struct{})
+	}
+
+	_, ok = cmsPluginVotesCache[v.Token][v.UserID]
+	if ok {
+		return errDuplicateVote
+	}
+
+	// Create journal entry
+	cvj := CastDCCVoteJournal{
+		CastVote: v,
+		Receipt:  receipt,
+	}
+	blob, err := encodeCastDCCVoteJournal(cvj)
+	if err != nil {
+		return fmt.Errorf("encodeCastVoteJournal: %v",
+			err)
+	}
+
+	// Write vote to journal
+	err = g.journal.Journal(journalPath, string(journalAdd)+
+		string(blob))
+	if err != nil {
+		return fmt.Errorf("could not journal vote %v: %v %v",
+			v.Token, v.UserID, err)
+	}
+
+	// Add vote to memory cache
+	cmsPluginVotesCache[v.Token][v.UserID] = struct{}{}
+
+	return nil
+}
+
+func (g *gitBackEnd) pluginCastVote(payload string) (string, error) {
+	log.Tracef("pluginCastVote")
+
+	// Check if journals were replayed
+	if !journalsReplayed {
+		return "", backend.ErrJournalsNotReplayed
+	}
+
+	// Decode ballot
+	vote, err := cmsplugin.DecodeCastVote([]byte(payload))
+	if err != nil {
+		return "", fmt.Errorf("DecodeBallot: %v", err)
+	}
+
+	// XXX this should become part of some sort of context
+	fiJSON, ok := cmsPluginSettings[cmsPluginIdentity]
+	if !ok {
+		return "", fmt.Errorf("full identity not set")
+	}
+	fi, err := identity.UnmarshalFullIdentity([]byte(fiJSON))
+	if err != nil {
+		return "", err
+	}
+
+	// Get best block
+	bb, err := bestBlock()
+	if err != nil {
+		return "", fmt.Errorf("bestBlock %v", err)
+	}
+
+	br := cmsplugin.CastVoteReply{}
+	// Verify proposal exists, we can run this lockless
+	if !g.vettedPropExists(vote.Token) {
+		log.Errorf("pluginCastVote: proposal not found: %v",
+			vote.Token)
+		e := cmsplugin.ErrorStatusDCCNotFound
+		err := fmt.Sprintf("%v: %v",
+			cmsplugin.ErrorStatus[e], vote.Token)
+		return "", fmt.Errorf("write vote: %v", err)
+	}
+
+	// Ensure that the votebits are correct
+	err = g.validateCMSVoteBit(vote.Token, vote.VoteBit)
+	if err != nil {
+		if e, ok := err.(invalidVoteBitError); ok {
+			es := cmsplugin.ErrorStatusInvalidVoteBit
+			err := fmt.Sprintf("%v: %v",
+				cmsplugin.ErrorStatus[es], e.err.Error())
+			return "", fmt.Errorf("validateCMSVoteBit: %v", err)
+
+		}
+		t := time.Now().Unix()
+		log.Errorf("pluginCastVote: validateCMSVoteBit %v %v %v %v",
+			vote.UserID, vote.Token, t, err)
+		e := cmsplugin.ErrorStatusInternalError
+		err := fmt.Sprintf("%v: %v",
+			cmsplugin.ErrorStatus[e], t)
+		return "", fmt.Errorf("write vote: %v", err)
+
+	}
+
+	// Verify voting period has not ended
+	endHeight, err := g.dccVoteEndHeight(vote.Token)
+	if err != nil {
+		t := time.Now().Unix()
+		log.Errorf("pluginCastVote: dccVoteEndHeight %v %v %v %v",
+			vote.UserID, vote.Token, t, err)
+		e := cmsplugin.ErrorStatusInternalError
+		err := fmt.Sprintf("%v: %v",
+			cmsplugin.ErrorStatus[e], t)
+		return "", fmt.Errorf("write vote: %v", err)
+
+	}
+	if bb.Height >= endHeight {
+		e := cmsplugin.ErrorStatusVoteHasEnded
+		br.ErrorStatus = e
+		err := fmt.Sprintf("%v: %v",
+			cmsplugin.ErrorStatus[e], vote.Token)
+		return "", fmt.Errorf("write vote: %v", err)
+
+	}
+
+	// Ensure journal directory exists
+	dir := pijoin(g.journals, vote.Token)
+	bfilename := pijoin(dir, defaultBallotFilename)
+	err = os.MkdirAll(dir, 0774)
+	if err != nil {
+		// Should not fail, so return failure to alert people
+		return "", fmt.Errorf("make journal dir: %v", err)
+	}
+
+	// Sign signature
+	r := fi.SignMessage([]byte(vote.Signature))
+	receipt := hex.EncodeToString(r[:])
+
+	// Write vote to journal
+	err = g.writeDCCVote(*vote, receipt, bfilename)
+	if err != nil {
+		switch err {
+		case errDuplicateVote:
+			e := cmsplugin.ErrorStatusDuplicateVote
+			err := fmt.Sprintf("%v: %v",
+				cmsplugin.ErrorStatus[e], vote.Token)
+			return "", fmt.Errorf("write vote: %v", err)
+		case errIneligibleUserID:
+			e := cmsplugin.ErrorStatusIneligibleUserID
+			err := fmt.Sprintf("%v: %v",
+				cmsplugin.ErrorStatus[e], vote.Token)
+			return "", fmt.Errorf("write vote: %v", err)
+		default:
+			// Should not fail, so return failure to alert people
+			return "", fmt.Errorf("write vote: %v", err)
+		}
+	}
+
+	// Update reply
+	br.ClientSignature = vote.Signature
+	br.Signature = receipt
+
+	// Mark comment journal dirty
+	flushFilename := pijoin(g.journals, vote.Token,
+		defaultBallotFlushed)
+	_ = os.Remove(flushFilename)
+
+	// Encode reply
+	brb, err := cmsplugin.EncodeCastVoteReply(br)
+	if err != nil {
+		return "", fmt.Errorf("EncodeCastVoteReply: %v", err)
+	}
+
+	// return success and encoded answer
+	return string(brb), nil
+}
+
+// tallyDCCVotes replays the ballot journal for a proposal and tallies the votes.
+//
+// Function must be called WITH the lock held.
+func (g *gitBackEnd) tallyDCCVotes(token string) ([]cmsplugin.CastVote, error) {
+	// Do some cheap things before expensive calls
+	bfilename := pijoin(g.journals, token, defaultBallotFilename)
+
+	// Replay journal
+	err := g.journal.Open(bfilename)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("journal.Open: %v", err)
+		}
+		return []cmsplugin.CastVote{}, nil
+	}
+	defer func() {
+		err = g.journal.Close(bfilename)
+		if err != nil {
+			log.Errorf("journal.Close: %v", err)
+		}
+	}()
+
+	cv := make([]cmsplugin.CastVote, 0, 41000)
+	for {
+		err = g.journal.Replay(bfilename, func(s string) error {
+			ss := bytes.NewReader([]byte(s))
+			d := json.NewDecoder(ss)
+
+			// Decode action
+			var action JournalAction
+			err = d.Decode(&action)
+			if err != nil {
+				return fmt.Errorf("journal action: %v", err)
+			}
+
+			switch action.Action {
+			case journalActionAdd:
+				var cvj CastDCCVoteJournal
+				err = d.Decode(&cvj)
+				if err != nil {
+					return fmt.Errorf("journal add: %v",
+						err)
+				}
+				cv = append(cv, cvj.CastVote)
+
+			default:
+				return fmt.Errorf("invalid action: %v",
+					action.Action)
+			}
+			return nil
+		})
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+	}
+
+	return cv, nil
+}
+
+// pluginDCCVotes tallies all votes for a dcc. We can run the tally
+// unlocked and just replay the journal. If the replay becomes an issue we
+// could cache it. The Vote that is returned does have to be locked.
+func (g *gitBackEnd) pluginDCCVotes(payload string) (string, error) {
+	log.Tracef("pluginDCCVotes: %v", payload)
+
+	vote, err := cmsplugin.DecodeVoteResults([]byte(payload))
+	if err != nil {
+		return "", fmt.Errorf("DecodeVoteResults %v", err)
+	}
+
+	// Verify proposal exists, we can run this lockless
+	if !g.vettedPropExists(vote.Token) {
+		return "", fmt.Errorf("proposal not found: %v", vote.Token)
+	}
+
+	// This portion is must run locked
+
+	g.Lock()
+	defer g.Unlock()
+
+	if g.shutdown {
+		return "", backend.ErrShutdown
+	}
+
+	// Prepare reply
+	var vrr cmsplugin.VoteResultsReply
+
+	// Fill out cast votes
+	vrr.CastVotes, err = g.tallyDCCVotes(vote.Token)
+	if err != nil {
+		return "", fmt.Errorf("Could not tally votes: %v", err)
+	}
+
+	// git checkout master
+	err = g.gitCheckout(g.vetted, "master")
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare reply
+	var (
+		dd *json.Decoder
+		ff *os.File
+	)
+	// Fill out vote
+	filename := mdFilename(g.vetted, vote.Token,
+		cmsplugin.MDStreamVoteBits)
+	ff, err = os.Open(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			goto nodata
+		}
+		return "", err
+	}
+	defer ff.Close()
+	dd = json.NewDecoder(ff)
+
+	err = dd.Decode(&vrr.StartVote)
+	if err != nil {
+		if err == io.EOF {
+			goto nodata
+		}
+		return "", err
+	}
+
+nodata:
+	reply, err := cmsplugin.EncodeVoteResultsReply(vrr)
+	if err != nil {
+		return "", fmt.Errorf("Could not encode VoteResultsReply: %v",
+			err)
+	}
+
+	return string(reply), nil
+}
+
+// pluginCMSInventory returns the cms plugin inventory for all dccs.  The
+// inventory consists vote details, and cast votes.
+func (g *gitBackEnd) pluginCMSInventory() (string, error) {
+	log.Tracef("pluginInventory")
+
+	g.Lock()
+	defer g.Unlock()
+
+	// Ensure journal has been replayed
+	if !journalsReplayed {
+		return "", backend.ErrJournalsNotReplayed
+	}
+
+	// Walk vetted repo and compile all file paths
+	paths := make([]string, 0, 2048) // PNOOMA
+	err := filepath.Walk(g.vetted,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			paths = append(paths, path)
+			return nil
+		})
+	if err != nil {
+		return "", fmt.Errorf("walk vetted: %v", err)
+	}
+
+	// Filter out the file paths for authorize vote metadata and
+	// start vote metadata
+	svPaths := make([]string, 0, len(paths))
+	svFile := fmt.Sprintf("%02v%v", cmsplugin.MDStreamVoteBits,
+		defaultMDFilenameSuffix)
+	for _, v := range paths {
+		switch filepath.Base(v) {
+		case svFile:
+			svPaths = append(svPaths, v)
+		}
+	}
+
+	// Compile the start vote tuples. The in-memory caches that
+	// contain the vote bits and the vote snapshots are lazy
+	// loaded so we have to read vote metadata directly from disk.
+	svt := make([]cmsplugin.StartVoteTuple, 0, len(cmsPluginVoteCache))
+	for _, v := range svPaths {
+		// Read vote bits file into memory
+		b, err := ioutil.ReadFile(v)
+		if err != nil {
+			return "", fmt.Errorf("ReadFile %v: %v", v, err)
+		}
+
+		// Decode vote bits
+		sv, err := cmsplugin.DecodeStartVote(b)
+		if err != nil {
+			return "", fmt.Errorf("DecodeStartVote: %v", err)
+		}
+
+		// Read vote snapshot file into memory
+		dir := filepath.Dir(v)
+		filename := fmt.Sprintf("%02v%v", cmsplugin.MDStreamVoteSnapshot,
+			defaultMDFilenameSuffix)
+		path := filepath.Join(dir, filename)
+		b, err = ioutil.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("ReadFile %v: %v", path, err)
+		}
+
+		// Decode vote snapshot
+		svr, err := cmsplugin.DecodeStartVoteReply(b)
+		if err != nil {
+			return "", fmt.Errorf("DecodeStartVoteReply: %v", err)
+		}
+
+		// Create start vote tuple
+		svt = append(svt, cmsplugin.StartVoteTuple{
+			StartVote:      *sv,
+			StartVoteReply: *svr,
+		})
+	}
+
+	// Compile cast votes. The in-memory votes cache does not
+	// store the full cast vote struct so we need to replay the
+	// vote journals.
+
+	// Walk journals directory and tally votes for all ballot
+	// journals that are found.
+	cv := make([][]cmsplugin.CastVote, 0, len(svt))
+	err = filepath.Walk(g.journals,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if info.Name() == defaultBallotFilename {
+				token := filepath.Base(filepath.Dir(path))
+				votes, err := g.tallyDCCVotes(token)
+				if err != nil {
+					return fmt.Errorf("tallyDCCVotes %v: %v", token, err)
+				}
+
+				cv = append(cv, votes)
+			}
+
+			return nil
+		})
+	if err != nil {
+		return "", fmt.Errorf("walk journals: %v", err)
+	}
+
+	var count = 0
+	for _, v := range cv {
+		count += len(v)
+	}
+	votes := make([]cmsplugin.CastVote, 0, count)
+	for _, v := range cv {
+		votes = append(votes, v...)
+	}
+
+	// Prepare reply
+	ir := cmsplugin.InventoryReply{
+		StartVoteTuples: svt,
+		CastVotes:       votes,
+	}
+
+	payload, err := cmsplugin.EncodeInventoryReply(ir)
+	if err != nil {
+		return "", fmt.Errorf("EncodeInventoryReply: %v", err)
+	}
+
+	return string(payload), nil
+}

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/politeia/cmsplugin"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiad/backend"
@@ -320,7 +319,7 @@ func (g *gitBackEnd) pluginStartDCCVote(payload string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("DecodeStartVote %v", err)
 	}
-	spew.Dump(vote)
+
 	// Verify vote bits are somewhat sane
 	for _, v := range vote.Vote.Options {
 		err = _validateCMSVoteBit(vote.Vote.Options, vote.Vote.Mask, v.Bits)

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -520,7 +520,7 @@ func _validateCMSVoteBit(options []cmsplugin.VoteOption, mask uint64, bit uint64
 		if v.Id != cmsplugin.DCCApprovalString &&
 			v.Id != cmsplugin.DCCDisapprovalString {
 			return invalidVoteBitError{
-				err: fmt.Errorf("bit option not valid found: ", v.Id),
+				err: fmt.Errorf("bit option not valid found: %s", v.Id),
 			}
 		}
 	}

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -81,21 +81,6 @@ func getCMSPlugin(testnet bool) backend.Plugin {
 		Settings: []backend.PluginSetting{},
 	}
 
-	if testnet {
-		cmsPlugin.Settings = append(cmsPlugin.Settings,
-			backend.PluginSetting{
-				Key:   "dcrdata",
-				Value: "https://testnet.dcrdata.org:443/",
-			},
-		)
-	} else {
-		cmsPlugin.Settings = append(cmsPlugin.Settings,
-			backend.PluginSetting{
-				Key:   "dcrdata",
-				Value: "https://explorer.dcrdata.org:443/",
-			})
-	}
-
 	// This setting is used to tell politeiad how to retrieve the
 	// decred plugin data that is required to build the external
 	// politeiad cache.

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -60,8 +60,7 @@ var (
 	cmsPluginHooks    map[string]func(string) error // [key]func(token) error
 
 	// Cached values, requires lock. These caches are lazy loaded.
-	// XXX why is this a pointer? Convert if possible after investigating
-	cmsPluginVoteCache         = make(map[string]*cmsplugin.StartVote)     // [token]startvote
+	cmsPluginVoteCache         = make(map[string]cmsplugin.StartVote)      // [token]startvote
 	cmsPluginVoteSnapshotCache = make(map[string]cmsplugin.StartVoteReply) // [token]StartVoteReply
 
 	// Plugin specific data that CANNOT be treated as metadata
@@ -74,33 +73,6 @@ var (
 	// ineligible userid.
 	errIneligibleUserID = errors.New("ineligible userid")
 )
-
-// init is used to pregenerate the JSON journal actions.
-func init() {
-	var err error
-
-	journalAdd, err = json.Marshal(JournalAction{
-		Version: journalVersion,
-		Action:  journalActionAdd,
-	})
-	if err != nil {
-		panic(err.Error())
-	}
-	journalDel, err = json.Marshal(JournalAction{
-		Version: journalVersion,
-		Action:  journalActionDel,
-	})
-	if err != nil {
-		panic(err.Error())
-	}
-	journalAddLike, err = json.Marshal(JournalAction{
-		Version: journalVersion,
-		Action:  journalActionAddLike,
-	})
-	if err != nil {
-		panic(err.Error())
-	}
-}
 
 func getCMSPlugin(testnet bool) backend.Plugin {
 	cmsPlugin := backend.Plugin{
@@ -429,7 +401,7 @@ func (g *gitBackEnd) pluginStartDCCVote(payload string) (string, error) {
 
 	// Add version to on disk structure
 	vote.Version = cmsplugin.VersionStartVote
-	voteb, err := cmsplugin.EncodeStartVote(*vote)
+	voteb, err := cmsplugin.EncodeStartVote(vote)
 	if err != nil {
 		return "", fmt.Errorf("EncodeStartVote: %v", err)
 	}
@@ -1125,8 +1097,8 @@ func (g *gitBackEnd) pluginCMSInventory() (string, error) {
 
 		// Create start vote tuple
 		svt = append(svt, cmsplugin.StartVoteTuple{
-			StartVote:      *sv,
-			StartVoteReply: *svr,
+			StartVote:      sv,
+			StartVoteReply: svr,
 		})
 	}
 

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/politeia/cmsplugin"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiad/backend"
@@ -319,7 +320,7 @@ func (g *gitBackEnd) pluginStartDCCVote(payload string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("DecodeStartVote %v", err)
 	}
-
+	spew.Dump(vote)
 	// Verify vote bits are somewhat sane
 	for _, v := range vote.Vote.Options {
 		err = _validateCMSVoteBit(vote.Vote.Options, vote.Vote.Mask, v.Bits)

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -368,7 +368,6 @@ func (g *gitBackEnd) pluginStartDCCVote(payload string) (string, error) {
 	// This will become the format "userid+weight"
 	eligbleUsers := make([]string, len(vote.UserWeights))
 	for i, uw := range vote.UserWeights {
-		fmt.Println(i, uw, len(vote.UserWeights))
 		eligbleUsers[i] = uw.UserID + "," + strconv.Itoa(int(uw.Weight))
 	}
 

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -416,15 +416,11 @@ func (g *gitBackEnd) pluginStartDCCVote(payload string) (string, error) {
 	}
 
 	svr := cmsplugin.StartVoteReply{
-		Version: cmsplugin.VersionStartVoteReply,
-		StartBlockHeight: strconv.FormatUint(uint64(startVoteBlock.Height),
-			10),
-		StartBlockHash: startVoteBlock.Hash,
-		// On EndHeight: we start in the past, add maturity to correct
-		EndHeight: strconv.FormatUint(uint64(startVoteBlock.Height+
-			vote.Vote.Duration+
-			uint32(g.activeNetParams.TicketMaturity)), 10),
-		EligibleUsers: eligbleUsers,
+		Version:          cmsplugin.VersionStartVoteReply,
+		StartBlockHeight: startVoteBlock.Height,
+		StartBlockHash:   startVoteBlock.Hash,
+		EndHeight:        startVoteBlock.Height + vote.Vote.Duration,
+		EligibleUsers:    eligbleUsers,
 	}
 	svrb, err := cmsplugin.EncodeStartVoteReply(svr)
 	if err != nil {
@@ -713,12 +709,7 @@ func (g *gitBackEnd) dccVoteEndHeight(token string) (uint32, error) {
 		svr = *s
 	}
 
-	endHeight, err := strconv.ParseUint(svr.EndHeight, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-
-	return uint32(endHeight), nil
+	return svr.EndHeight, nil
 }
 
 // writeVote writes the provided vote to the provided journal file path, if the

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -517,6 +517,12 @@ func _validateCMSVoteBit(options []cmsplugin.VoteOption, mask uint64, bit uint64
 		if v.Bits == bit {
 			return nil
 		}
+		if v.Id != cmsplugin.DCCApprovalString &&
+			v.Id != cmsplugin.DCCDisapprovalString {
+			return invalidVoteBitError{
+				err: fmt.Errorf("bit option not valid found: ", v.Id),
+			}
+		}
 	}
 	return invalidVoteBitError{
 		err: fmt.Errorf("bit not found 0x%x", bit),

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2814,10 +2814,13 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 		setDecredPluginSetting(decredPluginVoteDurationMin, voteDurationMin)
 		setDecredPluginSetting(decredPluginVoteDurationMax, voteDurationMax)
 	case cmsMode:
-		g.plugins = []backend.Plugin{getDecredPlugin(dcrdataHost), getCMSPlugin(anp.Name != "mainnet")}
+		g.plugins = []backend.Plugin{getDecredPlugin(dcrdataHost),
+			getCMSPlugin(anp.Name != "mainnet")}
 
 		setCMSPluginSetting(cmsPluginIdentity, string(idJSON))
 		setCMSPluginSetting(cmsPluginJournals, g.journals)
+	default:
+		return nil, fmt.Errorf("invalid mode")
 	}
 
 	setDecredPluginSetting(decredPluginIdentity, string(idJSON))

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -27,6 +27,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	v1 "github.com/decred/dcrtime/api/v1"
 	"github.com/decred/dcrtime/merkle"
+	"github.com/decred/politeia/cmsplugin"
 	"github.com/decred/politeia/decredplugin"
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
@@ -2616,6 +2617,12 @@ func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
 	case decredplugin.CmdLoadVoteResults:
 		payload, err := g.pluginLoadVoteResults()
 		return decredplugin.CmdLoadVoteResults, payload, err
+	case cmsplugin.CmdStartVote:
+		payload, err := g.pluginStartDCCVote(payload)
+		return cmsplugin.CmdStartVote, payload, err
+	case cmsplugin.CmdCastVote:
+		payload, err := g.pluginCastVote(payload)
+		return cmsplugin.CmdCastVote, payload, err
 	}
 	return "", "", fmt.Errorf("invalid payload command") // XXX this needs to become a type error
 }
@@ -2759,7 +2766,8 @@ func (g *gitBackEnd) rebasePR(id string) error {
 }
 
 // New returns a gitBackEnd context.  It verifies that git is installed.
-func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, id *identity.FullIdentity, gitTrace bool, dcrdataHost string) (*gitBackEnd, error) {
+func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, id *identity.FullIdentity, gitTrace bool, dcrdataHost string, cmsMode bool) (*gitBackEnd, error) {
+
 	// Default to system git
 	if gitPath == "" {
 		gitPath = "git"
@@ -2780,25 +2788,34 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 		testAnchors:     make(map[string]bool),
 		plugins:         []backend.Plugin{getDecredPlugin(dcrdataHost)},
 	}
+
 	idJSON, err := id.Marshal()
 	if err != nil {
 		return nil, err
 	}
 
-	// Setup decred plugin settings
-	var voteDurationMin, voteDurationMax string
-	switch anp.Name {
-	case chaincfg.MainNetParams.Name:
-		voteDurationMin = strconv.Itoa(decredplugin.VoteDurationMinMainnet)
-		voteDurationMax = strconv.Itoa(decredplugin.VoteDurationMaxMainnet)
-	case chaincfg.TestNet3Params.Name:
-		voteDurationMin = strconv.Itoa(decredplugin.VoteDurationMinTestnet)
-		voteDurationMax = strconv.Itoa(decredplugin.VoteDurationMaxTestnet)
-	default:
-		return nil, fmt.Errorf("unknown chaincfg params '%v'", anp.Name)
+	if !cmsMode {
+		// Setup decred plugin settings
+		var voteDurationMin, voteDurationMax string
+		switch anp.Name {
+		case chaincfg.MainNetParams.Name:
+			voteDurationMin = strconv.Itoa(decredplugin.VoteDurationMinMainnet)
+			voteDurationMax = strconv.Itoa(decredplugin.VoteDurationMaxMainnet)
+		case chaincfg.TestNet3Params.Name:
+			voteDurationMin = strconv.Itoa(decredplugin.VoteDurationMinTestnet)
+			voteDurationMax = strconv.Itoa(decredplugin.VoteDurationMaxTestnet)
+		default:
+			return nil, fmt.Errorf("unknown chaincfg params '%v'", anp.Name)
+		}
+		setDecredPluginSetting(decredPluginVoteDurationMin, voteDurationMin)
+		setDecredPluginSetting(decredPluginVoteDurationMax, voteDurationMax)
+	} else {
+		g.plugins = []backend.Plugin{getDecredPlugin(dcrdataHost), getCMSPlugin(anp.Name != "mainnet")}
+
+		setCMSPluginSetting(cmsPluginIdentity, string(idJSON))
+		setCMSPluginSetting(cmsPluginJournals, g.journals)
 	}
-	setDecredPluginSetting(decredPluginVoteDurationMin, voteDurationMin)
-	setDecredPluginSetting(decredPluginVoteDurationMax, voteDurationMax)
+
 	setDecredPluginSetting(decredPluginIdentity, string(idJSON))
 	setDecredPluginSetting(decredPluginJournals, g.journals)
 	setDecredPluginHook(PluginPostHookEdit, g.decredPluginPostEdit)
@@ -2819,6 +2836,14 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 		return nil, err
 	}
 
+	if cmsMode {
+		// this function must be called after g.journal is created
+		err = g.initCMSPluginJournals()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	err = g.newLocked()
 	if err != nil {
 		return nil, err
@@ -2835,6 +2860,10 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 	err = g.cron.AddFunc(anchorSchedule, func() {
 		// Flush journals
 		g.decredPluginJournalFlusher()
+
+		if cmsMode {
+			g.cmsPluginJournalFlusher()
+		}
 
 		// Anchor commit
 		g.anchorAllReposCronJob()

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -88,6 +88,9 @@ const (
 	// where an anchor confirmation has been committed.  This value is
 	// parsed and therefore must be a const.
 	markerAnchorConfirmation = "Anchor confirmation"
+
+	piMode  = "piwww"
+	cmsMode = "cmswww"
 )
 
 var (
@@ -2766,7 +2769,7 @@ func (g *gitBackEnd) rebasePR(id string) error {
 }
 
 // New returns a gitBackEnd context.  It verifies that git is installed.
-func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, id *identity.FullIdentity, gitTrace bool, dcrdataHost string, cmsMode bool) (*gitBackEnd, error) {
+func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, id *identity.FullIdentity, gitTrace bool, dcrdataHost string, mode string) (*gitBackEnd, error) {
 
 	// Default to system git
 	if gitPath == "" {
@@ -2794,7 +2797,8 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 		return nil, err
 	}
 
-	if !cmsMode {
+	switch mode {
+	case piMode:
 		// Setup decred plugin settings
 		var voteDurationMin, voteDurationMax string
 		switch anp.Name {
@@ -2809,7 +2813,7 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 		}
 		setDecredPluginSetting(decredPluginVoteDurationMin, voteDurationMin)
 		setDecredPluginSetting(decredPluginVoteDurationMax, voteDurationMax)
-	} else {
+	case cmsMode:
 		g.plugins = []backend.Plugin{getDecredPlugin(dcrdataHost), getCMSPlugin(anp.Name != "mainnet")}
 
 		setCMSPluginSetting(cmsPluginIdentity, string(idJSON))
@@ -2836,7 +2840,7 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 		return nil, err
 	}
 
-	if cmsMode {
+	if mode == cmsMode {
 		// this function must be called after g.journal is created
 		err = g.initCMSPluginJournals()
 		if err != nil {
@@ -2861,7 +2865,7 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 		// Flush journals
 		g.decredPluginJournalFlusher()
 
-		if cmsMode {
+		if mode == cmsMode {
 			g.cmsPluginJournalFlusher()
 		}
 

--- a/politeiad/backend/gitbe/gitbe_test.go
+++ b/politeiad/backend/gitbe/gitbe_test.go
@@ -66,7 +66,7 @@ func TestAnchorWithCommits(t *testing.T) {
 
 	// Initialize stuff we need
 	g, err := New(&chaincfg.TestNet3Params, dir, "", "", nil,
-		testing.Verbose(), "", false)
+		testing.Verbose(), "", "piwww")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +466,7 @@ func TestUpdateReadme(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	g, err := New(&chaincfg.TestNet3Params, dir, "", "", nil,
-		testing.Verbose(), "", false)
+		testing.Verbose(), "", "piwww")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/politeiad/backend/gitbe/gitbe_test.go
+++ b/politeiad/backend/gitbe/gitbe_test.go
@@ -66,7 +66,7 @@ func TestAnchorWithCommits(t *testing.T) {
 
 	// Initialize stuff we need
 	g, err := New(&chaincfg.TestNet3Params, dir, "", "", nil,
-		testing.Verbose(), "")
+		testing.Verbose(), "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +466,7 @@ func TestUpdateReadme(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	g, err := New(&chaincfg.TestNet3Params, dir, "", "", nil,
-		testing.Verbose(), "")
+		testing.Verbose(), "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/politeiad/cache/cockroachdb/cms.go
+++ b/politeiad/cache/cockroachdb/cms.go
@@ -56,7 +56,7 @@ func (c *cms) cmdStartVote(cmdPayload, replyPayload string) (string, error) {
 		return "", err
 	}
 
-	s := convertStartVoteFromCMS(*sv, *svr, svr.EndHeight)
+	s := convertStartVoteFromCMS(sv, svr, svr.EndHeight)
 	err = c.newStartDCCVote(c.recordsdb, s)
 	if err != nil {
 		return "", err

--- a/politeiad/cache/cockroachdb/cms.go
+++ b/politeiad/cache/cockroachdb/cms.go
@@ -323,12 +323,9 @@ func (c *cms) newVoteResults(token string) error {
 	quorum := uint64(int(sv.QuorumPercentage) / 100 * len(eligible))
 	pass := uint64(float64(sv.PassPercentage) / 100 * float64(total))
 
-	// XXX: this only supports proposals with yes/no
-	// voting options. Multiple voting option support
-	// will need to be added in the future.
 	var approvedVotes uint64
 	for _, v := range results {
-		if v.Option.ID == voteOptionIDApproved {
+		if v.Option.ID == cmsplugin.DCCApprovalString {
 			approvedVotes = v.Votes
 		}
 	}

--- a/politeiad/cache/cockroachdb/cms.go
+++ b/politeiad/cache/cockroachdb/cms.go
@@ -1,0 +1,834 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package cockroachdb
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/decred/politeia/cmsplugin"
+	"github.com/decred/politeia/politeiad/cache"
+	"github.com/jinzhu/gorm"
+)
+
+const (
+	// cmsVersion is the version of the cache implementation of
+	// cms plugin. This may differ from the cmsplugin package
+	// version.
+	cmsVersion = "1"
+
+	tableCastDCCVotes         = "cast_dcc_votes"
+	tableStartDCCVotes        = "start_dcc_votes"
+	tableDCCUserWeights       = "user_weights"
+	tableVoteDCCOptionResults = "vote_dcc_options_results"
+	tableVoteDCCOptions       = "vote_dcc_options"
+	tableVoteDCCResults       = "vote_dcc_results"
+)
+
+// cms implements the PluginDriver interface.
+type cms struct {
+	recordsdb *gorm.DB              // Database context
+	version   string                // Version of cms cache plugin
+	settings  []cache.PluginSetting // Plugin settings
+}
+
+// newStartDCCVote inserts a StartDCCVote record into the database.  This function
+// has a database parameter so that it can be called inside of a transaction
+// when required.
+func (c *cms) newStartDCCVote(db *gorm.DB, sv StartDCCVote) error {
+	return db.Create(&sv).Error
+}
+
+// cmdStartVote creates a StartDCCVote record using the passed in payloads and
+// inserts it into the database.
+func (c *cms) cmdStartVote(cmdPayload, replyPayload string) (string, error) {
+	log.Tracef("cms cmdStartDCCVote")
+
+	sv, err := cmsplugin.DecodeStartVote([]byte(cmdPayload))
+	if err != nil {
+		return "", err
+	}
+	svr, err := cmsplugin.DecodeStartVoteReply([]byte(replyPayload))
+	if err != nil {
+		return "", err
+	}
+
+	endHeight, err := strconv.ParseUint(svr.EndHeight, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("parse end height '%v': %v",
+			svr.EndHeight, err)
+	}
+
+	s := convertStartVoteFromCMS(*sv, *svr, endHeight)
+	err = c.newStartDCCVote(c.recordsdb, s)
+	if err != nil {
+		return "", err
+	}
+
+	return replyPayload, nil
+}
+
+// cmdVoteDetails returns the StartDCCVote records for the
+// passed in record token.
+func (c *cms) cmdVoteDetails(payload string) (string, error) {
+	log.Tracef("cms cmdDCCVoteDetails")
+
+	vd, err := cmsplugin.DecodeVoteDetails([]byte(payload))
+	if err != nil {
+		return "", nil
+	}
+
+	// Lookup the most recent version of the record
+	var r Record
+	err = c.recordsdb.
+		Where("records.token = ?", vd.Token).
+		Order("records.version desc").
+		Limit(1).
+		Find(&r).
+		Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			err = cache.ErrRecordNotFound
+		}
+		return "", err
+	}
+
+	// Lookup start vote
+	var sv StartDCCVote
+	err = c.recordsdb.
+		Where("token = ?", vd.Token).
+		Preload("Options").
+		Preload("EligibleUserIDs").
+		Find(&sv).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		// A start vote may note exist. This is ok.
+	} else if err != nil {
+		return "", fmt.Errorf("start vote lookup failed: %v", err)
+	}
+
+	// Prepare reply
+	dsv, dsvr := convertStartVoteToCMS(sv)
+	vdr := cmsplugin.VoteDetailsReply{
+		StartVote:      dsv,
+		StartVoteReply: dsvr,
+	}
+	vdrb, err := cmsplugin.EncodeVoteDetailsReply(vdr)
+	if err != nil {
+		return "", err
+	}
+
+	return string(vdrb), nil
+}
+
+// cmdCastVote creates CastVote records using the passed in payloads and
+// inserts them into the database.
+func (c *cms) cmdCastVote(cmdPayload, replyPayload string) (string, error) {
+	log.Tracef("cms cmdNewCastVote")
+
+	b, err := cmsplugin.DecodeCastVote([]byte(cmdPayload))
+	if err != nil {
+		return "", err
+	}
+
+	if b.Signature == "" {
+		log.Debugf("cmdNewCastVote: vote receipt not found %v %v",
+			b.Token, b.UserID)
+		return "", nil
+	}
+	cv := convertCastVoteFromCMS(*b)
+	err = c.recordsdb.Create(&cv).Error
+	if err != nil {
+		return "", err
+	}
+
+	return replyPayload, nil
+}
+
+// cmdProposalVotes returns the StartVote record and all CastVote records for
+// the passed in record token.
+func (c *cms) cmdDCCVotes(payload string) (string, error) {
+	log.Tracef("cms cmdProposalVotes")
+
+	vr, err := cmsplugin.DecodeVoteResults([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	// Lookup start vote
+	var sv StartDCCVote
+	err = c.recordsdb.
+		Where("token = ?", vr.Token).
+		Preload("Options").
+		Find(&sv).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		// A start vote may note exist if the voting period has not
+		// been started yet. This is ok.
+	} else if err != nil {
+		return "", fmt.Errorf("start vote lookup failed: %v", err)
+	}
+
+	// Lookup all cast votes
+	var cv []CastDCCVote
+	err = c.recordsdb.
+		Where("token = ?", vr.Token).
+		Find(&cv).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		// No cast votes may exist yet. This is ok.
+	} else if err != nil {
+		return "", fmt.Errorf("cast votes lookup failed: %v", err)
+	}
+
+	// Prepare reply
+	dsv, _ := convertStartVoteToCMS(sv)
+	dcv := make([]cmsplugin.CastVote, 0, len(cv))
+	for _, v := range cv {
+		dcv = append(dcv, convertCastVoteToCMS(v))
+	}
+
+	vrr := cmsplugin.VoteResultsReply{
+		StartVote: dsv,
+		CastVotes: dcv,
+	}
+
+	vrrb, err := cmsplugin.EncodeVoteResultsReply(vrr)
+	if err != nil {
+		return "", err
+	}
+
+	return string(vrrb), nil
+}
+
+// cmdInventory returns the cms plugin inventory.
+func (c *cms) cmdInventory() (string, error) {
+	log.Tracef("cms cmdInventory")
+
+	// XXX we don't currently return anything for inventory here
+
+	return "", nil
+}
+
+// cmdLoadVoteResults creates vote results entries for any dccs that have
+// a finished voting period but have not yet been added to the vote results
+// table. The vote results table is lazy loaded.
+func (c *cms) cmdLoadVoteResults(payload string) (string, error) {
+	log.Tracef("cmdLoadVoteResults")
+
+	lvs, err := cmsplugin.DecodeLoadVoteResults([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	// Find dccs that have a finished voting period but
+	// have not yet been added to the vote results table.
+	q := `SELECT start__dcc_votes.token
+        FROM start_dcc_votes
+        LEFT OUTER JOIN vote_dcc_results
+          ON start_dcc_votes.token = vote_dcc_results.token
+          WHERE start_dcc_votes.end_height <= ?
+          AND vote_dcc_results.token IS NULL`
+	rows, err := c.recordsdb.Raw(q, lvs.BestBlock).Rows()
+	if err != nil {
+		return "", fmt.Errorf("no vote results: %v", err)
+	}
+	defer rows.Close()
+
+	var token string
+	tokens := make([]string, 0, 1024)
+	for rows.Next() {
+		err = rows.Scan(&token)
+		if err != nil {
+			return "", err
+		}
+		tokens = append(tokens, token)
+	}
+	if err = rows.Err(); err != nil {
+		return "", err
+	}
+
+	// Create vote result entries
+	for _, v := range tokens {
+		err := c.newVoteResults(v)
+		if err != nil {
+			return "", fmt.Errorf("newVoteResults %v: %v", v, err)
+		}
+	}
+
+	// Prepare reply
+	r := cmsplugin.LoadVoteResultsReply{}
+	reply, err := cmsplugin.EncodeLoadVoteResultsReply(r)
+	if err != nil {
+		return "", err
+	}
+
+	return string(reply), nil
+}
+
+// newVoteResults creates a VoteDCCResults record for a proposal and inserts it
+// into the cache. A VoteDCCResults record should only be created for proposals
+// once the voting period has ended.
+func (c *cms) newVoteResults(token string) error {
+	log.Tracef("newVoteResults %v", token)
+
+	// Lookup start vote
+	var sv StartDCCVote
+	err := c.recordsdb.
+		Where("token = ?", token).
+		Preload("Options").
+		Find(&sv).
+		Error
+	if err != nil {
+		return fmt.Errorf("lookup start vote: %v", err)
+	}
+
+	// Lookup cast votes
+	var cv []CastDCCVote
+	err = c.recordsdb.
+		Where("token = ?", token).
+		Find(&cv).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		// No cast votes exists. In theory, this could
+		// happen if no one were to vote on a proposal.
+		// In practice, this shouldn't happen.
+	} else if err != nil {
+		return fmt.Errorf("lookup cast votes: %v", err)
+	}
+
+	// Tally cast votes
+	tally := make(map[string]uint64) // [voteBit]voteCount
+	for _, v := range cv {
+		tally[v.VoteBit]++
+	}
+
+	// Create vote option results
+	results := make([]VoteDCCOptionResult, 0, len(sv.Options))
+	for _, v := range sv.Options {
+		voteBit := strconv.FormatUint(v.Bits, 16)
+		voteCount := tally[voteBit]
+
+		results = append(results, VoteDCCOptionResult{
+			Key:    token + voteBit,
+			Votes:  voteCount,
+			Option: v,
+		})
+	}
+
+	// Check whether vote was approved
+	var total uint64
+	for _, v := range results {
+		total += v.Votes
+	}
+
+	eligible := sv.EligibleUserIDs
+	quorum := uint64(int(sv.QuorumPercentage) / 100 * len(eligible))
+	pass := uint64(float64(sv.PassPercentage) / 100 * float64(total))
+
+	// XXX: this only supports proposals with yes/no
+	// voting options. Multiple voting option support
+	// will need to be added in the future.
+	var approvedVotes uint64
+	for _, v := range results {
+		if v.Option.ID == voteOptionIDApproved {
+			approvedVotes = v.Votes
+		}
+	}
+
+	var approved bool
+	switch {
+	case total < quorum:
+		// Quorum not met
+	case approvedVotes < pass:
+		// Pass percentage not met
+	default:
+		// Vote was approved
+		approved = true
+	}
+
+	// Create a vote results entry
+	err = c.recordsdb.Create(&VoteDCCResults{
+		Token:    token,
+		Approved: approved,
+		Results:  results,
+	}).Error
+	if err != nil {
+		return fmt.Errorf("new vote results: %v", err)
+	}
+
+	return nil
+}
+
+// getStartVotes looks up the start votes for records which have been
+// authorized to start voting.
+func (c *cms) getStartVotes(records map[string]Record) (map[string]StartDCCVote, error) {
+	startVotes := make(map[string]StartDCCVote)
+
+	if len(records) == 0 {
+		return startVotes, nil
+	}
+
+	keys := make([]string, 0, len(records))
+	for token, record := range records {
+		keys = append(keys, token+strconv.FormatUint(record.Version, 10))
+	}
+
+	svs := make([]StartDCCVote, 0, len(keys))
+	err := c.recordsdb.
+		Where("key IN (?)", keys).
+		Preload("Options").
+		Find(&svs).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	for _, sv := range svs {
+		startVotes[sv.Token] = sv
+	}
+
+	return startVotes, nil
+}
+
+// lookupResultsForVoteDCCOptions looks in the CastDCCVote table to see how many
+// votes each option has received.
+func (c *cms) lookupResultsForVoteDCCOptions(options []VoteDCCOption) ([]cmsplugin.VoteOptionResult, error) {
+	results := make([]cmsplugin.VoteOptionResult, 0, len(options))
+
+	for _, v := range options {
+		var votes uint64
+		tokenVoteBit := v.Token + strconv.FormatUint(v.Bits, 16)
+		err := c.recordsdb.
+			Model(&CastDCCVote{}).
+			Where("token_vote_bit = ?", tokenVoteBit).
+			Count(&votes).
+			Error
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results,
+			cmsplugin.VoteOptionResult{
+				ID:          v.ID,
+				Description: v.Description,
+				Bits:        v.Bits,
+				Votes:       votes,
+			})
+	}
+
+	return results, nil
+}
+
+// getVoteResults retrieves vote results for records that have begun the voting
+// process. Results are lazily loaded into this table, so some results are
+// manually looked up in the CastDCCVote table.
+func (c *cms) getVoteResults(startVotes map[string]StartDCCVote) (map[string][]cmsplugin.VoteOptionResult, error) {
+	results := make(map[string][]cmsplugin.VoteOptionResult)
+
+	if len(startVotes) == 0 {
+		return results, nil
+	}
+
+	tokens := make([]string, 0, len(startVotes))
+	for token := range startVotes {
+		tokens = append(tokens, token)
+	}
+
+	vrs := make([]VoteResults, 0, len(tokens))
+	err := c.recordsdb.
+		Where("token IN (?)", tokens).
+		Preload("Results").
+		Preload("Results.Option").
+		Find(&vrs).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vr := range vrs {
+		results[vr.Token] = convertVoteOptionResultsToCMS(vr.Results)
+	}
+
+	for token, sv := range startVotes {
+		_, ok := results[token]
+		if ok {
+			continue
+		}
+
+		res, err := c.lookupResultsForVoteDCCOptions(sv.Options)
+		if err != nil {
+			return nil, err
+		}
+
+		results[token] = res
+	}
+
+	return results, nil
+}
+
+func (c *cms) cmdVoteSummary(payload string) (string, error) {
+	log.Tracef("cms cmdVoteSummary")
+
+	vs, err := cmsplugin.DecodeVoteSummary([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	// Lookup the most recent record version
+	var r Record
+	err = c.recordsdb.
+		Where("records.token = ?", vs.Token).
+		Order("records.version desc").
+		Limit(1).
+		Find(&r).
+		Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			err = cache.ErrRecordNotFound
+		}
+		return "", err
+	}
+
+	// Declare here to prevent goto errors
+	results := make([]cmsplugin.VoteOptionResult, 0, 16)
+	var (
+		sv StartDCCVote
+		vr VoteResults
+	)
+
+	// Lookup start vote
+	err = c.recordsdb.
+		Where("token = ?", vs.Token).
+		Preload("Options").
+		Find(&sv).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		// If an start vote doesn't exist then
+		// there is no need to continue.
+		goto sendReply
+	} else if err != nil {
+		return "", fmt.Errorf("lookup start vote: %v", err)
+	}
+
+	// Lookup vote results
+	err = c.recordsdb.
+		Where("token = ?", vs.Token).
+		Preload("Results").
+		Preload("Results.Option").
+		Find(&vr).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		// A vote results record was not found. This means that
+		// the vote is either still active or has not been lazy
+		// loaded yet. The vote results will need to be looked
+		// up manually.
+	} else if err != nil {
+		return "", fmt.Errorf("lookup vote results: %v", err)
+	} else {
+		// Vote results record exists. We have all of the data
+		// that we need to send the reply.
+		vor := convertVoteOptionResultsToCMS(vr.Results)
+		results = append(results, vor...)
+		goto sendReply
+	}
+
+	// Lookup vote results manually
+	results, err = c.lookupResultsForVoteDCCOptions(sv.Options)
+	if err != nil {
+		return "", fmt.Errorf("count cast votes: %v", err)
+	}
+
+sendReply:
+	// Return "" not "0" if end height doesn't exist
+	var endHeight string
+	if sv.EndHeight != 0 {
+		endHeight = strconv.FormatUint(sv.EndHeight, 10)
+	}
+
+	vsr := cmsplugin.VoteSummaryReply{
+		Duration:       sv.Duration,
+		EndHeight:      endHeight,
+		PassPercentage: sv.PassPercentage,
+		Results:        results,
+	}
+	reply, err := cmsplugin.EncodeVoteSummaryReply(vsr)
+	if err != nil {
+		return "", err
+	}
+
+	return string(reply), nil
+}
+
+// Exec executes a cms plugin command.  Plugin commands that write data to
+// the cache require both the command payload and the reply payload.  Plugin
+// commands that fetch data from the cache require only the command payload.
+// All commands return the appropriate reply payload.
+func (c *cms) Exec(cmd, cmdPayload, replyPayload string) (string, error) {
+	log.Tracef("cms Exec: %v", cmd)
+
+	switch cmd {
+	case cmsplugin.CmdStartVote:
+		return c.cmdStartVote(cmdPayload, replyPayload)
+	case cmsplugin.CmdVoteDetails:
+		return c.cmdVoteDetails(cmdPayload)
+	case cmsplugin.CmdCastVote:
+		return c.cmdCastVote(cmdPayload, replyPayload)
+	case cmsplugin.CmdInventory:
+		return c.cmdInventory()
+	case cmsplugin.CmdVoteSummary:
+		return c.cmdVoteSummary(cmdPayload)
+	case cmsplugin.CmdLoadDCCVoteResults:
+		return c.cmdLoadVoteResults(cmdPayload)
+	}
+
+	return "", cache.ErrInvalidPluginCmd
+}
+
+// createTables creates the cache tables needed by the cms plugin if they do
+// not already exist. A cms plugin version record is inserted into the
+// database during table creation.
+//
+// This function must be called within a transaction.
+func (c *cms) createTables(tx *gorm.DB) error {
+	log.Tracef("createTables")
+
+	if !tx.HasTable(tableCastDCCVotes) {
+		err := tx.CreateTable(&CastDCCVote{}).Error
+		if err != nil {
+			return err
+		}
+	}
+	if !tx.HasTable(tableVoteDCCOptions) {
+		err := tx.CreateTable(&VoteDCCOption{}).Error
+		if err != nil {
+			return err
+		}
+	}
+	if !tx.HasTable(tableStartDCCVotes) {
+		err := tx.CreateTable(&StartDCCVote{}).Error
+		if err != nil {
+			return err
+		}
+	}
+	if !tx.HasTable(tableVoteDCCOptionResults) {
+		err := tx.CreateTable(&VoteDCCOptionResult{}).Error
+		if err != nil {
+			return err
+		}
+	}
+	if !tx.HasTable(tableVoteDCCResults) {
+		err := tx.CreateTable(&VoteDCCResults{}).Error
+		if err != nil {
+			return err
+		}
+	}
+	if !tx.HasTable(tableDCCUserWeights) {
+		err := tx.CreateTable(&DCCUserWeight{}).Error
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check if a cms version record exists. Insert one
+	// if no version record is found.
+	if !tx.HasTable(tableVersions) {
+		// This should never happen
+		return fmt.Errorf("versions table not found")
+	}
+
+	var v Version
+	err := tx.Where("id = ?", cmsplugin.ID).Find(&v).Error
+	if err == gorm.ErrRecordNotFound {
+		err = tx.Create(
+			&Version{
+				ID:        cmsplugin.ID,
+				Version:   cmsVersion,
+				Timestamp: time.Now().Unix(),
+			}).Error
+	}
+
+	return err
+}
+
+// dropTables drops all cms plugin tables from the cache and remove the
+// cms plugin version record.
+//
+// This function must be called within a transaction.
+func (c *cms) dropTables(tx *gorm.DB) error {
+	// Drop cms plugin tables
+	err := tx.DropTableIfExists(tableCastDCCVotes, tableStartDCCVotes,
+		tableVoteDCCOptions, tableVoteDCCOptionResults, tableVoteDCCResults,
+		tableDCCUserWeights).
+		Error
+	if err != nil {
+		return err
+	}
+
+	// Remove cms plugin version record
+	return tx.Delete(&Version{
+		ID: cmsplugin.ID,
+	}).Error
+}
+
+// build the cms plugin cache using the passed in inventory.
+//
+// This function cannot be called using a transaction because it could
+// potentially exceed cockroachdb's transaction size limit.
+func (c *cms) build(ir *cmsplugin.InventoryReply) error {
+	log.Tracef("cms build")
+
+	// Drop all cms plugin tables
+	tx := c.recordsdb.Begin()
+	err := c.dropTables(tx)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("drop tables: %v", err)
+	}
+	err = tx.Commit().Error
+	if err != nil {
+		return err
+	}
+
+	// Create cms plugin tables
+	tx = c.recordsdb.Begin()
+	err = c.createTables(tx)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("create tables: %v", err)
+	}
+	err = tx.Commit().Error
+	if err != nil {
+		return err
+	}
+
+	// Build start vote cache
+	log.Tracef("cms: building start vote cache")
+	for _, v := range ir.StartVoteTuples {
+		endHeight, err := strconv.ParseUint(v.StartVoteReply.EndHeight, 10, 64)
+		if err != nil {
+			log.Debugf("newStartVote failed on '%v'", v)
+			return fmt.Errorf("parse end height '%v': %v",
+				v.StartVoteReply.EndHeight, err)
+		}
+
+		sv := convertStartVoteFromCMS(v.StartVote,
+			v.StartVoteReply, endHeight)
+		err = c.newStartDCCVote(c.recordsdb, sv)
+		if err != nil {
+			log.Debugf("newStartVote failed on '%v'", sv)
+			return fmt.Errorf("newStartVote: %v", err)
+		}
+	}
+
+	// Build cast vote cache
+	log.Tracef("cms: building cast vote cache")
+	for _, v := range ir.CastVotes {
+		cv := convertCastVoteFromCMS(v)
+		err := c.recordsdb.Create(&cv).Error
+		if err != nil {
+			log.Debugf("insert cast vote failed on '%v'", cv)
+			return fmt.Errorf("insert cast vote: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Build drops all existing cms plugin tables from the database, recreates
+// them, then uses the passed in inventory payload to build the cms plugin
+// cache.
+func (c *cms) Build(payload string) error {
+	log.Tracef("cms Build")
+
+	// Decode the payload
+	ir, err := cmsplugin.DecodeInventoryReply([]byte(payload))
+	if err != nil {
+		return fmt.Errorf("DecodeInventoryReply: %v", err)
+	}
+
+	// Build the cms plugin cache. This is not run using
+	// a transaction because it could potentially exceed
+	// cockroachdb's transaction size limit.
+	err = c.build(ir)
+	if err != nil {
+		// Remove the version record. This will
+		// force a rebuild on the next start up.
+		err1 := c.recordsdb.Delete(&Version{
+			ID: cmsplugin.ID,
+		}).Error
+		if err1 != nil {
+			panic("the cache is out of sync and will not rebuild" +
+				"automatically; a rebuild must be forced")
+		}
+	}
+
+	return err
+}
+
+// Setup creates the cms plugin tables if they do not already exist.  A
+// cms plugin version record is inserted into the database during table
+// creation.
+func (c *cms) Setup() error {
+	log.Tracef("cms: Setup")
+
+	tx := c.recordsdb.Begin()
+	err := c.createTables(tx)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit().Error
+}
+
+// CheckVersion retrieves the cms plugin version record from the database,
+// if one exists, and checks that it matches the version of the current cms
+// plugin cache implementation.
+func (c *cms) CheckVersion() error {
+	log.Tracef("cms: CheckVersion")
+
+	// Sanity check. Ensure version table exists.
+	if !c.recordsdb.HasTable(tableVersions) {
+		return fmt.Errorf("versions table not found")
+	}
+
+	// Lookup version record. If the version is not found or
+	// if there is a version mismatch, return an error so
+	// that the cms plugin cache can be built/rebuilt.
+	var v Version
+	err := c.recordsdb.
+		Where("id = ?", cmsplugin.ID).
+		Find(&v).
+		Error
+	if err == gorm.ErrRecordNotFound {
+		log.Debugf("version record not found for ID '%v'",
+			cmsplugin.ID)
+		err = cache.ErrNoVersionRecord
+	} else if v.Version != cmsVersion {
+		log.Debugf("version mismatch for ID '%v': got %v, want %v",
+			cmsplugin.ID, v.Version, cmsVersion)
+		err = cache.ErrWrongVersion
+	}
+
+	return err
+}
+
+// Hook executes the given cms plugin hook.
+func (d *cms) Hook(tx *gorm.DB, hookID, payload string) error {
+	log.Tracef("cms Hook: %v", hookID)
+
+	return nil
+}
+
+// newCMSPlugin returns a cache cms plugin context.
+func newCMSPlugin(db *gorm.DB, p cache.Plugin) *cms {
+	log.Tracef("newCMSPlugin")
+	return &cms{
+		recordsdb: db,
+		version:   cmsVersion,
+		settings:  p.Settings,
+	}
+}

--- a/politeiad/cache/cockroachdb/cockroachdb.go
+++ b/politeiad/cache/cockroachdb/cockroachdb.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/decred/politeia/cmsplugin"
 	"github.com/decred/politeia/decredplugin"
 	"github.com/decred/politeia/politeiad/cache"
 	"github.com/jinzhu/gorm"
@@ -700,6 +701,9 @@ func (c *cockroachdb) RegisterPlugin(p cache.Plugin) error {
 	case decredplugin.ID:
 		pd = newDecredPlugin(c.recordsdb, p)
 		c.plugins[decredplugin.ID] = pd
+	case cmsplugin.ID:
+		pd = newCMSPlugin(c.recordsdb, p)
+		c.plugins[cmsplugin.ID] = pd
 	default:
 		return cache.ErrInvalidPlugin
 	}

--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/decred/politeia/cmsplugin"
 	"github.com/decred/politeia/decredplugin"
 	"github.com/decred/politeia/politeiad/cache"
 )
@@ -404,6 +405,118 @@ func convertVoteOptionResultsToDecred(r []VoteOptionResult) []decredplugin.VoteO
 	results := make([]decredplugin.VoteOptionResult, 0, len(r))
 	for _, v := range r {
 		results = append(results, convertVoteOptionResultToDecred(v))
+	}
+	return results
+}
+
+func convertStartVoteFromCMS(sv cmsplugin.StartVote, svr cmsplugin.StartVoteReply, endHeight uint64) StartDCCVote {
+	opts := make([]VoteDCCOption, 0, len(sv.Vote.Options))
+	for _, v := range sv.Vote.Options {
+		opts = append(opts, VoteDCCOption{
+			Token:       sv.Vote.Token,
+			ID:          v.Id,
+			Description: v.Description,
+			Bits:        v.Bits,
+		})
+	}
+	weights := make([]DCCUserWeight, 0, len(sv.UserWeights))
+	for _, v := range sv.UserWeights {
+		weights = append(weights, DCCUserWeight{
+			Key:    sv.Vote.Token + "-" + v.UserID,
+			Token:  sv.Vote.Token,
+			UserID: v.UserID,
+			Weight: v.Weight,
+		})
+	}
+	return StartDCCVote{
+		Token:            sv.Vote.Token,
+		Mask:             sv.Vote.Mask,
+		Duration:         sv.Vote.Duration,
+		QuorumPercentage: sv.Vote.QuorumPercentage,
+		PassPercentage:   sv.Vote.PassPercentage,
+		Options:          opts,
+		PublicKey:        sv.PublicKey,
+		Signature:        sv.Signature,
+		StartBlockHeight: svr.StartBlockHeight,
+		StartBlockHash:   svr.StartBlockHash,
+		EndHeight:        endHeight,
+		EligibleUserIDs:  weights,
+	}
+}
+
+func convertStartVoteToCMS(sv StartDCCVote) (cmsplugin.StartVote, cmsplugin.StartVoteReply) {
+	opts := make([]cmsplugin.VoteOption, 0, len(sv.Options))
+	for _, v := range sv.Options {
+		opts = append(opts, cmsplugin.VoteOption{
+			Id:          v.ID,
+			Description: v.Description,
+			Bits:        v.Bits,
+		})
+	}
+
+	weights := make([]cmsplugin.UserWeight, 0, len(sv.EligibleUserIDs))
+	for _, v := range sv.EligibleUserIDs {
+		weights = append(weights, cmsplugin.UserWeight{
+			UserID: v.UserID,
+			Weight: v.Weight,
+		})
+	}
+
+	dsv := cmsplugin.StartVote{
+		PublicKey: sv.PublicKey,
+		Signature: sv.Signature,
+		Vote: cmsplugin.Vote{
+			Token:            sv.Token,
+			Mask:             sv.Mask,
+			Duration:         sv.Duration,
+			QuorumPercentage: sv.QuorumPercentage,
+			PassPercentage:   sv.PassPercentage,
+			Options:          opts,
+		},
+		UserWeights: weights,
+	}
+
+	dsvr := cmsplugin.StartVoteReply{
+		StartBlockHeight: sv.StartBlockHeight,
+		StartBlockHash:   sv.StartBlockHash,
+		EndHeight:        fmt.Sprint(sv.EndHeight),
+	}
+
+	return dsv, dsvr
+}
+
+func convertCastVoteFromCMS(cv cmsplugin.CastVote) CastDCCVote {
+	return CastDCCVote{
+		Token:        cv.Token,
+		UserID:       cv.UserID,
+		VoteBit:      cv.VoteBit,
+		Signature:    cv.Signature,
+		TokenVoteBit: cv.Token + cv.VoteBit,
+	}
+}
+
+func convertCastVoteToCMS(cv CastDCCVote) cmsplugin.CastVote {
+	return cmsplugin.CastVote{
+		Token:     cv.Token,
+		UserID:    cv.UserID,
+		VoteBit:   cv.VoteBit,
+		Signature: cv.Signature,
+	}
+}
+
+func convertVoteOptionResultToCMS(r VoteOptionResult) cmsplugin.VoteOptionResult {
+	return cmsplugin.VoteOptionResult{
+		ID:          r.Option.ID,
+		Description: r.Option.Description,
+		Bits:        r.Option.Bits,
+		Votes:       r.Votes,
+	}
+}
+
+func convertVoteOptionResultsToCMS(r []VoteOptionResult) []cmsplugin.VoteOptionResult {
+	results := make([]cmsplugin.VoteOptionResult, 0, len(r))
+	for _, v := range r {
+		results = append(results, convertVoteOptionResultToCMS(v))
 	}
 	return results
 }

--- a/politeiad/cache/cockroachdb/convert.go
+++ b/politeiad/cache/cockroachdb/convert.go
@@ -409,7 +409,7 @@ func convertVoteOptionResultsToDecred(r []VoteOptionResult) []decredplugin.VoteO
 	return results
 }
 
-func convertStartVoteFromCMS(sv cmsplugin.StartVote, svr cmsplugin.StartVoteReply, endHeight uint64) StartDCCVote {
+func convertStartVoteFromCMS(sv cmsplugin.StartVote, svr cmsplugin.StartVoteReply, endHeight uint32) StartDCCVote {
 	opts := make([]VoteDCCOption, 0, len(sv.Vote.Options))
 	for _, v := range sv.Vote.Options {
 		opts = append(opts, VoteDCCOption{
@@ -479,7 +479,7 @@ func convertStartVoteToCMS(sv StartDCCVote) (cmsplugin.StartVote, cmsplugin.Star
 	dsvr := cmsplugin.StartVoteReply{
 		StartBlockHeight: sv.StartBlockHeight,
 		StartBlockHash:   sv.StartBlockHash,
-		EndHeight:        fmt.Sprint(sv.EndHeight),
+		EndHeight:        sv.EndHeight,
 	}
 
 	return dsv, dsvr

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -255,11 +255,11 @@ func (VoteResults) TableName() string {
 //
 // This is a cms plugin model.
 type VoteDCCOption struct {
-	Key         uint   `gorm:"primary_key"`      // Primary key
-	Token       string `gorm:"not null;size:64"` // StartVote foreign key
-	ID          string `gorm:"not null"`         // Single unique word identifying vote (e.g. yes)
-	Description string `gorm:"not null"`         // Longer description of the vote
-	Bits        uint64 `gorm:"not null"`         // Bits used for this option
+	Key         uint   `gorm:"primary_key"` // Primary key
+	Token       string `gorm:"not null"`    // StartVote foreign key
+	ID          string `gorm:"not null"`    // Single unique word identifying vote (e.g. yes)
+	Description string `gorm:"not null"`    // Longer description of the vote
+	Bits        uint64 `gorm:"not null"`    // Bits used for this option
 }
 
 // TableName returns the name of the VoteOption database table.
@@ -271,19 +271,19 @@ func (VoteDCCOption) TableName() string {
 //
 // This is a cms plugin model.
 type StartDCCVote struct {
-	Token            string          `gorm:"primary_key;size:64"` // Censorship token
-	Version          uint64          `gorm:"not null"`            // Version of files
-	Mask             uint64          `gorm:"not null"`            // Valid votebits
-	Duration         uint32          `gorm:"not null"`            // Duration in blocks
-	QuorumPercentage uint32          `gorm:"not null"`            // Percent of eligible votes required for quorum
-	PassPercentage   uint32          `gorm:"not null"`            // Percent of total votes required to pass
-	Options          []VoteDCCOption `gorm:"foreignkey:Token"`    // Vote option
-	PublicKey        string          `gorm:"not null;size:64"`    // Key used for signature
-	Signature        string          `gorm:"not null;size:128"`   // Signature of Votehash
-	StartBlockHeight uint32          `gorm:"not null"`            // Block height
-	StartBlockHash   string          `gorm:"not null"`            // Block hash
-	EndHeight        uint32          `gorm:"not null"`            // Height of vote end
-	EligibleUserIDs  []DCCUserWeight `gorm:"foreignkey:Token"`    // Valid user weights for DCC Vote
+	Token            string          `gorm:"primary_key"`       // Censorship token
+	Version          uint64          `gorm:"not null"`          // Version of files
+	Mask             uint64          `gorm:"not null"`          // Valid votebits
+	Duration         uint32          `gorm:"not null"`          // Duration in blocks
+	QuorumPercentage uint32          `gorm:"not null"`          // Percent of eligible votes required for quorum
+	PassPercentage   uint32          `gorm:"not null"`          // Percent of total votes required to pass
+	Options          []VoteDCCOption `gorm:"foreignkey:Token"`  // Vote option
+	PublicKey        string          `gorm:"not null;size:64"`  // Key used for signature
+	Signature        string          `gorm:"not null;size:128"` // Signature of Votehash
+	StartBlockHeight uint32          `gorm:"not null"`          // Block height
+	StartBlockHash   string          `gorm:"not null"`          // Block hash
+	EndHeight        uint32          `gorm:"not null"`          // Height of vote end
+	EligibleUserIDs  []DCCUserWeight `gorm:"foreignkey:Token"`  // Valid user weights for DCC Vote
 }
 
 // TableName returns the name of the StartDCCVote database table.
@@ -296,7 +296,7 @@ func (StartDCCVote) TableName() string {
 // This is a cms plugin model.
 type CastDCCVote struct {
 	Key       uint   `gorm:"primary_key"`       // Primary key
-	Token     string `gorm:"not null;size:64"`  // Censorship token
+	Token     string `gorm:"not null"`          // Censorship token
 	UserID    string `gorm:"not null"`          // User ID
 	VoteBit   string `gorm:"not null"`          // Hex encoded vote bit that was selected
 	Signature string `gorm:"not null;size:130"` // Signature of Token+Ticket+VoteBit
@@ -316,11 +316,11 @@ func (CastDCCVote) TableName() string {
 //
 // This is a cms plugin model.
 type VoteDCCOptionResult struct {
-	Key       string        `gorm:"primary_key"`      // Primary key (token+votebit)
-	Token     string        `gorm:"not null;size:64"` // Censorship token (VoteResults foreign key)
-	Votes     uint64        `gorm:"not null"`         // Number of votes cast for this option
-	Option    VoteDCCOption `gorm:"not null"`         // Vote option
-	OptionKey uint          `gorm:"not null"`         // VoteOption foreign key
+	Key       string        `gorm:"primary_key"` // Primary key (token+votebit)
+	Token     string        `gorm:"not null"`    // Censorship token (VoteResults foreign key)
+	Votes     uint64        `gorm:"not null"`    // Number of votes cast for this option
+	Option    VoteDCCOption `gorm:"not null"`    // Vote option
+	OptionKey uint          `gorm:"not null"`    // VoteOption foreign key
 }
 
 // TableName returns the name of the VoteOptionResult database table.
@@ -334,9 +334,9 @@ func (VoteDCCOptionResult) TableName() string {
 //
 // This is a cms plugin model.
 type VoteDCCResults struct {
-	Token    string                `gorm:"primary_key;size:64"` // Censorship tokenba
-	Approved bool                  `gorm:"not null"`            // Vote was approved
-	Results  []VoteDCCOptionResult `gorm:"foreignkey:Token"`    // Results for the vote options
+	Token    string                `gorm:"primary_key"`      // Censorship tokenba
+	Approved bool                  `gorm:"not null"`         // Vote was approved
+	Results  []VoteDCCOptionResult `gorm:"foreignkey:Token"` // Results for the vote options
 }
 
 // TableName returns the name of the VoteResults database table.
@@ -348,10 +348,10 @@ func (VoteDCCResults) TableName() string {
 //
 // This is a cms plugin model.
 type DCCUserWeight struct {
-	Key    string `gorm:"primary_key"`      // Primary Key (token + userid)
-	Token  string `gorm:"not null;size:64"` // StartDCCVote foreign key
-	UserID string `gorm:"not null"`         // User ID
-	Weight int64  `gorm:"not null"`         // Weight of User
+	Key    string `gorm:"primary_key"` // Primary Key (token + userid)
+	Token  string `gorm:"not null"`    // StartDCCVote foreign key
+	UserID string `gorm:"not null"`    // User ID
+	Weight int64  `gorm:"not null"`    // Weight of User
 }
 
 // TableName returns the name of the DCCUserWeight database table.

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -280,9 +280,9 @@ type StartDCCVote struct {
 	Options          []VoteDCCOption `gorm:"foreignkey:Token"`    // Vote option
 	PublicKey        string          `gorm:"not null;size:64"`    // Key used for signature
 	Signature        string          `gorm:"not null;size:128"`   // Signature of Votehash
-	StartBlockHeight string          `gorm:"not null"`            // Block height
+	StartBlockHeight uint32          `gorm:"not null"`            // Block height
 	StartBlockHash   string          `gorm:"not null"`            // Block hash
-	EndHeight        uint64          `gorm:"not null"`            // Height of vote end
+	EndHeight        uint32          `gorm:"not null"`            // Height of vote end
 	EligibleUserIDs  []DCCUserWeight `gorm:"foreignkey:Token"`    // Valid user weights for DCC Vote
 }
 

--- a/politeiad/config.go
+++ b/politeiad/config.go
@@ -41,6 +41,12 @@ const (
 
 	defaultMainnetDcrdata = "dcrdata.decred.org:443"
 	defaultTestnetDcrdata = "testnet.decred.org:443"
+
+	// Currently available modes to run politeia, by default piwww, is used.
+	politeiaWWWMode = "piwww"
+	cmsWWWMode      = "cmswww"
+
+	defaultWWWMode = politeiaWWWMode
 )
 
 var (
@@ -89,6 +95,7 @@ type config struct {
 	Identity      string `long:"identity" description:"File containing the politeiad identity file"`
 	GitTrace      bool   `long:"gittrace" description:"Enable git tracing in logs"`
 	DcrdataHost   string `long:"dcrdatahost" description:"Dcrdata ip:port"`
+	Mode          string `long:"mode" description:"Mode www runs as. Supported values: piwww, cmswww"`
 }
 
 // serviceOptions defines the configuration options for the daemon as a service
@@ -291,6 +298,7 @@ func loadConfig() (*config, []string, error) {
 		HTTPSKey:   defaultHTTPSKeyFile,
 		HTTPSCert:  defaultHTTPSCertFile,
 		Version:    version.String(),
+		Mode:       defaultWWWMode,
 	}
 
 	// Service options which are only added on Windows.
@@ -610,6 +618,16 @@ func loadConfig() (*config, []string, error) {
 		}
 		cfg.RPCPass = base64.StdEncoding.EncodeToString(pass)
 		log.Warnf("RPC password not set, using random value")
+	}
+
+	// Verify mode
+	switch cfg.Mode {
+	case cmsWWWMode:
+	case politeiaWWWMode:
+	default:
+		err := fmt.Errorf("invalid mode: %v", cfg.Mode)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, nil, err
 	}
 
 	// Warn about missing config file only after all other configuration is

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -1153,7 +1153,7 @@ func _main() error {
 	gitbe.UseLogger(gitbeLog)
 	b, err := gitbe.New(activeNetParams.Params, loadedCfg.DataDir,
 		loadedCfg.DcrtimeHost, "", p.identity, loadedCfg.GitTrace,
-		loadedCfg.DcrdataHost, loadedCfg.Mode == "cmswww")
+		loadedCfg.DcrdataHost, loadedCfg.Mode)
 	if err != nil {
 		return err
 	}

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -20,7 +20,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/decred/politeia/decredplugin"
 	v1 "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiad/backend"
@@ -1000,7 +999,7 @@ func (p *politeia) pluginCommand(w http.ResponseWriter, r *http.Request) {
 
 	// Send plugin command to cache
 	_, err = p.cache.PluginExec(cache.PluginCommand{
-		ID:             decredplugin.ID,
+		ID:             pc.ID,
 		Command:        pc.Command,
 		CommandPayload: pc.Payload,
 		ReplyPayload:   payload,
@@ -1150,12 +1149,11 @@ func _main() error {
 			return fmt.Errorf("unable to load cert")
 		}
 	}
-
 	// Setup backend.
 	gitbe.UseLogger(gitbeLog)
 	b, err := gitbe.New(activeNetParams.Params, loadedCfg.DataDir,
 		loadedCfg.DcrtimeHost, "", p.identity, loadedCfg.GitTrace,
-		loadedCfg.DcrdataHost)
+		loadedCfg.DcrdataHost, loadedCfg.Mode == "cmswww")
 	if err != nil {
 		return err
 	}

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -24,6 +24,7 @@ server side notifications.  It does not render HTML.
     - [`Set DCC Status`](#set-dcc-status)
     - [`User sub contractors`](#user-sub-contractors)
     - [`CMS Users`](#cms-users)
+    - [`Vote DCC`](#vote-dcc)
     - [Error codes](#error-codes)
     - [Invoice status codes](#invoice-status-codes)
     - [Line item type codes](#line-item-type-codes)
@@ -1087,7 +1088,7 @@ Reply:
 }
 ```
 
-### `Support/Oppose DCC`
+### `Support Oppose DCC`
 
 Creates a vote on a DCC Record that is used to tabulate support or opposition .
 
@@ -1101,7 +1102,6 @@ Creates a vote on a DCC Record that is used to tabulate support or opposition .
 | token | string | The token of the DCC to support | Yes |
 | publickey | string | The submitting user's public key | Yes |
 | signature | string | Signature of the Token+Vote by the submitting user | Yes |
-
 
 **Results:**
 
@@ -1351,7 +1351,7 @@ Returns a list of the user's associated subcontractors
 **Results:**
 
 | | Type | Description |
-|-|-|-|
+|-|-|-|-|
 | users | array of [`User`](#user)s | The list of subcontractors. |
 
 **Example**
@@ -1514,6 +1514,44 @@ Reply:
   "users": []
 }
 ```
+
+### `Vote DCC`
+
+Creates a vote on a DCC Record that is used for all contractor votes.
+
+**Route:** `POST /v1/dcc/vote`
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| vote | string | The vote for the given DCC | Yes |
+| token | string | The token of the DCC to support | Yes |
+| signature | string | Signature of Token and Vote | Yes |
+| publickey | string | Public key from the client side, sent to politeiawww for verification | Yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+
+**Example**
+
+Request:
+
+```json
+{
+  "vote": "aye",
+  "token":"5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b",
+  "signature":"af969d7f0f711e25cb411bdbbe3268bbf3004075cde8ebaee0fc9d988f24e45013cc2df6762dca5b3eb8abb077f76e0b016380a7eba2d46839b04c507d86290d",
+  "publickey":"4206fa1f45c898f1dee487d7a7a82e0ed293858313b8b022a6a88f2bcae6cdd7"
+}
+```
+
+Reply:
+
+```json
+{}
+```
+
 ### Error codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -25,6 +25,9 @@ server side notifications.  It does not render HTML.
     - [`User sub contractors`](#user-sub-contractors)
     - [`CMS Users`](#cms-users)
     - [`Vote DCC`](#vote-dcc)
+    - [`Vote Details`](#vote-details)
+    - [`Active votes`](#active-votes)
+    - [`Start vote`](#start-vote)
     - [Error codes](#error-codes)
     - [Invoice status codes](#invoice-status-codes)
     - [Line item type codes](#line-item-type-codes)
@@ -1683,6 +1686,81 @@ Reply:
   "startblockheight": 342692,
   "startblockhash": "0000005e341105be45fb9a7fe24d5ca7879e07bfb1ed2f786ee5ebc220ac1959",
   "endblockheight": 344724,
+  "userweights":[]
+}
+```
+### `Start vote`
+
+Start the voting period on the given dcc proposal that has been contentious.
+
+Signature is a signature of the hex encoded SHA256 digest of the JSON encoded
+Vote struct.
+
+**Route:** `POST /v1/dcc/startvote`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| publickey | string | Public key used to sign the vote | Yes |
+| vote | [`Vote`](#vote) | Vote details | Yes |
+| signature | string | Signature of the Vote digest | Yes |
+
+**Results (StartVoteReply):**
+
+| | Type | Description |
+| - | - | - |
+| startblockheight | number | Start block height of the vote |
+| startblockhash | string | Start block hash of the vote |
+| endblockheight | number | End block height of the vote |
+| userweights | []string | All user ids + "," + weight |
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusInvalidCensorshipToken`](#ErrorStatusInvalidCensorshipToken)
+- [`ErrorStatusDCCNotFound`](#ErrorStatusDCCNotFound)
+- [`ErrorStatusInvalidPropVoteBits`](#ErrorStatusInvalidPropVoteBits)
+- [`ErrorStatusInvalidVoteOptions`](#ErrorStatusInvalidVoteOptions)
+- [`ErrorStatusInvalidPropVoteParams`](#ErrorStatusInvalidPropVoteParams)
+- [`ErrorStatusInvalidSigningKey`](#ErrorStatusInvalidSigningKey)
+- [`ErrorStatusInvalidSignature`](#ErrorStatusInvalidSignature)
+- [`ErrorStatusWrongStatus`](#ErrorStatusWrongStatus)
+- [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
+- [`ErrorStatusInvalidVoteType`] (#ErrorStatusInvalidVoteType)
+
+**Example**
+
+Request:
+
+``` json
+{
+  "publickey": "d64d80c36441255e41fc1e7b6cd30259ff9a2b1276c32c7de1b7a832dff7f2c6",
+  "vote": {
+    "token": "127ea26cf994dabc27e115da0eb90a5657590e2ccc4e7c23c7f80c6fe4afaa59",
+    "type": 1,
+    "mask": 3,
+    "duration": 2016,
+    "Options": [{
+      "id": "no",
+      "description": "Don't approve dcc",
+      "bits": 1
+    },{
+      "id": "yes",
+      "description": "Approve dcc",
+      "bits": 2
+    }]
+  },
+  "signature": "5a40d699cdfe5ee31472ec252982e60265a345cd58e4a07b183cf06447b3942d06981e1bfaf8430195109d51428458449446fbfa1d7059aebedc4df769ddb300"
+}
+```
+
+Reply:
+
+```json
+{
+  "startblockheight": 282899,
+  "startblockhash":"00000000017236b62ff1ce136328e6fb4bcd171801a281ce0a662e63cbc4c4fa",
+  "endblockheight": 284915,
   "userweights":[]
 }
 ```

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1552,6 +1552,141 @@ Reply:
 {}
 ```
 
+### `Active votes`
+
+Retrieve all dcc active votes
+
+Note that the webserver does not interpret the plugin structures. These are
+forwarded as-is to the politeia daemon.
+
+**Route:** `POST /v1/dcc/activevotes`
+
+**Params:**
+
+**Results:**
+
+| | Type | Description |
+| - | - | - |
+| votes | array of VoteTuple | All current active dcc votes |
+
+**VoteTuple:**
+
+| | Type | Description |
+| - | - | - |
+| dcc | ProposalRecord | DCC record |
+| startvote | Vote | Vote bits, mask etc |
+| starvotereply | StartVoteReply | Vote details (user weights, start block etc |
+
+**Example**
+
+Request:
+
+``` json
+{}
+```
+
+Reply:
+
+```json
+{
+  "votes": [{
+    "dcc": {
+      "name":"This is a description",
+      "status":4,
+      "timestamp":1523902523,
+      "userid":"",
+      "publickey":"d64d80c36441255e41fc1e7b6cd30259ff9a2b1276c32c7de1b7a832dff7f2c6",
+      "signature":"3554f74c112c5da49c6ee1787770c21fe1ae16f7f1205f105e6df1b5bdeaa2439fff6c477445e248e21bcf081c31bbaa96bfe03acace1629494e795e5d296e04",
+      "files":[],
+      "censorshiprecord": {
+        "token":"8d14c77d9a28a1764832d0fcfb86b6af08f6b327347ab4af4803f9e6f7927225",
+        "merkle":"0dd10219cd79342198085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+        "signature":"97b1bf0d63d7689a2c6e66e32358d48e98d84e5389f455cc135b3401277d3a37518827da0f2bc892b535937421418e7e8ba6a4f940dfcf19a219867fa8c3e005"
+      }
+    }
+  }],
+  "vote": {
+    "token":"8d14c77d9a28a1764832d0fcfb86b6af08f6b327347ab4af4803f9e6f7927225",
+    "mask":3,
+    "duration":2016,
+    "Options": [{
+      "id":"no",
+      "description":"Don't approve dcc",
+      "bits":1
+    },{
+      "id":"yes",
+      "description":"Approve dcc",
+      "bits":2
+    }]
+  },
+  "votedetails": {
+    "startblockheight":"282893",
+    "startblockhash":"000000000227ff9b6bf3af53accb81e4fd1690ae44d521a665cb988bcd02ad94",
+    "endheight":"284909",
+    "userweights": []
+  }
+}
+```
+
+### `Vote details`
+
+Vote details returns all of the relevant dcc vote information for the
+given dcc token.  This includes all of the vote parameters and voting
+options.
+
+The returned version specifies the start vote version that was used to initiate
+the voting period for the given dcc. See the [`Start vote`](#start-vote)
+documentation for more details on the differences between the start vote
+versions.
+
+The "vote" field is a base64 encoded JSON byte slice of the Vote and will need
+to be decoded according to the returned version. See the
+[`Start vote`](#start-vote) documentation for more details on the differences
+between the Vote versions.
+
+**Route:** `POST /dcc/votedetails`
+
+**Params:** 
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| token | string | The token of the DCC to retreive details | Yes |
+
+**Results (VoteDetailsReply):**
+
+| | Type | Description |
+| - | - | - |
+| version | uint32 | Start vote version |
+| vote | string | JSON encoded Vote |
+| publickey | string | Key used for signature |
+| signature | string | Start vote signature |
+| startblockheight | uint32 | Start block height of the vote |
+| startblockhash | string | Start block hash of the vote |
+| endblockheight | uint32 | End block height of the vote |
+| userweights | []string | All userids + weights for eligible voters |
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusDCCNotFound`](#ErrorStatusDCCNotFound)
+- [`ErrorStatusWrongVoteStatus`](#ErrorStatusWrongVoteStatus)
+
+**Example**
+
+Reply:
+
+```
+{
+  "version": 2,
+  "vote": "{}",
+  "publickey": "8139793b84ad5efc48f395bbc53cc4be101936bc72167cd10c649e1e09bf698b",
+  "signature": "994c893b6c26c17f900c06f01aa68cc8008af52fcaf0ab223aed810833dbafe6da08728d2a76ea48b45b3a75c48fb8ce89a3feb4a460ad6b6e741f248c4fff0c",
+  "startblockheight": 342692,
+  "startblockhash": "0000005e341105be45fb9a7fe24d5ca7879e07bfb1ed2f786ee5ebc220ac1959",
+  "endblockheight": 344724,
+  "userweights":[]
+}
+```
+
 ### Error codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -825,15 +825,10 @@ type VoteDetails struct {
 }
 
 // VoteDetailsReply is the reply to the VoteDetails command. It contains all
-// of the information from a StartVote and StartVoteReply.
-//
-// Version specifies the StartVote version that was used to initiate the
-// proposal vote. See the StartVote comment for details on the differences
-// between the StartVote versions.
+// of the information from a StartVote and StartVoteReply
 //
 // Vote contains a JSON encoded Vote and needs to be decoded according to the
-// Version. See the Vote comment for details on the differences between the
-// Vote versions.
+// Version.
 type VoteDetailsReply struct {
 	Version          uint32   `json:"version"`          // StartVote version
 	Vote             string   `json:"vote"`             // JSON encoded Vote struct

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -898,7 +898,7 @@ type ProposalLineItems struct {
 
 // VoteDCC is an authenticated user request that will vote on a debated DCC proposal.
 type VoteDCC struct {
-	Vote      string `json:"comment"`   // Vote must be "aye" or "nay"
+	Vote      string `json:"comment"`   // Vote must be "yes" or "no"
 	Token     string `json:"token"`     // The censorship token of the given DCC issuance or revocation.
 	UserID    string `json:"userid"`    // UserID of the submitting user
 	PublicKey string `json:"publickey"` // Pubkey of the submitting user

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -37,7 +37,8 @@ const (
 	RouteNewCommentDCC       = "/dcc/newcomment"
 	RouteDCCComments         = "/dcc/{token:[A-z0-9]{64}}/comments"
 	RouteSetDCCStatus        = "/dcc/{token:[A-z0-9]{64}}/status"
-	RouteVoteDCC             = "/dcc/vote"
+	RouteCastVoteDCC         = "/dcc/vote"
+	RouteVoteDetailsDCC      = "/dcc/votedetails"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteManageCMSUser       = "/admin/managecms"
 	RouteAdminUserInvoices   = "/admin/userinvoices"
@@ -814,7 +815,7 @@ type StartVoteReply struct {
 	StartBlockHeight uint32   `json:"startblockheight"` // Block height of vote start
 	StartBlockHash   string   `json:"startblockhash"`   // Block hash of vote start
 	EndBlockHeight   uint32   `json:"endblockheight"`   // Block height of vote end
-	UserWeights      []string `json:"userweights"`      // Valid voting tickets
+	UserWeights      []string `json:"userweights"`      // Snapshot of users and their given weights
 }
 
 // VoteDetails returns the votes details for the specified proposal.
@@ -840,7 +841,7 @@ type VoteDetailsReply struct {
 	StartBlockHeight uint32   `json:"startblockheight"` // Block height
 	StartBlockHash   string   `json:"startblockhash"`   // Block hash
 	EndBlockHeight   uint32   `json:"endblockheight"`   // Height of vote end
-	EligibleTickets  []string `json:"eligibletickets"`  // Valid voting ticket
+	UserWeights      []string `json:"userweights"`      // Snapshot of users and their given weights
 }
 
 // VoteSummary contains a summary of the vote information for a specific
@@ -971,7 +972,7 @@ type CastVote struct {
 	Token     string `json:"token"`     // The censorship token of the given DCC issuance or revocation.
 	UserID    string `json:"userid"`    // UserID of the submitting user
 	PublicKey string `json:"publickey"` // Pubkey of the submitting user
-	Signature string `json:"signature"` // Signature of the Token+Vote+UserID by the submitting user.
+	Signature string `json:"signature"` // Signature of the Token+VoteBit+UserID by the submitting user.
 }
 
 // CastVoteReply is the answer to the CastVote command. The Error and

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -98,7 +98,7 @@ const (
 	DCCStatusActive   DCCStatusT = 1 // Currently active issuance/revocation (awaiting sponsors)
 	DCCStatusApproved DCCStatusT = 2 // Fully approved DCC proposal
 	DCCStatusRejected DCCStatusT = 3 // Rejected DCC proposal
-	DCCStatusDebate   DCCStatusT = 4 // Debated DCC proposal (full contractor vote)
+	DCCStatusAllVote  DCCStatusT = 4 // Debated DCC proposal (full contractor vote)
 
 	InvoiceInputVersion = 1
 
@@ -349,7 +349,7 @@ var (
 		ErrorStatusInvalidSubUserIDLineItem:       "the userid supplied for the subcontractor hours line item is invalid",
 		ErrorStatusInvalidSupervisorUser:          "attempted input of an invalid supervisor user id",
 		ErrorStatusMalformedDCC:                   "malformed dcc detected",
-		ErrorStatusInvalidDCCVoteStatus:           "the DCC to be voted isn't currently up for debate",
+		ErrorStatusInvalidDCCVoteStatus:           "the DCC to be voted isn't currently up for an all user vote",
 		ErrorStatusInvalidDCCAllVoteUserWeight:    "the user does not have a corresponding user weight for this vote",
 		ErrorStatusDCCVoteEnded:                   "the all contractor voting period has ended",
 		ErrorStatusDCCVoteStillLive:               "cannot update status of a DCC while a vote is still live",

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -16,6 +16,7 @@ type DomainTypeT int
 type ContractorTypeT int
 type DCCTypeT int
 type DCCStatusT int
+type DCCVoteStatusT int
 
 const (
 	APIVersion = 1
@@ -40,6 +41,7 @@ const (
 	RouteCastVoteDCC         = "/dcc/vote"
 	RouteVoteDetailsDCC      = "/dcc/votedetails"
 	RouteActiveVotesDCC      = "/dcc/activevotes"
+	RouteStartVoteDCC        = "/dcc/startvote"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteManageCMSUser       = "/admin/managecms"
 	RouteAdminUserInvoices   = "/admin/userinvoices"
@@ -101,7 +103,12 @@ const (
 	DCCStatusActive   DCCStatusT = 1 // Currently active issuance/revocation (awaiting sponsors)
 	DCCStatusApproved DCCStatusT = 2 // Fully approved DCC proposal
 	DCCStatusRejected DCCStatusT = 3 // Rejected DCC proposal
-	DCCStatusAllVote  DCCStatusT = 4 // Debated DCC proposal (full contractor vote)
+
+	// DCC vote status codes
+	DCCVoteStatusInvalid    DCCVoteStatusT = 0
+	DCCVoteStatusNotStarted DCCVoteStatusT = 1
+	DCCVoteStatusStarted    DCCVoteStatusT = 2
+	DCCVoteStatusFinished   DCCVoteStatusT = 3
 
 	InvoiceInputVersion = 1
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -773,7 +773,7 @@ type VoteSummary struct {
 	Status           DCCStatusT         `json:"status"`                     // Vote status
 	UserWeights      []DCCWeight        `json:"userweights"`                // User weights that is populated for all contractor votes.
 	Duration         uint32             `json:"duration,omitempty"`         // Duration of vote
-	EndHeight        uint64             `json:"endheight,omitempty"`        // Vote end height
+	EndHeight        uint32             `json:"endheight,omitempty"`        // Vote end height
 	QuorumPercentage uint32             `json:"quorumpercentage,omitempty"` // Percent of eligible votes required for quorum
 	PassPercentage   uint32             `json:"passpercentage,omitempty"`   // Percent of total votes required to pass
 	Results          []VoteOptionResult `json:"results,omitempty"`          // Vote results

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -39,6 +39,7 @@ const (
 	RouteSetDCCStatus        = "/dcc/{token:[A-z0-9]{64}}/status"
 	RouteCastVoteDCC         = "/dcc/vote"
 	RouteVoteDetailsDCC      = "/dcc/votedetails"
+	RouteActiveVotesDCC      = "/dcc/activevotes"
 	RouteAdminInvoices       = "/admin/invoices"
 	RouteManageCMSUser       = "/admin/managecms"
 	RouteAdminUserInvoices   = "/admin/userinvoices"

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -737,7 +737,8 @@ type DCCRecord struct {
 	CensorshipRecord www.CensorshipRecord `json:"censorshiprecord"`
 }
 
-// DCCWeight contains a user id and their assigned weight for a given DCC all contractor vote.
+// DCCWeight contains a user id and their assigned weight for a given DCC all
+// contractor vote.
 type DCCWeight struct {
 	UserID string // User ID
 	Weight int64  // User Weight of the vote (as calculated at the start of the vote).

--- a/politeiawww/cmd/cmswww/activevotes.go
+++ b/politeiawww/cmd/cmswww/activevotes.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import "github.com/decred/politeia/politeiawww/cmd/shared"
+
+// ActiveVotesCmd retreives all dccs that are currently being voted on.
+type ActiveVotesCmd struct{}
+
+// Execute executes the active votes command.
+func (cmd *ActiveVotesCmd) Execute(args []string) error {
+	// Send request
+	avr, err := client.ActiveVotesDCC()
+	if err != nil {
+		return err
+	}
+
+	// Print response details
+	return shared.PrintJSON(avr)
+}
+
+// activeVotesHelpMsg is the output for the help command when 'activevotes'
+// is specified.
+const activeVotesHelpMsg = `activevotes "token"
+
+Retrieve all dccs that are currently being voted on.
+
+Arguments: None
+
+Result:
+{
+  "votes": [
+    "dcc": {
+      "name":          (string)       Suggested short dcc name 
+      "state":         (PropStateT)   Current state of dcc
+      "status":        (PropStatusT)  Current status of dcc
+      "timestamp":     (int64)        Timestamp of last update of dcc
+      "userid":        (string)       ID of user who submitted dcc
+      "username":      (string)       Username of user who submitted dcc
+      "publickey":     (string)       Public key used to sign dcc
+      "signature":     (string)       Signature of merkle root
+      "files": [
+        {
+          "name":      (string)  Filename 
+          "mime":      (string)  Mime type 
+          "digest":    (string)  File digest 
+          "payload":   (string)  File payload 
+        }
+      ],
+      "numcomments":   (uint)  Number of comments on the dcc
+      "version": 		 (string)  Version of dcc
+      "censorshiprecord": {	
+        "token":       (string)  Censorship token
+        "merkle":      (string)  Merkle root of dcc
+        "signature":   (string)  Server side signature of []byte(Merkle+Token)
+      }
+    },
+    "startvote": {
+      "publickey"            (string)  Public key of user that submitted dcc
+      "vote": {
+        "token":             (string)  Censorship token
+        "mask"               (uint64)  Valid votebits
+        "duration":          (uint32)  Duration of vote in blocks
+        "quorumpercentage"   (uint32)  Percent of votes required for quorum
+        "passpercentage":    (uint32)  Percent of votes required to pass
+        "options": [
+          {
+            "id"             (string)  Unique word identifying vote (e.g. yes)
+            "description"    (string)  Longer description of the vote
+            "bits":          (uint64)  Bits used for this option
+          },
+        ]
+      },
+      "signature"            (string)  Signature of Votehash
+    },
+    "startvotereply": {
+      "startblockheight":    (string)  Block height at start of vote
+      "startblockhash":      (string)  Hash of first block of vote interval
+      "endheight":           (string)  Block height at end of vote
+      "eligibletickets": [
+        "removed by politeiawwwcli for readability"
+      ]
+    }
+  ]
+}
+`

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -97,6 +97,7 @@ type cmswww struct {
 	Secret              shared.SecretCmd         `command:"secret" description:"(user)   ping politeiawww"`
 	Version             shared.VersionCmd        `command:"version" description:"(public) get server info and CSRF token"`
 	VoteDCC             VoteDCCCmd               `command:"votedcc" description:"(user) vote for a given DCC during an all contractor vote"`
+	VoteDetails         VoteDetailsCmd           `command:"votedetails" description:"(user) get the details for a dcc vote"`
 }
 
 // verifyInvoice verifies a invoice's merkle root, author signature, and

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -89,6 +89,7 @@ type cmswww struct {
 	ResetPassword       shared.ResetPasswordCmd  `command:"resetpassword" description:"(public) reset the password for a user that is not logged in"`
 	SetDCCStatus        SetDCCStatusCmd          `command:"setdccstatus" description:"(admin)  set the status of a DCC"`
 	SetInvoiceStatus    SetInvoiceStatusCmd      `command:"setinvoicestatus" description:"(admin)  set the status of an invoice"`
+	StartVote           StartVoteCmd             `command:"startvote" description:"(admin)  start the voting period on a dcc"`
 	SupportOpposeDCC    SupportOpposeDCCCmd      `command:"supportopposedcc" description:"(user)   support or oppose a given DCC"`
 	UpdateUserKey       shared.UpdateUserKeyCmd  `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
 	UserDetails         UserDetailsCmd           `command:"userdetails" description:"(user)   get current cms user details"`

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -54,6 +54,7 @@ type cmswww struct {
 	Config shared.Config
 
 	// Commands
+	ActiveVotes         ActiveVotesCmd           `command:"activevotes" description:"(user) get the dccs that are being voted on"`
 	AdminInvoices       AdminInvoicesCmd         `command:"admininvoices" description:"(admin)  get all invoices (optional by month/year and/or status)"`
 	CensorComment       shared.CensorCommentCmd  `command:"censorcomment" description:"(admin)  censor a comment"`
 	ChangePassword      shared.ChangePasswordCmd `command:"changepassword" description:"(user)   change the password for the logged in user"`

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -96,6 +96,7 @@ type cmswww struct {
 	Users               shared.UsersCmd          `command:"users" description:"(user) get a list of users"`
 	Secret              shared.SecretCmd         `command:"secret" description:"(user)   ping politeiawww"`
 	Version             shared.VersionCmd        `command:"version" description:"(public) get server info and CSRF token"`
+	VoteDCC             VoteDCCCmd               `command:"votedcc" description:"(user) vote for a given DCC during an all contractor vote"`
 }
 
 // verifyInvoice verifies a invoice's merkle root, author signature, and

--- a/politeiawww/cmd/cmswww/setdccstatus.go
+++ b/politeiawww/cmd/cmswww/setdccstatus.go
@@ -24,9 +24,8 @@ type SetDCCStatusCmd struct {
 
 func (cmd *SetDCCStatusCmd) Execute(args []string) error {
 	DCCStatus := map[string]cms.DCCStatusT{
-		"rejected":  cms.DCCStatusRejected,
-		"approved":  cms.DCCStatusApproved,
-		"startvote": cms.DCCStatusAllVote,
+		"rejected": cms.DCCStatusRejected,
+		"approved": cms.DCCStatusApproved,
 	}
 	// Check for user identity
 	if cfg.Identity == nil {
@@ -35,11 +34,10 @@ func (cmd *SetDCCStatusCmd) Execute(args []string) error {
 
 	status, ok := DCCStatus[strings.ToLower(cmd.Args.Status)]
 	if !ok {
-		return fmt.Errorf("Invalid status: '%v'.  "+
-			"Valid statuses are:\n"+
-			"  rejected    reject the DCC\n"+
-			"  approved    approve the DCC\n"+
-			"  startvote   send the DCC to all-vote",
+		return fmt.Errorf("Invalid status: '%v'.  " +
+			"Valid statuses are:\n" +
+			"  rejected    reject the DCC\n" +
+			"  approved    approve the DCC\n" +
 			cmd.Args.Status)
 	}
 

--- a/politeiawww/cmd/cmswww/setdccstatus.go
+++ b/politeiawww/cmd/cmswww/setdccstatus.go
@@ -24,9 +24,9 @@ type SetDCCStatusCmd struct {
 
 func (cmd *SetDCCStatusCmd) Execute(args []string) error {
 	DCCStatus := map[string]cms.DCCStatusT{
-		"rejected": cms.DCCStatusRejected,
-		"approved": cms.DCCStatusApproved,
-		"debate":   cms.DCCStatusDebate,
+		"rejected":  cms.DCCStatusRejected,
+		"approved":  cms.DCCStatusApproved,
+		"startvote": cms.DCCStatusAllVote,
 	}
 	// Check for user identity
 	if cfg.Identity == nil {
@@ -37,9 +37,9 @@ func (cmd *SetDCCStatusCmd) Execute(args []string) error {
 	if !ok {
 		return fmt.Errorf("Invalid status: '%v'.  "+
 			"Valid statuses are:\n"+
-			"  rejected  reject the DCC\n"+
-			"  approved  approve the DCC\n"+
-			"  debate    send the DCC to all-vote",
+			"  rejected    reject the DCC\n"+
+			"  approved    approve the DCC\n"+
+			"  startvote   send the DCC to all-vote",
 			cmd.Args.Status)
 	}
 

--- a/politeiawww/cmd/cmswww/setdccstatus.go
+++ b/politeiawww/cmd/cmswww/setdccstatus.go
@@ -26,6 +26,7 @@ func (cmd *SetDCCStatusCmd) Execute(args []string) error {
 	DCCStatus := map[string]cms.DCCStatusT{
 		"rejected": cms.DCCStatusRejected,
 		"approved": cms.DCCStatusApproved,
+		"debate":   cms.DCCStatusDebate,
 	}
 	// Check for user identity
 	if cfg.Identity == nil {
@@ -37,7 +38,8 @@ func (cmd *SetDCCStatusCmd) Execute(args []string) error {
 		return fmt.Errorf("Invalid status: '%v'.  "+
 			"Valid statuses are:\n"+
 			"  rejected  reject the DCC\n"+
-			"  approved  approve the DCC",
+			"  approved  approve the DCC\n"+
+			"  debate    send the DCC to all-vote",
 			cmd.Args.Status)
 	}
 

--- a/politeiawww/cmd/cmswww/startvote.go
+++ b/politeiawww/cmd/cmswww/startvote.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+	"github.com/decred/politeia/util"
+)
+
+// StartVoteCmd starts the voting period on the specified proposal.
+type StartVoteCmd struct {
+	Args struct {
+		Token            string `positional-arg-name:"token" required:"true"`
+		Duration         uint32 `positional-arg-name:"duration"`
+		QuorumPercentage uint32 `positional-arg-name:"quorumpercentage"`
+		PassPercentage   uint32 `positional-arg-name:"passpercentage"`
+	} `positional-args:"true"`
+}
+
+// Execute executes the start vote command.
+func (cmd *StartVoteCmd) Execute(args []string) error {
+	// Check for user identity
+	if cfg.Identity == nil {
+		return shared.ErrUserIdentityNotFound
+	}
+
+	// Setup vote params
+	var (
+		// Default values
+		duration uint32 = 2016
+		quorum   uint32 = 20
+		pass     uint32 = 60
+	)
+	if cmd.Args.Duration != 0 {
+		duration = cmd.Args.Duration
+	}
+	if cmd.Args.QuorumPercentage != 0 {
+		quorum = cmd.Args.QuorumPercentage
+	}
+	if cmd.Args.PassPercentage != 0 {
+		pass = cmd.Args.PassPercentage
+	}
+
+	// Create StartVote
+	vote := v1.Vote{
+		Token:            cmd.Args.Token,
+		Mask:             0x03, // bit 0 no, bit 1 yes
+		Duration:         duration,
+		QuorumPercentage: quorum,
+		PassPercentage:   pass,
+		Options: []v1.VoteOption{
+			{
+				Id:          "no",
+				Description: "Don't approve proposal",
+				Bits:        0x01,
+			},
+			{
+				Id:          "yes",
+				Description: "Approve proposal",
+				Bits:        0x02,
+			},
+		},
+	}
+	vb, err := json.Marshal(vote)
+	if err != nil {
+		return err
+	}
+	msg := hex.EncodeToString(util.Digest(vb))
+	sig := cfg.Identity.SignMessage([]byte(msg))
+	sv := v1.StartVote{
+		Vote:      vote,
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+		Signature: hex.EncodeToString(sig[:]),
+	}
+
+	// Print request details
+	err = shared.PrintJSON(sv)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	svr, err := client.StartVoteDCC(sv)
+	if err != nil {
+		return err
+	}
+
+	// Remove ticket snapshot from the response so that the output
+	// is legible
+	svr.UserWeights = []string{"removed by piwww for readability"}
+
+	// Print response details
+	return shared.PrintJSON(svr)
+}
+
+// startVoteHelpMsg is the output of the help command when 'startvote' is
+// specified.
+var startVoteHelpMsg = `startvote <token> <duration> <quorumpercentage> <passpercentage>
+
+Start voting period for a dcc. Requires admin privileges.  The optional
+arguments must either all be used or none be used.
+
+Arguments:
+1. token              (string, required)  Proposal censorship token
+2. duration           (uint32, optional)  Duration of vote in blocks (default: 2016)
+3. quorumpercentage   (uint32, optional)  Percent of votes required for quorum (default: 10)
+4. passpercentage     (uint32, optional)  Percent of votes required to pass (default: 60)
+
+Result:
+
+{
+  "startblockheight"     (string)    Block height at start of vote
+  "startblockhash"       (string)    Hash of first block of vote interval
+  "endheight"            (string)    Height of vote end
+  "userweights"          ([]string)  Valid voting users and their weights   
+}`

--- a/politeiawww/cmd/cmswww/votedcc.go
+++ b/politeiawww/cmd/cmswww/votedcc.go
@@ -19,8 +19,7 @@ type VoteDCCCmd struct {
 	Args struct {
 		Vote  string `positional-arg-name:"vote"`
 		Token string `positional-arg-name:"token"`
-	} `positional-args:"true" required:"true"
--*`
+	} `positional-args:"true" required:"true"`
 }
 
 // Execute executes the support DCC command.

--- a/politeiawww/cmd/cmswww/votedcc.go
+++ b/politeiawww/cmd/cmswww/votedcc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/decred/politeia/cmsplugin"
 	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
@@ -25,7 +26,7 @@ func (cmd *VoteDCCCmd) Execute(args []string) error {
 	token := cmd.Args.Token
 	vote := cmd.Args.Vote
 
-	if vote != "yes" && vote != "no" {
+	if vote != cmsplugin.DCCApprovalString && vote != cmsplugin.DCCDisapprovalString {
 		return fmt.Errorf("invalid request: you must either vote yes or no")
 	}
 

--- a/politeiawww/cmd/cmswww/votedcc.go
+++ b/politeiawww/cmd/cmswww/votedcc.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// VoteDCCCmd allows a user to vote for a DCC proposal during an all contractor vote.
+type VoteDCCCmd struct {
+	Args struct {
+		Vote  string `positional-arg-name:"vote"`
+		Token string `positional-arg-name:"token"`
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the support DCC command.
+func (cmd *VoteDCCCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	vote := cmd.Args.Vote
+
+	if vote != "yes" && vote != "no" {
+		return fmt.Errorf("invalid request: you must either vote yes or no")
+	}
+
+	if token == "" {
+		return fmt.Errorf("invalid request: you must specify dcc " +
+			"token")
+	}
+
+	// Check for user identity
+	if cfg.Identity == nil {
+		return shared.ErrUserIdentityNotFound
+	}
+
+	sig := cfg.Identity.SignMessage([]byte(token + vote))
+	sd := v1.VoteDCC{
+		Vote:      vote,
+		Token:     token,
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+		Signature: hex.EncodeToString(sig[:]),
+	}
+
+	// Print request details
+	err := shared.PrintJSON(sd)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	sdr, err := client.VoteDCC(sd)
+	if err != nil {
+		return fmt.Errorf("VoteDCC: %v", err)
+	}
+
+	// Print response details
+	err = shared.PrintJSON(sdr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/cmswww/votedcc.go
+++ b/politeiawww/cmd/cmswww/votedcc.go
@@ -26,6 +26,11 @@ func (cmd *VoteDCCCmd) Execute(args []string) error {
 	token := cmd.Args.Token
 	vote := cmd.Args.Vote
 
+	dccDetails, err := client.DCCDetails(token)
+	if err != nil {
+		return fmt.Errorf("error retreiving vote details: %v", err)
+	}
+
 	if vote != cmsplugin.DCCApprovalString && vote != cmsplugin.DCCDisapprovalString {
 		return fmt.Errorf("invalid request: you must either vote yes or no")
 	}

--- a/politeiawww/cmd/cmswww/votedetails.go
+++ b/politeiawww/cmd/cmswww/votedetails.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// VoteDetailsCmd fetches the vote parameters and vote options from the
+// politeiawww v2 VoteDetails routes.
+type VoteDetailsCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"` // Proposal token
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the vote details command.
+func (cmd *VoteDetailsCmd) Execute(args []string) error {
+	vdr, err := client.VoteDetailsDCC(v1.VoteDetails{Token: cmd.Args.Token})
+	if err != nil {
+		return err
+	}
+
+	err = shared.PrintJSON(vdr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// voteDetailsHelpMsg is the output of the help command when 'votedetails' is
+// specified.
+const voteDetailsHelpMsg = `votedetails "token"
+
+Fetch the vote details for a dcc.
+
+Arguments:
+1. token    (string, required)  Proposal censorship token
+`

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -2213,6 +2213,31 @@ func (c *Client) VoteDetailsDCC(cv cms.VoteDetails) (*cms.VoteDetailsReply, erro
 	return &vdr, nil
 }
 
+// StartVoteV2 sends the provided v2 StartVote to the politeiawww backend.
+func (c *Client) StartVoteDCC(sv cms.StartVote) (*cms.StartVoteReply, error) {
+	responseBody, err := c.makeRequest(http.MethodPost,
+		cms.APIRoute, cms.RouteStartVoteDCC, sv)
+	if err != nil {
+		return nil, err
+	}
+
+	var svr cms.StartVoteReply
+	err = json.Unmarshal(responseBody, &svr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal StartVoteReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		svr.UserWeights = []string{"removed by piwww for readability"}
+		err := prettyPrintJSON(svr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &svr, nil
+}
+
 // WalletAccounts retrieves the walletprc accounts.
 func (c *Client) WalletAccounts() (*walletrpc.AccountsResponse, error) {
 	if c.wallet == nil {

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -1562,6 +1562,30 @@ func (c *Client) ActiveVotes() (*www.ActiveVoteReply, error) {
 	return &avr, nil
 }
 
+// ActiveVotesDCC retreives all dccs that are currently being voted on.
+func (c *Client) ActiveVotesDCC() (*cms.ActiveVoteReply, error) {
+	responseBody, err := c.makeRequest(http.MethodGet,
+		www.PoliteiaWWWAPIRoute, cms.RouteActiveVotesDCC, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var avr cms.ActiveVoteReply
+	err = json.Unmarshal(responseBody, &avr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal ActiveVoteDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(avr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &avr, nil
+}
+
 // CastVotes casts votes for a proposal.
 func (c *Client) CastVotes(b *www.Ballot) (*www.BallotReply, error) {
 	responseBody, err := c.makeRequest(http.MethodPost,

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -2103,7 +2103,6 @@ func (c *Client) UserSubContractors(usc *cms.UserSubContractors) (*cms.UserSubCo
 	if err != nil {
 		return nil, err
 	}
-
 	var uscr cms.UserSubContractorsReply
 	err = json.Unmarshal(responseBody, &uscr)
 	if err != nil {
@@ -2116,7 +2115,6 @@ func (c *Client) UserSubContractors(usc *cms.UserSubContractors) (*cms.UserSubCo
 			return nil, err
 		}
 	}
-
 	return &uscr, nil
 }
 
@@ -2142,6 +2140,29 @@ func (c *Client) ProposalOwner(po *cms.ProposalOwner) (*cms.ProposalOwnerReply, 
 	}
 
 	return &por, nil
+}
+
+// VoteDCC issues an admin approval for a given DCC proposal.
+func (c *Client) VoteDCC(vd cms.VoteDCC) (*cms.VoteDCCReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.APIRoute, cms.RouteVoteDCC,
+		vd)
+	if err != nil {
+		return nil, err
+	}
+	var vdr cms.VoteDCCReply
+	err = json.Unmarshal(responseBody, &vdr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal VoteDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(vdr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &vdr, nil
 }
 
 // WalletAccounts retrieves the walletprc accounts.

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -2142,14 +2142,38 @@ func (c *Client) ProposalOwner(po *cms.ProposalOwner) (*cms.ProposalOwnerReply, 
 	return &por, nil
 }
 
-// VoteDCC issues an admin approval for a given DCC proposal.
-func (c *Client) VoteDCC(vd cms.VoteDCC) (*cms.VoteDCCReply, error) {
-	responseBody, err := c.makeRequest("POST", cms.APIRoute, cms.RouteVoteDCC,
-		vd)
+// CastVoteDCC issues a signed vote for a given DCC proposal. approval
+func (c *Client) CastVoteDCC(cv cms.CastVote) (*cms.CastVoteReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.APIRoute, cms.RouteCastVoteDCC,
+		cv)
 	if err != nil {
 		return nil, err
 	}
-	var vdr cms.VoteDCCReply
+	var cvr cms.CastVoteReply
+	err = json.Unmarshal(responseBody, &cvr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal VoteDCCReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(cvr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &cvr, nil
+}
+
+// VoteDetailsDCC returns all the needed information about a given vote for a
+// DCC proposal.
+func (c *Client) VoteDetailsDCC(cv cms.VoteDetails) (*cms.VoteDetailsReply, error) {
+	responseBody, err := c.makeRequest("POST", cms.APIRoute, cms.RouteVoteDetailsDCC,
+		cv)
+	if err != nil {
+		return nil, err
+	}
+	var vdr cms.VoteDetailsReply
 	err = json.Unmarshal(responseBody, &vdr)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal VoteDCCReply: %v", err)

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -29,6 +29,7 @@ const (
 	tableNameExchangeRate  = "exchange_rates"
 	tableNamePayments      = "payments"
 	tableNameDCC           = "dcc"
+	tableNameDCCVote       = "dcc_vote"
 
 	userPoliteiawww = "politeiawww" // cmsdb user (read/write access)
 )
@@ -508,7 +509,6 @@ func createCmsTables(tx *gorm.DB) error {
 			}).Error
 		return err
 	}
-
 	return nil
 }
 

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -29,7 +29,6 @@ const (
 	tableNameExchangeRate  = "exchange_rates"
 	tableNamePayments      = "payments"
 	tableNameDCC           = "dcc"
-	tableNameDCCVote       = "dcc_vote"
 
 	userPoliteiawww = "politeiawww" // cmsdb user (read/write access)
 )

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -110,6 +110,7 @@ func EncodeInvoiceLineItem(dbLineItem *database.LineItem) LineItem {
 	lineItem.Labor = dbLineItem.Labor
 	lineItem.Expenses = dbLineItem.Expenses
 	lineItem.ContractorRate = dbLineItem.ContractorRate
+	lineItem.SubUserID = dbLineItem.SubUserID
 	return lineItem
 }
 
@@ -125,6 +126,7 @@ func DecodeInvoiceLineItem(lineItem *LineItem) *database.LineItem {
 	dbLineItem.Labor = lineItem.Labor
 	dbLineItem.Expenses = lineItem.Expenses
 	dbLineItem.ContractorRate = lineItem.ContractorRate
+	dbLineItem.SubUserID = lineItem.SubUserID
 
 	return dbLineItem
 }

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -66,6 +66,7 @@ type LineItem struct {
 	Labor          uint   `gorm:"not null"`    // Number of minutes worked
 	Expenses       uint   `gorm:"not null"`    // Total cost of line item (in USD cents)
 	ContractorRate uint   `gorm:"not null"`    // Optional contractor rate for line item, typically used for Sub Contractors
+	SubUserID      string `gorm:"not null"`    // SubContractor User ID if Subcontractor Line Item
 }
 
 // TableName returns the table name of the line items table.
@@ -137,7 +138,20 @@ type DCC struct {
 	OppositionUserIDs string
 }
 
-// TableName returns the table name of the issuance table.
+// TableName returns the table name of the DCC table.
 func (DCC) TableName() string {
 	return tableNameDCC
+}
+
+// DCCVote contains information about submitted DCC all contractor votes
+type DCCVote struct {
+	Token      string `gorm:"not null"`
+	UserID     string `gorm:"not null"`
+	Vote       string `gorm:"not null"`
+	UserWeight int64  `gorm:"not null"`
+}
+
+// TableName returns the table name of the issuance table.
+func (DCCVote) TableName() string {
+	return tableNameDCCVote
 }

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -142,16 +142,3 @@ type DCC struct {
 func (DCC) TableName() string {
 	return tableNameDCC
 }
-
-// DCCVote contains information about submitted DCC all contractor votes
-type DCCVote struct {
-	Token      string `gorm:"not null"`
-	UserID     string `gorm:"not null"`
-	Vote       string `gorm:"not null"`
-	UserWeight int64  `gorm:"not null"`
-}
-
-// TableName returns the table name of the issuance table.
-func (DCCVote) TableName() string {
-	return tableNameDCCVote
-}

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -122,6 +122,7 @@ type LineItem struct {
 	Labor          uint
 	Expenses       uint
 	ContractorRate uint
+	SubUserID      string
 }
 
 // InvoiceChange contains entries for any status update that occurs to a given

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/user"
@@ -563,7 +564,7 @@ func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 	weightStart := time.Now().AddDate(0, -1*userWeightMonthLookback, 0)
 	weightMonthStart := uint(weightStart.Month())
 	weightYearStart := uint(weightStart.Year())
-
+	fmt.Println(weightMonthStart, weightYearStart, weightMonthEnd, weightYearEnd)
 	err := p.db.AllUsers(func(user *user.User) {
 		cmsUser, err := p.getCMSUserByID(user.ID.String())
 		if err != nil {
@@ -629,7 +630,7 @@ func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	spew.Dump(userWeights)
 	return userWeights, nil
 
 }

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -553,7 +553,8 @@ func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 		1) Determine most recent payout month
 		2) For each user
 		   1) Look back for 6 months of invoices (that were paid out)
-		   2) Add up all hours billed over that time period.
+		   2) Add up all minutes billed over that time period.
+		   3) Set user weight as total number of billed minutes.
 	*/
 
 	weightEnd := time.Now()

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -549,8 +549,6 @@ func (p *politeiawww) getCMSUserByIDRaw(id string) (*user.CMSUser, error) {
 func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 	userWeights := make(map[string]int64, 1080)
 
-	//weightMonths := 6
-
 	/*
 		1) Determine most recent payout month
 		2) For each user

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -555,9 +555,7 @@ func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 		1) Determine most recent payout month
 		2) For each user
 		   1) Look back for 6 months of invoices (that were paid out)
-		   2) A full time employee should bill 180 hours of work per month (4.5 x 40 weeks)
-		   3) Each month invoice divide hours worked by 180 to determine monthly coeff.
-		   4) Average monthly results to reach 6 month average
+		   2) Add up all hours billed over that time period.
 	*/
 
 	weightEnd := time.Now()
@@ -571,7 +569,8 @@ func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 	err := p.db.AllUsers(func(user *user.User) {
 		cmsUser, err := p.getCMSUserByID(user.ID.String())
 		if err != nil {
-			log.Errorf("getCMSUserWeights: getCMSUserByID %v %v", user.ID.String(), err)
+			log.Errorf("getCMSUserWeights: getCMSUserByID %v %v",
+				user.ID.String(), err)
 			return
 		}
 
@@ -587,7 +586,8 @@ func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 			for _, superID := range cmsUser.SupervisorUserIDs {
 				superUser, err := p.getCMSUserByID(superID)
 				if err != nil {
-					log.Errorf("getCMSUserWeights: getCMSUserByID %v %v", superID, err)
+					log.Errorf("getCMSUserWeights: getCMSUserByID %v %v",
+						superID, err)
 					return
 				}
 				superInvoices, err := p.cmsDB.InvoicesByUserID(superUser.ID)
@@ -595,11 +595,14 @@ func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 					log.Errorf("getCMSUserWeights: InvoicesByUserID %v", err)
 				}
 				for _, i := range superInvoices {
-					if i.Month <= weightMonthEnd && i.Month >= weightMonthStart &&
+					if i.Month <= weightMonthEnd &&
+						i.Month >= weightMonthStart &&
 						i.Year <= weightYearEnd && i.Year >= weightYearStart {
 						for _, li := range i.LineItems {
-							// Only take into account billed minutes if the line item matches their userID
-							if li.Type == cms.LineItemTypeSubHours && li.SubUserID == user.ID.String() {
+							// Only take into account billed minutes if the line
+							// item matches their userID
+							if li.Type == cms.LineItemTypeSubHours &&
+								li.SubUserID == user.ID.String() {
 								billedMinutes += int64(li.Labor)
 							}
 						}
@@ -615,7 +618,8 @@ func (p *politeiawww) getCMSUserWeights() (map[string]int64, error) {
 			for _, i := range userInvoices {
 				if i.Month <= weightMonthEnd && i.Month >= weightMonthStart &&
 					i.Year <= weightYearEnd && i.Year >= weightYearStart {
-					// now look at the lineitems within that invoice and tabulate billed hours
+					// now look at the lineitems within that invoice and
+					// tabulate billed hours
 					for _, li := range i.LineItems {
 						billedMinutes += int64(li.Labor)
 					}

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -875,6 +875,20 @@ func (p *politeiawww) handleVoteDetailsDCC(w http.ResponseWriter, r *http.Reques
 	util.RespondWithJSON(w, http.StatusOK, vdr)
 }
 
+// handleActiveVoteDCC returns all active dccs that have an active vote.
+func (p *politeiawww) handleActiveVoteDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleActiveVoteDCC")
+
+	avr, err := p.processActiveVoteDCC()
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleActiveVoteDCC: processActiveVoteDCC %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, avr)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -952,6 +966,9 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		permissionLogin)
 	p.addRoute(http.MethodPost, cms.APIRoute,
 		cms.RouteVoteDetailsDCC, p.handleVoteDetailsDCC,
+		permissionLogin)
+	p.addRoute(http.MethodGet, www.PoliteiaWWWAPIRoute,
+		cms.RouteActiveVotesDCC, p.handleActiveVoteDCC,
 		permissionLogin)
 
 	// Unauthenticated websocket

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -335,9 +335,9 @@ func (p *politeiawww) handleNewCommentInvoice(w http.ResponseWriter, r *http.Req
 	util.RespondWithJSON(w, http.StatusOK, cr)
 }
 
-// handleCommentsGet handles batched comments get.
+// handleInvoiceComments handles batched invoice comments get.
 func (p *politeiawww) handleInvoiceComments(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("handleCommentsGet")
+	log.Tracef("handleInvoiceComments")
 
 	pathParams := mux.Vars(r)
 	token := pathParams["token"]
@@ -346,14 +346,14 @@ func (p *politeiawww) handleInvoiceComments(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		if err != errSessionNotFound {
 			RespondWithError(w, r, 0,
-				"handleCommentsGet: getSessionUser %v", err)
+				"handleInvoiceComments: getSessionUser %v", err)
 			return
 		}
 	}
 	gcr, err := p.processInvoiceComments(token, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleCommentsGet: processCommentsGet %v", err)
+			"handleInvoiceComments: processInvoiceComments %v", err)
 		return
 	}
 	util.RespondWithJSON(w, http.StatusOK, gcr)
@@ -824,6 +824,34 @@ func (p *politeiawww) handleProposalBilling(w http.ResponseWriter, r *http.Reque
 	util.RespondWithJSON(w, http.StatusOK, pbr)
 }
 
+func (p *politeiawww) handleVoteDCC(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleVoteDCC")
+
+	var vd cms.VoteDCC
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&vd); err != nil {
+		RespondWithError(w, r, 0, "handleVoteDCC: unmarshal", www.UserError{
+			ErrorCode: www.ErrorStatusInvalidInput,
+		})
+		return
+	}
+
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleVoteDCC: getSessionUser %v", err)
+		return
+	}
+
+	vdr, err := p.processVoteDCC(vd, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleVoteDCC: processVoteDCC: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, vdr)
+}
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -895,6 +923,9 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		permissionLogin)
 	p.addRoute(http.MethodPost, cms.APIRoute,
 		cms.RouteProposalBilling, p.handleProposalBilling,
+		permissionLogin)
+	p.addRoute(http.MethodPost, cms.APIRoute,
+		cms.RouteVoteDCC, p.handleVoteDCC,
 		permissionLogin)
 
 	// Unauthenticated websocket

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -865,7 +865,7 @@ func (p *politeiawww) handleVoteDetailsDCC(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	vdr, err := p.processVoteDetailsDCC(vd)
+	vdr, err := p.processVoteDetailsDCC(vd.Token)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleVoteDetailsDCC: processVoteDetailsDCC: %v", err)

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1768,3 +1768,31 @@ func convertCMSStartVoteReplyToCMS(svr cmsplugin.StartVoteReply) cms.StartVoteRe
 		UserWeights:      svr.EligibleUsers,
 	}
 }
+
+func convertStartVoteToCMS(sv cms.StartVote) cmsplugin.StartVote {
+	vote := cmsplugin.Vote{
+		Token:            sv.Vote.Token,
+		Mask:             sv.Vote.Mask,
+		Duration:         sv.Vote.Duration,
+		QuorumPercentage: sv.Vote.QuorumPercentage,
+		PassPercentage:   sv.Vote.PassPercentage,
+	}
+
+	voteOptions := make([]cmsplugin.VoteOption, 0, len(sv.Vote.Options))
+	for _, option := range sv.Vote.Options {
+		voteOption := cmsplugin.VoteOption{
+			Id:          option.Id,
+			Description: option.Description,
+			Bits:        option.Bits,
+		}
+		voteOptions = append(voteOptions, voteOption)
+	}
+	vote.Options = voteOptions
+
+	return cmsplugin.StartVote{
+		Vote:      vote,
+		PublicKey: sv.PublicKey,
+		Signature: sv.Signature,
+	}
+
+}

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1716,3 +1716,19 @@ func convertVoteOptionResultsToCMS(vr []cmsplugin.VoteOptionResult) []cms.VoteOp
 	}
 	return votes
 }
+func convertCMSStartVoteToCMSVoteDetailsReply(sv cmsplugin.StartVote, svr cmsplugin.StartVoteReply) (*cms.VoteDetailsReply, error) {
+	voteb, err := cmsplugin.EncodeVote(sv.Vote)
+	if err != nil {
+		return nil, err
+	}
+	return &cms.VoteDetailsReply{
+		Version:          uint32(sv.Version),
+		Vote:             string(voteb),
+		PublicKey:        sv.PublicKey,
+		Signature:        sv.Signature,
+		StartBlockHeight: svr.StartBlockHeight,
+		StartBlockHash:   svr.StartBlockHash,
+		EndBlockHeight:   svr.EndHeight,
+		UserWeights:      svr.EligibleUsers,
+	}, nil
+}

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1675,6 +1675,7 @@ func convertDatabaseInvoiceToProposalLineItems(inv *cmsdatabase.Invoice) cms.Pro
 
 func convertCastVoteFromCMS(b cms.VoteDCC) cmsplugin.CastVote {
 	return cmsplugin.CastVote{
+		VoteBit:   b.VoteBit,
 		Token:     b.Token,
 		UserID:    b.UserID,
 		Signature: b.Signature,

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1673,12 +1673,21 @@ func convertDatabaseInvoiceToProposalLineItems(inv *cmsdatabase.Invoice) cms.Pro
 	}
 }
 
-func convertCastVoteFromCMS(b cms.VoteDCC) cmsplugin.CastVote {
+func convertCastVoteFromCMS(b cms.CastVote) cmsplugin.CastVote {
 	return cmsplugin.CastVote{
 		VoteBit:   b.VoteBit,
 		Token:     b.Token,
 		UserID:    b.UserID,
 		Signature: b.Signature,
+	}
+}
+
+func convertCastVoteReplyToCMS(cv *cmsplugin.CastVoteReply) *cms.CastVoteReply {
+	return &cms.CastVoteReply{
+		ClientSignature: cv.ClientSignature,
+		Signature:       cv.Signature,
+		Error:           cv.Error,
+		ErrorStatus:     cv.ErrorStatus,
 	}
 }
 
@@ -1698,7 +1707,7 @@ func convertVoteOptionResultsToCMS(vr []cmsplugin.VoteOptionResult) []cms.VoteOp
 	for _, w := range vr {
 		votes = append(votes, cms.VoteOptionResult{
 			Option: cms.VoteOption{
-				ID:          w.ID,
+				Id:          w.ID,
 				Description: w.Description,
 				Bits:        w.Bits,
 			},

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1790,6 +1790,7 @@ func convertStartVoteToCMS(sv cms.StartVote) cmsplugin.StartVote {
 	vote.Options = voteOptions
 
 	return cmsplugin.StartVote{
+		Token:     sv.Vote.Token,
 		Vote:      vote,
 		PublicKey: sv.PublicKey,
 		Signature: sv.Signature,

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1732,3 +1732,39 @@ func convertCMSStartVoteToCMSVoteDetailsReply(sv cmsplugin.StartVote, svr cmsplu
 		UserWeights:      svr.EligibleUsers,
 	}, nil
 }
+
+func convertCMSStartVoteToCMS(sv cmsplugin.StartVote) cms.StartVote {
+	vote := cms.Vote{
+		Token:            sv.Vote.Token,
+		Mask:             sv.Vote.Mask,
+		Duration:         sv.Vote.Duration,
+		QuorumPercentage: sv.Vote.QuorumPercentage,
+		PassPercentage:   sv.Vote.PassPercentage,
+	}
+
+	voteOptions := make([]cms.VoteOption, 0, len(sv.Vote.Options))
+	for _, option := range sv.Vote.Options {
+		voteOption := cms.VoteOption{
+			Id:          option.Id,
+			Description: option.Description,
+			Bits:        option.Bits,
+		}
+		voteOptions = append(voteOptions, voteOption)
+	}
+	vote.Options = voteOptions
+
+	return cms.StartVote{
+		Vote:      vote,
+		PublicKey: sv.PublicKey,
+		Signature: sv.Signature,
+	}
+}
+
+func convertCMSStartVoteReplyToCMS(svr cmsplugin.StartVoteReply) cms.StartVoteReply {
+	return cms.StartVoteReply{
+		StartBlockHeight: svr.StartBlockHeight,
+		StartBlockHash:   svr.StartBlockHash,
+		EndBlockHeight:   svr.EndHeight,
+		UserWeights:      svr.EligibleUsers,
+	}
+}

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/politeia/cmsplugin"
 	"github.com/decred/politeia/decredplugin"
 	"github.com/decred/politeia/mdstream"
 	pd "github.com/decred/politeia/politeiad/api/v1"
@@ -867,6 +868,7 @@ func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) *cms.I
 			Labor:         dbLineItem.Labor,
 			Expenses:      dbLineItem.Expenses,
 			SubRate:       dbLineItem.ContractorRate,
+			SubUserID:     dbLineItem.SubUserID,
 		}
 		invInputLineItems = append(invInputLineItems, lineItem)
 	}
@@ -914,6 +916,7 @@ func convertInvoiceRecordToDatabaseInvoice(invRec *cms.InvoiceRecord) *cmsdataba
 			Labor:          lineItem.Labor,
 			Expenses:       lineItem.Expenses,
 			ContractorRate: lineItem.SubRate,
+			SubUserID:      lineItem.SubUserID,
 		}
 		dbInvoice.LineItems = append(dbInvoice.LineItems, dbLineItem)
 	}
@@ -1668,4 +1671,38 @@ func convertDatabaseInvoiceToProposalLineItems(inv *cmsdatabase.Invoice) cms.Pro
 			SubRate:       inv.LineItems[0].ContractorRate,
 		},
 	}
+}
+
+func convertCastVoteFromCMS(b cms.VoteDCC) cmsplugin.CastVote {
+	return cmsplugin.CastVote{
+		Token:     b.Token,
+		UserID:    b.UserID,
+		Signature: b.Signature,
+	}
+}
+
+func convertUserWeightToCMS(uw []cmsplugin.UserWeight) []cms.DCCWeight {
+	dccWeight := make([]cms.DCCWeight, 0, len(uw))
+	for _, w := range uw {
+		dccWeight = append(dccWeight, cms.DCCWeight{
+			UserID: w.UserID,
+			Weight: w.Weight,
+		})
+	}
+	return dccWeight
+}
+
+func convertVoteOptionResultsToCMS(vr []cmsplugin.VoteOptionResult) []cms.VoteOptionResult {
+	votes := make([]cms.VoteOptionResult, 0, len(vr))
+	for _, w := range vr {
+		votes = append(votes, cms.VoteOptionResult{
+			Option: cms.VoteOption{
+				ID:          w.ID,
+				Description: w.Description,
+				Bits:        w.Bits,
+			},
+			VotesReceived: w.Votes,
+		})
+	}
+	return votes
 }

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1721,6 +1721,11 @@ func convertCMSStartVoteToCMSVoteDetailsReply(sv cmsplugin.StartVote, svr cmsplu
 	if err != nil {
 		return nil, err
 	}
+	userWeights := make([]string, 0, len(sv.UserWeights))
+	for _, weights := range sv.UserWeights {
+		userWeight := weights.UserID + "-" + strconv.Itoa(int(weights.Weight))
+		userWeights = append(userWeights, userWeight)
+	}
 	return &cms.VoteDetailsReply{
 		Version:          uint32(sv.Version),
 		Vote:             string(voteb),
@@ -1729,7 +1734,7 @@ func convertCMSStartVoteToCMSVoteDetailsReply(sv cmsplugin.StartVote, svr cmsplu
 		StartBlockHeight: svr.StartBlockHeight,
 		StartBlockHash:   svr.StartBlockHash,
 		EndBlockHeight:   svr.EndHeight,
-		UserWeights:      svr.EligibleUsers,
+		UserWeights:      userWeights,
 	}, nil
 }
 
@@ -1765,7 +1770,6 @@ func convertCMSStartVoteReplyToCMS(svr cmsplugin.StartVoteReply) cms.StartVoteRe
 		StartBlockHeight: svr.StartBlockHeight,
 		StartBlockHash:   svr.StartBlockHash,
 		EndBlockHeight:   svr.EndHeight,
-		UserWeights:      svr.EligibleUsers,
 	}
 }
 

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -505,7 +505,7 @@ func (p *politeiawww) processDCCDetails(gd cms.DCCDetails) (*cms.DCCDetailsReply
 
 	voteSummary := cms.VoteSummary{
 		UserWeights:    convertUserWeightToCMS(vdr.StartVote.UserWeights),
-		EndHeight:      uint64(vsr.EndHeight),
+		EndHeight:      vsr.EndHeight,
 		Results:        voteResults,
 		Duration:       vsr.Duration,
 		PassPercentage: vsr.PassPercentage,

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -1321,7 +1321,7 @@ func (p *politeiawww) processActiveVoteDCC() (*cms.ActiveVoteReply, error) {
 					log.Errorf("convertCacheToDatabaseDCC: %v", err)
 					break
 				}
-				if d.Status == cms.DCCStatusActive {
+				if d.Status == cms.DCCStatusAllVote {
 					active = append(active, d.Token)
 				}
 			}

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -1140,13 +1140,7 @@ func (p *politeiawww) processVoteDetailsDCC(token string) (*cms.VoteDetailsReply
 			ErrorContext: []string{"voting has not started yet"},
 		}
 	}
-
-	b := []byte(dvdr.StartVote.Payload)
-	dsv, err := cmsplugin.DecodeStartVote(b)
-	if err != nil {
-		return nil, err
-	}
-	vdr, err := convertCMSStartVoteToCMSVoteDetailsReply(dsv,
+	vdr, err := convertCMSStartVoteToCMSVoteDetailsReply(dvdr.StartVote,
 		dvdr.StartVoteReply)
 	if err != nil {
 		return nil, err

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -1023,17 +1023,17 @@ func dccStatusInSlice(arr []cms.DCCStatusT, status cms.DCCStatusT) bool {
 	return false
 }
 
-func (p *politeiawww) processVoteDCC(vd cms.VoteDCC, u *user.User) (*cms.VoteDCCReply, error) {
-	log.Tracef("processVoteDCC: %v", u.PublicKey())
+func (p *politeiawww) processCastVoteDCC(cv cms.CastVote, u *user.User) (*cms.CastVoteReply, error) {
+	log.Tracef("processCastVoteDCC: %v", u.PublicKey())
 
-	vdr, err := p.cmsVoteDetails(vd.Token)
+	vdr, err := p.cmsVoteDetails(cv.Token)
 	if err != nil {
 		return nil, err
 	}
 
 	validVoteBit := false
 	for _, option := range vdr.StartVote.Vote.Options {
-		if vd.VoteBit == strconv.FormatUint(option.Bits, 16) {
+		if cv.VoteBit == strconv.FormatUint(option.Bits, 16) {
 			validVoteBit = true
 			break
 		}
@@ -1046,7 +1046,7 @@ func (p *politeiawww) processVoteDCC(vd cms.VoteDCC, u *user.User) (*cms.VoteDCC
 		}
 	}
 
-	dcc, err := p.getDCC(vd.Token)
+	dcc, err := p.getDCC(cv.Token)
 	if err != nil {
 		if err == cache.ErrRecordNotFound {
 			err = www.UserError{
@@ -1080,7 +1080,7 @@ func (p *politeiawww) processVoteDCC(vd cms.VoteDCC, u *user.User) (*cms.VoteDCC
 		return nil, err
 	}
 
-	vote := convertCastVoteFromCMS(vd)
+	vote := convertCastVoteFromCMS(cv)
 	payload, err := cmsplugin.EncodeCastVote(vote)
 	if err != nil {
 		return nil, err
@@ -1113,12 +1113,17 @@ func (p *politeiawww) processVoteDCC(vd cms.VoteDCC, u *user.User) (*cms.VoteDCC
 	}
 
 	// Decode plugin reply
-	_, err = cmsplugin.DecodeCastVoteReply([]byte(reply.Payload))
+	pluginCastVoteReply, err := cmsplugin.DecodeCastVoteReply([]byte(reply.Payload))
 	if err != nil {
 		return nil, err
 	}
 
-	return &cms.VoteDCCReply{}, nil
+	return convertCastVoteReplyToCMS(pluginCastVoteReply), nil
+}
+
+func (p *politeiawww) processVoteDetailsDCC(cv cms.VoteDetails) (*cms.VoteDetailsReply, error) {
+
+	return nil, nil
 }
 
 func (p *politeiawww) allVoteDCC(token, signature string, u *user.User) error {

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -59,9 +59,9 @@ var (
 		cms.DCCStatusActive: {
 			cms.DCCStatusApproved,
 			cms.DCCStatusRejected,
-			cms.DCCStatusDebate,
+			cms.DCCStatusAllVote,
 		},
-		cms.DCCStatusDebate: {
+		cms.DCCStatusAllVote: {
 			cms.DCCStatusApproved,
 			cms.DCCStatusRejected,
 		},
@@ -891,9 +891,9 @@ func (p *politeiawww) processSetDCCStatus(sds cms.SetDCCStatus, u *user.User) (*
 		return nil, err
 	}
 
-	// If it's a debated DCC and the vote is still occurring, admin cannot update
-	// the status.
-	if dcc.Status == cms.DCCStatusDebate && uint64(vd.StartVoteReply.EndHeight) > bb {
+	// If it's an all vote DCC and the vote is still occurring, admin cannot
+	// update the status.
+	if dcc.Status == cms.DCCStatusAllVote && uint64(vd.StartVoteReply.EndHeight) > bb {
 		return nil, www.UserError{
 			ErrorCode: cms.ErrorStatusDCCVoteStillLive,
 		}
@@ -965,9 +965,9 @@ func (p *politeiawww) processSetDCCStatus(sds cms.SetDCCStatus, u *user.User) (*
 				return nil, err
 			}
 		}
-	case cms.DCCStatusDebate:
-		// Do DCC user debate start processing
-		err = p.debateDCC(sds.Token, sds.Signature, u)
+	case cms.DCCStatusAllVote:
+		// Do DCC user all vote start processing
+		err = p.allVoteDCC(sds.Token, sds.Signature, u)
 		if err != nil {
 			return nil, err
 		}
@@ -1046,8 +1046,8 @@ func (p *politeiawww) processVoteDCC(vd cms.VoteDCC, u *user.User) (*cms.VoteDCC
 		return nil, err
 	}
 
-	// Only allow voting on Debated DCC proposals
-	if dcc.Status != cms.DCCStatusDebate {
+	// Only allow voting on All Vote DCC proposals
+	if dcc.Status != cms.DCCStatusAllVote {
 		return nil, www.UserError{
 			ErrorCode: cms.ErrorStatusInvalidDCCVoteStatus,
 		}
@@ -1117,8 +1117,8 @@ func (p *politeiawww) processVoteDCC(vd cms.VoteDCC, u *user.User) (*cms.VoteDCC
 	return &cms.VoteDCCReply{}, nil
 }
 
-func (p *politeiawww) debateDCC(token, signature string, u *user.User) error {
-	log.Tracef("debateDCC: %v %v", token, u.PublicKey())
+func (p *politeiawww) allVoteDCC(token, signature string, u *user.User) error {
+	log.Tracef("allVoteDCC: %v %v", token, u.PublicKey())
 
 	userWeights, err := p.getCMSUserWeights()
 	if err != nil {

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -523,6 +523,17 @@ func _main() error {
 			log.Errorf("Unable to setup pi dcrdata subs: %v", err)
 		}
 	case cmsWWWMode:
+		pluginFound := false
+		for _, plugin := range p.plugins {
+			if plugin.ID == "cms" {
+				pluginFound = true
+				break
+			}
+		}
+		if !pluginFound {
+			return fmt.Errorf("must start politeiad in cmswww mode, cms plugin not found")
+		}
+
 		p.setCMSWWWRoutes()
 		// XXX setup user routes
 		p.setCMSUserWWWRoutes()


### PR DESCRIPTION
This adds the final portion laid out in the stakeholder approved proposal:
https://proposals.decred.org/proposals/fa38a3593d9a3f6cb2478a24c25114f5097c572f6dadf24c78bb521ed10992a4

When a DCC proposal for either issuance or revocation is deemed "contentious,"
administrators may now start a "Debate." This will then allow all currently active and valid
contractors to submit a vote to determine the final outcome of any given DCC proposal.

When the status for a DCC is updated to "debated" a current snapshot of the user base
is taken and the "weights" of each user's vote is determined. Currently, the weight is
simply the amount of billed hours over the previous 6 months of invoices that have been paid out.
We can use this raw amount however we like to best tabulate the results in a future PR.

As is the case with the previously implemented DCC functionality, administrators
currently have final say to Approve, Reject and start a Debate on a DCC. This
will be replaced with an automated system that will complete these without centralized
admin intervention. We'd first like to iron out the process without the worry of that automation.
Initial rigging for DebateDCC admin request