### PR TITLE
[cms] Add passthroughs for proposals requests

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -228,6 +228,9 @@ const (
 	ErrorStatusDCCVoteEnded                   www.ErrorStatusT = 1054
 	ErrorStatusDCCVoteStillLive               www.ErrorStatusT = 1055
 	ErrorStatusDCCDuplicateVote               www.ErrorStatusT = 1056
+
+	ProposalsMainnet = "https://proposals.decred.org"
+	ProposalsTestnet = "https://test-proposals.decred.org"
 )
 
 var (

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -93,6 +93,7 @@ type cmswww struct {
 	StartVote           StartVoteCmd             `command:"startvote" description:"(admin)  start the voting period on a dcc"`
 	SupportOpposeDCC    SupportOpposeDCCCmd      `command:"supportopposedcc" description:"(user)   support or oppose a given DCC"`
 	TestRun             TestRunCmd               `command:"testrun" description:"         test cmswww routes"`
+	TokenInventory      shared.TokenInventoryCmd `command:"tokeninventory" description:"(user) get the censorship record tokens of all proposals (passthrough)"`
 	UpdateUserKey       shared.UpdateUserKeyCmd  `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
 	UserDetails         UserDetailsCmd           `command:"userdetails" description:"(user)   get current cms user details"`
 	UserInvoices        UserInvoicesCmd          `command:"userinvoices" description:"(user)   get all invoices submitted by a specific user"`

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -57,6 +57,7 @@ type cmswww struct {
 	// Commands
 	ActiveVotes         ActiveVotesCmd           `command:"activevotes" description:"(user) get the dccs that are being voted on"`
 	AdminInvoices       AdminInvoicesCmd         `command:"admininvoices" description:"(admin)  get all invoices (optional by month/year and/or status)"`
+	BatchProposals      shared.BatchProposalsCmd `command:"batchproposals" description:"(user)   retrieve a set of proposals"`
 	CensorComment       shared.CensorCommentCmd  `command:"censorcomment" description:"(admin)  censor a comment"`
 	ChangePassword      shared.ChangePasswordCmd `command:"changepassword" description:"(user)   change the password for the logged in user"`
 	ChangeUsername      shared.ChangeUsernameCmd `command:"changeusername" description:"(user)   change the username for the logged in user"`

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -166,7 +166,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 	}
 
 	// Verify proposal censorship record
-	err = verifyProposal(epr.Proposal, vr.PubKey)
+	err = shared.VerifyProposal(epr.Proposal, vr.PubKey)
 	if err != nil {
 		return fmt.Errorf("unable to verify proposal %v: %v",
 			epr.Proposal.CensorshipRecord.Token, err)

--- a/politeiawww/cmd/piwww/help.go
+++ b/politeiawww/cmd/piwww/help.go
@@ -114,7 +114,7 @@ func (cmd *HelpCmd) Execute(args []string) error {
 	case "resendverification":
 		fmt.Printf("%s\n", resendVerificationHelpMsg)
 	case "batchproposals":
-		fmt.Printf("%s\n", batchProposalsHelpMsg)
+		fmt.Printf("%s\n", shared.BatchProposalsHelpMsg)
 	case "batchvotesummary":
 		fmt.Printf("%s\n", batchVoteSummaryHelpMsg)
 	case "votedetails":

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -173,7 +173,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		Signature:        np.Signature,
 		CensorshipRecord: npr.CensorshipRecord,
 	}
-	err = verifyProposal(pr, vr.PubKey)
+	err = shared.VerifyProposal(pr, vr.PubKey)
 	if err != nil {
 		return fmt.Errorf("unable to verify proposal %v: %v",
 			pr.CensorshipRecord.Token, err)

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -87,7 +87,7 @@ type piwww struct {
 	Subscribe          SubscribeCmd             `command:"subscribe" description:"(public) subscribe to all websocket commands and do not exit tool"`
 	Tally              TallyCmd                 `command:"tally" description:"(public) get the vote tally for a proposal"`
 	TestRun            TestRunCmd               `command:"testrun" description:"         run a series of tests on the politeiawww routes (dev use only)"`
-	TokenInventory     TokenInventoryCmd        `command:"tokeninventory" description:"(public) get the censorship record tokens of all proposals"`
+	TokenInventory     shared.TokenInventoryCmd `command:"tokeninventory" description:"(public) get the censorship record tokens of all proposals"`
 	UpdateUserKey      shared.UpdateUserKeyCmd  `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
 	UserDetails        UserDetailsCmd           `command:"userdetails" description:"(public) get the details of a user profile"`
 	UserLikeComments   UserLikeCommentsCmd      `command:"userlikecomments" description:"(user)   get the logged in user's comment upvotes/downvotes for a proposal"`

--- a/politeiawww/cmd/piwww/proposaldetails.go
+++ b/politeiawww/cmd/piwww/proposaldetails.go
@@ -41,7 +41,7 @@ func (cmd *ProposalDetailsCmd) Execute(args []string) error {
 	}
 
 	// Verify proposal censorship record
-	err = verifyProposal(pdr.Proposal, vr.PubKey)
+	err = shared.VerifyProposal(pdr.Proposal, vr.PubKey)
 	if err != nil {
 		return fmt.Errorf("unable to verify proposal %v: %v",
 			pdr.Proposal.CensorshipRecord.Token, err)

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -387,7 +387,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 		Signature:        np.Signature,
 		CensorshipRecord: npr.CensorshipRecord,
 	}
-	err = verifyProposal(pr, version.PubKey)
+	err = shared.VerifyProposal(pr, version.PubKey)
 	if err != nil {
 		return fmt.Errorf("verify proposal failed: %v", err)
 	}
@@ -465,7 +465,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 		return err
 	}
 
-	err = verifyProposal(pdr.Proposal, version.PubKey)
+	err = shared.VerifyProposal(pdr.Proposal, version.PubKey)
 	if err != nil {
 		return fmt.Errorf("verify proposal failed: %v", err)
 	}
@@ -1142,7 +1142,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 
 	for _, v := range gavr.Proposals {
-		err = verifyProposal(v, version.PubKey)
+		err = shared.VerifyProposal(v, version.PubKey)
 		if err != nil {
 			return fmt.Errorf("verify proposal failed %v: %v",
 				v.CensorshipRecord.Token, err)
@@ -1181,7 +1181,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 
 	for _, v := range upr.Proposals {
-		err := verifyProposal(v, version.PubKey)
+		err := shared.VerifyProposal(v, version.PubKey)
 		if err != nil {
 			return fmt.Errorf("verify proposal failed %v: %v",
 				v.CensorshipRecord.Token, err)

--- a/politeiawww/cmd/piwww/userproposals.go
+++ b/politeiawww/cmd/piwww/userproposals.go
@@ -7,7 +7,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
@@ -37,7 +37,7 @@ func (cmd *UserProposalsCmd) Execute(args []string) error {
 
 	// Verify proposal censorship records
 	for _, p := range upr.Proposals {
-		err := verifyProposal(p, vr.PubKey)
+		err := shared.VerifyProposal(p, vr.PubKey)
 		if err != nil {
 			return fmt.Errorf("unable to verify proposal %v: %v",
 				p.CensorshipRecord.Token, err)

--- a/politeiawww/cmd/piwww/vettedproposals.go
+++ b/politeiawww/cmd/piwww/vettedproposals.go
@@ -7,7 +7,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
@@ -41,7 +41,7 @@ func (cmd *VettedProposalsCmd) Execute(args []string) error {
 
 	// Verify proposal censorship records
 	for _, p := range gavr.Proposals {
-		err = verifyProposal(p, vr.PubKey)
+		err = shared.VerifyProposal(p, vr.PubKey)
 		if err != nil {
 			return fmt.Errorf("unable to verify proposal %v: %v",
 				p.CensorshipRecord.Token, err)

--- a/politeiawww/cmd/shared/batchproposals.go
+++ b/politeiawww/cmd/shared/batchproposals.go
@@ -2,13 +2,12 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package shared
 
 import (
 	"fmt"
 
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
-	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
 // BatchProposalsCmd retrieves a set of proposals.
@@ -32,7 +31,7 @@ func (cmd *BatchProposalsCmd) Execute(args []string) error {
 
 	// Verify proposal censorship records
 	for _, p := range bpr.Proposals {
-		err = verifyProposal(p, vr.PubKey)
+		err = VerifyProposal(p, vr.PubKey)
 		if err != nil {
 			return fmt.Errorf("unable to verify proposal %v: %v",
 				p.CensorshipRecord.Token, err)
@@ -40,12 +39,12 @@ func (cmd *BatchProposalsCmd) Execute(args []string) error {
 	}
 
 	// Print proposals
-	return shared.PrintJSON(bpr)
+	return PrintJSON(bpr)
 }
 
 // batchProposalsHelpMsg is the output for the help command when
 // 'batchproposals' is specified.
-const batchProposalsHelpMsg = `batchproposals
+const BatchProposalsHelpMsg = `batchproposals
 
 Fetch a list of proposals.
 

--- a/politeiawww/cmd/shared/tokeninventory.go
+++ b/politeiawww/cmd/shared/tokeninventory.go
@@ -2,9 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
-
-import "github.com/decred/politeia/politeiawww/cmd/shared"
+package shared
 
 // TokenInventory retrieves the censorship record tokens of all proposals in
 // the inventory.
@@ -16,5 +14,6 @@ func (cmd *TokenInventoryCmd) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	return shared.PrintJSON(reply)
+
+	return PrintJSON(reply)
 }

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -943,9 +943,9 @@ func (p *politeiawww) handlePassThroughTokenInventory(w http.ResponseWriter, r *
 			"handlePassThroughTokenInventory: http.Get: %v", err)
 		return
 	}
+	defer resp.Body.Close()
 
 	data, _ := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
 	util.RespondRaw(w, http.StatusOK, data)
 }
 
@@ -964,12 +964,9 @@ func (p *politeiawww) handlePassThroughBatchProposals(w http.ResponseWriter, r *
 			"handlePassThroughBatchProposals: http.NewRequest: %v", err)
 		return
 	}
-	defer func() {
-		resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 
 	data, _ := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
 	util.RespondRaw(w, http.StatusOK, data)
 }
 

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -946,7 +946,6 @@ func (p *politeiawww) handlePassThroughTokenInventory(w http.ResponseWriter, r *
 
 	data, _ := ioutil.ReadAll(resp.Body)
 	util.RespondRaw(w, http.StatusOK, data)
-	//w.Write(util.ConvertBodyToByteArray(resp.Body, false))
 }
 
 func (p *politeiawww) setCMSWWWRoutes() {

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"text/template"
 
@@ -929,14 +930,23 @@ func (p *politeiawww) handleStartVoteDCC(w http.ResponseWriter, r *http.Request)
 
 func (p *politeiawww) handlePassThroughTokenInventory(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handlePassThroughTokenInventory")
-	resp, err := http.Get("https://proposals.decred.org/api/v1/proposals/tokeninventory")
+
+	route := cms.ProposalsMainnet
+	if p.cfg.TestNet {
+		route = cms.ProposalsTestnet
+	}
+	route = route + "/api/v1" + www.RouteTokenInventory
+
+	resp, err := http.Get(route)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"SOME ERROR", err)
 		return
 	}
 
-	w.Write(util.ConvertBodyToByteArray(resp.Body, false))
+	data, _ := ioutil.ReadAll(resp.Body)
+	util.RespondRaw(w, http.StatusOK, data)
+	//w.Write(util.ConvertBodyToByteArray(resp.Body, false))
 }
 
 func (p *politeiawww) setCMSWWWRoutes() {

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -945,6 +945,7 @@ func (p *politeiawww) handlePassThroughTokenInventory(w http.ResponseWriter, r *
 	}
 
 	data, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
 	util.RespondRaw(w, http.StatusOK, data)
 }
 

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -927,6 +927,18 @@ func (p *politeiawww) handleStartVoteDCC(w http.ResponseWriter, r *http.Request)
 	util.RespondWithJSON(w, http.StatusOK, svr)
 }
 
+func (p *politeiawww) handlePassThroughTokenInventory(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handlePassThroughTokenInventory")
+	resp, err := http.Get("https://proposals.decred.org/api/v1/proposals/tokeninventory")
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"SOME ERROR", err)
+		return
+	}
+
+	w.Write(util.ConvertBodyToByteArray(resp.Body, false))
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -948,6 +960,9 @@ func (p *politeiawww) setCMSWWWRoutes() {
 
 	p.addRoute(http.MethodGet, cms.APIRoute,
 		www.RoutePolicy, p.handleCMSPolicy,
+		permissionPublic)
+	p.addRoute(http.MethodGet, cms.APIRoute,
+		www.RouteTokenInventory, p.handlePassThroughTokenInventory,
 		permissionPublic)
 
 	// Routes that require being logged in.

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -949,6 +949,30 @@ func (p *politeiawww) handlePassThroughTokenInventory(w http.ResponseWriter, r *
 	util.RespondRaw(w, http.StatusOK, data)
 }
 
+func (p *politeiawww) handlePassThroughBatchProposals(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handlePassThroughBatchProposals")
+
+	route := cms.ProposalsMainnet
+	if p.cfg.TestNet {
+		route = cms.ProposalsTestnet
+	}
+	route = route + "/api/v1" + www.RouteBatchProposals
+
+	resp, err := http.Post(route, "application/json", r.Body)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handlePassThroughBatchProposals: http.NewRequest: %v", err)
+		return
+	}
+	defer func() {
+		resp.Body.Close()
+	}()
+
+	data, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	util.RespondRaw(w, http.StatusOK, data)
+}
+
 func (p *politeiawww) setCMSWWWRoutes() {
 	// Templates
 	//p.addTemplate(templateNewProposalSubmittedName,
@@ -1032,6 +1056,9 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		permissionLogin)
 	p.addRoute(http.MethodGet, cms.APIRoute,
 		www.RouteTokenInventory, p.handlePassThroughTokenInventory,
+		permissionLogin)
+	p.addRoute(http.MethodPost, www.PoliteiaWWWAPIRoute,
+		www.RouteBatchProposals, p.handlePassThroughBatchProposals,
 		permissionLogin)
 
 	// Unauthenticated websocket

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -940,7 +940,7 @@ func (p *politeiawww) handlePassThroughTokenInventory(w http.ResponseWriter, r *
 	resp, err := http.Get(route)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"SOME ERROR", err)
+			"handlePassThroughTokenInventory: http.Get: %v", err)
 		return
 	}
 
@@ -970,9 +970,6 @@ func (p *politeiawww) setCMSWWWRoutes() {
 
 	p.addRoute(http.MethodGet, cms.APIRoute,
 		www.RoutePolicy, p.handleCMSPolicy,
-		permissionPublic)
-	p.addRoute(http.MethodGet, cms.APIRoute,
-		www.RouteTokenInventory, p.handlePassThroughTokenInventory,
 		permissionPublic)
 
 	// Routes that require being logged in.
@@ -1032,6 +1029,9 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		permissionLogin)
 	p.addRoute(http.MethodGet, www.PoliteiaWWWAPIRoute,
 		cms.RouteActiveVotesDCC, p.handleActiveVoteDCC,
+		permissionLogin)
+	p.addRoute(http.MethodGet, cms.APIRoute,
+		www.RouteTokenInventory, p.handlePassThroughTokenInventory,
 		permissionLogin)
 
 	// Unauthenticated websocket

--- a/util/json.go
+++ b/util/json.go
@@ -26,10 +26,22 @@ func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Header().Set("Access-Control-Allow-Origin", "cms.decred.org")
 
 	w.WriteHeader(code)
 	w.Write(response)
+}
+
+func RespondRaw(w http.ResponseWriter, code int, payload []byte) {
+	w.Header().Set("Strict-Transport-Security",
+		"max-age=63072000; includeSubDomains")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Referrer-Policy", "same-origin")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("X-XSS-Protection", "1; mode=block")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	w.WriteHeader(code)
+	w.Write(payload)
 }
 
 // GetErrorFromJSON returns the error that is embedded in a JSON reply.

--- a/util/json.go
+++ b/util/json.go
@@ -6,9 +6,10 @@ package util
 
 import (
 	"encoding/json"
-	"github.com/gorilla/schema"
 	"io"
 	"net/http"
+
+	"github.com/gorilla/schema"
 )
 
 func RespondWithError(w http.ResponseWriter, code int, message string) {
@@ -25,6 +26,7 @@ func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Access-Control-Allow-Origin", "cms.decred.org")
 
 	w.WriteHeader(code)
 	w.Write(response)


### PR DESCRIPTION
This allows us to request `https://cms.decred.org/api/v1/proposals/tokeninventory` and `https://cms.decred.org/api/v1/proposals/batch` to avoid a cross site request that causes security issues.  This simple passes that request through via the API to the relevant proposals site (mainnet/testnet).