### PR TITLE
[www] Allow skipping lines on DCC Statement

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -242,7 +242,7 @@ var (
 	// sponsor statement for DCC in cms.
 	PolicySponsorStatementSupportedChars = []string{
 		"A-z", "0-9", "&", ".", ",", ":", ";", "-", " ", "@", "+", "#", "/",
-		"(", ")", "!", "?", "\"", "'"}
+		"(", ")", "!", "?", "\"", "'", "\n"}
 
 	// PolicySupportedCMSDomains supplies the currently available domain types
 	// and descriptions of them.


### PR DESCRIPTION
As mentioned by Elian on [Matrix contractor's chat](https://matrix.to/#/!zUNclAsjlDCTJWzPVS:decred.org/$15861818648444uYNui:decred.org?via=decred.org), the DCC statement is now allowing new lines, returning a _The DCC sponsor statement is malformed_ exception.

Since the DCC is something pretty critical, I think that, by adding this, the DCC usability will increase and we will be able support Markdown for DCC statements.