### PR TITLE
[cms] Re-add legacy mange user endpoit

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -757,7 +757,7 @@ Reply:
 
 Edits a user's details. This call requires admin privileges.
 
-**Route:** `POST /v1/user/manage`
+**Route:** `POST /v1/admin/managecms`
 
 **Params:**
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -34,6 +34,7 @@ const (
 	RouteDCCComments         = "/dcc/{token:[A-z0-9]{64}}/comments"
 	RouteSetDCCStatus        = "/dcc/{token:[A-z0-9]{64}}/status"
 	RouteAdminInvoices       = "/admin/invoices"
+	RouteManageCMSUser       = "/admin/managecms"
 	RouteAdminUserInvoices   = "/admin/userinvoices"
 	RouteGeneratePayouts     = "/admin/generatepayouts"
 	RouteInvoicePayouts      = "/admin/invoicepayouts"
@@ -594,16 +595,16 @@ type EditUser struct {
 // EditUserReply is the reply for the EditUser command.
 type EditUserReply struct{}
 
-// ManageUser performs the given action on a user.
-type ManageUser struct {
+// CMSManageUser updates the various fields for a given user.
+type CMSManageUser struct {
 	UserID            string          `json:"userid"`
 	Domain            DomainTypeT     `json:"domain,omitempty"`
 	ContractorType    ContractorTypeT `json:"contractortype,omitempty"`
 	SupervisorUserIDs []string        `json:"supervisoruserids,omitempty"`
 }
 
-// ManageUserReply is the reply for the ManageUserReply command.
-type ManageUserReply struct{}
+// CMSManageUserReply is the reply for the CMSManageUserReply command.
+type CMSManageUserReply struct{}
 
 // DCCInput contains all of the information concerning a DCC object that
 // will be submitted as a Record to the politeiad backend.

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -73,7 +73,8 @@ type cmswww struct {
 	InvoicePayouts      InvoicePayoutsCmd        `command:"invoicepayouts" description:"(admin)  generate paid invoice list for a given date range"`
 	Login               shared.LoginCmd          `command:"login" description:"(public) login to Politeia"`
 	Logout              shared.LogoutCmd         `command:"logout" description:"(public) logout of Politeia"`
-	ManageUser          ManageUserCmd            `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
+	CMSManageUser       CMSManageUserCmd         `command:"cmsmanageuser" description:"(admin)  edit certain properties of the specified user"`
+	ManageUser          shared.ManageUserCmd     `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
 	Me                  shared.MeCmd             `command:"me" description:"(user)   get user details for the logged in user"`
 	NewComment          shared.NewCommentCmd     `command:"newcomment" description:"(user)   create a new comment"`
 	NewDCC              NewDCCCmd                `command:"newdcc" description:"(user)   creates a new dcc proposal"`

--- a/politeiawww/cmd/cmswww/help.go
+++ b/politeiawww/cmd/cmswww/help.go
@@ -38,7 +38,7 @@ func (cmd *HelpCmd) Execute(args []string) error {
 	case "censorcomment":
 		fmt.Printf("%s\n", shared.CensorCommentHelpMsg)
 	case "manageuser":
-		fmt.Printf("%s\n", manageUserHelpMsg)
+		fmt.Printf("%s\n", cmsManageUserHelpMsg)
 	case "version":
 		fmt.Printf("%s\n", shared.VersionHelpMsg)
 	case "me":

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -14,9 +14,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// ManageUserCmd allows an administrator to update Domain, ContractorType
+// CMSManageUserCmd allows an administrator to update Domain, ContractorType
 // and SupervisorID of a given user.
-type ManageUserCmd struct {
+type CMSManageUserCmd struct {
 	Args struct {
 		UserID string `positional-arg-name:"userid" required:"true"`
 	} `positional-args:"true" optional:"true"`
@@ -26,7 +26,7 @@ type ManageUserCmd struct {
 }
 
 // Execute executes the cms manage user command.
-func (cmd *ManageUserCmd) Execute(args []string) error {
+func (cmd *CMSManageUserCmd) Execute(args []string) error {
 	domains := map[string]cms.DomainTypeT{
 		"developer":     cms.DomainTypeDeveloper,
 		"marketing":     cms.DomainTypeMarketing,
@@ -98,7 +98,7 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 	}
 
 	// Send request
-	mu := cms.ManageUser{
+	mu := cms.CMSManageUser{
 		UserID:            cmd.Args.UserID,
 		Domain:            domain,
 		ContractorType:    contractorType,
@@ -120,7 +120,7 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 	return nil
 }
 
-const manageUserHelpMsg = `manageuser [flags] "userid"
+const cmsManageUserHelpMsg = `cmsmanageuser [flags] "userid"
 
 Update the Domain, ContractorType and SupervisorID of the specified user. This
 command requires admin privileges.

--- a/politeiawww/cmd/piwww/help.go
+++ b/politeiawww/cmd/piwww/help.go
@@ -62,7 +62,7 @@ func (cmd *HelpCmd) Execute(args []string) error {
 	case "editproposal":
 		fmt.Printf("%s\n", editProposalHelpMsg)
 	case "manageuser":
-		fmt.Printf("%s\n", ManageUserHelpMsg)
+		fmt.Printf("%s\n", shared.ManageUserHelpMsg)
 	case "users":
 		fmt.Printf("%s\n", shared.UsersHelpMsg)
 	case "verifyuseremail":

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -66,7 +66,7 @@ type piwww struct {
 	LikeComment        LikeCommentCmd           `command:"likecomment" description:"(user)   upvote/downvote a comment"`
 	Login              shared.LoginCmd          `command:"login" description:"(public) login to Politeia"`
 	Logout             shared.LogoutCmd         `command:"logout" description:"(public) logout of Politeia"`
-	ManageUser         ManageUserCmd            `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
+	ManageUser         shared.ManageUserCmd     `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
 	Me                 shared.MeCmd             `command:"me" description:"(user)   get user details for the logged in user"`
 	NewComment         shared.NewCommentCmd     `command:"newcomment" description:"(user)   create a new comment"`
 	NewProposal        NewProposalCmd           `command:"newproposal" description:"(user)   create a new proposal"`

--- a/politeiawww/cmd/shared/censorcomment.go
+++ b/politeiawww/cmd/shared/censorcomment.go
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
 )
 

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -1750,14 +1750,14 @@ func (c *Client) CMSEditUser(uui cms.EditUser) (*cms.EditUserReply, error) {
 }
 
 // CMSManageUser updates the given user's information.
-func (c *Client) CMSManageUser(uui cms.ManageUser) (*cms.ManageUserReply, error) {
+func (c *Client) CMSManageUser(uui cms.CMSManageUser) (*cms.CMSManageUserReply, error) {
 	responseBody, err := c.makeRequest("POST", v1.RouteManageUser,
 		uui)
 	if err != nil {
 		return nil, err
 	}
 
-	var eur cms.ManageUserReply
+	var eur cms.CMSManageUserReply
 	err = json.Unmarshal(responseBody, &eur)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal CMSManageUserReply: %v", err)

--- a/politeiawww/cmd/shared/manageuser.go
+++ b/politeiawww/cmd/shared/manageuser.go
@@ -2,14 +2,13 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package shared
 
 import (
 	"fmt"
 	"strconv"
 
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
-	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
 // ManageUserCmd allows an admin to edit certain properties of the specified
@@ -63,7 +62,7 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 	}
 
 	// Print request details
-	err = shared.PrintJSON(mu)
+	err = PrintJSON(mu)
 	if err != nil {
 		return err
 	}
@@ -75,7 +74,7 @@ func (cmd *ManageUserCmd) Execute(args []string) error {
 	}
 
 	// Print response details
-	return shared.PrintJSON(mur)
+	return PrintJSON(mur)
 }
 
 // ManageUserHelpMsg is the output of the help command when 'edituser' is

--- a/politeiawww/cmd/shared/shared.go
+++ b/politeiawww/cmd/shared/shared.go
@@ -17,7 +17,7 @@ import (
 	"github.com/agl/ed25519"
 	"github.com/decred/dcrtime/merkle"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
 	"golang.org/x/crypto/sha3"
 )

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -334,7 +334,7 @@ func (p *politeiawww) processEditCMSUser(ecu cms.EditUser, u *user.User) (*cms.E
 	return &reply, nil
 }
 
-func (p *politeiawww) processManageCMSUser(mu cms.ManageUser) (*cms.ManageUserReply, error) {
+func (p *politeiawww) processManageCMSUser(mu cms.CMSManageUser) (*cms.CMSManageUserReply, error) {
 	log.Tracef("processManageCMSUser: %v", mu.UserID)
 
 	editUser, err := p.userByIDStr(mu.UserID)
@@ -397,7 +397,7 @@ func (p *politeiawww) processManageCMSUser(mu cms.ManageUser) (*cms.ManageUserRe
 	if err != nil {
 		return nil, err
 	}
-	return &cms.ManageUserReply{}, nil
+	return &cms.CMSManageUserReply{}, nil
 }
 
 // filterCMSUserPublicFields creates a filtered copy of a cms User that only

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -467,7 +467,7 @@ func (p *politeiawww) handleEditCMSUser(w http.ResponseWriter, r *http.Request) 
 func (p *politeiawww) handleManageCMSUser(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleManageCMSUser")
 
-	var mu cms.ManageUser
+	var mu cms.CMSManageUser
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&mu); err != nil {
 		RespondWithError(w, r, 0, "handleManageCMSUser: unmarshal",

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -867,6 +867,8 @@ func (p *politeiawww) setCMSUserWWWRoutes() {
 		p.handleCMSUsers, permissionLogin)
 
 	// Routes that require being logged in as an admin user.
-	p.addRoute(http.MethodPost, www.RouteManageUser,
+	p.addRoute(http.MethodPost, cms.RouteManageCMSUser,
 		p.handleManageCMSUser, permissionAdmin)
+	p.addRoute(http.MethodPost, www.RouteManageUser,
+		p.handleManageUser, permissionAdmin)
 }


### PR DESCRIPTION
This PR re-adds the legacy manage user endpoint and moves the newly added
CMS specific manage user endpoint to `/admin/manage/cms`  