### PR TITLE
dbutil: Add setemail command.

### DIFF
--- a/politeiawww/cmd/politeiawww_dbutil/README.md
+++ b/politeiawww/cmd/politeiawww_dbutil/README.md
@@ -51,6 +51,10 @@ You can specify the following options:
             Required DB flag : -leveldb or -cockroachdb
             LevelDB args     : <email> <true/false>
             CockroachDB args : <username> <true/false>
+      -setemail
+            Set a user's email to the provided email address
+            Required DB flag : -cockroachdb
+            CockroachDB args : <username> <email>
       -stubusers
             Create user stubs for the public keys in a politeia repo
             Required DB flag : -leveldb or -cockroachdb
@@ -69,7 +73,6 @@ You can specify the following options:
             Migrate a LevelDB user database to CockroachDB
             Required DB flag : None
             Args             : None
-
      -verifyidentities
           Verify a user's identities do not violate any politeia rules. Invalid
           identities are fixed.

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -318,6 +318,8 @@ func cmdSetEmail() error {
 
 	fmt.Printf("User with username '%v' email successfully updated to '%v'\n",
 		username, newEmail)
+	fmt.Printf("politeiawww MUST BE restarted so the user email memory cache " +
+		"gets updated; politeiad is fine and does not need to be restarted\n")
 
 	return nil
 }


### PR DESCRIPTION
This diff adds a setemail command to `politeiawww_dbutil`. A user's
email address can be updated manually using this command.

`$ politeiawww_dbutil -cockroachdb setemail username newemail@example.com`

**politeiawww must be restarted after the email address has been updated
so that the email address memory cache gets rebuilt. politeiad is fine
and does not need to be restarted.**