### PR TITLE
[cms] Fix cmsmanageuser command on cmswww cli

### DIFF
--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -1751,7 +1751,7 @@ func (c *Client) CMSEditUser(uui cms.EditUser) (*cms.EditUserReply, error) {
 
 // CMSManageUser updates the given user's information.
 func (c *Client) CMSManageUser(uui cms.CMSManageUser) (*cms.CMSManageUserReply, error) {
-	responseBody, err := c.makeRequest("POST", v1.RouteManageUser,
+	responseBody, err := c.makeRequest("POST", cms.RouteManageCMSUser,
 		uui)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The `cmsmanageuser` command was not working properly. This diff fixes it.