### PR TITLE
[www] Version timestamps route

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -35,6 +35,7 @@ const (
 	CmdProposalCommentsLikes = "proposalcommentslikes"
 	CmdInventory             = "inventory"
 	CmdTokenInventory        = "tokeninventory"
+	CmdVersionTimestamps     = "versiontimestamps"
 	MDStreamAuthorizeVote    = 13 // Vote authorization by proposal author
 	MDStreamVoteBits         = 14 // Vote bits and mask
 	MDStreamVoteSnapshot     = 15 // Vote tickets and start/end parameters
@@ -946,6 +947,55 @@ func DecodeGetCommentsReply(payload []byte) (*GetCommentsReply, error) {
 	}
 
 	return &gcr, nil
+}
+
+// GetVersionTimestamps retrieves the timestamps for when each version of a
+// record was created.
+type GetVersionTimestamps struct {
+	Token string `json:"token"`
+}
+
+// EncodeGetVersionTimestamps encodes GetVersionTimestamps into a JSON byte slice.
+func EncodeGetVersionTimestamps(gvt GetVersionTimestamps) ([]byte, error) {
+	return json.Marshal(gvt)
+}
+
+// DecodeGetVersionTimestamps decodes a JSON byte slice into a
+// GetVersionTimestamps.
+func DecodeGetVersionTimestamps(payload []byte) (*GetVersionTimestamps, error) {
+	var gvt GetVersionTimestamps
+
+	err := json.Unmarshal(payload, &gvt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gvt, nil
+}
+
+// GetVersionTimestampsReply returns the timestamps for when each version of a
+// record was created.
+type GetVersionTimestampsReply struct {
+	Timestamps []uint64 `json:"timestamps"`
+}
+
+// EncodeGetVersionTimestampsReply encodes GetVersionTimestampsReply into a
+// JSON byte slice.
+func EncodeGetVersionTimestampsReply(gvtr GetVersionTimestampsReply) ([]byte, error) {
+	return json.Marshal(gvtr)
+}
+
+// DecodeGetVersionTimestampsReply decodes a JSON byte slice into a
+// GetVersionTimestampsReply.
+func DecodeGetVersionTimestampsReply(payload []byte) (*GetVersionTimestampsReply, error) {
+	var gvtr GetVersionTimestampsReply
+
+	err := json.Unmarshal(payload, &gvtr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gvtr, nil
 }
 
 // GetNumComments returns a map that contains the number of comments for the

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -50,6 +50,7 @@ notifications.  It does not render HTML.
 - [`Get comments`](#get-comments)
 - [`Like comment`](#like-comment)
 - [`Censor comment`](#censor-comment)
+- [`Version Timestamps`](#version-timestamps)
 
 
 **Error status codes**
@@ -1557,6 +1558,44 @@ Reply:
       "signature": "f5ea17d547d8347a2f2d77edcb7e89fcc96613d7aaff1f2a26761779763d77688b57b423f1e7d2da8cd433ef2cfe6f58c7cf1c43065fa6716a03a3726d902d0a"
     }
   }
+}
+```
+
+### `Version Timestamps`
+
+Retreive the timestamps when each version of a proposal was created.
+
+**Routes:** `GET /v1/proposals/{token}/versiontimestamps`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| token | string | Censorship token | yes |
+
+**Results:**
+
+| | Type | Description |
+|-|-|-|
+| timestamps | []number | timestamps when each version of the proposal were created |
+
+On failure the call shall return `400 Bad Request` and one of the following
+error codes:
+- [`ErrorStatusProposalNotFound`](#ErrorStatusProposalNotFound)
+
+**Example:**
+
+Request:
+
+```
+/v1/proposals/f1c2042d36c8603517cf24768b6475e18745943e4c6a20bc0001f52a2a6f9bde/versiontimestamps
+```
+
+Reply:
+
+```json
+{
+  "timestamps": [1581975919, 1581975934]
 }
 ```
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -63,6 +63,7 @@ const (
 	RouteProposalDetails          = "/proposals/{token:[A-z0-9]{64}}"
 	RouteSetProposalStatus        = "/proposals/{token:[A-z0-9]{64}}/status"
 	RouteCommentsGet              = "/proposals/{token:[A-z0-9]{64}}/comments"
+	RouteVersionTimestamps        = "/proposals/{token:[A-z0-9]{64}}/versiontimestamps"
 	RouteVoteResults              = "/proposals/{token:[A-z0-9]{64}}/votes"
 	RouteVoteStatus               = "/proposals/{token:[A-z0-9]{64}}/votestatus"
 	RouteNewComment               = "/comments/new"
@@ -761,6 +762,18 @@ type ProposalsDetails struct {
 // ProposalDetailsReply is used to reply to a proposal details command.
 type ProposalDetailsReply struct {
 	Proposal ProposalRecord `json:"proposal"`
+}
+
+// VersionTimestamps is used to retrieve the timestamps of when each version
+// of a proposal was created.
+type VersionTimestamps struct {
+	Token string `json:"token"` // Censorship token
+}
+
+// VersionTimestampsReply is used to reply to a version VersionTimestamps
+// command.
+type VersionTimestampsReply struct {
+	Timestamps []uint64 `json:"timestamps"` // Timestamps for each version of proposal.
 }
 
 // BatchProposals is used to request the proposal details for each of the

--- a/politeiawww/cmd/piwww/help.go
+++ b/politeiawww/cmd/piwww/help.go
@@ -117,6 +117,8 @@ func (cmd *HelpCmd) Execute(args []string) error {
 		fmt.Printf("%s\n", batchVoteSummaryHelpMsg)
 	case "votedetails":
 		fmt.Printf("%s\n", voteDetailsHelpMsg)
+	case "versiontimestamps":
+		fmt.Printf("%s\n", versionTimestampsHelpMsg)
 
 	default:
 		fmt.Printf("invalid command: use 'piwww -h' " +

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -95,6 +95,7 @@ type piwww struct {
 	VerifyUserEmail    VerifyUserEmailCmd       `command:"verifyuseremail" description:"(public) verify a user's email address"`
 	VerifyUserPayment  VerifyUserPaymentCmd     `command:"verifyuserpayment" description:"(user)   check if the logged in user has paid their user registration fee"`
 	Version            shared.VersionCmd        `command:"version" description:"(public) get server info and CSRF token"`
+	VersionTimestamps  VersionTimestampsCmd     `command:"versiontimestamps" description:"(public) get the timestamps for each version of a proposal"`
 	VettedProposals    VettedProposalsCmd       `command:"vettedproposals" description:"(public) get a page of vetted proposals"`
 	Vote               VoteCmd                  `command:"vote" description:"(public) cast votes for a proposal"`
 	VoteDetails        VoteDetailsCmd           `command:"votedetails" description:"(public) get the details for a proposal vote"`

--- a/politeiawww/cmd/piwww/versiontimestamps.go
+++ b/politeiawww/cmd/piwww/versiontimestamps.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// VersionTimestampsCmd retrieves the timestamps at each each version of a
+// proposal was created.
+type VersionTimestampsCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token" required:"true"` // Censorship token
+	} `positional-args:"true"`
+}
+
+// Execute executes the version timestamps command
+func (cmd *VersionTimestampsCmd) Execute(args []string) error {
+	// Get timestamps
+	vtsr, err := client.VersionTimestamps(cmd.Args.Token)
+	if err != nil {
+		return err
+	}
+
+	// Print version timestamps reply
+	return shared.PrintJSON(vtsr)
+}
+
+// versionTimestampsHelpMsg is the output for the help command when
+// 'proposaldetails' is specified.
+const versionTimestampsHelpMsg = `versiontimestamps "token"
+
+Get the timestamps at which each version of a proposal were created.
+
+Arguments:
+1. token      (string, required)   Censorship token
+
+Result:
+{
+  "timestamps": ([]int64) Timestamps of each version of the proposal
+}`

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -822,6 +822,31 @@ func (c *Client) ProposalDetails(token string, pd *www.ProposalsDetails) (*www.P
 	return &pr, nil
 }
 
+// VersionTimestamps retrieves the timestamps for each verison of a proposal.
+func (c *Client) VersionTimestamps(token string) (*www.VersionTimestampsReply, error) {
+	route := "/proposals/" + token + "/versiontimestamps"
+	responseBody, err := c.makeRequest(http.MethodGet,
+		www.PoliteiaWWWAPIRoute, route, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var vtsr www.VersionTimestampsReply
+	err = json.Unmarshal(responseBody, &vtsr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal VersionTimestampsReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(vtsr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &vtsr, nil
+}
+
 // UserProposals retrieves the proposals that have been submitted by the
 // specified user.
 func (c *Client) UserProposals(up *www.UserProposals) (*www.UserProposalsReply, error) {

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -822,7 +822,7 @@ func (c *Client) ProposalDetails(token string, pd *www.ProposalsDetails) (*www.P
 	return &pr, nil
 }
 
-// VersionTimestamps retrieves the timestamps for each verison of a proposal.
+// VersionTimestamps retrieves the timestamps for each version of a proposal.
 func (c *Client) VersionTimestamps(token string) (*www.VersionTimestampsReply, error) {
 	route := "/proposals/" + token + "/versiontimestamps"
 	responseBody, err := c.makeRequest(http.MethodGet,

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -385,6 +385,36 @@ func (p *politeiawww) decredLoadVoteResults(bestBlock uint64) (*decredplugin.Loa
 	return reply, nil
 }
 
+// decredVersionTimestamps uses the decred plugin version timestamps command to
+// request the timestamps for each version of a proposal.
+func (p *politeiawww) decredVersionTimestamps(token string) (*decredplugin.GetVersionTimestampsReply, error) {
+	bvs := decredplugin.GetVersionTimestamps{
+		Token: token,
+	}
+	payload, err := decredplugin.EncodeGetVersionTimestamps(bvs)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := cache.PluginCommand{
+		ID:             decredplugin.ID,
+		Command:        decredplugin.CmdVersionTimestamps,
+		CommandPayload: string(payload),
+	}
+
+	res, err := p.cache.PluginExec(pc)
+	if err != nil {
+		return nil, err
+	}
+
+	reply, err := decredplugin.DecodeGetVersionTimestampsReply([]byte(res.Payload))
+	if err != nil {
+		return nil, err
+	}
+
+	return reply, nil
+}
+
 // decredBatchVoteSummary uses the decred plugin batch vote summary command to
 // request a vote summary for a set of proposals from the cache.
 func (p *politeiawww) decredBatchVoteSummary(tokens []string) (*decredplugin.BatchVoteSummaryReply, error) {

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -274,6 +274,28 @@ func (p *politeiawww) handleProposalDetails(w http.ResponseWriter, r *http.Reque
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
 
+// handleVersionTimestamps returns the timestamps when each version of a
+// proposal was created.
+func (p *politeiawww) handleVersionTimestamps(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleVersionTimestamps")
+
+	var vt www.VersionTimestamps
+
+	// Get proposal token from path parameters
+	pathParams := mux.Vars(r)
+	vt.Token = pathParams["token"]
+
+	reply, err := p.processVersionTimestamps(vt)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleProposalDetails: processProposalDetails %v", err)
+		return
+	}
+
+	// Reply with the timestamps.
+	util.RespondWithJSON(w, http.StatusOK, reply)
+}
+
 // handleBatchVoteSummary handles the incoming batch vote summary command. It
 // returns a VoteSummary for each of the provided censorship tokens.
 func (p *politeiawww) handleBatchVoteSummary(w http.ResponseWriter, r *http.Request) {
@@ -1237,6 +1259,9 @@ func (p *politeiawww) setPoliteiaWWWRoutes() {
 		permissionPublic)
 	p.addRoute(http.MethodPost, www.PoliteiaWWWAPIRoute,
 		www.RouteCastVotes, p.handleCastVotes,
+		permissionPublic)
+	p.addRoute(http.MethodGet, www.PoliteiaWWWAPIRoute,
+		www.RouteVersionTimestamps, p.handleVersionTimestamps,
 		permissionPublic)
 	p.addRoute(http.MethodGet, www.PoliteiaWWWAPIRoute,
 		www.RouteVoteResults, p.handleVoteResults,

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -807,6 +807,26 @@ func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*
 	}, nil
 }
 
+// processVersionTimestamps retrieves the timestamps for each update to a proposal.
+func (p *politeiawww) processVersionTimestamps(vt www.VersionTimestamps) (*www.VersionTimestampsReply, error) {
+	log.Tracef("processVersionTimestamps")
+
+	versionTimestampsResponse, err := p.decredVersionTimestamps(vt.Token)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(versionTimestampsResponse.Timestamps) <= 0 {
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusProposalNotFound,
+		}
+	}
+
+	return &www.VersionTimestampsReply{
+		Timestamps: versionTimestampsResponse.Timestamps,
+	}, nil
+}
+
 // processProposalDetails fetches a specific proposal version from the records
 // cache and returns it.
 func (p *politeiawww) processProposalDetails(propDetails www.ProposalsDetails, user *user.User) (*www.ProposalDetailsReply, error) {


### PR DESCRIPTION
This diff adds a new route to piwww which retrieves the timestamps for each version of a proposal. This is needed in order for the UI to be able to identify which version of a proposal a comment was made on.

Closes #1099 