### PR TITLE
[cms] Add proposalsOwned to CMSUsers information

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1469,6 +1469,41 @@ Reply:
 }
 ```
 
+### `Proposal Owners`
+
+Returns a list of cms users that are currently owning/mananging a given proposal.
+
+**Route:** `GET /v1/proposals/owner`
+
+**Params:**
+
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+| proposaltoken | string | A censorship token from a proposal on Politeia. | yes |
+
+**Results:**
+
+| Parameter | Type | Description |
+|-|-|-|
+| users | array of [Abridged CMS User](#abridged-cms-user) | The list of cms users that own/manage the proposal given.
+
+**Example**
+
+Request:
+
+```json
+{
+  "proposaltoken": "5203ab0bb739f3fc267ad20c945b81bcb68ff22414510c000305f4f0afb90d1b"
+}
+```
+
+Reply:
+
+```json
+{
+  "users": []
+}
+```
 ### Error codes
 
 | Status | Value | Description |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -766,7 +766,8 @@ Edits a user's details. This call requires admin privileges.
 | userid | string | UserID string of the user to be edited. | yes |
 | domain | int | The Domain Type that the user currently has | no |
 | contractortype | int | The contractor type of the user. | no |
-| supervisoruserid | string | The userid of the user (if the user is a sub contractor. ) | no |
+| supervisoruserid | []string | The userid of the user (if the user is a sub contractor. ) | no |
+| proposalsowned | []string | The tokens of any proposals that are "owned/managed" by this user. | no |
 
 **Results:**
 
@@ -782,6 +783,7 @@ Request:
   "domain": 1,
   "contractortype": 1,
   "supervisoruserid": "",
+  "proposalsowned":["337fc4762dac6bbe11d3d0130f33a09978004b190e6ebbbde9312ac63f223527"]
 }
 ```
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -44,6 +44,7 @@ const (
 	RoutePayInvoices         = "/admin/payinvoices"
 	RouteInvoiceComments     = "/invoices/{token:[A-z0-9]{64}}/comments"
 	RouteInvoiceExchangeRate = "/invoices/exchangerate"
+	RouteProposalOwner       = "/proposals/owner"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status
@@ -795,5 +796,17 @@ type CMSUsers struct {
 
 // CMSUsersReply returns a list of Users that are currently
 type CMSUsersReply struct {
+	Users []AbridgedCMSUser `json:"users"`
+}
+
+// ProposalOwner is a request for determining the current owners of a given
+// proposal.
+type ProposalOwner struct {
+	ProposalToken string `json:"proposaltoken"`
+}
+
+// ProposalOwnerReply returns the users that are currently associated with
+// the requested proposal token.
+type ProposalOwnerReply struct {
 	Users []AbridgedCMSUser `json:"users"`
 }

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -638,6 +638,7 @@ type User struct {
 	ContractorLocation string          `json:"contractorlocation"`
 	ContractorContact  string          `json:"contractorcontact"`
 	SupervisorUserIDs  []string        `json:"supervisoruserids"`
+	ProposalsOwned     []string        `json:"proposalsowned"`
 }
 
 // UserDetails fetches a cms user's details by their id.
@@ -668,6 +669,7 @@ type CMSManageUser struct {
 	Domain            DomainTypeT     `json:"domain,omitempty"`
 	ContractorType    ContractorTypeT `json:"contractortype,omitempty"`
 	SupervisorUserIDs []string        `json:"supervisoruserids,omitempty"`
+	ProposalsOwned    []string        `json:"proposalsowned,omitempty"`
 }
 
 // CMSManageUserReply is the reply for the CMSManageUserReply command.

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -82,6 +82,7 @@ type cmswww struct {
 	NewInvoice          NewInvoiceCmd            `command:"newinvoice" description:"(user)   create a new invoice"`
 	PayInvoices         PayInvoicesCmd           `command:"payinvoices" description:"(admin)  set all approved invoices to paid"`
 	Policy              PolicyCmd                `command:"policy" description:"(public) get the server policy"`
+	ProposalOwner       ProposalOwnerCmd         `command:"proposalowner" description:"(user) get owners of a proposal"`
 	RegisterUser        RegisterUserCmd          `command:"register" description:"(public) register an invited user to cms"`
 	ResetPassword       shared.ResetPasswordCmd  `command:"resetpassword" description:"(public) reset the password for a user that is not logged in"`
 	SetDCCStatus        SetDCCStatusCmd          `command:"setdccstatus" description:"(admin)  set the status of a DCC"`

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -23,6 +23,7 @@ type CMSManageUserCmd struct {
 	Domain            string `long:"domain" optional:"true"`
 	ContractorType    string `long:"contractortype" optional:"true"`
 	SupervisorUserIDs string `long:"supervisoruserids" optional:"true"`
+	ProposalsOwned    string `logn:"proposalsowned" optional:"true"`
 }
 
 // Execute executes the cms manage user command.
@@ -96,12 +97,19 @@ func (cmd *CMSManageUserCmd) Execute(args []string) error {
 		}
 	}
 
+	// Validate supervisor user IDs
+	proposalsOwned := make([]string, 0, 16)
+	if cmd.ProposalsOwned != "" {
+		proposalsOwned = strings.Split(cmd.ProposalsOwned, ",")
+	}
+
 	// Send request
 	mu := cms.CMSManageUser{
 		UserID:            cmd.Args.UserID,
 		Domain:            domain,
 		ContractorType:    contractorType,
 		SupervisorUserIDs: supervisorIDs,
+		ProposalsOwned:    proposalsOwned,
 	}
 	err = shared.PrintJSON(mu)
 	if err != nil {
@@ -134,11 +142,11 @@ Flags:
   --domain              (string, optional)  Domain of the contractor
   --contractortype      (string, optional)  Contractor Type
   --supervisoruserids   (string, optional)  Supervisor user IDs (comma separated)
+  --proposalsowned      (string, optional)  Proposals owned (comma separated)
 
 Domain types:
 1. developer
 2. marketing
-3. community
 4. research
 5. design
 6. documentation

--- a/politeiawww/cmd/cmswww/manageuser.go
+++ b/politeiawww/cmd/cmswww/manageuser.go
@@ -23,7 +23,7 @@ type CMSManageUserCmd struct {
 	Domain            string `long:"domain" optional:"true"`
 	ContractorType    string `long:"contractortype" optional:"true"`
 	SupervisorUserIDs string `long:"supervisoruserids" optional:"true"`
-	ProposalsOwned    string `logn:"proposalsowned" optional:"true"`
+	ProposalsOwned    string `long:"proposalsowned" optional:"true"`
 }
 
 // Execute executes the cms manage user command.

--- a/politeiawww/cmd/cmswww/proposalowner.go
+++ b/politeiawww/cmd/cmswww/proposalowner.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// ProposalOwnerCmd retreives a list of users that have been filtered using the
+// specified filtering params.
+type ProposalOwnerCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"`
+	} `positional-args:"true" optional:"true"`
+}
+
+// Execute executes the cmsusers command.
+func (cmd *ProposalOwnerCmd) Execute(args []string) error {
+	token := cmd.Args.Token
+	if token == "" {
+		return fmt.Errorf("token is required")
+	}
+	u := v1.ProposalOwner{
+		ProposalToken: cmd.Args.Token,
+	}
+
+	ur, err := client.ProposalOwner(&u)
+	if err != nil {
+		return err
+	}
+	return shared.PrintJSON(ur)
+}

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -2070,6 +2070,30 @@ func (c *Client) UserSubContractors(usc *cms.UserSubContractors) (*cms.UserSubCo
 	return &uscr, nil
 }
 
+// ProposalOwner retrieves the subcontractors that are linked to the requesting user
+func (c *Client) ProposalOwner(po *cms.ProposalOwner) (*cms.ProposalOwnerReply, error) {
+	responseBody, err := c.makeRequest(http.MethodGet,
+		cms.APIRoute, cms.RouteProposalOwner, po)
+	if err != nil {
+		return nil, err
+	}
+
+	var por cms.ProposalOwnerReply
+	err = json.Unmarshal(responseBody, &por)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal ProposalOwnerReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(por)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &por, nil
+}
+
 // WalletAccounts retrieves the walletprc accounts.
 func (c *Client) WalletAccounts() (*walletrpc.AccountsResponse, error) {
 	if c.wallet == nil {

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -548,10 +548,6 @@ func (p *politeiawww) getCMSUserByIDRaw(id string) (*user.CMSUser, error) {
 
 // convertCMSUserFromDatabaseUser converts a user User to a cms User.
 func convertCMSUserFromDatabaseUser(user *user.CMSUser) cms.User {
-	proposalsOwned := make([]string, 0, len(user.ProposalsOwned))
-	for _, proposal := range user.ProposalsOwned {
-		proposalsOwned = append(proposalsOwned, proposal)
-	}
 	superUserIDs := make([]string, 0, len(user.SupervisorUserIDs))
 	for _, userIDs := range user.SupervisorUserIDs {
 		superUserIDs = append(superUserIDs, userIDs.String())
@@ -581,7 +577,7 @@ func convertCMSUserFromDatabaseUser(user *user.CMSUser) cms.User {
 		MatrixName:                      user.MatrixName,
 		GitHubName:                      user.GitHubName,
 		SupervisorUserIDs:               superUserIDs,
-		ProposalsOwned:                  proposalsOwned,
+		ProposalsOwned:                  user.ProposalsOwned,
 	}
 }
 

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -394,6 +394,10 @@ func (p *politeiawww) processManageCMSUser(mu cms.CMSManageUser) (*cms.CMSManage
 		uu.SupervisorUserIDs = parseSuperUserIds
 	}
 
+	if len(mu.ProposalsOwned) > 0 {
+		uu.ProposalsOwned = mu.ProposalsOwned
+	}
+
 	payload, err := user.EncodeUpdateCMSUser(uu)
 	if err != nil {
 		return nil, err
@@ -544,6 +548,10 @@ func (p *politeiawww) getCMSUserByIDRaw(id string) (*user.CMSUser, error) {
 
 // convertCMSUserFromDatabaseUser converts a user User to a cms User.
 func convertCMSUserFromDatabaseUser(user *user.CMSUser) cms.User {
+	proposalsOwned := make([]string, 0, len(user.ProposalsOwned))
+	for _, proposal := range user.ProposalsOwned {
+		proposalsOwned = append(proposalsOwned, proposal)
+	}
 	superUserIDs := make([]string, 0, len(user.SupervisorUserIDs))
 	for _, userIDs := range user.SupervisorUserIDs {
 		superUserIDs = append(superUserIDs, userIDs.String())
@@ -573,6 +581,7 @@ func convertCMSUserFromDatabaseUser(user *user.CMSUser) cms.User {
 		MatrixName:                      user.MatrixName,
 		GitHubName:                      user.GitHubName,
 		SupervisorUserIDs:               superUserIDs,
+		ProposalsOwned:                  proposalsOwned,
 	}
 }
 

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -771,15 +771,11 @@ func (p *politeiawww) handleUserSubContractors(w http.ResponseWriter, r *http.Re
 func (p *politeiawww) handleProposalOwner(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleProposalOwner")
 
+	pathParams := mux.Vars(r)
+	token := pathParams["proposaltoken"]
+
 	var po cms.ProposalOwner
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&po); err != nil {
-		RespondWithError(w, r, 0, "handleProposalOwner: unmarshal",
-			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidInput,
-			})
-		return
-	}
+	po.ProposalToken = token
 
 	por, err := p.processProposalOwner(po)
 	if err != nil {

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -771,11 +771,15 @@ func (p *politeiawww) handleUserSubContractors(w http.ResponseWriter, r *http.Re
 func (p *politeiawww) handleProposalOwner(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleProposalOwner")
 
-	pathParams := mux.Vars(r)
-	token := pathParams["proposaltoken"]
-
 	var po cms.ProposalOwner
-	po.ProposalToken = token
+	err := util.ParseGetParams(r, &po)
+	if err != nil {
+		RespondWithError(w, r, 0, "handleProposalOwner: ParseGetParams",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
 
 	por, err := p.processProposalOwner(po)
 	if err != nil {

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -768,6 +768,29 @@ func (p *politeiawww) handleUserSubContractors(w http.ResponseWriter, r *http.Re
 	util.RespondWithJSON(w, http.StatusOK, uscr)
 }
 
+func (p *politeiawww) handleProposalOwner(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleProposalOwner")
+
+	var po cms.ProposalOwner
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&po); err != nil {
+		RespondWithError(w, r, 0, "handleProposalOwner: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	por, err := p.processProposalOwner(po)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleProposalOwner: processProposalOwner: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, por)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -833,6 +856,9 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		permissionLogin)
 	p.addRoute(http.MethodGet, cms.APIRoute,
 		cms.RouteUserSubContractors, p.handleUserSubContractors,
+		permissionLogin)
+	p.addRoute(http.MethodGet, cms.APIRoute,
+		cms.RouteProposalOwner, p.handleProposalOwner,
 		permissionLogin)
 
 	// Unauthenticated websocket

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -29,6 +29,7 @@ type CMSUser struct {
 	ContractorLocation string      `json:"contractorlocation"`
 	ContractorContact  string      `json:"contractorcontact"`
 	SupervisorUserIDs  []uuid.UUID `json:"supervisoruserids"`
+	ProposalsOwned     []string    `json:"proposalsowned"`
 }
 
 // EncodeCMSUser encodes a CMSUser into a JSON byte slice.
@@ -202,6 +203,7 @@ type UpdateCMSUser struct {
 	ContractorLocation string      `json:"contractorlocation"`
 	ContractorContact  string      `json:"contractorcontact"`
 	SupervisorUserIDs  []uuid.UUID `json:"supervisoruserids"`
+	ProposalsOwned     []string    `json:"proposalsowned"`
 }
 
 // EncodeUpdateCMSUser encodes a UpdateCMSUser into a JSON byte slice.

--- a/politeiawww/user/cms.go
+++ b/politeiawww/user/cms.go
@@ -15,6 +15,7 @@ const (
 	CmdUpdateCMSUser            = "updatecmsuser"
 	CmdCMSUserByID              = "cmsuserbyid"
 	CmdCMSUserSubContractors    = "cmsusersubcontractors"
+	CmdCMSUsersByProposalToken  = "cmsusersbyproposaltoken"
 )
 
 // CMSUser represents a CMS user. It contains the standard politeiawww user
@@ -330,6 +331,57 @@ func EncodeCMSUserSubContractorsReply(u CMSUserSubContractorsReply) ([]byte, err
 // CMSUserSubContractorsReply.
 func DecodeCMSUserSubContractorsReply(b []byte) (*CMSUserSubContractorsReply, error) {
 	var reply CMSUserSubContractorsReply
+
+	err := json.Unmarshal(b, &reply)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reply, nil
+}
+
+// CMSUsersByProposalToken returns all CMS users within the provided
+// proposal token.
+type CMSUsersByProposalToken struct {
+	Token string `json:"token"` // Proposal token
+}
+
+// EncodeCMSUsersByProposalToken encodes a CMSUsersByProposalToken into a
+// JSON byte slice.
+func EncodeCMSUsersByProposalToken(u CMSUsersByProposalToken) ([]byte, error) {
+	return json.Marshal(u)
+}
+
+// DecodeCMSUsersByProposalToken decodes JSON byte slice into a
+// CMSUsersByProposalToken.
+func DecodeCMSUsersByProposalToken(b []byte) (*CMSUsersByProposalToken, error) {
+	var u CMSUsersByProposalToken
+
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		return nil, err
+	}
+
+	return &u, nil
+}
+
+// CMSUsersByProposalTokenReply is the reply to the CMSUsersByProposalToken
+// command.
+type CMSUsersByProposalTokenReply struct {
+	Users []CMSUser `json:"users"`
+}
+
+// EncodeCMSUsersByProposalTokenReply encodes a CMSUsersByProposalTokenReply
+// into a JSON
+// byte slice.
+func EncodeCMSUsersByProposalTokenReply(u CMSUsersByProposalTokenReply) ([]byte, error) {
+	return json.Marshal(u)
+}
+
+// DecodeCMSUsersByProposalTokenReply decodes JSON byte slice into a
+// CMSUsersByProposalTokenReply.
+func DecodeCMSUsersByProposalTokenReply(b []byte) (*CMSUsersByProposalTokenReply, error) {
+	var reply CMSUsersByProposalTokenReply
 
 	err := json.Unmarshal(b, &reply)
 	if err != nil {

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -86,6 +86,7 @@ type CMSUser struct {
 	ContractorLocation string    `gorm:"not null"`               // General IRL Contractor Location
 	ContractorContact  string    `gorm:"not null"`               // Point of contact outside of matrix
 	SupervisorUserID   string    `gorm:"not null"`               // This is can either be 1 SupervisorUserID or a comma separated string of many supervisor user ids
+	ProposalsOwned     string    `gorm:"not null"`               // This can either be 1 Proposal or a comma separated string of many.
 
 	// Set by gorm
 	CreatedAt time.Time // Time of record creation


### PR DESCRIPTION
This allows administrators to add proposal "ownership" to a user information.  

This will be used in an upcoming request that will let proposal owners receive a report of 
users and line items that have been billed against their proposal.