### PR TITLE
multi: Add metadata to proposal submissions.

### DIFF
--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -28,13 +28,14 @@ const (
 	IDDCCGeneral           = 6
 	IDDCCStatusChange      = 7
 	IDDCCSupportOpposition = 8
+	IDProposalDetails      = 9
 
 	// Note that 13 is in use by the decred plugin
 	// Note that 14 is in use by the decred plugin
 	// Note that 15 is in use by the decred plugin
 
 	// mdstream current supported versions
-	VersionProposalGeneral      = 1
+	VersionProposalGeneral      = 2
 	VersionRecordStatusChange   = 2
 	VersionInvoiceGeneral       = 1
 	VersionInvoiceStatusChange  = 1
@@ -42,19 +43,39 @@ const (
 	VersionDCCGeneral           = 1
 	VersionDCCStatusChange      = 1
 	VersionDCCSupposeOpposition = 1
+	VersionProposalDetails      = 1
 )
 
-// ProposalGeneral represents general metadata for a proposal.
-type ProposalGeneral struct {
+// DecodeVersion returns the version of the provided mstream payload. This
+// function should only be used when the payload contains a single struct with
+// a version field.
+func DecodeVersion(payload []byte) (uint, error) {
+	data := make(map[string]interface{}, 32)
+	err := json.Unmarshal(payload, &data)
+	if err != nil {
+		return 0, err
+	}
+	version := uint(data["version"].(float64))
+	if version == 0 {
+		return 0, fmt.Errorf("version not found")
+	}
+	return version, nil
+}
+
+// ProposalGeneralV1 represents general metadata for a proposal.
+//
+// Signature is the signature of the merkle root where the merkle root contains
+// the proposal file payloads.
+type ProposalGeneralV1 struct {
 	Version   uint64 `json:"version"`   // Struct version
 	Timestamp int64  `json:"timestamp"` // Last update of proposal
 	Name      string `json:"name"`      // Provided proposal name
 	PublicKey string `json:"publickey"` // Key used for signature
-	Signature string `json:"signature"` // Signature of proposal files merkle root
+	Signature string `json:"signature"` // Proposal signature
 }
 
-// EncodeProposalGeneral encodes a ProposalGeneral into a JSON byte slice.
-func EncodeProposalGeneral(md ProposalGeneral) ([]byte, error) {
+// EncodeProposalGeneralV1 encodes a ProposalGeneralV1 into a JSON byte slice.
+func EncodeProposalGeneralV1(md ProposalGeneralV1) ([]byte, error) {
 	b, err := json.Marshal(md)
 	if err != nil {
 		return nil, err
@@ -62,9 +83,69 @@ func EncodeProposalGeneral(md ProposalGeneral) ([]byte, error) {
 	return b, nil
 }
 
-// DecodeProposalGeneral decodes a JSON byte slice into a ProposalGeneral.
-func DecodeProposalGeneral(payload []byte) (*ProposalGeneral, error) {
-	var md ProposalGeneral
+// DecodeProposalGeneralV1 decodes a JSON byte slice into a ProposalGeneralV1.
+func DecodeProposalGeneralV1(payload []byte) (*ProposalGeneralV1, error) {
+	var md ProposalGeneralV1
+	err := json.Unmarshal(payload, &md)
+	if err != nil {
+		return nil, err
+	}
+	return &md, nil
+}
+
+// ProposalGeneralV2 represents general metadata for a proposal.
+//
+// Signature is the signature of the proposal merkle root. The merkle root
+// contains the ordered files and metadata digests. The file digests are first
+// in the ordering.
+//
+// Differences between v1 and v2:
+// * Name has been removed and is now part of ProposalDetails.
+// * Signature has been updated to include ProposalDetails.
+type ProposalGeneralV2 struct {
+	Version   uint64 `json:"version"`   // Struct version
+	Timestamp int64  `json:"timestamp"` // Last update of proposal
+	PublicKey string `json:"publickey"` // Key used for signature
+	Signature string `json:"signature"` // Proposal signature
+}
+
+// EncodeProposalGeneralV2 encodes a ProposalGeneralV2 into a JSON byte slice.
+func EncodeProposalGeneralV2(md ProposalGeneralV2) ([]byte, error) {
+	b, err := json.Marshal(md)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// DecodeProposalGeneralV2 decodes a JSON byte slice into a ProposalGeneralV2.
+func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
+	var md ProposalGeneralV2
+	err := json.Unmarshal(payload, &md)
+	if err != nil {
+		return nil, err
+	}
+	return &md, nil
+}
+
+// ProposalDetails represents proposal metadata that is specified by the
+// user when submitting the proposal.
+type ProposalDetails struct {
+	Name string `json:"name"` // Proposal name
+}
+
+// EncodeProposalDetails encodes a ProposalDetails into a JSON byte slice.
+func EncodeProposalDetails(md ProposalDetails) ([]byte, error) {
+	b, err := json.Marshal(md)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// DecodeProposalDetails decodes a JSON byte slice into a ProposalDetails.
+func DecodeProposalDetails(payload []byte) (*ProposalDetails, error) {
+	var md ProposalDetails
 	err := json.Unmarshal(payload, &md)
 	if err != nil {
 		return nil, err

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -28,7 +28,6 @@ const (
 	IDDCCGeneral           = 6
 	IDDCCStatusChange      = 7
 	IDDCCSupportOpposition = 8
-	IDProposalDetails      = 9
 
 	// Note that 13 is in use by the decred plugin
 	// Note that 14 is in use by the decred plugin
@@ -43,7 +42,11 @@ const (
 	VersionDCCGeneral           = 1
 	VersionDCCStatusChange      = 1
 	VersionDCCSupposeOpposition = 1
-	VersionProposalDetails      = 1
+
+	// Filenames of user defined metadata that is stored as politeiad
+	// files instead of politeiad metadata streams. This is done so
+	// that the metadata is included in the politeiad merkle root calc.
+	FilenameProposalMetadata = "proposalmetadata.json"
 )
 
 // DecodeVersion returns the version of the provided mstream payload. This
@@ -100,8 +103,8 @@ func DecodeProposalGeneralV1(payload []byte) (*ProposalGeneralV1, error) {
 // in the ordering.
 //
 // Differences between v1 and v2:
-// * Name has been removed and is now part of ProposalDetails.
-// * Signature has been updated to include ProposalDetails.
+// * Name has been removed and is now part of proposal metadata.
+// * Signature has been updated to include propoposal metadata.
 type ProposalGeneralV2 struct {
 	Version   uint64 `json:"version"`   // Struct version
 	Timestamp int64  `json:"timestamp"` // Last update of proposal
@@ -121,31 +124,6 @@ func EncodeProposalGeneralV2(md ProposalGeneralV2) ([]byte, error) {
 // DecodeProposalGeneralV2 decodes a JSON byte slice into a ProposalGeneralV2.
 func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 	var md ProposalGeneralV2
-	err := json.Unmarshal(payload, &md)
-	if err != nil {
-		return nil, err
-	}
-	return &md, nil
-}
-
-// ProposalDetails represents proposal metadata that is specified by the
-// user when submitting the proposal.
-type ProposalDetails struct {
-	Name string `json:"name"` // Proposal name
-}
-
-// EncodeProposalDetails encodes a ProposalDetails into a JSON byte slice.
-func EncodeProposalDetails(md ProposalDetails) ([]byte, error) {
-	b, err := json.Marshal(md)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
-}
-
-// DecodeProposalDetails decodes a JSON byte slice into a ProposalDetails.
-func DecodeProposalDetails(payload []byte) (*ProposalDetails, error) {
-	var md ProposalDetails
 	err := json.Unmarshal(payload, &md)
 	if err != nil {
 		return nil, err

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -1418,7 +1418,7 @@ func (d *decred) hookPostNewRecord(tx *gorm.DB, payload string) error {
 	// this new proposal request could be for a brand new proposal or
 	// it could be for a new proposal version that is the result of a
 	// proposal edit. We only need to store the ProposalMetadata for
-	// the most recent version of the proposal. Deleting any existing
+	// the most recent version of the proposal. Delete any existing
 	// metadata.
 	err = tx.Delete(ProposalMetadata{
 		Token: r.Token,
@@ -1466,7 +1466,7 @@ func (d *decred) hookPostUpdateRecord(tx *gorm.DB, payload string) error {
 	// this new proposal request could be for a brand new proposal or
 	// it could be for a new proposal version that is the result of a
 	// proposal edit. We only need to store the ProposalMetadata for
-	// the most recent version of the proposal. Deleting any existing
+	// the most recent version of the proposal. Delete any existing
 	// metadata.
 	err = tx.Delete(ProposalMetadata{
 		Token: r.Token,
@@ -1849,8 +1849,9 @@ func (d *decred) build(ir *decredplugin.InventoryReply) error {
 		keys = append(keys, v.Key)
 	}
 
-	// Lookup the metadata streams for each record
+	// Lookup the files and metadata streams for each record
 	err = d.recordsdb.
+		Preload("Files").
 		Preload("Metadata").
 		Where(keys).
 		Find(&records).

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -25,15 +25,15 @@ const (
 	decredVersion = "1.2"
 
 	// Decred plugin table names
-	tableProposalGeneralMetadata = "proposal_general_metadata"
-	tableComments                = "comments"
-	tableCommentLikes            = "comment_likes"
-	tableCastVotes               = "cast_votes"
-	tableAuthorizeVotes          = "authorize_votes"
-	tableVoteOptions             = "vote_options"
-	tableStartVotes              = "start_votes"
-	tableVoteOptionResults       = "vote_option_results"
-	tableVoteResults             = "vote_results"
+	tableProposalMetadata  = "proposal_metadata"
+	tableComments          = "comments"
+	tableCommentLikes      = "comment_likes"
+	tableCastVotes         = "cast_votes"
+	tableAuthorizeVotes    = "authorize_votes"
+	tableVoteOptions       = "vote_options"
+	tableStartVotes        = "start_votes"
+	tableVoteOptionResults = "vote_option_results"
+	tableVoteResults       = "vote_results"
 
 	// Vote option IDs
 	voteOptionIDApproved = "yes"
@@ -1338,35 +1338,64 @@ sendReply:
 	return string(reply), nil
 }
 
+func newProposalMetadata(r Record) (*ProposalMetadata, error) {
+	var name string
+	for _, v := range r.Metadata {
+		switch v.ID {
+		case mdstream.IDProposalGeneral:
+			// Pull the name out of the mdstream
+			b := []byte(v.Payload)
+			version, err := mdstream.DecodeVersion(b)
+			if err != nil {
+				return nil, err
+			}
+			switch version {
+			case 1:
+				pg, err := mdstream.DecodeProposalGeneralV1(b)
+				if err != nil {
+					return nil, err
+				}
+				name = pg.Name
+			case 2:
+				// The name is not included in ProposalGeneralV2. It was
+				// moved to the mdstream ProposalMetadata.
+			}
+
+		case mdstream.IDProposalDetails:
+			pd, err := mdstream.DecodeProposalDetails([]byte(v.Payload))
+			if err != nil {
+				return nil, err
+			}
+			name = pd.Name
+		}
+	}
+
+	return &ProposalMetadata{
+		Token: r.Token,
+		Name:  name,
+	}, nil
+}
+
 // hookPostNewRecord executes the decred plugin post new record hook. This
-// includes inserting a ProposalGeneralMetadata record for the given proposal.
+// includes inserting a ProposalMetadata record for the given proposal.
 //
 // This function must be called using a transaction.
 func (d *decred) hookPostNewRecord(tx *gorm.DB, payload string) error {
-	// Decode ProposalGeneral mdstream
 	var r Record
 	err := json.Unmarshal([]byte(payload), &r)
 	if err != nil {
 		return err
 	}
-
-	var pg *mdstream.ProposalGeneral
-	for _, md := range r.Metadata {
-		if md.ID == mdstream.IDProposalGeneral {
-			pg, err = mdstream.DecodeProposalGeneral([]byte(md.Payload))
-			if err != nil {
-				return err
-			}
-			break
-		}
+	pm, err := newProposalMetadata(r)
+	if err != nil {
+		return err
 	}
-	if pg == nil {
+	if pm.Name == "" {
 		// XXX Commented out as a temporary workaround for CMS using decred
 		// plugin. This needs to be fixed once the plugin architecture is
 		// sorted out.
 		//
-		// return fmt.Errorf("mdstream %v not found",
-		//		mdstream.IDProposalGeneral)
+		// return fmt.Errorf("proposal user metadata not found")
 
 		return nil
 	}
@@ -1374,28 +1403,18 @@ func (d *decred) hookPostNewRecord(tx *gorm.DB, payload string) error {
 	// All prososal versions are stored in the cache which means that
 	// this new proposal request could be for a brand new proposal or
 	// it could be for a new proposal version that is the result of a
-	// proposal edit. We only need to store the ProposalGeneralMetadata
-	// for the most recent version of the proposal.
-	if r.Version > 1 {
-		// Delete existing metadata
-		err := tx.Delete(ProposalGeneralMetadata{
-			Token: r.Token,
-		}).Error
-		if err != nil {
-			return fmt.Errorf("delete: %v", err)
-		}
+	// proposal edit. We only need to store the ProposalMetadata for
+	// the most recent version of the proposal. Deleting any existing
+	// metadata.
+	err = tx.Delete(ProposalMetadata{
+		Token: r.Token,
+	}).Error
+	if err != nil {
+		return fmt.Errorf("delete: %v", err)
 	}
 
 	// Insert new metadata
-	err = tx.Create(&ProposalGeneralMetadata{
-		Token:           r.Token,
-		ProposalVersion: r.Version,
-		Version:         pg.Version,
-		Timestamp:       pg.Timestamp,
-		Name:            pg.Name,
-		Signature:       pg.Signature,
-		PublicKey:       pg.PublicKey,
-	}).Error
+	err = tx.Create(pm).Error
 	if err != nil {
 		return fmt.Errorf("create: %v", err)
 	}
@@ -1404,57 +1423,46 @@ func (d *decred) hookPostNewRecord(tx *gorm.DB, payload string) error {
 }
 
 // hookPostUpdateRecord executes the decred plugin post update record hook.
-// This includes updating the ProposalGeneralMetadata in the cache for the
-// given proposal. The existing metadata is first deleted before the new
-// metadata is inserted.
+// This includes updating the ProposalMetadata in the cache for the given
+// proposal. The existing metadata is first deleted before the new metadata is
+// inserted.
 //
 // This function must be called using a transaction.
 func (d *decred) hookPostUpdateRecord(tx *gorm.DB, payload string) error {
-	// Decode ProposalGeneral mdstream
 	var r Record
 	err := json.Unmarshal([]byte(payload), &r)
 	if err != nil {
 		return err
 	}
-	var pg *mdstream.ProposalGeneral
-	for _, md := range r.Metadata {
-		if md.ID == mdstream.IDProposalGeneral {
-			pg, err = mdstream.DecodeProposalGeneral([]byte(md.Payload))
-			if err != nil {
-				return err
-			}
-			break
-		}
+	pm, err := newProposalMetadata(r)
+	if err != nil {
+		return err
 	}
-	if pg == nil {
+	if pm.Name == "" {
 		// XXX Commented out as a temporary workaround for CMS using decred
 		// plugin. This needs to be fixed once the plugin architecture is
 		// sorted out.
 		//
-		// return fmt.Errorf("mdstream %v not found",
-		//	mdstream.IDProposalGeneral)
+		// return fmt.Errorf("proposal user metadata not found")
 
 		return nil
 	}
 
-	// Delete existing metadata
-	err = tx.Delete(ProposalGeneralMetadata{
+	// All prososal versions are stored in the cache which means that
+	// this new proposal request could be for a brand new proposal or
+	// it could be for a new proposal version that is the result of a
+	// proposal edit. We only need to store the ProposalMetadata for
+	// the most recent version of the proposal. Deleting any existing
+	// metadata.
+	err = tx.Delete(ProposalMetadata{
 		Token: r.Token,
 	}).Error
 	if err != nil {
 		return fmt.Errorf("delete: %v", err)
 	}
 
-	// Insert new metadata record
-	err = tx.Create(&ProposalGeneralMetadata{
-		Token:           r.Token,
-		ProposalVersion: r.Version,
-		Version:         pg.Version,
-		Timestamp:       pg.Timestamp,
-		Name:            pg.Name,
-		Signature:       pg.Signature,
-		PublicKey:       pg.PublicKey,
-	}).Error
+	// Insert new metadata
+	err = tx.Create(pm).Error
 	if err != nil {
 		return fmt.Errorf("create: %v", err)
 	}
@@ -1467,8 +1475,8 @@ func (d *decred) hookPostUpdateRecord(tx *gorm.DB, payload string) error {
 func (d *decred) hookPostUpdateRecordMetadata(tx *gorm.DB, payload string) error {
 	// piwww does not currently use the UpdateRecordMetadata route.
 	// If this changes, this panic is here as a reminder that any piwww
-	// mdstream tables, such as ProposalGeneralMetadata and StartVote,
-	// need to be properly updated in this hook.
+	// mdstream tables, such as ProposalMetadata and StartVote, need to
+	// be properly updated in this hook.
 
 	// XXX Commented out as a temporary workaround for CMS using decred
 	// plugin. This needs to be fixed once the plugin architecture is
@@ -1555,8 +1563,8 @@ func (d *decred) createTables(tx *gorm.DB) error {
 	log.Tracef("createTables")
 
 	// Create decred plugin tables
-	if !tx.HasTable(tableProposalGeneralMetadata) {
-		err := tx.CreateTable(&ProposalGeneralMetadata{}).Error
+	if !tx.HasTable(tableProposalMetadata) {
+		err := tx.CreateTable(&ProposalMetadata{}).Error
 		if err != nil {
 			return err
 		}
@@ -1640,7 +1648,7 @@ func (d *decred) dropTables(tx *gorm.DB) error {
 	err := tx.DropTableIfExists(tableComments, tableCommentLikes,
 		tableCastVotes, tableAuthorizeVotes, tableVoteOptions,
 		tableStartVotes, tableVoteOptionResults, tableVoteResults,
-		tableProposalGeneralMetadata).Error
+		tableProposalMetadata).Error
 	if err != nil {
 		return err
 	}
@@ -1788,13 +1796,12 @@ func (d *decred) build(ir *decredplugin.InventoryReply) error {
 		}
 	}
 
-	// Build the ProposalGeneralMetadata cache. This metadata is not
-	// part of the decredplugin InventoryReply. It is already stored
-	// in the cached as a MetadataStream with an encoded payload. We
-	// need to lookup the MetadataStreams for each record, decode the
-	// mdstream, and save it as a ProposalGeneralMetadata record so
-	// that it is queriable. Only the ProposalGeneralMetadata for the
-	// most recent version of the proposal is saved to the cache.
+	// Build the ProposalMetadata cache. This metadata is not part of
+	// the decredplugin InventoryReply. It is already stored in the
+	// cached as a MetadataStream with an encoded payload. We need to
+	// pull the ProposalMetadata out so it can be queried. Only the
+	// ProposalMetadata for the most recent version of the proposal
+	// is saved to the cache.
 
 	// Lookup latest version of each record
 	query := `SELECT a.*
@@ -1839,43 +1846,24 @@ func (d *decred) build(ir *decredplugin.InventoryReply) error {
 	}
 
 	for _, v := range records {
-		// Decode the ProposalGeneral mdstream
-		var pg *mdstream.ProposalGeneral
-		for _, md := range v.Metadata {
-			if md.ID == mdstream.IDProposalGeneral {
-				pg, err = mdstream.DecodeProposalGeneral([]byte(md.Payload))
-				if err != nil {
-					return fmt.Errorf("decode ProposalGenral %v '%v': %v",
-						v.Token, md.Payload, err)
-				}
-			}
+		pm, err := newProposalMetadata(v)
+		if err != nil {
+			return err
 		}
-		if pg == nil {
+		if pm.Name == "" {
 			// XXX we cannot return an error here until the plugin
 			// architecture is sorted out. Right now, politeiad registers
 			// the decred plugin by default. CMS needs a way to register
 			// just the functionality it needs so that proposal specific
 			// tables do not get built for CMS.
-			// return fmt.Errorf("no ProposalGenral mdstream found %v",
+			// return fmt.Errorf("no proposal user metadata found %v",
 			//	v.Token)
 
 			continue
 		}
-
-		// Insert the ProposalGeneralMetadata record
-		pgm := ProposalGeneralMetadata{
-			Token:           v.Token,
-			ProposalVersion: v.Version,
-			Version:         pg.Version,
-			Timestamp:       pg.Timestamp,
-			Name:            pg.Name,
-			Signature:       pg.Signature,
-			PublicKey:       pg.PublicKey,
-		}
-		err := d.recordsdb.Create(&pgm).Error
+		err = d.recordsdb.Create(pm).Error
 		if err != nil {
-			return fmt.Errorf("insert ProposalGeneralMetadata %v: %v",
-				pgm, err)
+			return fmt.Errorf("create: %v", err)
 		}
 	}
 

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -64,24 +64,18 @@ func (Record) TableName() string {
 	return tableRecords
 }
 
-// ProposalGeneralMetadata represents general medadata for a proposal.
+// ProposalMetadata represents user defined proposal metadata.
 //
-// This mdstream data is already saved to the cache as a MetadataStream with an
-// encoded payload. The ProposalGeneralMetadata duplicates existing data, but
-// is necessary so that the metadata fields can be queried, which is not
-// possible with the encoded MetadataStream payload. ProposalGeneralMetadata
-// is only saved for the most recent proposal version since this is the only
-// metadata that currently needs to be queried.
+// This data is already saved to the cache as a MetadataStream with an encoded
+// payload. The ProposalMetadata duplicates existing data, but is necessary so
+// that the metadata fields can be queried. ProposalMetadata is only saved for
+// the most recent proposal version since this is the only metadata that
+// currently needs to be queried.
 //
 // This is a decred plugin model.
-type ProposalGeneralMetadata struct {
-	Token           string `gorm:"primary_key;size:64"` // Censorship token
-	ProposalVersion uint64 `gorm:"not null"`            // Proposal version
-	Version         uint64 `gorm:"not null"`            // Struct version
-	Timestamp       int64  `gorm:"not null"`            // Last update of proposal
-	Name            string `gorm:"not null"`            // Proposal name
-	Signature       string `gorm:"not null;size:128"`   // Client signature
-	PublicKey       string `gorm:"not null;size:64"`    // Pubkey used for Signature
+type ProposalMetadata struct {
+	Token string `gorm:"primary_key"` // Censorship token
+	Name  string `gorm:"not null"`    // Proposal name
 }
 
 // Comment represents a record comment, including all of the server side

--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -1098,7 +1098,9 @@ Reply:
 ### `New proposal`
 
 Submit a new proposal to the politeiawww server.
-The proposal name is derived from the first line of the markdown file - index.md.
+
+The Metadata field is required to include a [`Metadata`](#metadata) object that
+contains an encoded [`ProposalMetadata`](#proposal-metadata).
 
 **Route:** `POST /v1/proposals/new`
 
@@ -1107,7 +1109,8 @@ The proposal name is derived from the first line of the markdown file - index.md
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | files | array of [`File`](#file)s | Files are the body of the proposal. It should consist of one markdown file - named "index.md" - and up to five pictures. **Note:** all parameters within each [`File`](#file) are required. | Yes |
-| signature | string | Signature of the string representation of the Merkle root of the files payload. Note that the merkle digests are calculated on the decoded payload.. | Yes |
+| metadata | array of [`Metadata`](#metadata) | User specified proposal metadata.  |
+| signature | string | Signature of the string representation of the Merkle root of the file payloads and the metadata payloads. Note that the merkle digests are calculated on the decoded payload.. | Yes |
 | publickey | string | Public key from the client side, sent to politeiawww for verification | Yes |
 
 **Results:**
@@ -1162,14 +1165,16 @@ Reply:
 ### `Edit proposal`
 
 Edit an existent proposal into the politeiawww server.
-The proposal name is derived from the first line of the markdown file - index.md.
+
+The Metadata field is required to include a [`Metadata`](#metadata) object that
+contains an encoded [`ProposalMetadata`](#proposal-metadata).
 
 Note that updating public proposals will generate a new record version. While
 updating an unvetted record will change the record but it will not generate
 a new version.
 
-The example shown below is for a public proposal where the proposal version is increased
-by one after the update.
+The example shown below is for a public proposal where the proposal version is
+increased by one after the update.
 
 **Route:** `POST /v1/proposals/edit`
 
@@ -1178,7 +1183,8 @@ by one after the update.
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | files | array of [`File`](#file)s | Files are the body of the proposal. It should consist of one markdown file - named "index.md" - and up to five pictures. **Note:** all parameters within each [`File`](#file) are required. | Yes |
-| signature | string | Signature of the string representation of the Merkle root of the files payload. Note that the merkle digests are calculated on the decoded payload.. | Yes |
+| metadata | array of [`Metadata`](#metadata) | User specified proposal metadata.  |
+| signature | string | Signature of the string representation of the Merkle root of the file payloads and the metadata payloads. Note that the merkle digests are calculated on the decoded payload.. | Yes |
 | publickey | string | Public key from the client side, sent to politeiawww for verification | Yes |
 
 **Results:**
@@ -2786,6 +2792,19 @@ This is a shortened representation of a user, used for lists.
 | mime | string | MIME type of the payload. Currently the system only supports md and png files. The server shall reject invalid MIME types. |
 | digest | string | Digest is a SHA256 digest of the payload. The digest shall be verified by politeiad. |
 | payload | string | Payload is the actual file content. It shall be base64 encoded. Files have size limits that can be obtained via the [`Policy`](#policy) call. The server shall strictly enforce policy limits. |
+
+### `Metadata`
+
+| | Type | Description |
+|-|-|-|
+| Digest | string | SHA256 digest of the JSON encoded payload |
+| Hint | string | Hint that describes the payload |
+| Payload | string | Base64 encoded metadata content where the metadata content is JSON encoded. |
+
+### `Proposal Metadata`
+| | Type | Description |
+|-|-|-|
+| Name | string | Proposal name. |
 
 ### `Vote Summary`
 

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -102,7 +102,7 @@ type cmswww struct {
 func verifyInvoice(p cms.InvoiceRecord, serverPubKey string) error {
 	// Verify merkle root
 	if len(p.Files) > 0 {
-		mr, err := shared.MerkleRoot(p.Files)
+		mr, err := shared.MerkleRoot(p.Files, nil)
 		if err != nil {
 			return err
 		}
@@ -261,7 +261,7 @@ func verifyDCC(p cms.DCCRecord, serverPubKey string) error {
 	// Verify merkle root
 	files := make([]pi.File, 0, 1)
 	files = append(files, p.File)
-	mr, err := shared.MerkleRoot(files)
+	mr, err := shared.MerkleRoot(files, nil)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/cmswww/editinvoice.go
+++ b/politeiawww/cmd/cmswww/editinvoice.go
@@ -151,7 +151,7 @@ func (cmd *EditInvoiceCmd) Execute(args []string) error {
 	}
 
 	// Compute merkle root and sign it
-	sig, err := shared.SignedMerkleRoot(files, cfg.Identity)
+	sig, err := shared.SignedMerkleRoot(files, nil, cfg.Identity)
 	if err != nil {
 		return fmt.Errorf("SignMerkleRoot: %v", err)
 	}

--- a/politeiawww/cmd/cmswww/newdcc.go
+++ b/politeiawww/cmd/cmswww/newdcc.go
@@ -203,7 +203,7 @@ func (cmd *NewDCCCmd) Execute(args []string) error {
 	files = append(files, f)
 
 	// Compute merkle root and sign it
-	sig, err := shared.SignedMerkleRoot(files, cfg.Identity)
+	sig, err := shared.SignedMerkleRoot(files, nil, cfg.Identity)
 	if err != nil {
 		return fmt.Errorf("SignMerkleRoot: %v", err)
 	}

--- a/politeiawww/cmd/cmswww/newinvoice.go
+++ b/politeiawww/cmd/cmswww/newinvoice.go
@@ -168,7 +168,7 @@ func (cmd *NewInvoiceCmd) Execute(args []string) error {
 	}
 
 	// Compute merkle root and sign it
-	sig, err := shared.SignedMerkleRoot(files, cfg.Identity)
+	sig, err := shared.SignedMerkleRoot(files, nil, cfg.Identity)
 	if err != nil {
 		return fmt.Errorf("SignMerkleRoot: %v", err)
 	}

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -30,8 +30,6 @@ type EditProposalCmd struct {
 	Random bool   `long:"random" optional:"true"` // Generate random proposal data
 }
 
-// TODO fetch existing metadata and keep it the same if not changed
-
 // Execute executes the edit proposal command.
 func (cmd *EditProposalCmd) Execute(args []string) error {
 	token := cmd.Args.Token

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -117,7 +117,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		return err
 	}
 	metadata := []v1.Metadata{
-		v1.Metadata{
+		{
 			Digest:  hex.EncodeToString(util.Digest(pmb)),
 			Hint:    v1.HintProposalMetadata,
 			Payload: base64.StdEncoding.EncodeToString(pmb),

--- a/politeiawww/cmd/piwww/inventory.go
+++ b/politeiawww/cmd/piwww/inventory.go
@@ -102,7 +102,7 @@ func (cmd *InventoryCmd) Execute(args []string) error {
 			fmt.Printf("    Description          : %v\n",
 				vo.Description)
 			fmt.Printf("    Bits                 : %v\n", vo.Bits)
-			fmt.Printf("    To choose this option: politeiawwwcli vote %v %v\n",
+			fmt.Printf("    To choose this option: piwww vote %v %v\n",
 				v.StartVote.Vote.Token, vo.Id)
 		}
 	}
@@ -135,4 +135,4 @@ Token: (string)  Proposal censorship token
     ID                   : (string)  Unique word identifying vote (e.g. 'yes')
     Description          : (string)  Longer description of the vote
     Bits                 : (uint64)  Bits used for this option (e.g. '2')
-    To choose this option: politeiawwwcli vote 'Token' 'ID'`
+    To choose this option: piwww vote 'Token' 'ID'`

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -8,12 +8,13 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
 	"github.com/decred/politeia/politeiad/api/v1/mime"
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 	"github.com/decred/politeia/util"
 )
@@ -24,7 +25,8 @@ type NewProposalCmd struct {
 		Markdown    string   `positional-arg-name:"markdownfile"`    // Proposal MD file
 		Attachments []string `positional-arg-name:"attachmentfiles"` // Proposal attachment files
 	} `positional-args:"true" optional:"true"`
-	Random bool `long:"random" optional:"true"` // Generate random proposal data
+	Name   string `long:"name" optional:"true"`
+	Random bool   `long:"random" optional:"true"` // Generate random proposal data
 }
 
 // Execute executes the new proposal command.
@@ -32,8 +34,12 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 	mdFile := cmd.Args.Markdown
 	attachmentFiles := cmd.Args.Attachments
 
-	if !cmd.Random && mdFile == "" {
+	switch {
+	case !cmd.Random && mdFile == "":
 		return errProposalMDNotFound
+	case !cmd.Random && cmd.Name == "":
+		return fmt.Errorf("you must either provide a proposal name using the " +
+			"--name flag or use the --random flag to generate a random name")
 	}
 
 	// Check for user identity
@@ -47,13 +53,12 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		return err
 	}
 
+	// Prepare proposal index file
 	var md []byte
 	files := make([]v1.File, 0, v1.PolicyMaxImages+1)
 	if cmd.Random {
 		// Generate random proposal markdown text
 		var b bytes.Buffer
-		b.WriteString("This is the proposal title\n")
-
 		for i := 0; i < 10; i++ {
 			r, err := util.Random(32)
 			if err != nil {
@@ -101,8 +106,27 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		files = append(files, f)
 	}
 
+	// Setup metadata
+	if cmd.Name == "" {
+		cmd.Name = "Some proposal title"
+	}
+	pm := v1.ProposalMetadata{
+		Name: cmd.Name,
+	}
+	pmb, err := json.Marshal(pm)
+	if err != nil {
+		return err
+	}
+	metadata := []v1.Metadata{
+		v1.Metadata{
+			Digest:  hex.EncodeToString(util.Digest(pmb)),
+			Hint:    v1.HintProposalMetadata,
+			Payload: base64.StdEncoding.EncodeToString(pmb),
+		},
+	}
+
 	// Compute merkle root and sign it
-	sig, err := shared.SignedMerkleRoot(files, cfg.Identity)
+	sig, err := shared.SignedMerkleRoot(files, metadata, cfg.Identity)
 	if err != nil {
 		return fmt.Errorf("SignMerkleRoot: %v", err)
 	}
@@ -110,6 +134,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 	// Setup new proposal request
 	np := &v1.NewProposal{
 		Files:     files,
+		Metadata:  metadata,
 		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
 		Signature: sig,
 	}
@@ -129,6 +154,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 	// Verify the censorship record
 	pr := v1.ProposalRecord{
 		Files:            np.Files,
+		Metadata:         np.Metadata,
 		PublicKey:        np.PublicKey,
 		Signature:        np.Signature,
 		CensorshipRecord: npr.CensorshipRecord,

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -118,7 +118,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		return err
 	}
 	metadata := []v1.Metadata{
-		v1.Metadata{
+		{
 			Digest:  hex.EncodeToString(util.Digest(pmb)),
 			Hint:    v1.HintProposalMetadata,
 			Payload: base64.StdEncoding.EncodeToString(pmb),

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -130,7 +130,7 @@ func createMDFile() (*v1.File, error) {
 func verifyProposal(p v1.ProposalRecord, serverPubKey string) error {
 	// Verify merkle root
 	if len(p.Files) > 0 {
-		mr, err := shared.MerkleRoot(p.Files)
+		mr, err := shared.MerkleRoot(p.Files, p.Metadata)
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -62,7 +62,7 @@ func newProposal() (*v1.NewProposal, error) {
 		return nil, err
 	}
 	metadata := []v1.Metadata{
-		v1.Metadata{
+		{
 			Digest:  hex.EncodeToString(util.Digest(pmb)),
 			Hint:    v1.HintProposalMetadata,
 			Payload: base64.StdEncoding.EncodeToString(pmb),

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -5,7 +5,9 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -45,7 +47,6 @@ func login(email, password string) error {
 
 // newProposal returns a NewProposal object contains randomly generated
 // markdown text and a signature from the logged in user.
-// TODO fix this
 func newProposal() (*v1.NewProposal, error) {
 	md, err := createMDFile()
 	if err != nil {
@@ -53,13 +54,29 @@ func newProposal() (*v1.NewProposal, error) {
 	}
 	files := []v1.File{*md}
 
-	sig, err := shared.SignedMerkleRoot(files, nil, cfg.Identity)
+	pm := v1.ProposalMetadata{
+		Name: "Some proposal name",
+	}
+	pmb, err := json.Marshal(pm)
+	if err != nil {
+		return nil, err
+	}
+	metadata := []v1.Metadata{
+		v1.Metadata{
+			Digest:  hex.EncodeToString(util.Digest(pmb)),
+			Hint:    v1.HintProposalMetadata,
+			Payload: base64.StdEncoding.EncodeToString(pmb),
+		},
+	}
+
+	sig, err := shared.SignedMerkleRoot(files, metadata, cfg.Identity)
 	if err != nil {
 		return nil, fmt.Errorf("sign merkle root: %v", err)
 	}
 
 	return &v1.NewProposal{
 		Files:     files,
+		Metadata:  metadata,
 		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
 		Signature: sig,
 	}, nil
@@ -365,6 +382,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	// Verify proposal censorship record
 	pr := v1.ProposalRecord{
 		Files:            np.Files,
+		Metadata:         np.Metadata,
 		PublicKey:        np.PublicKey,
 		Signature:        np.Signature,
 		CensorshipRecord: npr.CensorshipRecord,

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -45,6 +45,7 @@ func login(email, password string) error {
 
 // newProposal returns a NewProposal object contains randomly generated
 // markdown text and a signature from the logged in user.
+// TODO fix this
 func newProposal() (*v1.NewProposal, error) {
 	md, err := createMDFile()
 	if err != nil {
@@ -52,7 +53,7 @@ func newProposal() (*v1.NewProposal, error) {
 	}
 	files := []v1.File{*md}
 
-	sig, err := shared.SignedMerkleRoot(files, cfg.Identity)
+	sig, err := shared.SignedMerkleRoot(files, nil, cfg.Identity)
 	if err != nil {
 		return nil, fmt.Errorf("sign merkle root: %v", err)
 	}

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -310,9 +310,9 @@ func convertPropStatusFromCache(s cache.RecordStatusT) www.PropStatusT {
 func convertPropFromCache(r cache.Record) (*www.ProposalRecord, error) {
 	// Decode metadata stream payloads
 	var (
-		// The proposal name was orginally saved in the ProposalGeneralV1
-		// mdstream but was moved to the ProposalData mdsteam, which is
-		// saved to politeiad as a File, not a MetadataStream.
+		// The name was originally saved in the ProposalGeneralV1
+		// mdstream but was moved to the ProposalData mdsteam, which
+		// is saved to politeiad as a File, not a MetadataStream.
 		name   string
 		pubkey string
 		sig    string

--- a/politeiawww/events.go
+++ b/politeiawww/events.go
@@ -439,9 +439,12 @@ func (p *politeiawww) _setupProposalVoteAuthorizedEmailNotification() {
 				log.Errorf("proposal not found: %v", err)
 				continue
 			}
-			proposal := convertPropFromCache(*record)
+			proposal, err := convertPropFromCache(*record)
+			if err != nil {
+				log.Errorf("invalid proposal %v", token)
+			}
 
-			err = p.emailAdminsForProposalVoteAuthorized(&proposal, pvs.User)
+			err = p.emailAdminsForProposalVoteAuthorized(proposal, pvs.User)
 			if err != nil {
 				log.Errorf("email all admins for new submitted proposal %v: %v",
 					token, err)

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -436,7 +436,7 @@ func (p *politeiawww) getProps(tokens []string) (map[string]www.ProposalRecord, 
 	log.Tracef("getProps: %v", tokens)
 
 	// Get the proposals from the cache
-	records, err := p.cache.Records(tokens, false)
+	records, err := p.cache.Records(tokens, true)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
@@ -79,26 +78,6 @@ func convertFileFromMetadata(m www.Metadata) pd.File {
 		Digest:  m.Digest,
 		Payload: m.Payload,
 	}
-}
-
-// parseProposalName returns the proposal name given the proposal index file
-// payload.
-func parseProposalName(payload string) (string, error) {
-	// decode payload (base64)
-	rawPayload, err := base64.StdEncoding.DecodeString(payload)
-	if err != nil {
-		return "", err
-	}
-	// @rgeraldes - used reader instead of scanner
-	// due to the size of the input (scanner > token too long)
-	// get the first line from the payload
-	reader := bufio.NewReader(bytes.NewReader(rawPayload))
-	proposalName, _, err := reader.ReadLine()
-	if err != nil {
-		return "", err
-	}
-
-	return string(proposalName), nil
 }
 
 // isValidProposalName returns whether the provided string is a valid proposal

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -34,10 +34,17 @@ import (
 const (
 	// indexFile contains the file name of the index file
 	indexFile = "index.md"
+
+	// MIME types
+	mimeTypeText     = "text/plain"
+	mimeTypeTextUTF8 = "text/plain; charset=utf-8"
 )
 
 var (
 	validProposalName = regexp.MustCompile(createProposalNameRegex())
+
+	// polieiad filenames for www.Metadata
+	filenameProposalMetadata = fmt.Sprintf("%s.json", www.HintProposalMetadata)
 )
 
 // proposalStats is used to provide a summary of the number of proposals
@@ -157,32 +164,32 @@ func validateVoteBit(vote www2.Vote, bit uint64) error {
 
 // validateProposal ensures that a submitted proposal hashes, merkle and
 // signarures are valid.
-func validateProposal(np www.NewProposal, u *user.User) error {
+func validateProposal(np www.NewProposal, u *user.User) (*www.ProposalMetadata, error) {
 	log.Tracef("validateProposal")
 
 	// Obtain signature
 	sig, err := util.ConvertSignature(np.Signature)
 	if err != nil {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusInvalidSignature,
 		}
 	}
 
 	// Verify public key
 	if u.PublicKey() != np.PublicKey {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusInvalidSigningKey,
 		}
 	}
 
 	pk, err := identity.PublicIdentityFromBytes(u.ActiveIdentity().Key[:])
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Check for at least 1 markdown file with a non-empty payload.
 	if len(np.Files) == 0 || np.Files[0].Payload == "" {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusProposalMissingFiles,
 		}
 	}
@@ -205,7 +212,7 @@ func validateProposal(np www.NewProposal, u *user.User) error {
 			numImages++
 			data, err = base64.StdEncoding.DecodeString(v.Payload)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if len(data) > www.PolicyMaxImageSize {
 				imageExceedsMaxSize = true
@@ -219,7 +226,7 @@ func validateProposal(np www.NewProposal, u *user.User) error {
 
 			data, err = base64.StdEncoding.DecodeString(v.Payload)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if len(data) > www.PolicyMaxMDSize {
 				mdExceedsMaxSize = true
@@ -242,7 +249,7 @@ func validateProposal(np www.NewProposal, u *user.User) error {
 			}
 		}
 		if len(repeated) > 0 {
-			return www.UserError{
+			return nil, www.UserError{
 				ErrorCode:    www.ErrorStatusProposalDuplicateFilenames,
 				ErrorContext: repeated,
 			}
@@ -251,43 +258,98 @@ func validateProposal(np www.NewProposal, u *user.User) error {
 
 	// we expect one index file
 	if numIndexFiles == 0 {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode:    www.ErrorStatusProposalMissingFiles,
 			ErrorContext: []string{indexFile},
 		}
 	}
 
 	if numMDs > www.PolicyMaxMDs {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusMaxMDsExceededPolicy,
 		}
 	}
 
 	if numImages > www.PolicyMaxImages {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusMaxImagesExceededPolicy,
 		}
 	}
 
 	if mdExceedsMaxSize {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusMaxMDSizeExceededPolicy,
 		}
 	}
 
 	if imageExceedsMaxSize {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusMaxImageSizeExceededPolicy,
 		}
 	}
 
-	// proposal title validation
-	name, err := getProposalName(np.Files)
-	if err != nil {
-		return err
+	// Validate metadata
+	var pm *www.ProposalMetadata
+	for _, v := range np.Metadata {
+		// Decode payload
+		b, err := base64.StdEncoding.DecodeString(v.Payload)
+		if err != nil {
+			e := fmt.Sprintf("invalid base64 for '%v'", v.Hint)
+			return nil, www.UserError{
+				ErrorCode:    www.ErrorStatusMetadataInvalid,
+				ErrorContext: []string{e},
+			}
+		}
+		d := json.NewDecoder(bytes.NewReader(b))
+		d.DisallowUnknownFields()
+
+		// Unmarshal payload
+		switch v.Hint {
+		case www.HintProposalMetadata:
+			var p www.ProposalMetadata
+			err := d.Decode(&p)
+			if err != nil {
+				log.Debugf("validateProposal: decode ProposalMetadata: %v", err)
+				return nil, www.UserError{
+					ErrorCode:    www.ErrorStatusMetadataInvalid,
+					ErrorContext: []string{v.Hint},
+				}
+			}
+			pm = &p
+		default:
+			e := fmt.Sprintf("unknown hint '%v'", v.Hint)
+			return nil, www.UserError{
+				ErrorCode:    www.ErrorStatusMetadataInvalid,
+				ErrorContext: []string{e},
+			}
+		}
+
+		// Validate digest
+		digest := util.Digest(b)
+		if v.Digest != hex.EncodeToString(digest) {
+			e := fmt.Sprintf("%v got digest %v, want %v",
+				v.Hint, v.Digest, hex.EncodeToString(digest))
+			return nil, www.UserError{
+				ErrorCode:    www.ErrorStatusMetadataDigestInvalid,
+				ErrorContext: []string{e},
+			}
+		}
+
+		// Add to hashes slice for merkle root calc
+		var h [sha256.Size]byte
+		copy(h[:], digest)
+		hashes = append(hashes, &h)
 	}
-	if !isValidProposalName(name) {
-		return www.UserError{
+	if pm == nil {
+		return nil, www.UserError{
+			ErrorCode:    www.ErrorStatusMetadataMissing,
+			ErrorContext: []string{www.HintProposalMetadata},
+		}
+	}
+
+	// Validate ProposalMetadata
+	if !isValidProposalName(pm.Name) {
+		return nil, www.UserError{
 			ErrorCode:    www.ErrorStatusProposalInvalidTitle,
 			ErrorContext: []string{createProposalNameRegex()},
 		}
@@ -296,12 +358,12 @@ func validateProposal(np www.NewProposal, u *user.User) error {
 	// Note that we need validate the string representation of the merkle
 	mr := merkle.Root(hashes)
 	if !pk.VerifyMessage([]byte(hex.EncodeToString(mr[:])), sig) {
-		return www.UserError{
+		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusInvalidSignature,
 		}
 	}
 
-	return nil
+	return pm, nil
 }
 
 func voteStatusFromVoteSummary(r decredplugin.VoteSummaryReply, bestBlock uint64) www.PropVoteStatusT {
@@ -326,16 +388,6 @@ func voteStatusFromVoteSummary(r decredplugin.VoteSummaryReply, bestBlock uint64
 	}
 }
 
-// getProposalName returns the proposal name based on the index markdown file.
-func getProposalName(files []www.File) (string, error) {
-	for _, file := range files {
-		if file.Name == indexFile {
-			return parseProposalName(file.Payload)
-		}
-	}
-	return "", nil
-}
-
 // convertWWWPropCreditFromDatabasePropCredit coverts a database proposal
 // credit to a v1 proposal credit.
 func convertWWWPropCreditFromDatabasePropCredit(credit user.ProposalCredit) www.ProposalCredit {
@@ -356,7 +408,10 @@ func (p *politeiawww) getProp(token string) (*www.ProposalRecord, error) {
 	if err != nil {
 		return nil, err
 	}
-	pr := convertPropFromCache(*r)
+	pr, err := convertPropFromCache(*r)
+	if err != nil {
+		return nil, err
+	}
 
 	// Find the number of comments for the proposal
 	dc, err := p.decredGetComments(token)
@@ -376,7 +431,7 @@ func (p *politeiawww) getProp(token string) (*www.ProposalRecord, error) {
 		pr.Username = u.Username
 	}
 
-	return &pr, nil
+	return pr, nil
 }
 
 // getProps returns a [token]www.ProposalRecord map for the provided list of
@@ -396,8 +451,12 @@ func (p *politeiawww) getProps(tokens []string) (map[string]www.ProposalRecord, 
 	// Use pointers for now so the props can be easily updated
 	props := make(map[string]*www.ProposalRecord, len(records))
 	for _, v := range records {
-		pr := convertPropFromCache(v)
-		props[v.CensorshipRecord.Token] = &pr
+		pr, err := convertPropFromCache(v)
+		if err != nil {
+			return nil, fmt.Errorf("convertPropFromCache %v: %v",
+				v.CensorshipRecord.Token, err)
+		}
+		props[v.CensorshipRecord.Token] = pr
 	}
 
 	// Get the number of comments for each proposal. Comments
@@ -467,7 +526,10 @@ func (p *politeiawww) getPropVersion(token, version string) (*www.ProposalRecord
 	if err != nil {
 		return nil, err
 	}
-	pr := convertPropFromCache(*r)
+	pr, err := convertPropFromCache(*r)
+	if err != nil {
+		return nil, err
+	}
 
 	// Fetch number of comments for proposal from cache
 	dc, err := p.decredGetComments(token)
@@ -485,7 +547,7 @@ func (p *politeiawww) getPropVersion(token, version string) (*www.ProposalRecord
 		pr.Username = u.Username
 	}
 
-	return &pr, nil
+	return pr, nil
 }
 
 // getAllProps gets the latest version of all proposals from the cache then
@@ -502,7 +564,11 @@ func (p *politeiawww) getAllProps() ([]www.ProposalRecord, error) {
 	// Convert props and fill in missing info
 	props := make([]www.ProposalRecord, 0, len(records))
 	for _, v := range records {
-		pr := convertPropFromCache(v)
+		pr, err := convertPropFromCache(v)
+		if err != nil {
+			return nil, fmt.Errorf("convertPropFromCache %v: %v",
+				pr.CensorshipRecord.Token, err)
+		}
 
 		// Fill in num comments
 		dc, err := p.decredGetComments(pr.CensorshipRecord.Token)
@@ -522,7 +588,7 @@ func (p *politeiawww) getAllProps() ([]www.ProposalRecord, error) {
 			pr.Username = u.Username
 		}
 
-		props = append(props, pr)
+		props = append(props, *pr)
 	}
 
 	return props, nil
@@ -710,6 +776,20 @@ func (p *politeiawww) getPropComments(token string) ([]www.Comment, error) {
 	return comments, nil
 }
 
+func convertFileFromMetadata(m www.Metadata) pd.File {
+	var name string
+	switch m.Hint {
+	case www.HintProposalMetadata:
+		name = filenameProposalMetadata
+	}
+	return pd.File{
+		Name:    name,
+		MIME:    mimeTypeTextUTF8,
+		Digest:  m.Digest,
+		Payload: m.Payload,
+	}
+}
+
 // processNewProposal tries to submit a new proposal to politeiad.
 func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*www.NewProposalReply, error) {
 	log.Tracef("processNewProposal")
@@ -726,23 +806,41 @@ func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*
 		}
 	}
 
-	err := validateProposal(np, user)
+	pm, err := validateProposal(np, user)
 	if err != nil {
 		return nil, err
 	}
 
-	// Assemble metadata record
-	name, err := getProposalName(np.Files)
+	// politeiad only includes files in its merkle root calc, not the
+	// metadata streams. This is why we include the ProposalMetadata
+	// as both a a politeiad file and metadata stream. Including it as
+	// a file ensures that it's included in the merkle calc. Including
+	// it as a metadata stream allows its fields to be queried.
+
+	// Setup politeaid files
+	files := convertPropFilesFromWWW(np.Files)
+	for _, v := range np.Metadata {
+		switch v.Hint {
+		case www.HintProposalMetadata:
+			files = append(files, convertFileFromMetadata(v))
+		}
+	}
+
+	// Setup politeiad metadata
+	pg := mdstream.ProposalGeneralV2{
+		Version:   mdstream.VersionProposalGeneral,
+		Timestamp: time.Now().Unix(),
+		PublicKey: np.PublicKey,
+		Signature: np.Signature,
+	}
+	pgb, err := mdstream.EncodeProposalGeneralV2(pg)
 	if err != nil {
 		return nil, err
 	}
-	md, err := mdstream.EncodeProposalGeneral(mdstream.ProposalGeneral{
-		Version:   mdstream.VersionProposalGeneral,
-		Timestamp: time.Now().Unix(),
-		Name:      name,
-		PublicKey: np.PublicKey,
-		Signature: np.Signature,
-	})
+	pdb, err := mdstream.EncodeProposalDetails(
+		mdstream.ProposalDetails{
+			Name: pm.Name,
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -754,11 +852,17 @@ func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*
 	}
 	n := pd.NewRecord{
 		Challenge: hex.EncodeToString(challenge),
-		Metadata: []pd.MetadataStream{{
-			ID:      mdstream.IDProposalGeneral,
-			Payload: string(md),
-		}},
-		Files: convertPropFilesFromWWW(np.Files),
+		Metadata: []pd.MetadataStream{
+			{
+				ID:      mdstream.IDProposalGeneral,
+				Payload: string(pgb),
+			},
+			{
+				ID:      mdstream.IDProposalDetails,
+				Payload: string(pdb),
+			},
+		},
+		Files: files,
 	}
 
 	// Send politeiad request
@@ -768,7 +872,7 @@ func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*
 		return nil, err
 	}
 
-	log.Infof("Submitted proposal name: %v", name)
+	log.Infof("Submitted proposal name: %v", pm.Name)
 	for k, f := range n.Files {
 		log.Infof("%02v: %v %v", k, f.Name, f.Digest)
 	}
@@ -797,7 +901,7 @@ func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*
 	p.fireEvent(EventTypeProposalSubmitted,
 		EventDataProposalSubmitted{
 			CensorshipRecord: &cr,
-			ProposalName:     name,
+			ProposalName:     pm.Name,
 			User:             user,
 		},
 	)
@@ -1283,6 +1387,53 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 	}, nil
 }
 
+// filesToDel returns the names of the files that are included in filesOld but
+// are not included in filesNew. These are the files that need to be deleted
+// from a proposal on update.
+func filesToDel(filesOld []www.File, filesNew []www.File) []string {
+	newf := make(map[string]struct{}, len(filesOld)) // [name]struct
+	for _, v := range filesNew {
+		newf[v.Name] = struct{}{}
+	}
+
+	del := make([]string, 0, len(filesOld))
+	for _, v := range filesOld {
+		_, ok := newf[v.Name]
+		if !ok {
+			del = append(del, v.Name)
+		}
+	}
+
+	return del
+}
+
+// filesAreDifferent returns whether the two sets of files have any
+// differences. This can be differences in the number of files, differences
+// in the file names, and/or differences in the file payloads.
+func filesAreDifferent(files1 []www.File, files2 []www.File) bool {
+	if len(files1) != len(files2) {
+		return true
+	}
+
+	files := make(map[string]string, len(files1)+len(files2)) // [name]payload
+	for _, v := range files1 {
+		files[v.Name] = v.Payload
+	}
+	for _, v := range files2 {
+		p, ok := files[v.Name]
+		if !ok {
+			// Found file with a different name
+			return true
+		}
+		if v.Payload != p {
+			// Found file with the same name but different payloads
+			return true
+		}
+	}
+
+	return false
+}
+
 // processEditProposal attempts to edit a proposal on politeiad.
 func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*www.EditProposalReply, error) {
 	log.Tracef("processEditProposal %v", ep.Token)
@@ -1335,74 +1486,62 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 	// we can reuse the function validateProposal.
 	np := www.NewProposal{
 		Files:     ep.Files,
+		Metadata:  ep.Metadata,
 		PublicKey: ep.PublicKey,
 		Signature: ep.Signature,
 	}
-	err = validateProposal(np, u)
+	pm, err := validateProposal(np, u)
 	if err != nil {
 		return nil, err
 	}
-
-	// Assemble metadata record
-	name, err := getProposalName(ep.Files)
-	if err != nil {
-		return nil, err
-	}
-
-	backendMetadata := mdstream.ProposalGeneral{
-		Version:   mdstream.VersionProposalGeneral,
-		Timestamp: time.Now().Unix(),
-		Name:      name,
-		PublicKey: ep.PublicKey,
-		Signature: ep.Signature,
-	}
-	md, err := mdstream.EncodeProposalGeneral(backendMetadata)
-	if err != nil {
-		return nil, err
-	}
-
-	mds := []pd.MetadataStream{{
-		ID:      mdstream.IDProposalGeneral,
-		Payload: string(md),
-	}}
-
-	// Check if any files need to be deleted
-	var delFiles []string
-	for _, v := range cachedProp.Files {
-		found := false
-		for _, c := range ep.Files {
-			if v.Name == c.Name {
-				found = true
-			}
-		}
-		if !found {
-			delFiles = append(delFiles, v.Name)
-		}
-	}
-
-	// Check for changes in the index.md file
-	var newMDFile www.File
-	for _, v := range ep.Files {
-		if v.Name == indexFile {
-			newMDFile = v
-		}
-	}
-
-	var oldMDFile www.File
-	for _, v := range cachedProp.Files {
-		if v.Name == indexFile {
-			oldMDFile = v
-		}
-	}
-
-	mdChanges := newMDFile.Payload != oldMDFile.Payload
-
-	// Check that the proposal has been changed
-	if !mdChanges && len(delFiles) == 0 &&
-		len(cachedProp.Files) == len(ep.Files) {
+	if !filesAreDifferent(cachedProp.Files, ep.Files) {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusNoProposalChanges,
 		}
+	}
+
+	// politeiad only includes files in its merkle root calc, not the
+	// metadata streams. This is why we include the ProposalMetadata
+	// as both a a politeiad file and metadata stream. Including it as
+	// a file ensures that it's included in the merkle calc. Including
+	// it as a metadata stream allows its fields to be queried.
+
+	// Setup files
+	files := convertPropFilesFromWWW(ep.Files)
+	for _, v := range ep.Metadata {
+		switch v.Hint {
+		case www.HintProposalMetadata:
+			files = append(files, convertFileFromMetadata(v))
+		}
+	}
+
+	// Setup metadata streams
+	pg := mdstream.ProposalGeneralV2{
+		Version:   mdstream.VersionProposalGeneral,
+		Timestamp: time.Now().Unix(),
+		PublicKey: ep.PublicKey,
+		Signature: ep.Signature,
+	}
+	pgb, err := mdstream.EncodeProposalGeneralV2(pg)
+	if err != nil {
+		return nil, err
+	}
+	pdb, err := mdstream.EncodeProposalDetails(
+		mdstream.ProposalDetails{
+			Name: pm.Name,
+		})
+	if err != nil {
+		return nil, err
+	}
+	mds := []pd.MetadataStream{
+		{
+			ID:      mdstream.IDProposalGeneral,
+			Payload: string(pgb),
+		},
+		{
+			ID:      mdstream.IDProposalDetails,
+			Payload: string(pdb),
+		},
 	}
 
 	// Setup politeiad request
@@ -1415,8 +1554,8 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		Token:       ep.Token,
 		Challenge:   hex.EncodeToString(challenge),
 		MDOverwrite: mds,
-		FilesAdd:    convertPropFilesFromWWW(ep.Files),
-		FilesDel:    delFiles,
+		FilesAdd:    files,
+		FilesDel:    filesToDel(cachedProp.Files, ep.Files),
 	}
 
 	var pdRoute string

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -140,7 +140,7 @@ func newProposalMetadata(t *testing.T, name string) []www.Metadata {
 		t.Fatal(err)
 	}
 	return []www.Metadata{
-		www.Metadata{
+		{
 			Digest:  hex.EncodeToString(util.Digest(pmb)),
 			Hint:    www.HintProposalMetadata,
 			Payload: base64.StdEncoding.EncodeToString(pmb),

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -15,6 +15,7 @@ import (
 	"image/color"
 	"image/png"
 	"math/rand"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -77,11 +78,10 @@ func createFilePNG(t *testing.T, addColor bool) *www.File {
 
 // createFileMD creates a File that contains a markdown file.  The markdown
 // file is filled with randomly generated data.
-func createFileMD(t *testing.T, size int, title string) *www.File {
+func createFileMD(t *testing.T, size int) *www.File {
 	t.Helper()
 
 	var b bytes.Buffer
-	b.WriteString(title + "\n")
 	r, err := util.Random(size)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -90,7 +90,7 @@ func createFileMD(t *testing.T, size int, title string) *www.File {
 
 	return &www.File{
 		Name:    indexFile,
-		MIME:    mime.DetectMimeType(b.Bytes()),
+		MIME:    http.DetectContentType(b.Bytes()),
 		Digest:  hex.EncodeToString(util.Digest(b.Bytes())),
 		Payload: base64.StdEncoding.EncodeToString(b.Bytes()),
 	}
@@ -101,15 +101,7 @@ func createFileMD(t *testing.T, size int, title string) *www.File {
 func newFileRandomMD(t *testing.T) www.File {
 	t.Helper()
 
-	r, err := util.Random(www.PolicyMinProposalNameLength)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var b bytes.Buffer
-	title := fmt.Sprintf("%s\n\n", hex.EncodeToString(r))
-	b.WriteString(title)
-
 	// Add ten lines of random base64 text.
 	for i := 0; i < 10; i++ {
 		r, err := util.Random(32)
@@ -127,46 +119,70 @@ func newFileRandomMD(t *testing.T) www.File {
 	}
 }
 
+func proposalNameRandom(t *testing.T) string {
+	r, err := util.Random(www.PolicyMinProposalNameLength)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(r)
+}
+
+func newProposalMetadata(t *testing.T, name string) []www.Metadata {
+	if name == "" {
+		// Generate a random name if none was given
+		name = proposalNameRandom(t)
+	}
+	pm := www.ProposalMetadata{
+		Name: name,
+	}
+	pmb, err := json.Marshal(pm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return []www.Metadata{
+		www.Metadata{
+			Digest:  hex.EncodeToString(util.Digest(pmb)),
+			Hint:    www.HintProposalMetadata,
+			Payload: base64.StdEncoding.EncodeToString(pmb),
+		},
+	}
+}
+
 // createNewProposal computes the merkle root of the given files, signs the
 // merkle root with the given identity then returns a NewProposal object.
-func createNewProposal(t *testing.T, id *identity.FullIdentity, files []www.File) *www.NewProposal {
+func createNewProposal(t *testing.T, id *identity.FullIdentity, files []www.File, title string) *www.NewProposal {
 	t.Helper()
 
 	if len(files) == 0 {
 		t.Fatalf("no files found")
 	}
 
-	// Compute merkle
-	digests := make([]*[sha256.Size]byte, 0, len(files))
-	for _, f := range files {
-		d, ok := util.ConvertDigest(f.Digest)
-		if !ok {
-			t.Fatalf("could not convert digest %v", f.Digest)
-		}
-		digests = append(digests, &d)
-	}
-	root := hex.EncodeToString(merkle.Root(digests)[:])
+	// Setup metadata
+	metadata := newProposalMetadata(t, title)
 
-	// Sign merkle
-	sig := id.SignMessage([]byte(root))
+	// Compute and sign merkle root
+	m := merkleRoot(t, files, metadata)
+	sig := id.SignMessage([]byte(m))
 
 	return &www.NewProposal{
 		Files:     files,
+		Metadata:  metadata,
 		PublicKey: hex.EncodeToString(id.Public.Key[:]),
 		Signature: hex.EncodeToString(sig[:]),
 	}
 }
 
-// merkleRoot returns a hex encoded merkle root of the passed in files.
-func merkleRoot(t *testing.T, files []www.File) string {
+// merkleRoot returns a hex encoded merkle root of the passed in files and
+// metadata.
+func merkleRoot(t *testing.T, files []www.File, metadata []www.Metadata) string {
 	t.Helper()
 
 	if len(files) == 0 {
 		t.Fatalf("no files")
 	}
 
-	digests := make([]*[sha256.Size]byte, len(files))
-	for i, f := range files {
+	digests := make([]*[sha256.Size]byte, 0, len(files))
+	for _, f := range files {
 		// Compute file digest
 		b, err := base64.StdEncoding.DecodeString(f.Payload)
 		if err != nil {
@@ -187,7 +203,28 @@ func merkleRoot(t *testing.T, files []www.File) string {
 		}
 
 		// Digest is valid
-		digests[i] = &d
+		digests = append(digests, &d)
+	}
+
+	for _, v := range metadata {
+		b, err := base64.StdEncoding.DecodeString(v.Payload)
+		if err != nil {
+			t.Fatalf("decode payload for metadata %v: %v",
+				v.Hint, err)
+		}
+		digest := util.Digest(b)
+		d, ok := util.ConvertDigest(v.Digest)
+		if !ok {
+			t.Fatalf("invalid digest: metadata:%v digest:%v",
+				v.Hint, v.Digest)
+		}
+		if !bytes.Equal(digest, d[:]) {
+			t.Fatalf("digests do not match for metadata %v",
+				v.Hint)
+		}
+
+		// Digest is valid
+		digests = append(digests, &d)
 	}
 
 	// Compute merkle root
@@ -288,13 +325,10 @@ func newProposalRecord(t *testing.T, u *user.User, id *identity.FullIdentity, s 
 
 	f := newFileRandomMD(t)
 	files := []www.File{f}
-	m := merkleRoot(t, files)
+	name := proposalNameRandom(t)
+	metadata := newProposalMetadata(t, name)
+	m := merkleRoot(t, files, metadata)
 	sig := id.SignMessage([]byte(m))
-
-	title, err := parseProposalName(f.Payload)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	var (
 		publishedAt int64
@@ -324,7 +358,7 @@ func newProposalRecord(t *testing.T, u *user.User, id *identity.FullIdentity, s 
 	// generates the token locally to make setting up tests easier.
 	// The censorship record signature is left intentionally blank.
 	return www.ProposalRecord{
-		Name:                title,
+		Name:                name,
 		State:               convertPropStatusToState(s),
 		Status:              s,
 		Timestamp:           time.Now().Unix(),
@@ -332,13 +366,14 @@ func newProposalRecord(t *testing.T, u *user.User, id *identity.FullIdentity, s 
 		Username:            u.Username,
 		PublicKey:           u.PublicKey(),
 		Signature:           hex.EncodeToString(sig[:]),
-		Files:               files,
 		NumComments:         0,
 		Version:             "1",
 		StatusChangeMessage: changeMsg,
 		PublishedAt:         publishedAt,
 		CensoredAt:          censoredAt,
 		AbandonedAt:         abandonedAt,
+		Files:               files,
+		Metadata:            metadata,
 		CensorshipRecord: www.CensorshipRecord{
 			Token:     hex.EncodeToString(tokenb),
 			Merkle:    m,
@@ -350,16 +385,20 @@ func newProposalRecord(t *testing.T, u *user.User, id *identity.FullIdentity, s 
 func convertPropToPD(t *testing.T, p www.ProposalRecord) pd.Record {
 	t.Helper()
 
-	name, err := getProposalName(p.Files)
-	if err != nil {
-		t.Fatal(err)
+	// Attach ProposalMetadata as a politeiad file
+	files := convertPropFilesFromWWW(p.Files)
+	for _, v := range p.Metadata {
+		switch v.Hint {
+		case www.HintProposalMetadata:
+			files = append(files, convertFileFromMetadata(v))
+		}
 	}
 
-	md, err := mdstream.EncodeProposalGeneral(
-		mdstream.ProposalGeneral{
+	// Create a ProposalGeneralV2 mdstream
+	md, err := mdstream.EncodeProposalGeneralV2(
+		mdstream.ProposalGeneralV2{
 			Version:   mdstream.VersionProposalGeneral,
 			Timestamp: time.Now().Unix(),
-			Name:      name,
 			PublicKey: p.PublicKey,
 			Signature: p.Signature,
 		})
@@ -378,40 +417,7 @@ func convertPropToPD(t *testing.T, p www.ProposalRecord) pd.Record {
 		Version:          p.Version,
 		Metadata:         mdStreams,
 		CensorshipRecord: convertPropCensorFromWWW(p.CensorshipRecord),
-		Files:            convertPropFilesFromWWW(p.Files),
-	}
-}
-
-func TestParseProposalName(t *testing.T) {
-	// Setup tests
-	tests := []struct {
-		payload string // Base64 proposal payload
-		want    string // Expected output name
-	}{
-		{
-			base64.StdEncoding.EncodeToString([]byte("this is-the-title")),
-			"this is-the-title",
-		},
-		{
-			base64.StdEncoding.EncodeToString([]byte("this-is-the title\nbody")),
-			"this-is-the title",
-		},
-		// No title
-		{
-			base64.StdEncoding.EncodeToString([]byte("\n\nbody")),
-			"",
-		},
-	}
-
-	// Run tests
-	for _, test := range tests {
-		name, err := parseProposalName(test.payload)
-		if err != nil {
-			t.Errorf("got error %v, want nil", err)
-		}
-		if name != test.want {
-			t.Errorf("got %v, want %v", name, test.want)
-		}
+		Files:            files,
 	}
 }
 
@@ -495,9 +501,9 @@ func TestValidateProposal(t *testing.T) {
 	usr, id := newUser(t, p, true, false)
 
 	// Create test data
-	md := createFileMD(t, 8, "Valid Title")
+	md := createFileMD(t, 8)
 	png := createFilePNG(t, false)
-	np := createNewProposal(t, id, []www.File{*md, *png})
+	np := createNewProposal(t, id, []www.File{*md, *png}, "")
 
 	// Invalid signature
 	propInvalidSig := &www.NewProposal{
@@ -507,7 +513,7 @@ func TestValidateProposal(t *testing.T) {
 	}
 
 	// Signature is valid but incorrect
-	propBadSig := createNewProposal(t, id, []www.File{*md})
+	propBadSig := createNewProposal(t, id, []www.File{*md}, "")
 	propBadSig.Signature = np.Signature
 
 	// No files
@@ -520,10 +526,10 @@ func TestValidateProposal(t *testing.T) {
 	// Invalid markdown filename
 	mdBadFilename := *md
 	mdBadFilename.Name = "bad_filename.md"
-	propBadFilename := createNewProposal(t, id, []www.File{mdBadFilename})
+	propBadFilename := createNewProposal(t, id, []www.File{mdBadFilename}, "")
 
 	// Duplicate filenames
-	propDupFiles := createNewProposal(t, id, []www.File{*md, *png, *png})
+	propDupFiles := createNewProposal(t, id, []www.File{*md, *png, *png}, "")
 
 	// Too many markdown files. We need one correctly named md
 	// file and the rest must have their names changed so that we
@@ -535,7 +541,7 @@ func TestValidateProposal(t *testing.T) {
 		m.Name = fmt.Sprintf("%v.md", i)
 		files = append(files, m)
 	}
-	propMaxMDFiles := createNewProposal(t, id, files)
+	propMaxMDFiles := createNewProposal(t, id, files, "")
 
 	// Too many image files. All of their names must be different
 	// so that we don't get a duplicate filename error.
@@ -546,19 +552,20 @@ func TestValidateProposal(t *testing.T) {
 		p.Name = fmt.Sprintf("%v.png", i)
 		files = append(files, p)
 	}
-	propMaxImages := createNewProposal(t, id, files)
+	propMaxImages := createNewProposal(t, id, files, "")
 
 	// Markdown file too large
-	mdLarge := createFileMD(t, www.PolicyMaxMDSize, "Valid Title")
-	propMDLarge := createNewProposal(t, id, []www.File{*mdLarge, *png})
+	mdLarge := createFileMD(t, www.PolicyMaxMDSize)
+	propMDLarge := createNewProposal(t, id, []www.File{*mdLarge, *png}, "")
 
 	// Image too large
 	pngLarge := createFilePNG(t, true)
-	propImageLarge := createNewProposal(t, id, []www.File{*md, *pngLarge})
+	propImageLarge := createNewProposal(t, id, []www.File{*md, *pngLarge}, "")
 
 	// Invalid proposal title
-	mdBadTitle := createFileMD(t, 8, "{invalid-title}")
-	propBadTitle := createNewProposal(t, id, []www.File{*mdBadTitle})
+	mdBadTitle := createFileMD(t, 8)
+	propBadTitle := createNewProposal(t, id,
+		[]www.File{*mdBadTitle}, "{invalid-title}")
 
 	// Setup test cases
 	var tests = []struct {
@@ -623,7 +630,7 @@ func TestValidateProposal(t *testing.T) {
 	// Run test cases
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateProposal(test.newProposal, test.user)
+			_, err := validateProposal(test.newProposal, test.user)
 			got := errToStr(err)
 			want := errToStr(test.want)
 			if got != want {
@@ -831,7 +838,7 @@ func TestProcessNewProposal(t *testing.T) {
 
 	// Create a NewProposal
 	f := newFileRandomMD(t)
-	np := createNewProposal(t, id, []www.File{f})
+	np := createNewProposal(t, id, []www.File{f}, "")
 
 	// Setup tests
 	var tests = []struct {
@@ -918,7 +925,7 @@ func TestProcessEditProposal(t *testing.T) {
 	tokenPropPublic := propPublic.CensorshipRecord.Token
 	d.AddRecord(t, convertPropToPD(t, propPublic))
 
-	root := merkleRoot(t, propPublic.Files)
+	root := merkleRoot(t, propPublic.Files, propPublic.Metadata)
 	s := id.SignMessage([]byte(root))
 	sigPropPublic := hex.EncodeToString(s[:])
 
@@ -927,7 +934,7 @@ func TestProcessEditProposal(t *testing.T) {
 	png := createFilePNG(t, false)
 	newFiles := []www.File{newMD, *png}
 
-	root = merkleRoot(t, newFiles)
+	root = merkleRoot(t, newFiles, propPublic.Metadata)
 	s = id.SignMessage([]byte(root))
 	sigPropPublicEdited := hex.EncodeToString(s[:])
 
@@ -997,6 +1004,7 @@ func TestProcessEditProposal(t *testing.T) {
 			www.EditProposal{
 				Token:     tokenPropPublic,
 				Files:     propPublic.Files,
+				Metadata:  propPublic.Metadata,
 				PublicKey: usr.PublicKey(),
 				Signature: sigPropPublic,
 			},
@@ -1010,6 +1018,7 @@ func TestProcessEditProposal(t *testing.T) {
 			www.EditProposal{
 				Token:     tokenPropPublic,
 				Files:     newFiles,
+				Metadata:  propPublic.Metadata,
 				PublicKey: usr.PublicKey(),
 				Signature: sigPropPublicEdited,
 			},


### PR DESCRIPTION
This diff seperates out proposal metadata from the proposal files when
submitting a proposal. The `NewProposal` and `EditProposal` routes now
contain a `Metadata` field that allows the client to submit user
specified metadata about the proposal. The metadata is included in the
signed merkle root of the proposal.

# Issue Background

The only user defined proposal metadata up to this point has been the
proposal name. It is inserted into the `index.md` file as the first line
of the file and parsed out by the server. This is a very hacky way to
accomplish passing in user defined metadata.

The politeia RFP work adds additional user defined metadata fields
(`LinkTo`, `LinkBy`) to a proposal and cms is also getting to the point
where additional user defined metadata fields are required in an
invoice. We didn't want to keep building on the hacky method that was
originally used, so this diff adds a way for user defined metadata to be
passed in correctly.

The main issue with passing in proposal metadata seperate from the
proposal files is that the metadata provided to politeaid is not
currently included in the merkle root calculation. Updating the merkle
root to include the metadata on record submission is problematic because
the metadata passed in to politeiawww from the user is not the same
metadata that is passed in to politeiad. An additional metadata stream
has to be created by politeiawww in order to store the user's signature
and public key. Adding this additional metadata stream to the politeaid
request means that the merkle root calculated and signed by the user
will not be the same merkle root calculated by politeiad. This is the
reason that the proposal title was originally inserted in the index.md
file itself. There has to be a layer violation somewhere and up until
this point, we had the layer violation in the user facing api. This diff
essentially moves the layer violation into the backend and has
politeiawww deal with the addittional complexity rather than push it
onto the user.

# Changes

* Added a `Metadata` field to the v1 `NewProposal` and `EditProposal`
  routes that can be used to pass in artibrary `Metadata` objects. This
  metadata is not stored as metadata streams in politeiad. They are
  stored as files so that they are included in the merkle root that
  politeiad calculates and signs.
* Proposals are now required to contain a `ProposalMetadata` that
  specifies the proposal's name. This metadata is encoded and passed in
  as a generic `Metadata` object on proposal submission.
* Added a `ProposalGeneralV2` mdstream that removes the `Name` from the
  mdstream. The proposal name, and any other user defined metadata, is
  now stored using the methods defined above.
