### PR TITLE
www: Set csrf.MaxAge to 1 Day

### DIFF
--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -491,7 +491,7 @@ func _main() error {
 	csrfHandle := csrf.Protect(
 		csrfKey,
 		csrf.Path("/"),
-		csrf.MaxAge(0),
+		csrf.MaxAge(86400),
 	)
 
 	p.router = mux.NewRouter()

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -491,6 +491,7 @@ func _main() error {
 	csrfHandle := csrf.Protect(
 		csrfKey,
 		csrf.Path("/"),
+		csrf.MaxAge(0),
 	)
 
 	p.router = mux.NewRouter()

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -491,7 +491,7 @@ func _main() error {
 	csrfHandle := csrf.Protect(
 		csrfKey,
 		csrf.Path("/"),
-		csrf.MaxAge(86400),
+		csrf.MaxAge(sessionMaxAge),
 	)
 
 	p.router = mux.NewRouter()


### PR DESCRIPTION
Previously, we were receiving 403s frequently with cmswww and piwww.  

This matches what have set for sessionMaxAge in sessions.go