### PR TITLE
[cms] Update Temp to Deactivated on paid invoice

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -72,13 +72,14 @@ const (
 	DomainTypeDocumentation DomainTypeT = 6 // Documentation domain
 
 	// Contractor types
-	ContractorTypeInvalid       ContractorTypeT = 0 // Invalid contractor type
-	ContractorTypeDirect        ContractorTypeT = 1 // Direct contractor
-	ContractorTypeSupervisor    ContractorTypeT = 2 // Supervisor contractor
-	ContractorTypeSubContractor ContractorTypeT = 3 // SubContractor
-	ContractorTypeNominee       ContractorTypeT = 4 // Nominated DCC user
-	ContractorTypeRevoked       ContractorTypeT = 5 // Revoked CMS User
-	ContractorTypeTemp          ContractorTypeT = 6 // Temporary Contractor (only allowed 1 invoice)
+	ContractorTypeInvalid         ContractorTypeT = 0 // Invalid contractor type
+	ContractorTypeDirect          ContractorTypeT = 1 // Direct contractor
+	ContractorTypeSupervisor      ContractorTypeT = 2 // Supervisor contractor
+	ContractorTypeSubContractor   ContractorTypeT = 3 // SubContractor
+	ContractorTypeNominee         ContractorTypeT = 4 // Nominated DCC user
+	ContractorTypeRevoked         ContractorTypeT = 5 // Revoked CMS User
+	ContractorTypeTemp            ContractorTypeT = 6 // Temporary Contractor (only allowed 1 invoice)
+	ContractorTypeTempDeactivated ContractorTypeT = 7 // Temporary Contractor that has been deactivated
 
 	// Payment information status types
 	PaymentStatusInvalid  PaymentStatusT = 0 // Invalid status

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -61,9 +61,10 @@ var (
 	}
 	// The valid contractor
 	invalidNewInvoiceContractorType = map[cms.ContractorTypeT]bool{
-		cms.ContractorTypeNominee:       true,
-		cms.ContractorTypeInvalid:       true,
-		cms.ContractorTypeSubContractor: true,
+		cms.ContractorTypeNominee:         true,
+		cms.ContractorTypeInvalid:         true,
+		cms.ContractorTypeSubContractor:   true,
+		cms.ContractorTypeTempDeactivated: true,
 	}
 
 	validInvoiceField = regexp.MustCompile(createInvoiceFieldRegex())


### PR DESCRIPTION
This PR is the first step into limiting the access for users that have been given the "temp" contractor qualifier.  

When a temp contractor has an invoice moved to 'paid' status this will update their contractor type to the newly added "TempDeactivated."

Then if this temp contractor would like to submit another, they must first get approval from an administrator who will update their contractor type back to Temp in the admin user panel.