### PR TITLE
[wip] [cms] Corrects domain type in LineItemInputs

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -447,7 +447,7 @@ type InvoiceInput struct {
 // invoice input.
 type LineItemsInput struct {
 	Type          LineItemTypeT `json:"type"`          // Type of work performed
-	Domain        string        `json:"domain"`        // Domain of work performed
+	Domain        DomainTypeT   `json:"domain"`        // Domain of work performed
 	Subdomain     string        `json:"subdomain"`     // Subdomain of work performed
 	Description   string        `json:"description"`   // Description of work performed
 	ProposalToken string        `json:"proposaltoken"` // Link to politeia proposal that work is associated with

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -194,6 +194,13 @@ func validateParseCSV(data []byte) (*cms.InvoiceInput, error) {
 		"misc":    cms.LineItemTypeMisc,
 		"sub":     cms.LineItemTypeSubHours,
 	}
+	DomainType := map[string]cms.DomainTypeT{
+		"developer":     cms.DomainTypeDeveloper,
+		"marketing":     cms.DomainTypeMarketing,
+		"research":      cms.DomainTypeResearch,
+		"design":        cms.DomainTypeDesign,
+		"documentation": cms.DomainTypeDocumentation,
+	}
 	invInput := &cms.InvoiceInput{}
 
 	// Validate that the invoice is CSV-formatted.
@@ -237,9 +244,14 @@ func validateParseCSV(data []byte) (*cms.InvoiceInput, error) {
 			return invInput,
 				fmt.Errorf("invalid line item type on line: %v", i)
 		}
+		domainType, ok := DomainType[strings.ToLower(lineContents[1])]
+		if !ok {
+			return invInput,
+				fmt.Errorf("invalid domain type on line: %v", i)
+		}
 
 		lineItem.Type = lineItemType
-		lineItem.Domain = lineContents[1]
+		lineItem.Domain = domainType
 		lineItem.Subdomain = lineContents[2]
 		lineItem.Description = lineContents[3]
 		lineItem.ProposalToken = lineContents[4]

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -103,7 +103,7 @@ func EncodeInvoiceLineItem(dbLineItem *database.LineItem) LineItem {
 	lineItem := LineItem{}
 	lineItem.InvoiceToken = dbLineItem.InvoiceToken
 	lineItem.Type = uint(dbLineItem.Type)
-	lineItem.Domain = dbLineItem.Domain
+	lineItem.Domain = uint(dbLineItem.Domain)
 	lineItem.Subdomain = dbLineItem.Subdomain
 	lineItem.Description = dbLineItem.Description
 	lineItem.ProposalURL = dbLineItem.ProposalURL
@@ -118,7 +118,7 @@ func DecodeInvoiceLineItem(lineItem *LineItem) *database.LineItem {
 	dbLineItem := &database.LineItem{}
 	dbLineItem.InvoiceToken = lineItem.InvoiceToken
 	dbLineItem.Type = cms.LineItemTypeT(lineItem.Type)
-	dbLineItem.Domain = lineItem.Domain
+	dbLineItem.Domain = cms.DomainTypeT(lineItem.Domain)
 	dbLineItem.Subdomain = lineItem.Subdomain
 	dbLineItem.Description = lineItem.Description
 	dbLineItem.ProposalURL = lineItem.ProposalURL

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -59,7 +59,7 @@ type LineItem struct {
 	LineItemKey    string `gorm:"primary_key"` // Token of the Invoice + array index
 	InvoiceToken   string `gorm:"not null"`    // Censorship token of the invoice
 	Type           uint   `gorm:"not null"`    // Type of line item
-	Domain         string `gorm:"not null"`    // Domain of the work performed (dev, marketing etc)
+	Domain         uint   `gorm:"not null"`    // Domain of the work performed (dev, marketing etc)
 	Subdomain      string `gorm:"not null"`    // Subdomain of the work performed (decrediton, event X etc)
 	Description    string `gorm:"not null"`    // Description of work performed
 	ProposalURL    string `gorm:"not null"`    // Link to politeia proposal that work is associated with

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -114,7 +114,7 @@ type LineItem struct {
 	LineNumber     uint
 	InvoiceToken   string
 	Type           cms.LineItemTypeT
-	Domain         string
+	Domain         cms.DomainTypeT
 	Subdomain      string
 	Description    string
 	ProposalURL    string

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -639,6 +639,12 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 				}
 			}
 
+			// Map for valid domain verification
+			validDomains := make(map[cms.DomainTypeT]string)
+			for _, domain := range cms.PolicySupportedCMSDomains {
+				validDomains[domain.Type] = domain.Description
+			}
+
 			// Validate line items
 			if len(invInput.LineItems) < 1 {
 				return www.UserError{
@@ -646,8 +652,8 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 				}
 			}
 			for _, lineInput := range invInput.LineItems {
-				domain := formatInvoiceField(lineInput.Domain)
-				if !validateInvoiceField(domain) {
+				_, ok := validDomains[lineInput.Domain]
+				if !ok {
 					return www.UserError{
 						ErrorCode: cms.ErrorStatusMalformedDomain,
 					}


### PR DESCRIPTION
This diff includes a fix for domain type from `string` to `DomainTypeT` in the `LineItemsInput` struct, and the code changes that were needed.