### PR TITLE
politeiawww: Delete sessions on password change.

### DIFF
--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -467,6 +467,9 @@ type Database interface {
 	// Delete a user session given its id
 	SessionDeleteByID(sessionID string) error
 
+	// Delete all sessions for a user except for the given session IDs
+	SessionsDeleteByUserID(id uuid.UUID, exemptSessionIDs []string) error
+
 	// Register a plugin
 	RegisterPlugin(Plugin) error
 

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -445,7 +445,7 @@ func (p *politeiawww) handleChangePassword(w http.ResponseWriter, r *http.Reques
 	session, err := p.getSession(r)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleChangePassword: getSessionUser %v", err)
+			"handleChangePassword: getSession %v", err)
 		return
 	}
 	user, err := p.getSessionUser(w, r)


### PR DESCRIPTION
Closes #647

This diff makes the following changes.

ChangePassword - on success, delete all existing sessions for the logged
in user except for the current session.

VerifyResetPassword - on success, delete all existing sessions for the
user whose password was reset.