### PR TITLE
[www] Reset Password Token/Expiry on password change

### DIFF
--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1378,6 +1378,9 @@ func (p *politeiawww) processChangePassword(email string, cp www.ChangePassword)
 
 	// Add the updated user information to the db.
 	u.HashedPassword = hashedPassword
+	u.ResetPasswordVerificationToken = nil
+	u.ResetPasswordVerificationExpiry = 0
+
 	err = p.db.UserUpdate(*u)
 	if err != nil {
 		return nil, err

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1378,6 +1378,11 @@ func (p *politeiawww) processChangePassword(email string, cp www.ChangePassword)
 
 	// Add the updated user information to the db.
 	u.HashedPassword = hashedPassword
+
+	// We will also reset any possibly issued verification token to avoid
+	// a small chance of one having been issued by a potential attacker.
+	// Any update to the password by a logged in user, should be seen as
+	// an authorized request and therefore override any potential request.
 	u.ResetPasswordVerificationToken = nil
 	u.ResetPasswordVerificationExpiry = 0
 


### PR DESCRIPTION
Closes #650 

Seems like a rare instance, but it makes sense to also reset the token/expiry if they are possibly set when a user changes their passphrase.