### PR TITLE
[cms] Add billed hours into CMSUsers response

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -918,12 +918,14 @@ type AbridgedCMSUser struct {
 	Domain         DomainTypeT     `json:"domain"`
 	ContractorType ContractorTypeT `json:"contractortype"`
 	Username       string          `json:"username"`
+	BilledHours    []Hours         `json:"billedhours"`
 }
 
 // CMSUsers is used to request a list of CMS users given a filter.
 type CMSUsers struct {
 	Domain         DomainTypeT     `json:"domain"`
 	ContractorType ContractorTypeT `json:"contractortype"`
+	LastMonthHours bool            `json:"hours"` // Boolean whether to include last month's billed hours for users in the same domain
 }
 
 // CMSUsersReply returns a list of Users that are currently
@@ -987,4 +989,11 @@ type CastVoteReply struct {
 	Signature       string                 `json:"signature"`             // Signature of the ClientSignature
 	Error           string                 `json:"error"`                 // Error status message
 	ErrorStatus     cmsplugin.ErrorStatusT `json:"errorstatus,omitempty"` // Error status code
+}
+
+// Hours contains a given month and year's billable hours.
+type Hours struct {
+	Month int `json:"month"`
+	Year  int `json:"year"`
+	Hours int `json:"hours"`
 }

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -925,7 +925,7 @@ type AbridgedCMSUser struct {
 type CMSUsers struct {
 	Domain         DomainTypeT     `json:"domain"`
 	ContractorType ContractorTypeT `json:"contractortype"`
-	LastMonthHours bool            `json:"hours"` // Boolean whether to include last month's billed hours for users in the same domain
+	BillingHistory bool            `json:"billinghistory"` // Boolean whether to include previous billed hours for users in the same domain.
 }
 
 // CMSUsersReply returns a list of Users that are currently

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -993,7 +993,7 @@ type CastVoteReply struct {
 
 // Hours contains a given month and year's billable hours.
 type Hours struct {
-	Month int `json:"month"`
-	Year  int `json:"year"`
-	Hours int `json:"hours"`
+	Month uint `json:"month"`
+	Year  uint `json:"year"`
+	Hours int  `json:"hours"`
 }

--- a/politeiawww/cmd/cmswww/cmsusers.go
+++ b/politeiawww/cmd/cmswww/cmsusers.go
@@ -38,8 +38,8 @@ Fetch a list of cms users based on filters provided.
 Arguments: None
 
 Flags:
-  --domain            (int, optional)      Email filter
-  --contractortype    (string, optional)   Username filter
+  --domain            (int, optional)   domain filter
+  --contractortype    (int, optional)   contractor type filter
 
 
 Example (Admin):

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -846,7 +846,9 @@ func (p *politeiawww) processCMSUsers(users *cms.CMSUsers, u *user.User) (*cms.C
 					}
 					// Only users of the same domain can receive the billed
 					// hours information, otherwise it will just be empty.
-					if u.Domain == int(requestingUser.Domain) {
+					// Admins are allowed to see all of anyone's past billed
+					// hours.
+					if u.Domain == int(requestingUser.Domain) || u.Admin {
 						// Request last 3 months of billed hours for the user
 						dbInvs, err := p.cmsDB.InvoicesByUserID(u.ID.String())
 						if err != nil {
@@ -864,7 +866,8 @@ func (p *politeiawww) processCMSUsers(users *cms.CMSUsers, u *user.User) (*cms.C
 						})
 
 						for i, inv := range dbInvs {
-							if i >= invoiceLimit {
+							// Only get the invoice limit if not an admin
+							if i >= invoiceLimit && !u.Admin {
 								break
 							}
 							hours := 0

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -969,8 +969,8 @@ func (p *politeiawww) processCMSUsers(cmsUsers *cms.CMSUsers, u *user.User) (*cm
 						Hours: hours,
 					})
 				}
-				match.BilledHours = billedHours
 			}
+			match.BilledHours = billedHours
 			matchedUsers[ii] = match
 		}
 	}

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -961,7 +961,17 @@ func (p *politeiawww) processCMSUsers(cmsUsers *cms.CMSUsers, u *user.User) (*cm
 					}
 					hours := 0
 					for _, li := range inv.LineItems {
-						hours += int(li.Labor)
+						// Only add up hours of line items that are of the
+						// matching requested domain. (or add up all for admin)
+						// This method is used since currently line items
+						// contain domains as strings instead of types.
+						for _, domain := range cms.PolicySupportedCMSDomains {
+							if u.Admin || (requestingUser.Domain == domain.Type &&
+								li.Domain == domain.Description) {
+								hours += int(li.Labor)
+								break
+							}
+						}
 					}
 					billedHours = append(billedHours, cms.Hours{
 						Month: inv.Month,

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -589,7 +589,15 @@ func (p *politeiawww) handleCMSUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cur, err := p.processCMSUsers(&cu)
+	// Get session user. This is a public route so one might not exist.
+	user, err := p.getSessionUser(w, r)
+	if err != nil && err != errSessionNotFound {
+		RespondWithError(w, r, 0,
+			"handleUsers: getSessionUser %v", err)
+		return
+	}
+
+	cur, err := p.processCMSUsers(&cu, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleCMSUsers: processCMSUsers %v", err)


### PR DESCRIPTION
~NOTE:  Do not merge this until approved by the stakeholders.  There will be an upcoming proposal that will cover this and other upcoming functionality.~
This has been discussed and determined to be approved implicitly by our previous contractor recruiting material located here: https://blog.decred.org/2017/07/25/Decred-Recruiting/

All development contractors are held to the same standard of visibility of their work output within their domain.  

This adds BilledHours to the AbridgedCMSUser type.  This field will be populated upon users of the same domain requesting CMSUser information of that domain.   

Currently, it will show the hours billed for the 3 most recent invoices.