### PR TITLE
politiawww: Move sessions to userdb.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/gorilla/csrf v1.6.0
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/schema v1.1.0
+	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/gorilla/websocket v1.4.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -105,7 +105,7 @@ func (p *politeiawww) handleInvoiceDetails(w http.ResponseWriter, r *http.Reques
 
 	user, err := p.getSessionUser(w, r)
 	if err != nil {
-		if err != ErrSessionUUIDNotFound {
+		if err != errSessionNotFound {
 			RespondWithError(w, r, 0,
 				"handleInvoiceDetails: getSessionUser %v", err)
 			return
@@ -340,7 +340,7 @@ func (p *politeiawww) handleInvoiceComments(w http.ResponseWriter, r *http.Reque
 
 	user, err := p.getSessionUser(w, r)
 	if err != nil {
-		if err != ErrSessionUUIDNotFound {
+		if err != errSessionNotFound {
 			RespondWithError(w, r, 0,
 				"handleCommentsGet: getSessionUser %v", err)
 			return
@@ -702,7 +702,7 @@ func (p *politeiawww) handleDCCComments(w http.ResponseWriter, r *http.Request) 
 
 	user, err := p.getSessionUser(w, r)
 	if err != nil {
-		if err != ErrSessionUUIDNotFound {
+		if err != errSessionNotFound {
 			RespondWithError(w, r, 0,
 				"handleDCCComments: getSessionUser %v", err)
 			return

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -22,7 +22,7 @@ func (p *politeiawww) isLoggedIn(f http.HandlerFunc) http.HandlerFunc {
 		log.Debugf("isLoggedIn: %v %v %v %v", remoteAddr(r), r.Method,
 			r.URL, r.Proto)
 
-		uid, err := p.getSessionUserID(w, r)
+		id, err := p.getSessionUserID(w, r)
 		if err != nil {
 			util.RespondWithJSON(w, http.StatusUnauthorized, www.ErrorReply{
 				ErrorCode: int64(www.ErrorStatusNotLoggedIn),
@@ -31,7 +31,7 @@ func (p *politeiawww) isLoggedIn(f http.HandlerFunc) http.HandlerFunc {
 		}
 
 		// Check if user is authenticated
-		if uid == "" {
+		if id == "" {
 			util.RespondWithJSON(w, http.StatusUnauthorized, www.ErrorReply{
 				ErrorCode: int64(www.ErrorStatusNotLoggedIn),
 			})

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -22,7 +22,7 @@ func (p *politeiawww) isLoggedIn(f http.HandlerFunc) http.HandlerFunc {
 		log.Debugf("isLoggedIn: %v %v %v %v", remoteAddr(r), r.Method,
 			r.URL, r.Proto)
 
-		id, err := p.getSessionUUID(r)
+		uid, err := p.getSessionUserID(w, r)
 		if err != nil {
 			util.RespondWithJSON(w, http.StatusUnauthorized, www.ErrorReply{
 				ErrorCode: int64(www.ErrorStatusNotLoggedIn),
@@ -31,7 +31,7 @@ func (p *politeiawww) isLoggedIn(f http.HandlerFunc) http.HandlerFunc {
 		}
 
 		// Check if user is authenticated
-		if id == "" {
+		if uid == "" {
 			util.RespondWithJSON(w, http.StatusUnauthorized, www.ErrorReply{
 				ErrorCode: int64(www.ErrorStatusNotLoggedIn),
 			})

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -42,6 +42,16 @@ func (p *politeiawww) isLoggedIn(f http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// isAdmin returns true if the current session has admin privileges.
+func (p *politeiawww) isAdmin(w http.ResponseWriter, r *http.Request) (bool, error) {
+	user, err := p.getSessionUser(w, r)
+	if err != nil {
+		return false, err
+	}
+
+	return user.Admin, nil
+}
+
 // isLoggedInAsAdmin ensures that a user is logged in as an admin user
 // before calling the next function.
 func (p *politeiawww) isLoggedInAsAdmin(f http.HandlerFunc) http.HandlerFunc {

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/csrf"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 	"github.com/gorilla/websocket"
 	"github.com/robfig/cron"
 )
@@ -85,7 +86,7 @@ func (w *wsContext) isAuthenticated() bool {
 type politeiawww struct {
 	cfg      *config
 	router   *mux.Router
-	sessions *SessionStore
+	sessions sessions.Store
 
 	ws    map[string]map[string]*wsContext // [uuid][]*context
 	wsMtx sync.RWMutex

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -83,10 +83,9 @@ func (w *wsContext) isAuthenticated() bool {
 
 // politeiawww application context.
 type politeiawww struct {
-	cfg    *config
-	router *mux.Router
-
-	store *SessionStore
+	cfg      *config
+	router   *mux.Router
+	sessions *SessionStore
 
 	ws    map[string]map[string]*wsContext // [uuid][]*context
 	wsMtx sync.RWMutex

--- a/politeiawww/sessions.go
+++ b/politeiawww/sessions.go
@@ -46,7 +46,9 @@ func (p *politeiawww) getSession(r *http.Request) (*sessions.Session, error) {
 	return p.sessions.Get(r, www.CookieSession)
 }
 
-// getSessionUserID returns the user ID of the user for the given session.
+// getSessionUserID returns the user ID of the user for the given session. A
+// errSessionNotFound error is returned if a user session does not exist or
+// has expired.
 func (p *politeiawww) getSessionUserID(w http.ResponseWriter, r *http.Request) (string, error) {
 	session, err := p.getSession(r)
 	if err != nil {
@@ -67,7 +69,8 @@ func (p *politeiawww) getSessionUserID(w http.ResponseWriter, r *http.Request) (
 	return session.Values[sessionValueUserID].(string), nil
 }
 
-// getSessionUser returns the User for the given session.
+// getSessionUser returns the User for the given session. A errSessionFound
+// error is returned if a user session does not exist or has expired.
 func (p *politeiawww) getSessionUser(w http.ResponseWriter, r *http.Request) (*user.User, error) {
 	log.Tracef("getSessionUser")
 
@@ -91,9 +94,7 @@ func (p *politeiawww) getSessionUser(w http.ResponseWriter, r *http.Request) (*u
 		if err != nil {
 			return nil, err
 		}
-		return nil, www.UserError{
-			ErrorCode: www.ErrorStatusNotLoggedIn,
-		}
+		return nil, errSessionNotFound
 	}
 
 	return user, nil

--- a/politeiawww/sessions.go
+++ b/politeiawww/sessions.go
@@ -121,10 +121,10 @@ func (p *politeiawww) removeSession(w http.ResponseWriter, r *http.Request) erro
 	return p.sessions.Save(r, w, session)
 }
 
-// initSession creates a new session, adds it to the given http.Request, and
-// saves it to the session store. If the http request already contains a
-// session cookie then the session values will be updated and the session will
-// be updated in the session store.
+// initSession creates a new session, adds it to the given http response
+// session cookie, and saves it to the session store. If the http request
+// already contains a session cookie then the session values will be updated
+// and the session will be updated in the session store.
 func (p *politeiawww) initSession(w http.ResponseWriter, r *http.Request, userID string) error {
 	log.Tracef("initSession: %v", userID)
 
@@ -138,6 +138,6 @@ func (p *politeiawww) initSession(w http.ResponseWriter, r *http.Request, userID
 	session.Values[sessionValueCreatedAt] = time.Now().Unix()
 	session.Values[sessionValueUserID] = userID
 
-	// Update session in the database and the http response
+	// Update session in the store and update the response cookie
 	return p.sessions.Save(r, w, session)
 }

--- a/politeiawww/sessions.go
+++ b/politeiawww/sessions.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	www "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/politeiawww/user"
+	"github.com/google/uuid"
+	"github.com/gorilla/sessions"
+)
+
+func hasExpired(session *sessions.Session) (bool, error) {
+	createdAt, ok := session.Values[sessionValueCreatedAt].(int64)
+	if !ok {
+		return false, fmt.Errorf("no created_at timestamp found")
+	}
+	expiresAt := createdAt + int64(session.Options.MaxAge)
+	return time.Now().Unix() > expiresAt, nil
+}
+
+// getSession returns the active cookie session. If no active cookie session
+// exists then a new session object is returned. Access IsNew on the session to
+// check if it is an existing session or a new one. The new session will also
+// not have any sessions values set, such as user_id, and has not been saved to
+// the session store yet.
+func (p *politeiawww) getSession(r *http.Request) (*sessions.Session, error) {
+	return p.sessions.Get(r, www.CookieSession)
+}
+
+// getSessionUserID returns the uuid address of the currently logged in user
+// from the session store.
+func (p *politeiawww) getSessionUserID(w http.ResponseWriter, r *http.Request) (string, error) {
+	session, err := p.getSession(r)
+	if err != nil {
+		return "", err
+	}
+	if session.IsNew {
+		return "", errSessionNotFound
+	}
+
+	// Delete the session if its expired. Setting the MaxAge
+	// to <= 0 and then saving it will trigger a deletion.
+	obsolete, err := hasExpired(session)
+	if err != nil || obsolete {
+		session.Options.MaxAge = -1
+		p.sessions.Save(r, w, session)
+		return "", errSessionNotFound
+	}
+
+	return session.Values[sessionValueUserID].(string), nil
+}
+
+// getSessionUser retrieves the current session user from the database.
+func (p *politeiawww) getSessionUser(w http.ResponseWriter, r *http.Request) (*user.User, error) {
+	uid, err := p.getSessionUserID(w, r)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Tracef("getSessionUser: %v", uid)
+	pid, err := uuid.Parse(uid)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := p.db.UserGetById(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	if user.Deactivated {
+		p.removeSession(w, r)
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusNotLoggedIn,
+		}
+	}
+
+	return user, nil
+}
+
+func (p *politeiawww) getSessionID(r *http.Request) string {
+	session, err := p.getSession(r)
+	if err != nil {
+		return ""
+	}
+
+	return session.ID
+}
+
+// removeSession deletes the session from the database.
+func (p *politeiawww) removeSession(w http.ResponseWriter, r *http.Request) error {
+	log.Tracef("removeSession")
+
+	session, err := p.getSession(r)
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Deleting user session: %v %v",
+		session.ID, session.Values[sessionValueUserID])
+
+	// Saving the session with a negative MaxAge will cause it to be deleted.
+	session.Options.MaxAge = -1
+	return session.Save(r, w)
+}
+
+// initSession adds a session record to the database and links it to the given
+// user ID.
+func (p *politeiawww) initSession(w http.ResponseWriter, r *http.Request, userID string) error {
+	log.Tracef("initSession: %v", userID)
+
+	session, err := p.getSession(r)
+	if err != nil {
+		return err
+	}
+	if !session.IsNew {
+		return fmt.Errorf("session already exists")
+	}
+
+	session.Values[sessionValueCreatedAt] = time.Now().Unix()
+	session.Values[sessionValueUserID] = userID
+
+	return session.Save(r, w)
+}

--- a/politeiawww/sessions.go
+++ b/politeiawww/sessions.go
@@ -26,7 +26,8 @@ const (
 )
 
 var (
-	// errSessionNotFound is emitted when a session is not found.
+	// errSessionNotFound is emitted when a session is not found in the
+	// session store.
 	errSessionNotFound = errors.New("session not found")
 )
 
@@ -36,11 +37,11 @@ func sessionIsExpired(session *sessions.Session) bool {
 	return time.Now().Unix() > expiresAt
 }
 
-// getSession returns the active cookie session. If no active cookie session
-// exists then a new session object is returned. Access IsNew on the session to
-// check if it is an existing session or a new one. The new session will not
-// have any sessions values set, such as user_id, and will not have been saved
-// to the session store yet.
+// getSession returns the Session for the session ID from the given http
+// request cookie. If no session exists then a new session object is returned.
+// Access IsNew on the session to check if it is an existing session or a new
+// one. The new session will not have any sessions values set, such as user_id,
+// and will not have been saved to the session store yet.
 func (p *politeiawww) getSession(r *http.Request) (*sessions.Session, error) {
 	return p.sessions.Get(r, www.CookieSession)
 }
@@ -136,6 +137,6 @@ func (p *politeiawww) initSession(w http.ResponseWriter, r *http.Request, userID
 	session.Values[sessionValueCreatedAt] = time.Now().Unix()
 	session.Values[sessionValueUserID] = userID
 
-	// Update session in the database
+	// Update session in the database and the http response
 	return p.sessions.Save(r, w, session)
 }

--- a/politeiawww/sessionstore.go
+++ b/politeiawww/sessionstore.go
@@ -26,8 +26,8 @@ type SessionStore struct {
 
 // newSessionID returns a new session ID. A session ID is defined as a 32 byte
 // base32 string with padding. The session ID is set by the store and can be
-// whatever the store chooses. This ID was chosen simply because that's what
-// the gorilla/sesssions package reference implemenation uses.
+// whatever the store chooses. This ID was chosen simply because it's what the
+// gorilla/sesssions package reference implemenation uses.
 func newSessionID() string {
 	return base32.StdEncoding.EncodeToString(securecookie.GenerateRandomKey(32))
 }
@@ -51,13 +51,13 @@ func (s *SessionStore) Get(r *http.Request, name string) (*sessions.Session, err
 
 // New returns a session for the given name without adding it to the registry.
 //
-// The difference between New() and Get() is that calling New() twice will
-// decode the session data twice, while Get() registers and reuses the same
-// decoded session after the first call.
-//
 // The sessions.Store interface dictates that New() should never return a nil
 // session, even in the case of an error if using the Registry infrastructure
 // to cache the session.
+//
+// The difference between New() and Get() is that calling New() twice will
+// decode the session data twice, while Get() registers and reuses the same
+// decoded session after the first call.
 //
 // This function satisfies the sessions.Store interface.
 func (s *SessionStore) New(r *http.Request, name string) (*sessions.Session, error) {
@@ -181,8 +181,6 @@ func (s *SessionStore) Save(r *http.Request, w http.ResponseWriter, session *ses
 // The encryption key, if set, must be either 16, 24, or 32 bytes to select
 // AES-128, AES-192, or AES-256 modes.
 func NewSessionStore(db user.Database, sessionMaxAge int, keyPairs ...[]byte) *SessionStore {
-	// TODO: how does the securecookie instance MaxAge differ from the
-	// session store max age?
 	// Set the maxAge for each securecookie instance
 	codecs := securecookie.CodecsFromPairs(keyPairs...)
 	for _, codec := range codecs {

--- a/politeiawww/sessionstore.go
+++ b/politeiawww/sessionstore.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/base32"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/decred/politeia/politeiawww/user"
+	"github.com/google/uuid"
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+)
+
+// SessionStore stores sessions in the database.
+//
+// Please note: this is (by and large) a clone of gorilla mux'
+// `sessions.FilesystemStore` with the save(), load() and erase()
+// methods adapted to use the database as the backing storage.
+type SessionStore struct {
+	Codecs  []securecookie.Codec
+	Options *sessions.Options // default configuration
+	db      user.Database
+}
+
+// NewSessionStore returns a new SessionStore.
+//
+// The db argument is the database where sessions will be saved.
+//
+// Keys are defined in pairs to allow key rotation, but the common case is
+// to set a single authentication key and optionally an encryption key.
+//
+// The first key in a pair is used for authentication and the second for
+// encryption. The encryption key can be set to nil or omitted in the last
+// pair, but the authentication key is required in all pairs.
+//
+// It is recommended to use an authentication key with 32 or 64 bytes.
+// The encryption key, if set, must be either 16, 24, or 32 bytes to select
+// AES-128, AES-192, or AES-256 modes.
+func NewSessionStore(db user.Database, keyPairs ...[]byte) *SessionStore {
+	ss := &SessionStore{
+		Codecs: securecookie.CodecsFromPairs(keyPairs...),
+		Options: &sessions.Options{
+			Path:     "/",
+			MaxAge:   sessionMaxAge,
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		},
+		db: db,
+	}
+
+	ss.MaxAge(ss.Options.MaxAge)
+	return ss
+}
+
+// Get returns a session for the given name after adding it to the registry.
+//
+// It returns a new session if the sessions doesn't exist. Access IsNew on
+// the session to check if it is an existing session or a new one.
+//
+// It returns a new session and an error if the session exists but could
+// not be decoded.
+func (s *SessionStore) Get(r *http.Request, name string) (*sessions.Session, error) {
+	return sessions.GetRegistry(r).Get(s, name)
+}
+
+// New returns a session for the given name without adding it to the registry.
+//
+// The difference between New() and Get() is that calling New() twice will
+// decode the session data twice, while Get() registers and reuses the same
+// decoded session after the first call.
+func (s *SessionStore) New(r *http.Request, name string) (*sessions.Session, error) {
+	session := sessions.NewSession(s, name)
+	opts := *s.Options
+	session.Options = &opts
+	session.IsNew = true
+	var err error
+	if c, errCookie := r.Cookie(name); errCookie == nil {
+		err = securecookie.DecodeMulti(name, c.Value, &session.ID, s.Codecs...)
+		if err == nil {
+			err = s.load(session)
+			if err == nil {
+				// Session found in database
+				session.IsNew = false
+			} else if err == user.ErrSessionDoesNotExist {
+				// Session not found in database, return the *new* session
+			} else {
+				return nil, err
+			}
+		}
+	}
+	return session, nil
+}
+
+// Save adds a single session to the response.
+//
+// If the Options.MaxAge of the session is <= 0 then the session file will be
+// deleted from the database. With this process it enforces proper session
+// cookie handling so no need to trust in the cookie management in the web
+// browser.
+func (s *SessionStore) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
+	// Delete if max-age is <= 0
+	if session.Options.MaxAge <= 0 {
+		if err := s.erase(session); err != nil {
+			return err
+		}
+		http.SetCookie(w, sessions.NewCookie(session.Name(), "", session.Options))
+		return nil
+	}
+
+	if session.ID == "" {
+		// Because the ID is used in the filename, encode it to
+		// use alphanumeric characters only.
+		session.ID = strings.TrimRight(
+			base32.StdEncoding.EncodeToString(
+				securecookie.GenerateRandomKey(32)), "=")
+	}
+	if err := s.save(session); err != nil {
+		return err
+	}
+	encoded, err := securecookie.EncodeMulti(session.Name(), session.ID,
+		s.Codecs...)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, sessions.NewCookie(session.Name(), encoded, session.Options))
+	return nil
+}
+
+// MaxAge sets the maximum age for the store and the underlying cookie
+// implementation. Individual sessions can be deleted by setting Options.MaxAge
+// = -1 for that session.
+func (s *SessionStore) MaxAge(age int) {
+	s.Options.MaxAge = age
+
+	// Set the maxAge for each securecookie instance.
+	for _, codec := range s.Codecs {
+		if sc, ok := codec.(*securecookie.SecureCookie); ok {
+			sc.MaxAge(age)
+		}
+	}
+}
+
+// save writes encoded session.Values to the database.
+func (s *SessionStore) save(session *sessions.Session) error {
+	// get the user for this session
+	id, ok := session.Values["user_id"].(string)
+	if !ok {
+		return fmt.Errorf("no user_id found in session")
+	}
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+
+	encoded, err := securecookie.EncodeMulti(session.Name(), session.Values,
+		s.Codecs...)
+	if err != nil {
+		return err
+	}
+	us := user.Session{
+		ID:     session.ID,
+		Values: encoded,
+		UserID: uid,
+	}
+
+	return s.db.SessionSave(us)
+}
+
+// load reads a database record and decodes its content into session.Values.
+func (s *SessionStore) load(session *sessions.Session) error {
+	us, err := s.db.SessionGetById(session.ID)
+	if err != nil {
+		return err
+	}
+	err = securecookie.DecodeMulti(
+		session.Name(), us.Values, &session.Values, s.Codecs...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// delete removes the database record for the provided session.
+func (s *SessionStore) erase(session *sessions.Session) error {
+	return s.db.SessionDeleteById(session.ID)
+}

--- a/politeiawww/sessionstore.go
+++ b/politeiawww/sessionstore.go
@@ -149,8 +149,8 @@ func (s *SessionStore) Save(r *http.Request, w http.ResponseWriter, session *ses
 	}
 	err = s.db.SessionSave(user.Session{
 		ID:     session.ID,
-		Values: encodedValues,
 		UserID: uid,
+		Values: encodedValues,
 	})
 	if err != nil {
 		return err
@@ -166,6 +166,17 @@ func (s *SessionStore) Save(r *http.Request, w http.ResponseWriter, session *ses
 	http.SetCookie(w, c)
 
 	return nil
+}
+
+// newSessionOptions returns the default session configuration for politeiawww.
+func newSessionOptions() *sessions.Options {
+	return &sessions.Options{
+		Path:     "/",
+		MaxAge:   sessionMaxAge, // Max age for the store
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	}
 }
 
 // NewSessionStore returns a new SessionStore.
@@ -190,14 +201,8 @@ func NewSessionStore(db user.Database, sessionMaxAge int, keyPairs ...[]byte) *S
 	}
 
 	return &SessionStore{
-		Codecs: codecs,
-		Options: &sessions.Options{
-			Path:     "/",
-			MaxAge:   sessionMaxAge, // Max age for the store
-			Secure:   true,
-			HttpOnly: true,
-			SameSite: http.SameSiteStrictMode,
-		},
-		db: db,
+		Codecs:  codecs,
+		Options: newSessionOptions(),
+		db:      db,
 	}
 }

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -225,7 +225,7 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 		cache:           testcache.New(),
 		params:          &chaincfg.TestNet3Params,
 		router:          mux.NewRouter(),
-		sessions:        NewSessionStore(db, cookieKey),
+		sessions:        NewSessionStore(db, sessionMaxAge, cookieKey),
 		smtp:            smtp,
 		test:            true,
 		userEmails:      make(map[string]uuid.UUID),

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -26,7 +26,6 @@ import (
 	"github.com/decred/politeia/util"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/gorilla/sessions"
 )
 
 // errToStr returns the string representation of the error. If the error is a
@@ -214,19 +213,7 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 	if err != nil {
 		t.Fatalf("create cookie key: %v", err)
 	}
-	sessionsDir := filepath.Join(cfg.DataDir, "sessions")
-	err = os.MkdirAll(sessionsDir, 0700)
-	if err != nil {
-		t.Fatalf("make sessions dir: %v", err)
-	}
-	store := sessions.NewFilesystemStore(sessionsDir, cookieKey)
-	store.Options = &sessions.Options{
-		Path:     "/",
-		MaxAge:   sessionMaxAge,
-		Secure:   true,
-		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
-	}
+	store := NewSessionStore(db, cookieKey)
 
 	// Setup logging
 	initLogRotator(filepath.Join(dataDir, "politeiawww.test.log"))

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -1,16 +1,12 @@
-// Copyright (c) 2017-2019 The Decred developers
+// Copyright (c) 2017-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package main
 
 import (
-	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,20 +38,6 @@ func errToStr(e error) string {
 	}
 
 	return e.Error()
-}
-
-// newPostReq returns an httptest post request that was created using the
-// passed in data.
-func newPostReq(t *testing.T, route string, body interface{}) *http.Request {
-	t.Helper()
-
-	b, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	return httptest.NewRequest(http.MethodPost, route,
-		bytes.NewReader(b))
 }
 
 func payRegistrationFee(t *testing.T, p *politeiawww, u *user.User) {

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -213,7 +213,6 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 	if err != nil {
 		t.Fatalf("create cookie key: %v", err)
 	}
-	store := NewSessionStore(db, cookieKey)
 
 	// Setup logging
 	initLogRotator(filepath.Join(dataDir, "politeiawww.test.log"))
@@ -226,7 +225,7 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 		cache:           testcache.New(),
 		params:          &chaincfg.TestNet3Params,
 		router:          mux.NewRouter(),
-		store:           store,
+		sessions:        NewSessionStore(db, cookieKey),
 		smtp:            smtp,
 		test:            true,
 		userEmails:      make(map[string]uuid.UUID),

--- a/politeiawww/user/cockroachdb/cockroachdb.go
+++ b/politeiawww/user/cockroachdb/cockroachdb.go
@@ -414,60 +414,21 @@ func (c *cockroachdb) SessionSave(us user.Session) error {
 		return user.ErrShutdown
 	}
 
-	// Check if session already exists
-	var update bool
-	var session Session
-	err := c.userDB.
-		Where("id = ?", us.ID).
-		Find(&session).
-		Error
-	if err == gorm.ErrRecordNotFound {
-		// Session already exists. Update session instead of
-		// creating a new one.
-		update = true
-	} else if err != nil {
-		return fmt.Errorf("lookup: %v", err)
-	}
-	_ = update
-
 	/*
-		// Save session
-		session = Session{
-			Key:    us.ID,
-			UserID: us.UserID,
-			Blob:   b,
+		// Check if session already exists
+		var update bool
+		var session Session
+		err := c.userDB.
+			Where("id = ?", us.ID).
+			Find(&session).
+			Error
+		if err == gorm.ErrRecordNotFound {
+			// Session already exists. Update session instead of
+			// creating a new one.
+			update = true
+		} else if err != nil {
+			return fmt.Errorf("lookup: %v", err)
 		}
-
-		if update {
-		}
-
-			var model Session
-			var update bool
-
-			err := c.userDB.
-				Where("id = ?", us.ID).
-				First(&model).
-				Error
-			if err == nil {
-				// session exists, update the record.
-				update = true
-			} else if err != gorm.ErrRecordNotFound {
-				return err
-			}
-
-			model = Session{
-				ID:     us.ID,
-				UserID: us.UserID,
-				Values: us.Values}
-
-			if update {
-				err = c.userDB.Save(&model).Error
-			} else {
-				err = c.userDB.Create(&model).Error
-			}
-			if err != nil {
-				return fmt.Errorf("create session: %v", err)
-			}
 	*/
 
 	return nil
@@ -483,25 +444,25 @@ func (c *cockroachdb) SessionGetByID(sid string) (*user.Session, error) {
 		return nil, user.ErrShutdown
 	}
 
-	var model Session
-	err := c.userDB.
-		Where("id = ?", sid).
-		First(&model).
-		Error
-	if err != nil {
-		if err == gorm.ErrRecordNotFound {
-			err = user.ErrSessionNotFound
-		}
-		return nil, err
-	}
-
 	/*
-		us := user.Session{
-			ID:     model.ID,
-			UserID: model.UserID,
-			Values: model.Values,
+		var model Session
+		err := c.userDB.
+			Where("id = ?", sid).
+			First(&model).
+			Error
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				err = user.ErrSessionNotFound
+			}
+			return nil, err
 		}
-		return &us, nil
+
+			us := user.Session{
+				ID:     model.ID,
+				UserID: model.UserID,
+				Values: model.Values,
+			}
+			return &us, nil
 	*/
 
 	return nil, nil
@@ -541,24 +502,27 @@ func (c *cockroachdb) SessionsDeleteByUserID(uid uuid.UUID,
 		return user.ErrShutdown
 	}
 
-	var err error
-	// this may delete 0+ records, hence the transaction
-	tx := c.userDB.Begin()
+	/*
+		var err error
+		// this may delete 0+ records, hence the transaction
+		tx := c.userDB.Begin()
 
-	if sessionToKeep == "" {
-		err = tx.
-			Delete(Session{}, "user_id = ?", uid).
-			Error
-	} else {
-		err = tx.
-			Delete(Session{}, "user_id = ? AND id != ?", uid, sessionToKeep).
-			Error
-	}
-	if err != nil {
-		tx.Rollback()
-		return err
-	}
-	return tx.Commit().Error
+		if sessionToKeep == "" {
+			err = tx.
+				Delete(Session{}, "user_id = ?", uid).
+				Error
+		} else {
+			err = tx.
+				Delete(Session{}, "user_id = ? AND id != ?", uid, sessionToKeep).
+				Error
+		}
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+		return tx.Commit().Error
+	*/
+	return nil
 }
 
 // rotateKeys rotates the existing database encryption key with the given new

--- a/politeiawww/user/cockroachdb/cockroachdb.go
+++ b/politeiawww/user/cockroachdb/cockroachdb.go
@@ -413,9 +413,10 @@ func (c *cockroachdb) convertSessionFromUser(s user.Session) (*Session, error) {
 		return nil, err
 	}
 	return &Session{
-		Key:    hex.EncodeToString(util.Digest([]byte(s.ID))),
-		UserID: s.UserID,
-		Blob:   eb,
+		Key:       hex.EncodeToString(util.Digest([]byte(s.ID))),
+		UserID:    s.UserID,
+		CreatedAt: s.CreatedAt,
+		Blob:      eb,
 	}, nil
 }
 

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -48,12 +48,22 @@ func (User) TableName() string {
 	return tableUsers
 }
 
-// Session represents a politeiawww user session.
+// Session represents a politeiawww user session. The actual session data is
+// stored as an encrypted blob. Lookups can be done using either a SHA256 hash
+// of the session ID or the user ID.
+type Session struct {
+	Key    string    `gorm:"primary_key"` // SHA256 hash of the session ID
+	UserID uuid.UUID `gorm:"not null"`    // User UUID (foreign key)
+	Blob   []byte    `gorm:"not null"`
+}
+
+/*
 type Session struct {
 	ID     string    `gorm:"primary_key"` // Unique session id
 	UserID uuid.UUID `gorm:"not null"`    // User UUID (foreign key)
 	Values string    `gorm:"not null"`    // session values (base64 encoded)
 }
+*/
 
 // TableName returns the table name of the Session table.
 func (Session) TableName() string {

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -48,22 +48,14 @@ func (User) TableName() string {
 	return tableUsers
 }
 
-// Session represents a politeiawww user session. The actual session data is
-// stored as an encrypted blob. Lookups can be done using either a SHA256 hash
-// of the session ID or the user ID.
+// Session represents a user session. The actual session data is stored as an
+// encrypted blob. Lookups can be done using either the user ID or a SHA256
+// hash of the session ID.
 type Session struct {
 	Key    string    `gorm:"primary_key"` // SHA256 hash of the session ID
 	UserID uuid.UUID `gorm:"not null"`    // User UUID (foreign key)
-	Blob   []byte    `gorm:"not null"`
+	Blob   []byte    `gorm:"not null"`    // Encrypted user session
 }
-
-/*
-type Session struct {
-	ID     string    `gorm:"primary_key"` // Unique session id
-	UserID uuid.UUID `gorm:"not null"`    // User UUID (foreign key)
-	Values string    `gorm:"not null"`    // session values (base64 encoded)
-}
-*/
 
 // TableName returns the table name of the Session table.
 func (Session) TableName() string {

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -48,6 +48,18 @@ func (User) TableName() string {
 	return tableUsers
 }
 
+// Session represents a politeiawww user session.
+type Session struct {
+	ID     string    `gorm:"primary_key"` // Unique session id
+	UserID uuid.UUID `gorm:"not null"`    // User UUID (foreign key)
+	Values string    `gorm:"not null"`    // session values (base64 encoded)
+}
+
+// TableName returns the table name of the Session table.
+func (Session) TableName() string {
+	return tableSessions
+}
+
 // CMSUser represents a CMS user. A CMS user includes the politeiawww User
 // object as well as CMS specific user fields. A CMS user must correspond to
 // a politeiawww User.

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -48,13 +48,18 @@ func (User) TableName() string {
 	return tableUsers
 }
 
-// Session represents a user session. The actual session data is stored as an
-// encrypted user.Session blob. Lookups can be done using either the user ID or
-// a SHA256 hash of the session ID.
+// Session represents a user session.
+//
+// Key is a SHA256 hash of the decoded session ID. The session Store handles
+// encoding/decoding the ID.
+//
+// Blob represents an ecrypted user.Session. The fields that have been broken
+// out of the encrypted blob are the fields that need to be queryable.
 type Session struct {
-	Key    string    `gorm:"primary_key"` // SHA256 hash of the session ID
-	UserID uuid.UUID `gorm:"not null"`    // User UUID
-	Blob   []byte    `gorm:"not null"`    // Encrypted user session
+	Key       string    `gorm:"primary_key"` // SHA256 hash of the session ID
+	UserID    uuid.UUID `gorm:"not null"`    // User UUID
+	CreatedAt int64     `gorm:"not null"`    // Created at UNIX timestamp
+	Blob      []byte    `gorm:"not null"`    // Encrypted user session
 }
 
 // TableName returns the table name of the Session table.

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -49,8 +49,8 @@ func (User) TableName() string {
 }
 
 // Session represents a user session. The actual session data is stored as an
-// encrypted blob. Lookups can be done using either the user ID or a SHA256
-// hash of the session ID.
+// encrypted user.Session blob. Lookups can be done using either the user ID or
+// a SHA256 hash of the session ID.
 type Session struct {
 	Key    string    `gorm:"primary_key"` // SHA256 hash of the session ID
 	UserID uuid.UUID `gorm:"not null"`    // User UUID

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -53,7 +53,7 @@ func (User) TableName() string {
 // hash of the session ID.
 type Session struct {
 	Key    string    `gorm:"primary_key"` // SHA256 hash of the session ID
-	UserID uuid.UUID `gorm:"not null"`    // User UUID (foreign key)
+	UserID uuid.UUID `gorm:"not null"`    // User UUID
 	Blob   []byte    `gorm:"not null"`    // Encrypted user session
 }
 

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -410,19 +410,19 @@ func (l *localdb) SessionSave(s user.Session) error {
 
 // Get a session by its id if present in the database.
 //
-// SessionGetById satisfies the Database interface.
-func (l *localdb) SessionGetById(sid string) (*user.Session, error) {
+// SessionGetByID satisfies the Database interface.
+func (l *localdb) SessionGetByID(sid string) (*user.Session, error) {
 	l.RLock()
 	defer l.RUnlock()
 
 	if l.shutdown {
 		return nil, user.ErrShutdown
 	}
-	log.Debugf("SessionGetById: %v", sid)
+	log.Debugf("SessionGetByID: %v", sid)
 
 	payload, err := l.userdb.Get([]byte(sessionPrefix+sid), nil)
 	if err == leveldb.ErrNotFound {
-		return nil, user.ErrSessionDoesNotExist
+		return nil, user.ErrSessionNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -438,14 +438,14 @@ func (l *localdb) SessionGetById(sid string) (*user.Session, error) {
 // Delete the session with the given id.
 //
 // SessionDeleteById satisfies the Database interface.
-func (l *localdb) SessionDeleteById(sid string) error {
+func (l *localdb) SessionDeleteByID(sid string) error {
 	l.RLock()
 	defer l.RUnlock()
 
 	if l.shutdown {
 		return user.ErrShutdown
 	}
-	log.Debugf("SessionDeleteById: %v", sid)
+	log.Debugf("SessionDeleteByID: %v", sid)
 
 	err := l.userdb.Delete([]byte(sessionPrefix+sid), nil)
 	if err != nil {
@@ -458,7 +458,7 @@ func (l *localdb) SessionDeleteById(sid string) error {
 // Delete all sessions for the given user id except the one specified.
 //
 // SessionsDeleteByUserId satisfies the Database interface.
-func (l *localdb) SessionsDeleteByUserId(uid uuid.UUID,
+func (l *localdb) SessionsDeleteByUserID(uid uuid.UUID,
 	sessionToKeep string) error {
 	l.RLock()
 	defer l.RUnlock()
@@ -467,7 +467,7 @@ func (l *localdb) SessionsDeleteByUserId(uid uuid.UUID,
 		return user.ErrShutdown
 	}
 
-	log.Debugf("SessionsDeleteByUserId %v", uid)
+	log.Debugf("SessionsDeleteByUserID %v", uid)
 
 	batch := new(leveldb.Batch)
 	iter := l.userdb.NewIterator(util.BytesPrefix([]byte(sessionPrefix)), nil)

--- a/politeiawww/user/localdb/localdb_test.go
+++ b/politeiawww/user/localdb/localdb_test.go
@@ -86,64 +86,64 @@ func TestSessionExistsAlready(t *testing.T) {
 	if err != nil {
 		t.Error("SessionSave() #2 returned an error")
 	}
-	us2, err := db.SessionGetById(s.ID)
+	us2, err := db.SessionGetByID(s.ID)
 	if err != nil {
-		t.Error("SessionGetById() returned an error")
+		t.Error("SessionGetByID() returned an error")
 	}
 	if s.Values != us2.Values {
 		t.Errorf("got Values: %v, want: %v", us2.Values, s.Values)
 	}
 }
 
-func TestSessionGetById(t *testing.T) {
+func TestSessionGetByID(t *testing.T) {
 	var err error
 	db, dataDir := setupTestData(t)
 	defer teardownTestData(t, db, dataDir)
 	s := user.Session{
 		ID:     uuid.New().String(),
 		UserID: uuid.New(),
-		Values: "TestSessionGetById()",
+		Values: "TestSessionGetByID()",
 	}
 	err = db.SessionSave(s)
 	if err != nil {
 		t.Error("SessionSave() returned an error")
 	}
-	sessionInDB, err := db.SessionGetById(s.ID)
+	sessionInDB, err := db.SessionGetByID(s.ID)
 	if err != nil {
-		t.Errorf("SessionGetById() returned an error: %v", err)
+		t.Errorf("SessionGetByID() returned an error: %v", err)
 	}
 	if sessionInDB == nil {
-		t.Error("SessionGetById() returned a nil pointer")
+		t.Error("SessionGetByID() returned a nil pointer")
 	}
 	if s != *sessionInDB {
 		t.Errorf("got session: %v, want: %v", sessionInDB, s)
 	}
 }
 
-func TestSessionGetByIdAndNoRecord(t *testing.T) {
+func TestSessionGetByIDAndNoRecord(t *testing.T) {
 	var err error
 	db, dataDir := setupTestData(t)
 	defer teardownTestData(t, db, dataDir)
-	_, err = db.SessionGetById(uuid.New().String())
+	_, err = db.SessionGetByID(uuid.New().String())
 	if err != user.ErrSessionDoesNotExist {
 		t.Errorf("got error: %v, want: %v", err, user.ErrSessionDoesNotExist)
 	}
 }
 
-func TestSessionDeleteById(t *testing.T) {
+func TestSessionDeleteByID(t *testing.T) {
 	var err error
 	db, dataDir := setupTestData(t)
 	defer teardownTestData(t, db, dataDir)
 	sa := []user.Session{
 		{ID: uuid.New().String(),
 			UserID: uuid.New(),
-			Values: "TestSessionDeleteById() / 1"},
+			Values: "TestSessionDeleteByID() / 1"},
 		{ID: uuid.New().String(),
 			UserID: uuid.New(),
-			Values: "TestSessionDeleteById() / 2"},
+			Values: "TestSessionDeleteByID() / 2"},
 		{ID: uuid.New().String(),
 			UserID: uuid.New(),
-			Values: "TestSessionDeleteById() / 3"},
+			Values: "TestSessionDeleteByID() / 3"},
 	}
 	for _, s := range sa {
 		err = db.SessionSave(s)
@@ -151,21 +151,21 @@ func TestSessionDeleteById(t *testing.T) {
 			t.Errorf("SessionSave() returned an error for: %v", s)
 		}
 	}
-	err = db.SessionDeleteById(sa[1].ID)
+	err = db.SessionDeleteByID(sa[1].ID)
 	if err != nil {
-		t.Errorf("SessionDeleteById() returned an error: %v", err)
+		t.Errorf("SessionDeleteByID() returned an error: %v", err)
 	}
 	// make sure the right session got deleted
-	_, err = db.SessionGetById(sa[1].ID)
+	_, err = db.SessionGetByID(sa[1].ID)
 	if err != user.ErrSessionDoesNotExist {
 		t.Errorf("got error: %v, want: %v", err, user.ErrSessionDoesNotExist)
 	}
 	// make sure the other 2 sessions are still in place
 	kept := []int{0, 2}
 	for _, idx := range kept {
-		sessionInDB, err := db.SessionGetById(sa[idx].ID)
+		sessionInDB, err := db.SessionGetByID(sa[idx].ID)
 		if err != nil {
-			t.Errorf("SessionGetById() returned an error: %v", err)
+			t.Errorf("SessionGetByID() returned an error: %v", err)
 		}
 		if *sessionInDB != sa[idx] {
 			t.Errorf("got session: %v, want: %v", sessionInDB, sa[idx])
@@ -180,7 +180,7 @@ func TestIsUserRecordWithSessionKey(t *testing.T) {
 	}
 }
 
-func TestSessionsDeleteByUserId(t *testing.T) {
+func TestSessionsDeleteByUserID(t *testing.T) {
 	var err error
 	db, dataDir := setupTestData(t)
 	defer teardownTestData(t, db, dataDir)
@@ -189,19 +189,19 @@ func TestSessionsDeleteByUserId(t *testing.T) {
 	sa := []user.Session{
 		{ID: uuid.New().String(),
 			UserID: keep,
-			Values: "TestSessionDeleteByUserId() / 1"},
+			Values: "TestSessionDeleteByUserID() / 1"},
 		{ID: uuid.New().String(),
 			UserID: remove,
-			Values: "TestSessionDeleteByUserId() / 2"},
+			Values: "TestSessionDeleteByUserID() / 2"},
 		{ID: uuid.New().String(),
 			UserID: keep,
-			Values: "TestSessionDeleteByUserId() / 3"},
+			Values: "TestSessionDeleteByUserID() / 3"},
 		{ID: uuid.New().String(),
 			UserID: remove,
-			Values: "TestSessionDeleteByUserId() / 5"},
+			Values: "TestSessionDeleteByUserID() / 5"},
 		{ID: uuid.New().String(),
 			UserID: keep,
-			Values: "TestSessionDeleteByUserId() / 5"},
+			Values: "TestSessionDeleteByUserID() / 5"},
 	}
 	for _, s := range sa {
 		err = db.SessionSave(s)
@@ -209,14 +209,14 @@ func TestSessionsDeleteByUserId(t *testing.T) {
 			t.Errorf("SessionSave() returned an error for: %v", s)
 		}
 	}
-	err = db.SessionsDeleteByUserId(remove, "")
+	err = db.SessionsDeleteByUserID(remove, "")
 	if err != nil {
-		t.Errorf("SessionsDeleteByUserId() returned an error: %v", err)
+		t.Errorf("SessionsDeleteByUserID() returned an error: %v", err)
 	}
 	// make sure the right session got deleted
 	removed := []int{1, 3}
 	for _, idx := range removed {
-		_, err := db.SessionGetById(sa[idx].ID)
+		_, err := db.SessionGetByID(sa[idx].ID)
 		if err != user.ErrSessionDoesNotExist {
 			t.Errorf("index: %v, got error: %v, want: %v", idx, err,
 				user.ErrSessionDoesNotExist)
@@ -225,9 +225,9 @@ func TestSessionsDeleteByUserId(t *testing.T) {
 	// make sure the other sessions are still in place
 	kept := []int{0, 2, 4}
 	for _, idx := range kept {
-		sessionInDB, err := db.SessionGetById(sa[idx].ID)
+		sessionInDB, err := db.SessionGetByID(sa[idx].ID)
 		if err != nil {
-			t.Errorf("index: %v, SessionGetById() returned an error: %v", idx, err)
+			t.Errorf("index: %v, SessionGetByID() returned an error: %v", idx, err)
 		}
 		if *sessionInDB != sa[idx] {
 			t.Errorf("index: %v, got session: %v, want: %v", idx, sessionInDB,
@@ -236,7 +236,7 @@ func TestSessionsDeleteByUserId(t *testing.T) {
 	}
 }
 
-func TestSessionsDeleteByUserIdAndKeepOneSession(t *testing.T) {
+func TestSessionsDeleteByUserIDAndKeepOneSession(t *testing.T) {
 	var err error
 	db, dataDir := setupTestData(t)
 	defer teardownTestData(t, db, dataDir)
@@ -245,19 +245,19 @@ func TestSessionsDeleteByUserIdAndKeepOneSession(t *testing.T) {
 	sa := []user.Session{
 		{ID: uuid.New().String(),
 			UserID: keep,
-			Values: "TestSessionDeleteByUserId() / 6"},
+			Values: "TestSessionDeleteByUserID() / 6"},
 		{ID: uuid.New().String(),
 			UserID: remove,
-			Values: "TestSessionDeleteByUserId() / 7"},
+			Values: "TestSessionDeleteByUserID() / 7"},
 		{ID: uuid.New().String(),
 			UserID: keep,
-			Values: "TestSessionDeleteByUserId() / 8"},
+			Values: "TestSessionDeleteByUserID() / 8"},
 		{ID: uuid.New().String(),
 			UserID: remove,
-			Values: "TestSessionDeleteByUserId() / 9"},
+			Values: "TestSessionDeleteByUserID() / 9"},
 		{ID: uuid.New().String(),
 			UserID: remove,
-			Values: "TestSessionDeleteByUserId() /10"},
+			Values: "TestSessionDeleteByUserID() /10"},
 	}
 	for _, s := range sa {
 		err = db.SessionSave(s)
@@ -267,14 +267,14 @@ func TestSessionsDeleteByUserIdAndKeepOneSession(t *testing.T) {
 	}
 	// delete all sessions associated with the `removed` user id
 	// except the one with index 3.
-	err = db.SessionsDeleteByUserId(remove, sa[3].ID)
+	err = db.SessionsDeleteByUserID(remove, sa[3].ID)
 	if err != nil {
-		t.Errorf("SessionsDeleteByUserId() returned an error: %v", err)
+		t.Errorf("SessionsDeleteByUserID() returned an error: %v", err)
 	}
 	// make sure the right sessions got deleted
 	removed := []int{1, 4}
 	for _, idx := range removed {
-		_, err := db.SessionGetById(sa[idx].ID)
+		_, err := db.SessionGetByID(sa[idx].ID)
 		if err != user.ErrSessionDoesNotExist {
 			t.Errorf("index: %v, got error: %v, want: %v", idx, err,
 				user.ErrSessionDoesNotExist)
@@ -283,9 +283,9 @@ func TestSessionsDeleteByUserIdAndKeepOneSession(t *testing.T) {
 	// make sure the other sessions are still in place
 	kept := []int{0, 2, 3}
 	for _, idx := range kept {
-		sessionInDB, err := db.SessionGetById(sa[idx].ID)
+		sessionInDB, err := db.SessionGetByID(sa[idx].ID)
 		if err != nil {
-			t.Errorf("index: %v, SessionGetById() returned an error: %v", idx, err)
+			t.Errorf("index: %v, SessionGetByID() returned an error: %v", idx, err)
 		}
 		if *sessionInDB != sa[idx] {
 			t.Errorf("index: %v, got session: %v, want: %v", idx, sessionInDB,
@@ -294,11 +294,11 @@ func TestSessionsDeleteByUserIdAndKeepOneSession(t *testing.T) {
 	}
 }
 
-func TestSessionDeleteByIdAndNoSession(t *testing.T) {
+func TestSessionDeleteByIDAndNoSession(t *testing.T) {
 	db, dataDir := setupTestData(t)
 	defer teardownTestData(t, db, dataDir)
-	err := db.SessionDeleteById(uuid.Nil.String())
+	err := db.SessionDeleteByID(uuid.Nil.String())
 	if err != nil {
-		t.Errorf("SessionDeleteById() returned an error: %v", err)
+		t.Errorf("SessionDeleteByID() returned an error: %v", err)
 	}
 }

--- a/politeiawww/user/localdb/localdb_test.go
+++ b/politeiawww/user/localdb/localdb_test.go
@@ -1,0 +1,304 @@
+package localdb
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/decred/politeia/politeiawww/user"
+	"github.com/google/uuid"
+)
+
+func setupTestData(t *testing.T) (*localdb, string) {
+	// Setup database
+	dataDir, err := ioutil.TempDir("", "politeiawww.user.localdb.test")
+	if err != nil {
+		t.Error("TempDir() returned an error")
+	}
+	db, err := New(filepath.Join(dataDir, "localdb"))
+	if err != nil {
+		t.Fatalf("setup database: %v", err)
+	}
+	return db, dataDir
+}
+
+func teardownTestData(t *testing.T, db *localdb, dataDir string) {
+	t.Helper()
+
+	err := db.Close()
+	if err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	err = os.RemoveAll(dataDir)
+	if err != nil {
+		t.Fatalf("remove tmp dir: %v", err)
+	}
+}
+
+func TestSessionSave(t *testing.T) {
+	var err error
+	db, dataDir := setupTestData(t)
+	defer teardownTestData(t, db, dataDir)
+	s := user.Session{
+		ID:     uuid.New().String(),
+		UserID: uuid.New(),
+		Values: "TestSessionSave()",
+	}
+	err = db.SessionSave(s)
+	if err != nil {
+		t.Error("SessionSave() returned an error")
+	}
+	data, err := db.userdb.Get([]byte(sessionPrefix+s.ID), nil)
+	if err != nil {
+		t.Errorf("db.Get() returned an error: %v", err)
+	}
+	sessionInDB, err := user.DecodeSession(data)
+	if err != nil {
+		t.Errorf("DecodeSession() returned an error: %v", err)
+	}
+	if sessionInDB == nil {
+		t.Error("DecodeSession() returned a nil pointer")
+	}
+	if s != *sessionInDB {
+		t.Errorf("got session: %v, want: %v", sessionInDB, s)
+	}
+}
+
+func TestSessionExistsAlready(t *testing.T) {
+	var err error
+	db, dataDir := setupTestData(t)
+	defer teardownTestData(t, db, dataDir)
+	s := user.Session{
+		ID:     uuid.New().String(),
+		UserID: uuid.New(),
+		Values: "TestSessionExistsAlready()",
+	}
+	err = db.SessionSave(s)
+	if err != nil {
+		t.Error("SessionSave() #1 returned an error")
+	}
+	// repeated insertion should not result in an error but just update
+	// the record.
+	s.Values += " -- version 2"
+	err = db.SessionSave(s)
+	if err != nil {
+		t.Error("SessionSave() #2 returned an error")
+	}
+	us2, err := db.SessionGetById(s.ID)
+	if err != nil {
+		t.Error("SessionGetById() returned an error")
+	}
+	if s.Values != us2.Values {
+		t.Errorf("got Values: %v, want: %v", us2.Values, s.Values)
+	}
+}
+
+func TestSessionGetById(t *testing.T) {
+	var err error
+	db, dataDir := setupTestData(t)
+	defer teardownTestData(t, db, dataDir)
+	s := user.Session{
+		ID:     uuid.New().String(),
+		UserID: uuid.New(),
+		Values: "TestSessionGetById()",
+	}
+	err = db.SessionSave(s)
+	if err != nil {
+		t.Error("SessionSave() returned an error")
+	}
+	sessionInDB, err := db.SessionGetById(s.ID)
+	if err != nil {
+		t.Errorf("SessionGetById() returned an error: %v", err)
+	}
+	if sessionInDB == nil {
+		t.Error("SessionGetById() returned a nil pointer")
+	}
+	if s != *sessionInDB {
+		t.Errorf("got session: %v, want: %v", sessionInDB, s)
+	}
+}
+
+func TestSessionGetByIdAndNoRecord(t *testing.T) {
+	var err error
+	db, dataDir := setupTestData(t)
+	defer teardownTestData(t, db, dataDir)
+	_, err = db.SessionGetById(uuid.New().String())
+	if err != user.ErrSessionDoesNotExist {
+		t.Errorf("got error: %v, want: %v", err, user.ErrSessionDoesNotExist)
+	}
+}
+
+func TestSessionDeleteById(t *testing.T) {
+	var err error
+	db, dataDir := setupTestData(t)
+	defer teardownTestData(t, db, dataDir)
+	sa := []user.Session{
+		{ID: uuid.New().String(),
+			UserID: uuid.New(),
+			Values: "TestSessionDeleteById() / 1"},
+		{ID: uuid.New().String(),
+			UserID: uuid.New(),
+			Values: "TestSessionDeleteById() / 2"},
+		{ID: uuid.New().String(),
+			UserID: uuid.New(),
+			Values: "TestSessionDeleteById() / 3"},
+	}
+	for _, s := range sa {
+		err = db.SessionSave(s)
+		if err != nil {
+			t.Errorf("SessionSave() returned an error for: %v", s)
+		}
+	}
+	err = db.SessionDeleteById(sa[1].ID)
+	if err != nil {
+		t.Errorf("SessionDeleteById() returned an error: %v", err)
+	}
+	// make sure the right session got deleted
+	_, err = db.SessionGetById(sa[1].ID)
+	if err != user.ErrSessionDoesNotExist {
+		t.Errorf("got error: %v, want: %v", err, user.ErrSessionDoesNotExist)
+	}
+	// make sure the other 2 sessions are still in place
+	kept := []int{0, 2}
+	for _, idx := range kept {
+		sessionInDB, err := db.SessionGetById(sa[idx].ID)
+		if err != nil {
+			t.Errorf("SessionGetById() returned an error: %v", err)
+		}
+		if *sessionInDB != sa[idx] {
+			t.Errorf("got session: %v, want: %v", sessionInDB, sa[idx])
+		}
+	}
+}
+
+func TestIsUserRecordWithSessionKey(t *testing.T) {
+	result := isUserRecord(sessionPrefix + uuid.New().String())
+	if result != false {
+		t.Error("isUserRecord() confuses User and Session records")
+	}
+}
+
+func TestSessionsDeleteByUserId(t *testing.T) {
+	var err error
+	db, dataDir := setupTestData(t)
+	defer teardownTestData(t, db, dataDir)
+	remove := uuid.New()
+	keep := uuid.New()
+	sa := []user.Session{
+		{ID: uuid.New().String(),
+			UserID: keep,
+			Values: "TestSessionDeleteByUserId() / 1"},
+		{ID: uuid.New().String(),
+			UserID: remove,
+			Values: "TestSessionDeleteByUserId() / 2"},
+		{ID: uuid.New().String(),
+			UserID: keep,
+			Values: "TestSessionDeleteByUserId() / 3"},
+		{ID: uuid.New().String(),
+			UserID: remove,
+			Values: "TestSessionDeleteByUserId() / 5"},
+		{ID: uuid.New().String(),
+			UserID: keep,
+			Values: "TestSessionDeleteByUserId() / 5"},
+	}
+	for _, s := range sa {
+		err = db.SessionSave(s)
+		if err != nil {
+			t.Errorf("SessionSave() returned an error for: %v", s)
+		}
+	}
+	err = db.SessionsDeleteByUserId(remove, "")
+	if err != nil {
+		t.Errorf("SessionsDeleteByUserId() returned an error: %v", err)
+	}
+	// make sure the right session got deleted
+	removed := []int{1, 3}
+	for _, idx := range removed {
+		_, err := db.SessionGetById(sa[idx].ID)
+		if err != user.ErrSessionDoesNotExist {
+			t.Errorf("index: %v, got error: %v, want: %v", idx, err,
+				user.ErrSessionDoesNotExist)
+		}
+	}
+	// make sure the other sessions are still in place
+	kept := []int{0, 2, 4}
+	for _, idx := range kept {
+		sessionInDB, err := db.SessionGetById(sa[idx].ID)
+		if err != nil {
+			t.Errorf("index: %v, SessionGetById() returned an error: %v", idx, err)
+		}
+		if *sessionInDB != sa[idx] {
+			t.Errorf("index: %v, got session: %v, want: %v", idx, sessionInDB,
+				sa[idx])
+		}
+	}
+}
+
+func TestSessionsDeleteByUserIdAndKeepOneSession(t *testing.T) {
+	var err error
+	db, dataDir := setupTestData(t)
+	defer teardownTestData(t, db, dataDir)
+	remove := uuid.New()
+	keep := uuid.New()
+	sa := []user.Session{
+		{ID: uuid.New().String(),
+			UserID: keep,
+			Values: "TestSessionDeleteByUserId() / 6"},
+		{ID: uuid.New().String(),
+			UserID: remove,
+			Values: "TestSessionDeleteByUserId() / 7"},
+		{ID: uuid.New().String(),
+			UserID: keep,
+			Values: "TestSessionDeleteByUserId() / 8"},
+		{ID: uuid.New().String(),
+			UserID: remove,
+			Values: "TestSessionDeleteByUserId() / 9"},
+		{ID: uuid.New().String(),
+			UserID: remove,
+			Values: "TestSessionDeleteByUserId() /10"},
+	}
+	for _, s := range sa {
+		err = db.SessionSave(s)
+		if err != nil {
+			t.Errorf("SessionSave() returned an error for: %v", s)
+		}
+	}
+	// delete all sessions associated with the `removed` user id
+	// except the one with index 3.
+	err = db.SessionsDeleteByUserId(remove, sa[3].ID)
+	if err != nil {
+		t.Errorf("SessionsDeleteByUserId() returned an error: %v", err)
+	}
+	// make sure the right sessions got deleted
+	removed := []int{1, 4}
+	for _, idx := range removed {
+		_, err := db.SessionGetById(sa[idx].ID)
+		if err != user.ErrSessionDoesNotExist {
+			t.Errorf("index: %v, got error: %v, want: %v", idx, err,
+				user.ErrSessionDoesNotExist)
+		}
+	}
+	// make sure the other sessions are still in place
+	kept := []int{0, 2, 3}
+	for _, idx := range kept {
+		sessionInDB, err := db.SessionGetById(sa[idx].ID)
+		if err != nil {
+			t.Errorf("index: %v, SessionGetById() returned an error: %v", idx, err)
+		}
+		if *sessionInDB != sa[idx] {
+			t.Errorf("index: %v, got session: %v, want: %v", idx, sessionInDB,
+				sa[idx])
+		}
+	}
+}
+
+func TestSessionDeleteByIdAndNoSession(t *testing.T) {
+	db, dataDir := setupTestData(t)
+	defer teardownTestData(t, db, dataDir)
+	err := db.SessionDeleteById(uuid.Nil.String())
+	if err != nil {
+		t.Errorf("SessionDeleteById() returned an error: %v", err)
+	}
+}

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -380,16 +380,21 @@ type Plugin struct {
 
 // Session represents a user session.
 //
-// The session ID is the decoded session ID. The ID present in the session
-// cookie is the encoded session ID. The encoding/decoding is handled by
-// the session Store.
+// ID is the decoded session ID. The ID present in the session cookie is the
+// encoded session ID. The encoding/decoding is handled by the session Store.
 //
-// The encoded session values decodes to a map[interface{}]interface{}. The
-// encodeding/decodeding is handled by the session Store.
+// Values are politeiawww specific encoded session values. The encoding is
+// handled by the session Store.
+//
+// UserID and CreatedAt are included in the encoded Values but have also been
+// broken out into their own fields so that they can be queryable. UserID
+// allows for lookups by UserID and CreatedAt allows for periodically cleaning
+// up expired sessions in the database.
 type Session struct {
-	ID     string    `json:"id"`     // Unique session ID
-	UserID uuid.UUID `json:"userid"` // User UUID
-	Values string    `json:"values"` // Encoded session values
+	ID        string    `json:"id"`        // Unique session ID
+	UserID    uuid.UUID `json:"userid"`    // User UUID
+	CreatedAt int64     `json:"createdat"` // Created at UNIX timestamp
+	Values    string    `json:"values"`    // Encoded session values
 }
 
 // VersionSession is the version of the Session struct.

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -380,8 +380,12 @@ type Plugin struct {
 
 // Session represents a user session.
 //
+// The session ID is the decoded session ID. The ID present in the session
+// cookie is the encoded session ID. The encoding/decoding is handled by
+// the session Store.
+//
 // The encoded session values decodes to a map[interface{}]interface{}. The
-// encodeding/decodeding is handled by the gorilla/securecookie package.
+// encodeding/decodeding is handled by the session Store.
 type Session struct {
 	ID     string    `json:"id"`     // Unique session ID
 	UserID uuid.UUID `json:"userid"` // User UUID
@@ -437,13 +441,13 @@ type Database interface {
 	// Iterate over all users
 	AllUsers(callbackFn func(u *User)) error
 
-	// Create or update a session for an authenticated user
+	// Create or update a user session
 	SessionSave(Session) error
 
-	// Return user session record given its id
+	// Return a user session given its id
 	SessionGetByID(sessionID string) (*Session, error)
 
-	// Delete the session with the given id
+	// Delete a user session given its id
 	SessionDeleteByID(sessionID string) error
 
 	// Register a plugin

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -17,15 +17,16 @@ import (
 )
 
 var (
-	// ErrSessionDoesNotExist indicates that a user session was not found in the
-	// database.
-	ErrSessionDoesNotExist = errors.New("no user session found")
+	// ErrSessionNotFound indicates that a user session was not found
+	// in the database.
+	ErrSessionNotFound = errors.New("no user session found")
 
 	// ErrUserNotFound indicates that a user name was not found in the
 	// database.
 	ErrUserNotFound = errors.New("user not found")
 
-	// ErrUserExists indicates that a user already exists in the database.
+	// ErrUserExists indicates that a user already exists in the
+	// database.
 	ErrUserExists = errors.New("user already exists")
 
 	// ErrShutdown is emitted when the database is shutting down.
@@ -378,11 +379,17 @@ type Plugin struct {
 }
 
 // Session represents a user session.
+//
+// The encoded session values decodes to a map[interface{}]interface{}. The
+// encodeding/decodeding is handled by the gorilla/securecookie package.
 type Session struct {
-	ID     string    `json:"id"`     // Unique session id
-	UserID uuid.UUID `json:"userid"` // The user's uuid
-	Values string    `json:"values"` // session values (encoded)
+	ID     string    `json:"id"`     // Unique session ID
+	UserID uuid.UUID `json:"userid"` // User UUID
+	Values string    `json:"values"` // Encoded session values
 }
+
+// VersionSession is the version of the Session struct.
+const VersionSession uint32 = 1
 
 // EncodeSession encodes Session into a JSON byte slice.
 func EncodeSession(s Session) ([]byte, error) {
@@ -434,13 +441,13 @@ type Database interface {
 	SessionSave(Session) error
 
 	// Return user session record given its id
-	SessionGetById(string) (*Session, error)
+	SessionGetByID(sessionID string) (*Session, error)
 
 	// Delete the session with the given id
-	SessionDeleteById(string) error
+	SessionDeleteByID(sessionID string) error
 
 	// Delete all sessions with the given user id except the one specified.
-	SessionsDeleteByUserId(uid uuid.UUID, sessionToKeep string) error
+	SessionsDeleteByUserID(uid uuid.UUID, sessionToKeep string) error
 
 	// Register a plugin
 	RegisterPlugin(Plugin) error

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -446,9 +446,6 @@ type Database interface {
 	// Delete the session with the given id
 	SessionDeleteByID(sessionID string) error
 
-	// Delete all sessions with the given user id except the one specified.
-	SessionsDeleteByUserID(uid uuid.UUID, sessionToKeep string) error
-
 	// Register a plugin
 	RegisterPlugin(Plugin) error
 

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -147,15 +147,15 @@ func (p *politeiawww) handleLogin(w http.ResponseWriter, r *http.Request) {
 	reply, err := p.processLogin(l)
 	if err != nil {
 		RespondWithError(w, r, http.StatusUnauthorized,
-			"handleLogin: processLogin %v", err)
+			"handleLogin: processLogin: %v", err)
 		return
 	}
 
-	// initialize a session for the logged in user
+	// Initialize a session for the logged in user
 	err = p.initSession(w, r, reply.UserID)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleLogin: initSession %v", err)
+			"handleLogin: initSession: %v", err)
 		return
 	}
 
@@ -235,21 +235,6 @@ func (p *politeiawww) handleVerifyResetPassword(w http.ResponseWriter, r *http.R
 		RespondWithError(w, r, 0,
 			"handleVerifyResetPassword: processVerifyResetPassword %v", err)
 		return
-	}
-
-	// Log off the user everywhere by deleting all sessions associated
-	// with the user's ID. If anything fails here log the error instead
-	// of returning it since the password change was already successful.
-	user, err := p.db.UserGetByUsername(vrp.Username)
-	if err != nil {
-		log.Errorf("handleVerifyResetPassword: failed to delete user "+
-			"sessions UserGetByUsername(%v) error: %v", vrp.Username, err)
-	} else {
-		err = p.db.SessionsDeleteByUserID(user.ID, "")
-		if err != nil {
-			log.Errorf("handleVerifyResetPassword: SessionsDeleteByUserId(%v): %v",
-				user.ID, err)
-		}
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)
@@ -451,14 +436,6 @@ func (p *politeiawww) handleChangePassword(w http.ResponseWriter, r *http.Reques
 		RespondWithError(w, r, 0,
 			"handleChangePassword: processChangePassword %v", err)
 		return
-	}
-
-	// Valid, authenticated user changing his password, delete
-	// all sesssions except this current one.
-	err = p.db.SessionsDeleteByUserID(user.ID, p.getSessionID(r))
-	if err != nil {
-		log.Errorf("handleChangePassword: SessionsDeleteByUserId(%v): %v",
-			user.ID, err)
 	}
 
 	// Reply with the error code.

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -257,10 +257,12 @@ func (p *politeiawww) handleUserDetails(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Get session user. This is a public route so one might not exist.
 	user, err := p.getSessionUser(w, r)
-	if err != nil {
-		// This is a public route so a logged in user is not required
-		log.Debugf("handleUserDetails: could not get session user: %v", err)
+	if err != nil && err != errSessionNotFound {
+		RespondWithError(w, r, 0,
+			"handleUserDetails: getSessionUser %v", err)
+		return
 	}
 
 	udr, err := p.processUserDetails(&ud,
@@ -522,10 +524,12 @@ func (p *politeiawww) handleUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Get session user. This is a public route so one might not exist.
 	user, err := p.getSessionUser(w, r)
-	if err != nil {
-		// This is a public route so a logged in user is not required
-		log.Debugf("handleUsers: could not get session user: %v", err)
+	if err != nil && err != errSessionNotFound {
+		RespondWithError(w, r, 0,
+			"handleUsers: getSessionUser %v", err)
+		return
 	}
 
 	isAdmin := (user != nil && user.Admin)

--- a/politeiawww/userwww_test.go
+++ b/politeiawww/userwww_test.go
@@ -1,10 +1,11 @@
-// Copyright (c) 2017-2019 The Decred developers
+// Copyright (c) 2017-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
@@ -18,7 +19,58 @@ import (
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/go-test/deep"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 )
+
+// newPostReq returns an httptest post request that was created using the
+// passed in data.
+func newPostReq(t *testing.T, route string, body interface{}) *http.Request {
+	t.Helper()
+
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	return httptest.NewRequest(http.MethodPost, route,
+		bytes.NewReader(b))
+}
+
+// addSessionToReq initializes a user session and adds a session cookie to the
+// given http request. The user session is saved to the politeiawww session
+// store during intialization.
+func addSessionToReq(t *testing.T, p *politeiawww, req *http.Request, userID string) {
+	t.Helper()
+
+	// Init session adds a session cookie onto the http response.
+	r := httptest.NewRequest(http.MethodGet, "/", bytes.NewReader([]byte{}))
+	w := httptest.NewRecorder()
+	err := p.initSession(w, r, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := w.Result()
+
+	// Grab the session cookie from the response and add it to the
+	// request.
+	var c *http.Cookie
+	for _, v := range res.Cookies() {
+		if v.Name == www.CookieSession {
+			c = v
+			break
+		}
+	}
+	req.AddCookie(c)
+
+	// Verify the session was added successfully.
+	s, err := p.getSession(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.IsNew {
+		t.Fatal("session not found in store")
+	}
+}
 
 func TestHandleNewUser(t *testing.T) {
 	p, cleanup := newTestPoliteiawww(t)
@@ -407,11 +459,29 @@ func TestHandleLogin(t *testing.T) {
 			}
 
 			if res.StatusCode == http.StatusOK {
-				// A user session should have been
-				// created if login was successful.
-				_, err := p.getSessionUser(w, r)
-				if err != nil {
-					t.Errorf("session not created: %v", err)
+				// A user session should have been added to the response
+				// cookie.
+				var sessionID string
+				for _, v := range res.Cookies() {
+					if v.Name == www.CookieSession && v.Value != "" {
+						sessionID = v.Value
+					}
+				}
+				if sessionID == "" {
+					t.Errorf("no session cookie in response")
+				}
+
+				// A user session should have been added to the session
+				// store. The best way to check this is to add a session
+				// cookie onto a request and use the getSession() method.
+				req := httptest.NewRequest(http.MethodGet, "/",
+					bytes.NewReader([]byte{}))
+				opts := newSessionOptions()
+				c := sessions.NewCookie(www.CookieSession, sessionID, opts)
+				req.AddCookie(c)
+				s, err := p.getSession(req)
+				if s.IsNew {
+					t.Errorf("session not saved to session store")
 				}
 
 				// Check response body
@@ -613,13 +683,8 @@ func TestHandleChangePassword(t *testing.T) {
 		t.Run(v.name, func(t *testing.T) {
 			// Setup request
 			r := newPostReq(t, www.RouteChangePassword, v.reqBody)
+			addSessionToReq(t, p, r, usr.ID.String())
 			w := httptest.NewRecorder()
-
-			// Initialize the user session
-			err := p.initSession(w, r, usr.ID.String())
-			if err != nil {
-				t.Fatalf("%v", err)
-			}
 
 			// Run test case
 			p.handleChangePassword(w, r)
@@ -639,7 +704,7 @@ func TestHandleChangePassword(t *testing.T) {
 			}
 
 			var ue www.UserError
-			err = json.Unmarshal(body, &ue)
+			err := json.Unmarshal(body, &ue)
 			if err != nil {
 				t.Errorf("unmarshal UserError: %v", err)
 			}
@@ -883,13 +948,8 @@ func TestHandleChangeUsername(t *testing.T) {
 		t.Run(v.name, func(t *testing.T) {
 			// Setup request
 			r := newPostReq(t, www.RouteChangeUsername, v.reqBody)
+			addSessionToReq(t, p, r, usr.ID.String())
 			w := httptest.NewRecorder()
-
-			// Initialize the user session
-			err := p.initSession(w, r, usr.ID.String())
-			if err != nil {
-				t.Fatalf("%v", err)
-			}
 
 			// Run test case
 			p.handleChangeUsername(w, r)
@@ -909,7 +969,7 @@ func TestHandleChangeUsername(t *testing.T) {
 			}
 
 			var ue www.UserError
-			err = json.Unmarshal(body, &ue)
+			err := json.Unmarshal(body, &ue)
 			if err != nil {
 				t.Errorf("unmarshal UserError: %v", err)
 			}
@@ -1044,13 +1104,8 @@ func TestHandleEditUser(t *testing.T) {
 		t.Run(v.name, func(t *testing.T) {
 			// Setup request
 			r := newPostReq(t, www.RouteEditUser, v.reqBody)
+			addSessionToReq(t, p, r, usr.ID.String())
 			w := httptest.NewRecorder()
-
-			// Initialize the user session
-			err := p.initSession(w, r, usr.ID.String())
-			if err != nil {
-				t.Fatalf("%v", err)
-			}
 
 			// Run test case
 			p.handleEditUser(w, r)
@@ -1070,7 +1125,7 @@ func TestHandleEditUser(t *testing.T) {
 			}
 
 			var ue www.UserError
-			err = json.Unmarshal(body, &ue)
+			err := json.Unmarshal(body, &ue)
 			if err != nil {
 				t.Errorf("unmarshal UserError: %v", err)
 			}

--- a/politeiawww/userwww_test.go
+++ b/politeiawww/userwww_test.go
@@ -411,7 +411,7 @@ func TestHandleLogin(t *testing.T) {
 				// created if login was successful.
 				_, err := p.getSessionUser(w, r)
 				if err != nil {
-					t.Errorf("session not created")
+					t.Errorf("session not created: %v", err)
 				}
 
 				// Check response body
@@ -615,8 +615,8 @@ func TestHandleChangePassword(t *testing.T) {
 			r := newPostReq(t, www.RouteChangePassword, v.reqBody)
 			w := httptest.NewRecorder()
 
-			// Set user session
-			err := p.setSessionUserID(w, r, usr.ID.String())
+			// Initialize the user session
+			err := p.initSession(w, r, usr.ID.String())
 			if err != nil {
 				t.Fatalf("%v", err)
 			}
@@ -885,8 +885,8 @@ func TestHandleChangeUsername(t *testing.T) {
 			r := newPostReq(t, www.RouteChangeUsername, v.reqBody)
 			w := httptest.NewRecorder()
 
-			// Set user session
-			err := p.setSessionUserID(w, r, usr.ID.String())
+			// Initialize the user session
+			err := p.initSession(w, r, usr.ID.String())
 			if err != nil {
 				t.Fatalf("%v", err)
 			}
@@ -969,9 +969,9 @@ func TestHandleUserDetails(t *testing.T) {
 			})
 			w := httptest.NewRecorder()
 
-			// Set user session
+			// Initialize the user session
 			if v.loggedIn {
-				err := p.setSessionUserID(w, r, usr.ID.String())
+				err := p.initSession(w, r, usr.ID.String())
 				if err != nil {
 					t.Fatalf("%v", err)
 				}
@@ -1046,8 +1046,8 @@ func TestHandleEditUser(t *testing.T) {
 			r := newPostReq(t, www.RouteEditUser, v.reqBody)
 			w := httptest.NewRecorder()
 
-			// Set user session
-			err := p.setSessionUserID(w, r, usr.ID.String())
+			// Initialize the user session
+			err := p.initSession(w, r, usr.ID.String())
 			if err != nil {
 				t.Fatalf("%v", err)
 			}

--- a/politeiawww/userwww_test.go
+++ b/politeiawww/userwww_test.go
@@ -50,6 +50,7 @@ func addSessionToReq(t *testing.T, p *politeiawww, req *http.Request, userID str
 		t.Fatal(err)
 	}
 	res := w.Result()
+	res.Body.Close()
 
 	// Grab the session cookie from the response and add it to the
 	// request.
@@ -480,6 +481,9 @@ func TestHandleLogin(t *testing.T) {
 				c := sessions.NewCookie(www.CookieSession, sessionID, opts)
 				req.AddCookie(c)
 				s, err := p.getSession(req)
+				if err != nil {
+					t.Error(err)
+				}
 				if s.IsNew {
 					t.Errorf("session not saved to session store")
 				}

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -50,7 +50,13 @@ const (
 	permissionAdmin
 
 	csrfKeyLength = 32
-	sessionMaxAge = 86400 //One day
+	sessionMaxAge = 86400 // One day
+
+	// Session value keys. A user session contains a map that is used
+	// for application specific values. The following is a list of the
+	// keys for the politeiawww user session values map.
+	sessionValueUserID    = "user_id"
+	sessionValueCreatedAt = "created_at"
 )
 
 var (
@@ -635,7 +641,7 @@ func _main() error {
 	if err != nil {
 		return err
 	}
-	p.store = NewSessionStore(p.db, cookieKey)
+	p.sessions = NewSessionStore(p.db, cookieKey)
 
 	// Bind to a port and pass our router in
 	listenC := make(chan error)

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -165,13 +165,6 @@ func RespondWithError(w http.ResponseWriter, r *http.Request, userHttpCode int, 
 		return
 	}
 
-	if err, ok := args[0].(error); ok {
-		// user session was deleted e.g. due to a password change or expired?
-		if err == errSessionNotFound {
-			http.Redirect(w, r, "/", http.StatusFound)
-		}
-	}
-
 	errorCode := time.Now().Unix()
 	ec := fmt.Sprintf("%v %v %v %v Internal error %v: ", remoteAddr(r),
 		r.Method, r.URL, r.Proto, errorCode)

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 The Decred developers
+// Copyright (c) 2017-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,7 +11,6 @@ import (
 	"crypto/tls"
 	_ "encoding/gob"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -50,19 +49,6 @@ const (
 	permissionAdmin
 
 	csrfKeyLength = 32
-	sessionMaxAge = 86400 // One day
-
-	// Session value keys. A user session contains a map that is used
-	// for application specific values. The following is a list of the
-	// keys for the politeiawww user session values map.
-	sessionValueUserID    = "user_id"
-	sessionValueCreatedAt = "created_at"
-)
-
-var (
-	// errSessionNotFound is emitted when a session is not found and indicates
-	// that the user is not logged in.
-	errSessionNotFound = errors.New("session not found")
 )
 
 // Fetch remote identity
@@ -641,7 +627,7 @@ func _main() error {
 	if err != nil {
 		return err
 	}
-	p.sessions = NewSessionStore(p.db, cookieKey)
+	p.sessions = NewSessionStore(p.db, sessionMaxAge, cookieKey)
 
 	// Bind to a port and pass our router in
 	listenC := make(chan error)


### PR DESCRIPTION
This diff moves user sessions from a session store backed by the
filesystem to a session store backed by the userdb. It implements a
custom sessions store that satisfies the gorrilla/sessions Store
interface. 

Moving the session store to the userdb accomplishes a few things:

1. Allows us to manually invalidate sessions. An example being when a
   user changes their password we can invalidate their sessions on all
   other devices. This was not previously possible with the filesystem
   store implementation. 

2. Removes one of the blocking issues that is preventing us from running
   multiple politeiawww instances.

This diff does not fix issues #647 or #650. It is a prerequisite for
fixing those issues, but those issues will be fixed in the next PR.