### PR TITLE
cache: Add ProposalGeneralMetadata table.

### DIFF
--- a/politeiad/cache/cache.go
+++ b/politeiad/cache/cache.go
@@ -6,6 +6,8 @@ package cache
 
 import (
 	"errors"
+
+	"github.com/jinzhu/gorm"
 )
 
 type RecordStatusT int
@@ -141,11 +143,19 @@ type PluginDriver interface {
 	// Setup the plugin tables
 	Setup() error
 
-	// Build the plugin tables from scratch
-	Build(string) error
+	// Build the plugin tables from scratch. The given payload should
+	// provide all data neccesary to build the plugin tables.
+	Build(payload string) error
 
-	// Execute a plugin command
-	Exec(string, string, string) (string, error)
+	// Execute a plugin command. Some commands are executed by
+	// politeiad first then fowarded to the cache. If this is the case
+	// the replyPayload will be populated with the politeiad reply,
+	// otherwise the replyPayload will be empty.
+	Exec(cmdID, cmdPayload, replyPayload string) (string, error)
+
+	// Run a plugin hook. The given gorm.DB should be a transaction so
+	// that the hook actions can be executed atomically.
+	Hook(tx *gorm.DB, hookID, payload string) error
 }
 
 // Cache describes the interface used for interacting with an external

--- a/politeiad/cache/cache.go
+++ b/politeiad/cache/cache.go
@@ -144,7 +144,7 @@ type PluginDriver interface {
 	Setup() error
 
 	// Build the plugin tables from scratch. The given payload should
-	// provide all data neccesary to build the plugin tables.
+	// provide all data necessary to build the plugin tables.
 	Build(payload string) error
 
 	// Execute a plugin command. Some commands are executed by

--- a/politeiad/cache/cockroachdb/cockroachdb.go
+++ b/politeiad/cache/cockroachdb/cockroachdb.go
@@ -5,6 +5,7 @@
 package cockroachdb
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -28,6 +29,11 @@ const (
 	tableMetadataStreams = "metadata_streams"
 	tableFiles           = "files"
 
+	// Plugin hooks
+	pluginHookPostNewRecord            = "postnewrecord"
+	pluginHookPostUpdateRecord         = "postupdaterecord"
+	pluginHookPostUpdateRecordMetadata = "postupdaterecordmetadata"
+
 	// Database users
 	UserPoliteiad   = "politeiad"   // politeiad user (read/write access)
 	UserPoliteiawww = "politeiawww" // politeiawww user (read access)
@@ -39,6 +45,32 @@ type cockroachdb struct {
 	shutdown  bool                          // Backend is shutdown
 	recordsdb *gorm.DB                      // Database context
 	plugins   map[string]cache.PluginDriver // [pluginID]PluginDriver
+}
+
+func (c *cockroachdb) newRecord(tx *gorm.DB, r Record) error {
+	// Insert record
+	err := tx.Create(&r).Error
+	if err != nil {
+		return err
+	}
+
+	// Call plugin hooks
+	if c.pluginIsRegistered(decredplugin.ID) {
+		plugin, err := c.getPlugin(decredplugin.ID)
+		if err != nil {
+			return err
+		}
+		payload, err := json.Marshal(r)
+		if err != nil {
+			return err
+		}
+		err = plugin.Hook(tx, pluginHookPostNewRecord, string(payload))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // NewRecord creates a new entry in the database for the passed in record.
@@ -58,9 +90,16 @@ func (c *cockroachdb) NewRecord(cr cache.Record) error {
 		return fmt.Errorf("parse version '%v' failed: %v",
 			cr.Version, err)
 	}
-
 	r := convertRecordFromCache(cr, v)
-	return c.recordsdb.Create(&r).Error
+
+	tx := c.recordsdb.Begin()
+	err = c.newRecord(tx, r)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit().Error
 }
 
 // recordVersion gets the specified version of a record from the database.
@@ -149,7 +188,7 @@ func (c *cockroachdb) Record(token string) (*cache.Record, error) {
 	return &cr, nil
 }
 
-// updateMetadataStreams updates a records metadata streams by deleting the
+// updateMetadataStreams updates a record's metadata streams by deleting the
 // existing metadata streams then adding the passed in metadata streams to the
 // database.
 //
@@ -234,6 +273,22 @@ func (c *cockroachdb) updateRecord(tx *gorm.DB, updated Record) error {
 		}).Error
 		if err != nil {
 			return fmt.Errorf("create file %v: %v", f.Name, err)
+		}
+	}
+
+	// Call plugin hooks
+	if c.pluginIsRegistered(decredplugin.ID) {
+		plugin, err := c.getPlugin(decredplugin.ID)
+		if err != nil {
+			return err
+		}
+		payload, err := json.Marshal(updated)
+		if err != nil {
+			return err
+		}
+		err = plugin.Hook(tx, pluginHookPostUpdateRecord, string(payload))
+		if err != nil {
+			return err
 		}
 	}
 
@@ -344,7 +399,25 @@ func (c *cockroachdb) updateRecordMetadata(tx *gorm.DB, token string, ms []Metad
 		return err
 	}
 
-	return updateMetadataStreams(tx, r.Key, ms)
+	// Update metadata
+	err = updateMetadataStreams(tx, r.Key, ms)
+	if err != nil {
+		return err
+	}
+
+	// Call plugin hooks
+	if c.pluginIsRegistered(decredplugin.ID) {
+		plugin, err := c.getPlugin(decredplugin.ID)
+		if err != nil {
+			return err
+		}
+		err = plugin.Hook(tx, pluginHookPostUpdateRecordMetadata, "")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // UpdateRecordMetadata updates the metadata streams of the given record. It
@@ -534,6 +607,14 @@ func (c *cockroachdb) Inventory() ([]cache.Record, error) {
 	}
 
 	return cr, nil
+}
+
+func (c *cockroachdb) pluginIsRegistered(pluginID string) bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	_, ok := c.plugins[pluginID]
+	return ok
 }
 
 func (c *cockroachdb) getPlugin(id string) (cache.PluginDriver, error) {

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -1449,7 +1449,6 @@ func (d *decred) hookPostUpdateRecordMetadata(tx *gorm.DB, payload string) error
 	// mdstream tables, such as ProposalGeneralMetadata and StartVote,
 	// need to be properly updated in this hook.
 	panic("cache decred plugin: hookPostUpdateRecordMetadata not implemented")
-	return nil
 }
 
 // Hook executes the given decred plugin hook.

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -5,12 +5,14 @@
 package cockroachdb
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/decred/politeia/decredplugin"
+	"github.com/decred/politeia/mdstream"
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/cache"
 	"github.com/jinzhu/gorm"
@@ -23,14 +25,15 @@ const (
 	decredVersion = "1.1"
 
 	// Decred plugin table names
-	tableComments          = "comments"
-	tableCommentLikes      = "comment_likes"
-	tableCastVotes         = "cast_votes"
-	tableAuthorizeVotes    = "authorize_votes"
-	tableVoteOptions       = "vote_options"
-	tableStartVotes        = "start_votes"
-	tableVoteOptionResults = "vote_option_results"
-	tableVoteResults       = "vote_results"
+	tableProposalGeneralMetadata = "proposal_general_metadata"
+	tableComments                = "comments"
+	tableCommentLikes            = "comment_likes"
+	tableCastVotes               = "cast_votes"
+	tableAuthorizeVotes          = "authorize_votes"
+	tableVoteOptions             = "vote_options"
+	tableStartVotes              = "start_votes"
+	tableVoteOptionResults       = "vote_option_results"
+	tableVoteResults             = "vote_results"
 
 	// Vote option IDs
 	voteOptionIDApproved = "yes"
@@ -1326,6 +1329,145 @@ sendReply:
 	return string(reply), nil
 }
 
+// hookPostNewRecord executes the decred plugin post new record hook. This
+// includes inserting a ProposalGeneralMetadata record for the given proposal.
+//
+// This function must be called using a transaction.
+func (d *decred) hookPostNewRecord(tx *gorm.DB, payload string) error {
+	// Decode ProposalGeneral mdstream
+	var r Record
+	err := json.Unmarshal([]byte(payload), &r)
+	if err != nil {
+		return err
+	}
+
+	var pg *mdstream.ProposalGeneral
+	for _, md := range r.Metadata {
+		if md.ID == mdstream.IDProposalGeneral {
+			pg, err = mdstream.DecodeProposalGeneral([]byte(md.Payload))
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+	if pg == nil {
+		return fmt.Errorf("mdstream %v not found",
+			mdstream.IDProposalGeneral)
+	}
+
+	// All prososal versions are stored in the cache which means that
+	// this new proposal request could be for a brand new proposal or
+	// it could be for a new proposal version that is the result of a
+	// proposal edit. We only need to store the ProposalGeneralMetadata
+	// for the most recent version of the proposal.
+	if r.Version > 1 {
+		// Delete existing metadata
+		err := tx.Delete(ProposalGeneralMetadata{
+			Token: r.Token,
+		}).Error
+		if err != nil {
+			return fmt.Errorf("delete: %v", err)
+		}
+	}
+
+	// Insert new metadata
+	err = tx.Create(&ProposalGeneralMetadata{
+		Token:           r.Token,
+		ProposalVersion: r.Version,
+		Version:         pg.Version,
+		Timestamp:       pg.Timestamp,
+		Name:            pg.Name,
+		Signature:       pg.Signature,
+		PublicKey:       pg.PublicKey,
+	}).Error
+	if err != nil {
+		return fmt.Errorf("create: %v", err)
+	}
+
+	return nil
+}
+
+// hookPostUpdateRecord executes the decred plugin post update record hook.
+// This includes updating the ProposalGeneralMetadata in the cache for the
+// given proposal. The existing metadata is first deleted before the new
+// metadata is inserted.
+//
+// This function must be called using a transaction.
+func (d *decred) hookPostUpdateRecord(tx *gorm.DB, payload string) error {
+	// Decode ProposalGeneral mdstream
+	var r Record
+	err := json.Unmarshal([]byte(payload), &r)
+	if err != nil {
+		return err
+	}
+	var pg *mdstream.ProposalGeneral
+	for _, md := range r.Metadata {
+		if md.ID == mdstream.IDProposalGeneral {
+			pg, err = mdstream.DecodeProposalGeneral([]byte(md.Payload))
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+	if pg == nil {
+		return fmt.Errorf("mdstream %v not found",
+			mdstream.IDProposalGeneral)
+	}
+
+	// Delete existing metadata
+	err = tx.Delete(ProposalGeneralMetadata{
+		Token: r.Token,
+	}).Error
+	if err != nil {
+		return fmt.Errorf("delete: %v", err)
+	}
+
+	// Insert new metadata record
+	err = tx.Create(&ProposalGeneralMetadata{
+		Token:           r.Token,
+		ProposalVersion: r.Version,
+		Version:         pg.Version,
+		Timestamp:       pg.Timestamp,
+		Name:            pg.Name,
+		Signature:       pg.Signature,
+		PublicKey:       pg.PublicKey,
+	}).Error
+	if err != nil {
+		return fmt.Errorf("create: %v", err)
+	}
+
+	return nil
+}
+
+// hookPostUpdateRecordMetadata executes the decred plugin post update record
+// metadata hook.
+func (d *decred) hookPostUpdateRecordMetadata(tx *gorm.DB, payload string) error {
+	// piwww does not currently use the UpdateRecordMetadata route.
+	// If this changes, this panic is here as a reminder that any piwww
+	// mdstream tables, such as ProposalGeneralMetadata and StartVote,
+	// need to be properly updated in this hook.
+	panic("cache decred plugin: hookPostUpdateRecordMetadata not implemented")
+	return nil
+}
+
+// Hook executes the given decred plugin hook.
+func (d *decred) Hook(tx *gorm.DB, hookID, payload string) error {
+	log.Tracef("decred Hook: %v", hookID)
+
+	switch hookID {
+	case pluginHookPostNewRecord:
+		return d.hookPostNewRecord(tx, payload)
+	case pluginHookPostUpdateRecord:
+		return d.hookPostUpdateRecord(tx, payload)
+	case pluginHookPostUpdateRecordMetadata:
+		return d.hookPostUpdateRecordMetadata(tx, payload)
+	}
+
+	return nil
+}
+
 // Exec executes a decred plugin command.  Plugin commands that write data to
 // the cache require both the command payload and the reply payload.  Plugin
 // commands that fetch data from the cache require only the command payload.
@@ -1386,6 +1528,12 @@ func (d *decred) createTables(tx *gorm.DB) error {
 	log.Tracef("createTables")
 
 	// Create decred plugin tables
+	if !tx.HasTable(tableProposalGeneralMetadata) {
+		err := tx.CreateTable(&ProposalGeneralMetadata{}).Error
+		if err != nil {
+			return err
+		}
+	}
 	if !tx.HasTable(tableComments) {
 		err := tx.CreateTable(&Comment{}).Error
 		if err != nil {
@@ -1464,8 +1612,8 @@ func (d *decred) dropTables(tx *gorm.DB) error {
 	// Drop decred plugin tables
 	err := tx.DropTableIfExists(tableComments, tableCommentLikes,
 		tableCastVotes, tableAuthorizeVotes, tableVoteOptions,
-		tableStartVotes, tableVoteOptionResults, tableVoteResults).
-		Error
+		tableStartVotes, tableVoteOptionResults, tableVoteResults,
+		tableProposalGeneralMetadata).Error
 	if err != nil {
 		return err
 	}
@@ -1587,6 +1735,90 @@ func (d *decred) build(ir *decredplugin.InventoryReply) error {
 		if err != nil {
 			log.Debugf("insert cast vote failed on '%v'", cv)
 			return fmt.Errorf("insert cast vote: %v", err)
+		}
+	}
+
+	// Build the ProposalGeneralMetadata cache. This metadata is not
+	// part of the decredplugin InventoryReply. It is already stored
+	// in the cached as a MetadataStream with an encoded payload. We
+	// need to lookup the MetadataStreams for each record, decode the
+	// mdstream, and save it as a ProposalGeneralMetadata record so
+	// that it is queriable. Only the ProposalGeneralMetadata for the
+	// most recent version of the proposal is saved to the cache.
+
+	// Lookup latest version of each record
+	query := `SELECT a.*
+            FROM records a
+            LEFT OUTER JOIN records b
+              ON a.token = b.token
+              AND a.version < b.version
+              WHERE b.token IS NULL`
+	rows, err := d.recordsdb.Raw(query).Rows()
+	if err != nil {
+		return fmt.Errorf("lookup latest records: %v", err)
+	}
+	defer rows.Close()
+
+	records := make([]Record, 0, 1024)
+	for rows.Next() {
+		var r Record
+		err := d.recordsdb.ScanRows(rows, &r)
+		if err != nil {
+			return err
+		}
+		records = append(records, r)
+	}
+	if err = rows.Err(); err != nil {
+		return err
+	}
+
+	// Compile a list of record primary keys
+	keys := make([]string, 0, len(records))
+	for _, v := range records {
+		keys = append(keys, v.Key)
+	}
+
+	// Lookup the metadata streams for each record
+	err = d.recordsdb.
+		Preload("Metadata").
+		Where(keys).
+		Find(&records).
+		Error
+	if err != nil {
+		return fmt.Errorf("lookup record metadata: %v", err)
+	}
+
+	for _, v := range records {
+		// Decode the ProposalGeneral mdstream
+		var pg *mdstream.ProposalGeneral
+		for _, md := range v.Metadata {
+			if md.ID == mdstream.IDProposalGeneral {
+				pg, err = mdstream.DecodeProposalGeneral([]byte(md.Payload))
+				if err != nil {
+					return fmt.Errorf("decode ProposalGenral %v '%v': %v",
+						v.Token, md.Payload, err)
+				}
+			}
+			if pg == nil {
+				return fmt.Errorf("no ProposalGenral mdstream found %v",
+					v.Token)
+			}
+		}
+
+		// Insert the ProposalGeneralMetadata record
+		pgm := ProposalGeneralMetadata{
+			Token:           v.Token,
+			ProposalVersion: v.Version,
+			Version:         pg.Version,
+			Timestamp:       pg.Timestamp,
+			Name:            pg.Name,
+			Signature:       pg.Signature,
+			PublicKey:       pg.PublicKey,
+		}
+		err := d.recordsdb.Create(&pgm).Error
+		if err != nil {
+			return fmt.Errorf("insert ProposalGeneralMetadata %v: %v",
+				pgm, err)
 		}
 	}
 

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -68,7 +68,7 @@ func (Record) TableName() string {
 //
 // This mdstream data is already saved to the cache as a MetadataStream with an
 // encoded payload. The ProposalGeneralMetadata duplicates existing data, but
-// is neccesary so that the metadata fields can be queried, which is not
+// is necessary so that the metadata fields can be queried, which is not
 // possible with the encoded MetadataStream payload. ProposalGeneralMetadata
 // is only saved for the most recent proposal version since this is the only
 // metadata that currently needs to be queried.
@@ -164,7 +164,7 @@ func (VoteOption) TableName() string {
 //
 // The data contained in the cache StartVote includes the decredplugin
 // StartVote and StartVoteReply mdstreams. These mdstreams are not saved in the
-// cache as seperate Record.Metadata for the given proposal. This means that
+// cache as separate Record.Metadata for the given proposal. This means that
 // this mdstream data will not be returned when a proposal record is fetched
 // from the cache. The cache StartVote must be queried directly to obtain this
 // data.

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -64,6 +64,26 @@ func (Record) TableName() string {
 	return tableRecords
 }
 
+// ProposalGeneralMetadata represents general medadata for a proposal.
+//
+// This mdstream data is already saved to the cache as a MetadataStream with an
+// encoded payload. The ProposalGeneralMetadata duplicates existing data, but
+// is neccesary so that the metadata fields can be queried, which is not
+// possible with the encoded MetadataStream payload. ProposalGeneralMetadata
+// is only saved for the most recent proposal version since this is the only
+// metadata that currently needs to be queried.
+//
+// This is a decred plugin model.
+type ProposalGeneralMetadata struct {
+	Token           string `gorm:"primary_key;size:64"` // Censorship token
+	ProposalVersion uint64 `gorm:"not null"`            // Proposal version
+	Version         uint64 `gorm:"not null"`            // Struct version
+	Timestamp       int64  `gorm:"not null"`            // Last update of proposal
+	Name            string `gorm:"not null"`            // Proposal name
+	Signature       string `gorm:"not null;size:128"`   // Client signature
+	PublicKey       string `gorm:"not null;size:64"`    // Pubkey used for Signature
+}
+
 // Comment represents a record comment, including all of the server side
 // metadata.
 //
@@ -141,6 +161,13 @@ func (VoteOption) TableName() string {
 }
 
 // StartVote records the details of a proposal vote.
+//
+// The data contained in the cache StartVote includes the decredplugin
+// StartVote and StartVoteReply mdstreams. These mdstreams are not saved in the
+// cache as seperate Record.Metadata for the given proposal. This means that
+// this mdstream data will not be returned when a proposal record is fetched
+// from the cache. The cache StartVote must be queried directly to obtain this
+// data.
 //
 // This is a decred plugin model.
 type StartVote struct {


### PR DESCRIPTION
This diff adds the ProposalGeneralMetadata table to the cache in order
to make the ProposalGeneral mdstream queryable. This mdstream was
previously being stored in the cache as a MetadataStream with an encoded
payload.  It still is stored as a MetadataStream, but a
ProposalGeneralMetadata record will now exist for the most recent
proposal version. This will be required once RFP proposals go live so
that the link between proposals can be queried.

The diff also required adding hooks for cache plugins so the the
ProposalGeneralMetadata table could be updated properly when a proposal
is submitted or edited.