### PR TITLE
[cms] Add ProposalBilling request

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -45,6 +45,7 @@ const (
 	RouteInvoiceComments     = "/invoices/{token:[A-z0-9]{64}}/comments"
 	RouteInvoiceExchangeRate = "/invoices/exchangerate"
 	RouteProposalOwner       = "/proposals/owner"
+	RouteProposalBilling     = "/proposals/billing"
 
 	// Invoice status codes
 	InvoiceStatusInvalid  InvoiceStatusT = 0 // Invalid status
@@ -811,4 +812,31 @@ type ProposalOwner struct {
 // the requested proposal token.
 type ProposalOwnerReply struct {
 	Users []AbridgedCMSUser `json:"users"`
+}
+
+// ProposalBilling collects information for administrators or proposal owners
+// for a given proposal.
+type ProposalBilling struct {
+	Token string `json:"token"`
+}
+
+// ProposalBillingReply returns all line items that have been billed to the
+// proposal token.
+type ProposalBillingReply struct {
+	BilledLineItems []ProposalLineItems `json:"lineitems"`
+}
+
+// ProposalLineItems includes all information required for a proper billing
+// history of line items from a given proposal token.
+type ProposalLineItems struct {
+	// User information
+	UserID   string `json:"userid"`
+	Username string `json:"username"`
+
+	// Invoice Information
+	Month int `json:"month"`
+	Year  int `json:"year"`
+
+	// Line Item Information
+	LineItem LineItemsInput `json:"lineitem"`
 }

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -83,6 +83,7 @@ type cmswww struct {
 	PayInvoices         PayInvoicesCmd           `command:"payinvoices" description:"(admin)  set all approved invoices to paid"`
 	Policy              PolicyCmd                `command:"policy" description:"(public) get the server policy"`
 	ProposalOwner       ProposalOwnerCmd         `command:"proposalowner" description:"(user) get owners of a proposal"`
+	ProposalBilling     ProposalBillingCmd       `command:"proposalbilling" description:"(user) get billing information for a proposal"`
 	RegisterUser        RegisterUserCmd          `command:"register" description:"(public) register an invited user to cms"`
 	ResetPassword       shared.ResetPasswordCmd  `command:"resetpassword" description:"(public) reset the password for a user that is not logged in"`
 	SetDCCStatus        SetDCCStatusCmd          `command:"setdccstatus" description:"(admin)  set the status of a DCC"`

--- a/politeiawww/cmd/cmswww/proposalbilling.go
+++ b/politeiawww/cmd/cmswww/proposalbilling.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2017-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// ProposalBillingCmd gets the invoices for the specified user.
+type ProposalBillingCmd struct {
+	Args struct {
+		Token string `positional-arg-name:"token"` // User ID
+	} `positional-args:"true" required:"true"`
+}
+
+// Execute executes the user invoices command.
+func (cmd *ProposalBillingCmd) Execute(args []string) error {
+	// Get user invoices
+	pbr, err := client.ProposalBilling(
+		&v1.ProposalBilling{
+			Token: cmd.Args.Token,
+		})
+	if err != nil {
+		return err
+	}
+
+	// Print user invoices
+	return shared.PrintJSON(pbr)
+}

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -872,6 +872,30 @@ func (c *Client) UserInvoices(up *cms.UserInvoices) (*cms.UserInvoicesReply, err
 	return &upr, nil
 }
 
+// ProposalBilling retrieves the billing for the requested proposal
+func (c *Client) ProposalBilling(pb *cms.ProposalBilling) (*cms.ProposalBillingReply, error) {
+	responseBody, err := c.makeRequest(http.MethodPost,
+		cms.APIRoute, cms.RouteProposalBilling, pb)
+	if err != nil {
+		return nil, err
+	}
+
+	var pbr cms.ProposalBillingReply
+	err = json.Unmarshal(responseBody, &pbr)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal ProposalBillingReply: %v", err)
+	}
+
+	if c.cfg.Verbose {
+		err := prettyPrintJSON(pbr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &pbr, nil
+}
+
 // AdminInvoices retrieves invoices base on possible field set in the request
 // month/year and/or status
 func (c *Client) AdminInvoices(ai *cms.AdminInvoices) (*cms.AdminInvoicesReply, error) {

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -385,20 +385,20 @@ func (c *cockroachdb) InvoicesByLineItemsProposalToken(token string) ([]*databas
 	log.Debugf("InvoicesByLineItemsProposalToken: %v", token)
 	// Get all line items with proposal token
 	query := `SELECT 
-				invoices.month, 
-				invoices.year, 
-				invoices.user_id,
-				invoices.public_key,
-				line_items.invoice_token,
-				line_items.type,
-				line_items.domain,
-				line_items.subdomain,
-				line_items.description,
-				line_items.proposal_url,
-				line_items.labor,
-				line_items.expenses,
-				line_items.contractor_rate
-				FROM invoices
+              invoices.month, 
+              invoices.year, 
+              invoices.user_id,
+              invoices.public_key,
+              line_items.invoice_token,
+              line_items.type,
+              line_items.domain,
+              line_items.subdomain,
+              line_items.description,
+              line_items.proposal_url,
+              line_items.labor,
+              line_items.expenses,
+              line_items.contractor_rate
+            FROM invoices
             INNER JOIN line_items
               ON invoices.token = line_items.invoice_token
               WHERE line_items.proposal_url = ? AND invoices.status = ?`

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -408,21 +408,6 @@ func (c *cockroachdb) InvoicesByLineItemsProposalToken(token string) ([]*databas
 	}
 	defer rows.Close()
 
-	type MatchingLineItems struct {
-		InvoiceToken   string
-		UserID         string
-		Month          uint
-		Year           uint
-		Type           uint
-		Domain         string
-		Subdomain      string
-		Description    string
-		ProposalURL    string
-		Labor          uint
-		Expenses       uint
-		ContractorRate uint
-		PublicKey      string
-	}
 	matching := make([]MatchingLineItems, 0, 1024)
 	for rows.Next() {
 		var i MatchingLineItems
@@ -436,30 +421,25 @@ func (c *cockroachdb) InvoicesByLineItemsProposalToken(token string) ([]*databas
 		return nil, err
 	}
 
-	dbInvoices := make([]*database.Invoice, 0, len(matching))
-	for _, vv := range matching {
-		li := make([]database.LineItem, 1)
-		li[0] = database.LineItem{
-			Type:           v1.LineItemTypeT(vv.Type),
-			Domain:         vv.Domain,
-			Subdomain:      vv.Subdomain,
-			Description:    vv.Description,
-			Labor:          vv.Labor,
-			Expenses:       vv.Expenses,
-			ProposalURL:    vv.ProposalURL,
-			ContractorRate: vv.ContractorRate,
-		}
-		inv := &database.Invoice{
-			PublicKey: vv.PublicKey,
-			Token:     vv.InvoiceToken,
-			Month:     vv.Month,
-			Year:      vv.Year,
-			UserID:    vv.UserID,
-			LineItems: li,
-		}
-		dbInvoices = append(dbInvoices, inv)
-	}
-	return dbInvoices, nil
+	return convertMatchingLineItemToInvoices(matching), nil
+}
+
+// MatchingLineItems is a type used for finding matched line items based on
+// proposal ownership.
+type MatchingLineItems struct {
+	InvoiceToken   string
+	UserID         string
+	Month          uint
+	Year           uint
+	Type           uint
+	Domain         string
+	Subdomain      string
+	Description    string
+	ProposalURL    string
+	Labor          uint
+	Expenses       uint
+	ContractorRate uint
+	PublicKey      string
 }
 
 // Close satisfies the database interface.

--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -249,3 +249,31 @@ func decodeDCC(dcc *DCC) *database.DCC {
 	}
 	return &dbDCC
 }
+
+func convertMatchingLineItemToInvoices(matching []MatchingLineItems) []*database.Invoice {
+	// Each invoice added will include just 1 line item.
+	dbInvoices := make([]*database.Invoice, 0, len(matching))
+	for _, vv := range matching {
+		li := make([]database.LineItem, 1)
+		li[0] = database.LineItem{
+			Type:           cms.LineItemTypeT(vv.Type),
+			Domain:         vv.Domain,
+			Subdomain:      vv.Subdomain,
+			Description:    vv.Description,
+			Labor:          vv.Labor,
+			Expenses:       vv.Expenses,
+			ProposalURL:    vv.ProposalURL,
+			ContractorRate: vv.ContractorRate,
+		}
+		inv := &database.Invoice{
+			PublicKey: vv.PublicKey,
+			Token:     vv.InvoiceToken,
+			Month:     vv.Month,
+			Year:      vv.Year,
+			UserID:    vv.UserID,
+			LineItems: li,
+		}
+		dbInvoices = append(dbInvoices, inv)
+	}
+	return dbInvoices
+}

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -52,6 +52,7 @@ type Database interface {
 	InvoicesByStatus(int) ([]Invoice, error)                          // Returns all invoices by status
 	InvoicesAll() ([]Invoice, error)                                  // Returns all invoices
 	InvoicesByDateRangeStatus(int64, int64, int) ([]*Invoice, error)  // Returns all paid invoice line items from range provided
+	InvoicesByLineItemsProposalToken(string) ([]*Invoice, error)      // Returns all Invoices with paid line item information based on proposal token.
 
 	// ExchangeRate functions
 	NewExchangeRate(*ExchangeRate) error          // Create new exchange rate

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -780,7 +780,6 @@ func (p *politeiawww) handleProposalOwner(w http.ResponseWriter, r *http.Request
 			})
 		return
 	}
-
 	por, err := p.processProposalOwner(po)
 	if err != nil {
 		RespondWithError(w, r, 0,
@@ -789,6 +788,35 @@ func (p *politeiawww) handleProposalOwner(w http.ResponseWriter, r *http.Request
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, por)
+}
+
+func (p *politeiawww) handleProposalBilling(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleProposalBilling")
+
+	var pb cms.ProposalBilling
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&pb); err != nil {
+		RespondWithError(w, r, 0, "handleProposalBilling: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+	u, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleProposalBilling: getSessionUser %v", err)
+		return
+	}
+
+	pbr, err := p.processProposalBilling(pb, u)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleProposalBilling: processSetDCCStatus: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, pbr)
 }
 
 func (p *politeiawww) setCMSWWWRoutes() {
@@ -859,6 +887,9 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		permissionLogin)
 	p.addRoute(http.MethodGet, cms.APIRoute,
 		cms.RouteProposalOwner, p.handleProposalOwner,
+		permissionLogin)
+	p.addRoute(http.MethodPost, cms.APIRoute,
+		cms.RouteProposalBilling, p.handleProposalBilling,
 		permissionLogin)
 
 	// Unauthenticated websocket

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1553,3 +1553,22 @@ func convertDCCDatabaseFromDCCRecord(dccRecord cms.DCCRecord) cmsdatabase.DCC {
 
 	return dbDCC
 }
+
+func convertDatabaseInvoiceToProposalLineItems(inv *cmsdatabase.Invoice) cms.ProposalLineItems {
+	return cms.ProposalLineItems{
+		Month:    int(inv.Month),
+		Year:     int(inv.Year),
+		UserID:   inv.UserID,
+		Username: inv.Username,
+		LineItem: cms.LineItemsInput{
+			Type:          inv.LineItems[0].Type,
+			Domain:        inv.LineItems[0].Domain,
+			Subdomain:     inv.LineItems[0].Subdomain,
+			Description:   inv.LineItems[0].Description,
+			ProposalToken: inv.LineItems[0].ProposalURL,
+			Labor:         inv.LineItems[0].Labor,
+			Expenses:      inv.LineItems[0].Expenses,
+			SubRate:       inv.LineItems[0].ContractorRate,
+		},
+	}
+}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1645,25 +1645,10 @@ func (p *politeiawww) processProposalBilling(pb cms.ProposalBilling, u *user.Use
 	propBilling := make([]cms.ProposalLineItems, 0, len(invoices))
 	for _, inv := range invoices {
 		// All invoices should have only 1 line item returned from that function
-		if len(inv.LineItems) < 1 {
+		if len(inv.LineItems) > 1 {
 			continue
 		}
-		lineItem := cms.ProposalLineItems{
-			Month:    int(inv.Month),
-			Year:     int(inv.Year),
-			UserID:   inv.UserID,
-			Username: inv.Username,
-			LineItem: cms.LineItemsInput{
-				Type:          inv.LineItems[0].Type,
-				Domain:        inv.LineItems[0].Domain,
-				Subdomain:     inv.LineItems[0].Subdomain,
-				Description:   inv.LineItems[0].Description,
-				ProposalToken: inv.LineItems[0].ProposalURL,
-				Labor:         inv.LineItems[0].Labor,
-				Expenses:      inv.LineItems[0].Expenses,
-				SubRate:       inv.LineItems[0].ContractorRate,
-			},
-		}
+		lineItem := convertDatabaseInvoiceToProposalLineItems(inv)
 		u, err := p.db.UserGetByPubKey(inv.PublicKey)
 		if err != nil {
 			log.Errorf("processProposalBilling: getUserByPubKey: token:%v "+

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1611,6 +1611,72 @@ func (p *politeiawww) processInvoicePayouts(lip cms.InvoicePayouts) (*cms.Invoic
 	return reply, nil
 }
 
+// processProposalBilling ensures that the request user is either an admin or
+// listed as an owner of the requested proposal.
+func (p *politeiawww) processProposalBilling(pb cms.ProposalBilling, u *user.User) (*cms.ProposalBillingReply, error) {
+	reply := &cms.ProposalBillingReply{}
+
+	cmsUser, err := p.getCMSUserByID(u.ID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	// Check to see if the user currently listed as owning the proposal
+	propOwned := false
+	for _, prop := range cmsUser.ProposalsOwned {
+		if prop == pb.Token {
+			propOwned = true
+		}
+	}
+	// If it's not owned and it's not an admin requesting return an error.
+	if !cmsUser.Admin && !propOwned {
+		err := www.UserError{
+			ErrorCode: www.ErrorStatusUserActionNotAllowed,
+		}
+		return nil, err
+	}
+
+	invoices, err := p.cmsDB.InvoicesByLineItemsProposalToken(pb.Token)
+	if err != nil {
+		return nil, www.UserError{
+			ErrorCode: cms.ErrorStatusInvoiceNotFound,
+		}
+	}
+	propBilling := make([]cms.ProposalLineItems, 0, len(invoices))
+	for _, inv := range invoices {
+		// All invoices should have only 1 line item returned from that function
+		if len(inv.LineItems) < 1 {
+			continue
+		}
+		lineItem := cms.ProposalLineItems{
+			Month:    int(inv.Month),
+			Year:     int(inv.Year),
+			UserID:   inv.UserID,
+			Username: inv.Username,
+			LineItem: cms.LineItemsInput{
+				Type:          inv.LineItems[0].Type,
+				Domain:        inv.LineItems[0].Domain,
+				Subdomain:     inv.LineItems[0].Subdomain,
+				Description:   inv.LineItems[0].Description,
+				ProposalToken: inv.LineItems[0].ProposalURL,
+				Labor:         inv.LineItems[0].Labor,
+				Expenses:      inv.LineItems[0].Expenses,
+				SubRate:       inv.LineItems[0].ContractorRate,
+			},
+		}
+		u, err := p.db.UserGetByPubKey(inv.PublicKey)
+		if err != nil {
+			log.Errorf("processProposalBilling: getUserByPubKey: token:%v "+
+				"pubKey:%v err:%v", pb.Token, inv.PublicKey, err)
+		} else {
+			lineItem.Username = u.Username
+		}
+		propBilling = append(propBilling, lineItem)
+	}
+	reply.BilledLineItems = propBilling
+	return reply, nil
+}
+
 // getInvoiceMonthYear will return the first invoice.json month/year that is
 // found, otherwise 0, 0 in the event of any error.
 func getInvoiceMonthYear(files []www.File) (uint, uint) {


### PR DESCRIPTION
Requires: #1135 

This request allows administrators and proposal "owners" to review all 
line items that have been billed to the given proposal.  

All other private user information for the invoices is hidden (name, address, etc),\
so just the raw information about a line item is given.  