### PR TITLE
[cms] Add Temporary contractor type

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -77,6 +77,7 @@ const (
 	ContractorTypeSubContractor ContractorTypeT = 3 // SubContractor
 	ContractorTypeNominee       ContractorTypeT = 4 // Nominated DCC user
 	ContractorTypeRevoked       ContractorTypeT = 5 // Revoked CMS User
+	ContractorTypeTemp          ContractorTypeT = 6 // Temporary Contractor (only allowed 1 invoice)
 
 	// Payment information status types
 	PaymentStatusInvalid  PaymentStatusT = 0 // Invalid status
@@ -358,7 +359,8 @@ type AvailableLineItemType struct {
 // InviteNewUser is used to request that a new user invitation be sent via email.
 // If successful, the user will require verification before being able to login.
 type InviteNewUser struct {
-	Email string `json:"email"`
+	Email     string `json:"email"`
+	Temporary bool   `json:"temp"` // This denotes if the user is a temporary user (only allowed to submit 1 invoice).
 }
 
 // InviteNewUserReply responds with the verification token for the user

--- a/politeiawww/cmd/cmswww/invitenewuser.go
+++ b/politeiawww/cmd/cmswww/invitenewuser.go
@@ -7,14 +7,15 @@ package main
 import (
 	"fmt"
 
-	"github.com/decred/politeia/politeiawww/api/cms/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
 // InviteNewUserCmd allows administrators to invite contractors to join CMS.
 type InviteNewUserCmd struct {
 	Args struct {
-		Email string `positional-arg-name:"email"`
+		Email     string `positional-arg-name:"email"`
+		Temporary bool   `positional-arg-name:"temp"`
 	} `positional-args:"true" required:"true"`
 }
 
@@ -28,7 +29,8 @@ func (cmd *InviteNewUserCmd) Execute(args []string) error {
 	}
 
 	inu := &v1.InviteNewUser{
-		Email: cmd.Args.Email,
+		Email:     cmd.Args.Email,
+		Temporary: cmd.Args.Temporary,
 	}
 
 	// Print request details

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -115,8 +115,18 @@ func (p *politeiawww) processInviteNewUser(u cms.InviteNewUser) (*cms.InviteNewU
 		Username:                  strings.ToLower(u.Email),
 		NewUserVerificationToken:  token,
 		NewUserVerificationExpiry: expiry,
-		ContractorType:            int(cms.ContractorTypeNominee),
 	}
+
+	// Set the user to temporary if request includes it.
+	// While this will allow a user to bypass the DCC process, the temporary
+	// users will have extensive restrictions on their account and ability
+	// to submit invoices.
+	if u.Temporary {
+		nu.ContractorType = int(cms.ContractorTypeTemp)
+	} else {
+		nu.ContractorType = int(cms.ContractorTypeNominee)
+	}
+
 	payload, err := user.EncodeNewCMSUser(nu)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is the beginnings of the ability to add "one-off" contractors that are allowed to submit invoices without having to proceed through the full DCC process as a normal regularly billing contractor would.  

The current use-case that comes to mind for these users are bug bounty folks.  While they need the ability to bill for work complete, they are not considered to be full members of our contractor community and with that will come a reduce amount of rights and access.