### PR TITLE
[cms] Return error when malformed DCC detected

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -207,6 +207,7 @@ const (
 	ErrorStatusMissingSubUserIDLineItem       www.ErrorStatusT = 1048
 	ErrorStatusInvalidSubUserIDLineItem       www.ErrorStatusT = 1049
 	ErrorStatusInvalidSupervisorUser          www.ErrorStatusT = 1050
+	ErrorStatusMalformedDCC                   www.ErrorStatusT = 1051
 )
 
 var (
@@ -338,6 +339,7 @@ var (
 		ErrorStatusMissingSubUserIDLineItem:       "must supply a userid for a subcontractor hours line item",
 		ErrorStatusInvalidSubUserIDLineItem:       "the userid supplied for the subcontractor hours line item is invalid",
 		ErrorStatusInvalidSupervisorUser:          "attempted input of an invalid supervisor user id",
+		ErrorStatusMalformedDCC:                   "malformed dcc detected",
 	}
 )
 


### PR DESCRIPTION
Previously malformed DCCs were being returned and appended to the getDCCs response.
Instead malformed detections will be logged and skipped from the response.