### PR TITLE
[cms] Allow direct and subs for issuance

### DIFF
--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -305,7 +305,11 @@ func (p *politeiawww) validateDCC(nd cms.NewDCC, u *user.User) error {
 			ErrorCode: cms.ErrorStatusInvalidDCCNominee,
 		}
 	}
-	if nomineeUser.ContractorType != cms.ContractorTypeNominee &&
+	// All nominees, direct and subcontractors are allowed to be submitted
+	// for an issuance.
+	if (nomineeUser.ContractorType != cms.ContractorTypeNominee &&
+		nomineeUser.ContractorType != cms.ContractorTypeDirect &&
+		nomineeUser.ContractorType != cms.ContractorTypeSubContractor) &&
 		dcc.Type == cms.DCCTypeIssuance {
 		return www.UserError{
 			ErrorCode: cms.ErrorStatusInvalidDCCNominee,


### PR DESCRIPTION
This allows for existing contractors to be submitted for DCC's for the following situation:

A previously accepted marketing/events contractor has worked on learning Dev and
needs to be approved via DCC to bill for the new Development work.