### PR TITLE
[cms] Add DCC Statement supported chars to policy response

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -492,6 +492,7 @@ type PolicyReply struct {
 	UsernameSupportedChars        []string                `json:"usernamesupportedchars"`
 	CMSNameLocationSupportedChars []string                `json:"cmsnamelocationsupportedchars"`
 	CMSContactSupportedChars      []string                `json:"cmscontactsupportedchars"`
+	CMSStatementSupportedChars    []string                `json:"cmsstatementsupportedchars"`
 	CMSSupportedLineItemTypes     []AvailableLineItemType `json:"supportedlineitemtypes"`
 	CMSSupportedDomains           []AvailableDomain       `json:"supporteddomains"`
 }

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -407,6 +407,7 @@ func (p *politeiawww) handleCMSPolicy(w http.ResponseWriter, r *http.Request) {
 		UsernameSupportedChars:        www.PolicyUsernameSupportedChars,
 		CMSNameLocationSupportedChars: cms.PolicyCMSNameLocationSupportedChars,
 		CMSContactSupportedChars:      cms.PolicyCMSContactSupportedChars,
+		CMSStatementSupportedChars:    cms.PolicySponsorStatementSupportedChars,
 		CMSSupportedDomains:           cms.PolicySupportedCMSDomains,
 		CMSSupportedLineItemTypes:     cms.PolicyCMSSupportedLineItemTypes,
 	}


### PR DESCRIPTION
This commit adds the DCC Statement supported chars to the `/policy` response.

https://github.com/decred/politeia/blob/635e23f1641262ed7bb0555d2f8d13454ecd7234/politeiawww/api/cms/v1/v1.go#L243-L245