### PR TITLE
cmswww: Add testrun command.

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -717,7 +717,7 @@ type DCCRecord struct {
 
 // NewDCC is a request for submitting a new DCC proposal.
 type NewDCC struct {
-	File      www.File `json:"file"`      // Issuance/Revocation file
+	File      www.File `json:"file"`      // Issuance/Revocation file (i.e DCCInput)
 	PublicKey string   `json:"publickey"` // Pubkey of the sponsoring user
 	Signature string   `json:"signature"` // Signature of the issuance struct by the sponsoring user.
 }

--- a/politeiawww/cmd/cmswww/README.md
+++ b/politeiawww/cmd/cmswww/README.md
@@ -60,5 +60,3 @@ used when running politeia locally.
 host=https://127.0.0.1:4443
 skipverify=true
 ```
-
-

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -89,11 +89,12 @@ type cmswww struct {
 	SetDCCStatus        SetDCCStatusCmd          `command:"setdccstatus" description:"(admin)  set the status of a DCC"`
 	SetInvoiceStatus    SetInvoiceStatusCmd      `command:"setinvoicestatus" description:"(admin)  set the status of an invoice"`
 	SupportOpposeDCC    SupportOpposeDCCCmd      `command:"supportopposedcc" description:"(user)   support or oppose a given DCC"`
+	TestRun             TestRunCmd               `command:"testrun" description:"         test cmswww routes"`
 	UpdateUserKey       shared.UpdateUserKeyCmd  `command:"updateuserkey" description:"(user)   generate a new identity for the logged in user"`
 	UserDetails         UserDetailsCmd           `command:"userdetails" description:"(user)   get current cms user details"`
 	UserInvoices        UserInvoicesCmd          `command:"userinvoices" description:"(user)   get all invoices submitted by a specific user"`
 	UserSubContractors  UserSubContractorsCmd    `command:"usersubcontractors" description:"(user)   get all users that are linked to the user"`
-	Users               shared.UsersCmd          `command:"users" description:"(user) get a list of users"`
+	Users               shared.UsersCmd          `command:"users" description:"(user)   get a list of users"`
 	Secret              shared.SecretCmd         `command:"secret" description:"(user)   ping politeiawww"`
 	Version             shared.VersionCmd        `command:"version" description:"(public) get server info and CSRF token"`
 }

--- a/politeiawww/cmd/cmswww/help.go
+++ b/politeiawww/cmd/cmswww/help.go
@@ -25,6 +25,8 @@ func (cmd *HelpCmd) Execute(args []string) error {
 	}
 
 	switch cmd.Args.Topic {
+	case "invite":
+		fmt.Printf("%s\n", inviteNewUserHelpMsg)
 	case "login":
 		fmt.Printf("%s\n", shared.LoginHelpMsg)
 	case "logout":
@@ -38,6 +40,8 @@ func (cmd *HelpCmd) Execute(args []string) error {
 	case "censorcomment":
 		fmt.Printf("%s\n", shared.CensorCommentHelpMsg)
 	case "manageuser":
+		fmt.Printf("%s\n", shared.ManageUserHelpMsg)
+	case "cmsmanageuser":
 		fmt.Printf("%s\n", cmsManageUserHelpMsg)
 	case "version":
 		fmt.Printf("%s\n", shared.VersionHelpMsg)

--- a/politeiawww/cmd/cmswww/invitenewuser.go
+++ b/politeiawww/cmd/cmswww/invitenewuser.go
@@ -14,23 +14,16 @@ import (
 // InviteNewUserCmd allows administrators to invite contractors to join CMS.
 type InviteNewUserCmd struct {
 	Args struct {
-		Email     string `positional-arg-name:"email"`
-		Temporary bool   `positional-arg-name:"temp"`
-	} `positional-args:"true" required:"true"`
+		Email string `positional-arg-name:"email" `
+	} `positional-args:"true"`
+	Temporary bool `long:"temp" optional:"true"`
 }
 
 // Execute executes the invite new user command.
 func (cmd *InviteNewUserCmd) Execute(args []string) error {
-	email := cmd.Args.Email
-
-	if email == "" {
-		return fmt.Errorf("invalid credentials: you must specify user " +
-			"email")
-	}
-
 	inu := &v1.InviteNewUser{
 		Email:     cmd.Args.Email,
-		Temporary: cmd.Args.Temporary,
+		Temporary: cmd.Temporary,
 	}
 
 	// Print request details
@@ -53,3 +46,20 @@ func (cmd *InviteNewUserCmd) Execute(args []string) error {
 
 	return nil
 }
+
+const inviteNewUserHelpMsg = `invite "email"
+
+Send a new user invitation to the given email.
+
+If email has been disabled on the politeiawww server then the verification
+token that would normally be sent to the email address will be returned in the
+response.
+
+Arguments:
+1. email      (string, required)  Email address
+
+Flags:
+  --temp      (bool, optional)    Designate the user as a temporary user. This 
+                                  means the user will only be able to submit a
+                                  single invoice before being deactivated.
+`

--- a/politeiawww/cmd/cmswww/newdcc.go
+++ b/politeiawww/cmd/cmswww/newdcc.go
@@ -42,7 +42,6 @@ type NewDCCCmd struct {
 		Type        uint     `positional-arg-name:"type"`            // 1 for Issuance, 2 for Revocation
 		Attachments []string `positional-arg-name:"attachmentfiles"` // DCC attachment files
 	} `positional-args:"true" optional:"true"`
-	Type           string ``
 	NomineeUserID  string `long:"nomineeuserid" optional:"true" description:"The UserID of the Nominated User"`
 	Statement      string `long:"statement" optional:"true" description:"Statement in support of the DCC"`
 	Domain         string `long:"domain" optional:"true" description:"The domain of the nominated user"`
@@ -173,6 +172,23 @@ func (cmd *NewDCCCmd) Execute(args []string) error {
 		fmt.Print("\nPlease carefully review your information and ensure it's " +
 			"correct. If not, press Ctrl + C to exit. Or, press Enter to continue.")
 		reader.ReadString('\n')
+	}
+
+	// XXX the above logic is missing validation for when the flags are
+	// set. Do it here for now.
+	if cmd.Domain != "" {
+		i, err := strconv.Atoi(cmd.Domain)
+		if err != nil {
+			return fmt.Errorf("parse domain: %v", err)
+		}
+		domainType = i
+	}
+	if cmd.ContractorType != "" {
+		i, err := strconv.Atoi(cmd.ContractorType)
+		if err != nil {
+			return fmt.Errorf("parse contractor type: %v", err)
+		}
+		contractorType = i
 	}
 
 	dccInput := &cms.DCCInput{}

--- a/politeiawww/cmd/cmswww/newinvoice.go
+++ b/politeiawww/cmd/cmswww/newinvoice.go
@@ -218,11 +218,15 @@ attachment filetypes: png or plain text.
 
 An invoice csv line item should use the following format:
 
-type,domain,subdomain,description,proposalToken,labor,expenses,subUserID
+type,domain,subdomain,description,proposalToken,labor,expenses,subUserID,subRate
 
 Valid types   : labor, expense, misc, sub
 Labor units   : hours
 Expenses units: USD
+
+Example csv lines:
+labor,random,subdomain,description,,180,0,,0
+expense,marketing,subdomain,description,,0,1500,,0
 
 Arguments:
 1. month             (string, required)   Month (MM, 01-12)

--- a/politeiawww/cmd/cmswww/setdccstatus.go
+++ b/politeiawww/cmd/cmswww/setdccstatus.go
@@ -32,8 +32,17 @@ func (cmd *SetDCCStatusCmd) Execute(args []string) error {
 		return shared.ErrUserIdentityNotFound
 	}
 
-	status, ok := DCCStatus[strings.ToLower(cmd.Args.Status)]
-	if !ok {
+	// Parse DCC status. This can be either the numeric status
+	// code or the human readable equivalent.
+	var status cms.DCCStatusT
+	s, err := strconv.ParseUint(cmd.Args.Status, 10, 32)
+	if err == nil {
+		// Numeric status code found
+		status = cms.DCCStatusT(s)
+	} else if s, ok := DCCStatus[strings.ToLower(cmd.Args.Status)]; ok {
+		// Human readable status code found
+		status = s
+	} else {
 		return fmt.Errorf("Invalid status: '%v'.  "+
 			"Valid statuses are:\n"+
 			"  rejected  reject the DCC\n"+
@@ -52,7 +61,7 @@ func (cmd *SetDCCStatusCmd) Execute(args []string) error {
 	}
 
 	// Print request details
-	err := shared.PrintJSON(sd)
+	err = shared.PrintJSON(sd)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/cmswww/setinvoicestatus.go
+++ b/politeiawww/cmd/cmswww/setinvoicestatus.go
@@ -49,8 +49,8 @@ func (cmd *SetInvoiceStatusCmd) Execute(args []string) error {
 		return fmt.Errorf("Invalid status: '%v'.  "+
 			"Valid statuses are:\n"+
 			"  rejected  reject the invoice\n"+
-			"  approved  approve the invoice\n",
-			"  disputed  mark the invoice as disputed\n",
+			"  approved  approve the invoice\n"+
+			"  disputed  mark the invoice as disputed\n"+
 			"  paid      mark the invoice as paid\n",
 			cmd.Args.Status)
 	}

--- a/politeiawww/cmd/cmswww/testrun.go
+++ b/politeiawww/cmd/cmswww/testrun.go
@@ -1,0 +1,662 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/decred/politeia/cmsplugin"
+	"github.com/decred/politeia/politeiad/api/v1/mime"
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+	www "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+	"github.com/decred/politeia/util"
+)
+
+// TestRunCmd performs a test run of cmswww routes.
+type TestRunCmd struct {
+	Args struct {
+		AdminEmail    string `positional-arg-name:"adminemail"`
+		AdminPassword string `positional-arg-name:"adminpassword"`
+	} `positional-args:"true" required:"true"`
+}
+
+const (
+	// DCC support/oppose options. These are not the all contractor
+	// vote options. Those are defined in cmsplugin.
+	dccIssuanceSupport = "aye"
+	dccIssuanceOppose  = "nay"
+)
+
+// user represents a cms user that is used during the test run.
+type user struct {
+	ID       string
+	Email    string
+	Username string
+	Password string
+}
+
+func randomString() string {
+	b, err := util.Random(16)
+	if err != nil {
+		return "uh oh, randomString() failed"
+	}
+	return hex.EncodeToString(b)
+}
+
+// login logs the given user into politeiawww. The full LoginCmd must be used
+// instead of just calling client.Login() so that the persistent CLI data is
+// updated properly.
+func login(u user) error {
+	lc := shared.LoginCmd{}
+	lc.Args.Email = u.Email
+	lc.Args.Password = u.Password
+	return lc.Execute(nil)
+}
+
+// logout logs out whatever user is currently logged in with the CLI. The full
+// LogoutCmd must be used instead of just calling client.Logout() so that the
+// persistent CLI data is updated properly.
+func logout() error {
+	l := shared.LogoutCmd{}
+	return l.Execute(nil)
+}
+
+// userNew returns a new cms user that has been invited and registered. The
+// user credentials are randomly generated.
+//
+// This function returns with the admin logged in.
+func userNew(admin user) (*user, error) {
+	// Login the admin
+	err := login(admin)
+	if err != nil {
+		return nil, fmt.Errorf("login: %v", err)
+	}
+
+	// Generate random user credentials
+	b, err := util.Random(www.PolicyMinPasswordLength)
+	if err != nil {
+		return nil, err
+	}
+	u := user{
+		Email:    hex.EncodeToString(b) + "@example.com",
+		Username: hex.EncodeToString(b),
+		Password: hex.EncodeToString(b),
+	}
+
+	// Invite user
+	inu := cms.InviteNewUser{
+		Email: u.Email,
+	}
+	inur, err := client.InviteNewUser(&inu)
+	if err != nil {
+		return nil, fmt.Errorf("InviteNewUser: %v", err)
+	}
+	if inur.VerificationToken == "" {
+		return nil, fmt.Errorf("InviteNewUserReply: verification token not " +
+			"found; the politeiawww email server likely needs to be disabled")
+	}
+
+	// Register user. Use the full command so that the identity is
+	// saved to disk. This will also log the user in.
+	r := RegisterUserCmd{}
+	r.Args.Email = u.Email
+	r.Args.Username = u.Username
+	r.Args.Password = u.Password
+	r.Args.Token = inur.VerificationToken
+	err = r.Execute(nil)
+	if err != nil {
+		return nil, fmt.Errorf("RegisterUserCmd: %v", err)
+	}
+
+	// Get the user ID
+	lr, err := client.Me()
+	if err != nil {
+		return nil, fmt.Errorf("Me: %v", err)
+	}
+	u.ID = lr.UserID
+
+	// Log the admin back in
+	err = login(admin)
+	if err != nil {
+		return nil, fmt.Errorf("login: %v", err)
+	}
+
+	return &u, nil
+}
+
+// contractorNew creates a new user then updates the user with the given
+// contractor details.
+//
+// This function returns with the admin logged in.
+func contractorNew(admin user, dt cms.DomainTypeT, ct cms.ContractorTypeT) (*user, error) {
+	// Invite and register a new user
+	u, err := userNew(admin)
+	if err != nil {
+		return nil, fmt.Errorf("userNew: %v", err)
+	}
+
+	// Update the user's contractor status
+	muc := CMSManageUserCmd{
+		Domain:         strconv.Itoa(int(dt)),
+		ContractorType: strconv.Itoa(int(ct)),
+	}
+	muc.Args.UserID = u.ID
+	err = muc.Execute(nil)
+	if err != nil {
+		return nil, fmt.Errorf("CMSManageUserCmd: %v", err)
+	}
+
+	return u, err
+}
+
+// dccNew submits a new DCC to cmswww then returns the submitted DCC.
+//
+// This function returns with the user logged out.
+func dccNew(sponsor user, nomineeID string, dcct cms.DCCTypeT, dt cms.DomainTypeT, ct cms.ContractorTypeT) (*cms.DCCRecord, error) {
+	err := login(sponsor)
+	if err != nil {
+		return nil, fmt.Errorf("login: %v", err)
+	}
+
+	// We can't use the NewDCCCmd here because we need the
+	// censorship token that is returned in the reply. Run
+	// the command manualy.
+	di := cms.DCCInput{
+		Type:             dcct,
+		NomineeUserID:    nomineeID,
+		Domain:           dt,
+		ContractorType:   ct,
+		SponsorStatement: "this person is good",
+	}
+	b, err := json.Marshal(di)
+	if err != nil {
+		return nil, err
+	}
+	f := www.File{
+		Name:    "dcc.json",
+		MIME:    mime.DetectMimeType(b),
+		Digest:  hex.EncodeToString(util.Digest(b)),
+		Payload: base64.StdEncoding.EncodeToString(b),
+	}
+	files := []www.File{f}
+	sig, err := shared.SignedMerkleRoot(files, cfg.Identity)
+	if err != nil {
+		return nil, err
+	}
+	nd := cms.NewDCC{
+		File:      f,
+		PublicKey: hex.EncodeToString(cfg.Identity.Public.Key[:]),
+		Signature: sig,
+	}
+	ndr, err := client.NewDCC(nd)
+	if err != nil {
+		return nil, fmt.Errorf("NewDCC: %v", err)
+	}
+
+	// Get the full DCC record to return
+	dcc, err := dcc(ndr.CensorshipRecord.Token)
+	if err != nil {
+		return nil, fmt.Errorf("dcc: %v", err)
+	}
+
+	// Log the user out
+	err = logout()
+	if err != nil {
+		return nil, fmt.Errorf("logout: %v", err)
+	}
+
+	return dcc, nil
+}
+
+// dcc returns the DCCRecord for the given token.
+func dcc(token string) (*cms.DCCRecord, error) {
+	ddr, err := client.DCCDetails(token)
+	if err != nil {
+		return nil, err
+	}
+	return &ddr.DCC, nil
+}
+
+// dccSetStatus updates the status of the given DCC.
+//
+// This function returns with the admin logged in.
+func dccSetStatus(admin user, token string, st cms.DCCStatusT, reason string) error {
+	err := login(admin)
+	if err != nil {
+		return fmt.Errorf("login: %v", err)
+	}
+	sds := SetDCCStatusCmd{}
+	sds.Args.Token = token
+	sds.Args.Status = strconv.Itoa(int(st))
+	sds.Args.Reason = reason
+	err = sds.Execute(nil)
+	if err != nil {
+		return fmt.Errorf("SetDCCStatusCmd: %v", err)
+	}
+	return nil
+}
+
+// dccSupport casts a support or oppose vote with the provided user for the
+// provided dcc.
+//
+// This function returns with the user logged out.
+func dccSupport(u user, token, vote string) error {
+	err := login(u)
+	if err != nil {
+		return fmt.Errorf("login: %v", err)
+	}
+
+	c := SupportOpposeDCCCmd{}
+	c.Args.Token = token
+	c.Args.Vote = vote
+	err = c.Execute(nil)
+	if err != nil {
+		return fmt.Errorf("SupportOpposeDCCCmd: %v", err)
+	}
+
+	err = logout()
+	if err != nil {
+		return fmt.Errorf("logout: %v")
+	}
+
+	return nil
+}
+
+// dccVote casts a support or oppose vote with the provided user for the
+// provided dcc all contractor vote.
+//
+// This function returns with the user logged out.
+func dccVote(u user, token, vote string) error {
+	err := login(u)
+	if err != nil {
+		return fmt.Errorf("login: %v", err)
+	}
+
+	c := VoteDCCCmd{}
+	c.Args.Token = token
+	c.Args.Vote = vote
+	err = c.Execute(nil)
+	if err != nil {
+		return fmt.Errorf("VoteDCCCmd: %v", err)
+	}
+
+	err = logout()
+	if err != nil {
+		return fmt.Errorf("logout: %v")
+	}
+
+	return nil
+}
+
+// dccVoteSummary returns the DCC vote summary for the provided DCC token.
+//
+// This function returns with the user logged out.
+func dccVoteSummary(u user, token string) (*cms.VoteSummary, error) {
+	err := login(u)
+	if err != nil {
+		return nil, fmt.Errorf("login: %v", err)
+	}
+
+	ddr, err := client.DCCDetails(token)
+	if err != nil {
+		return nil, fmt.Errorf("DCCDetails: %v", err)
+	}
+
+	err = logout()
+	if err != nil {
+		return nil, fmt.Errorf("logout: %v")
+	}
+
+	return &ddr.VoteSummary, nil
+}
+
+// dccCommentNew posts a new comment to the provided DCC.
+//
+// This function returns with the user logged out.
+func dccCommentNew(u user, token, parentID, comment string) error {
+	if parentID == "" {
+		parentID = "0"
+	}
+
+	err := login(u)
+	if err != nil {
+		return fmt.Errorf("login: %v", err)
+	}
+
+	c := NewDCCCommentCmd{}
+	c.Args.Token = token
+	c.Args.ParentID = parentID
+	c.Args.Comment = comment
+	err = c.Execute(nil)
+	if err != nil {
+		return fmt.Errorf("NewDCCCommentCmd: %v", err)
+	}
+
+	err = logout()
+	if err != nil {
+		return fmt.Errorf("logout: %v")
+	}
+
+	return nil
+}
+
+// dccComments returns the comments for the provided DCC token.
+//
+// This function returns with the user logged out.
+func dccComments(u user, token string) ([]www.Comment, error) {
+	err := login(u)
+	if err != nil {
+		return nil, fmt.Errorf("login: %v", err)
+	}
+
+	gcr, err := client.DCCComments(token)
+	if err != nil {
+		return nil, fmt.Errorf("DCCComments: %v", err)
+	}
+
+	err = logout()
+	if err != nil {
+		return nil, fmt.Errorf("logout: %v")
+	}
+
+	return gcr.Comments, nil
+}
+
+// testDCC tests the DCC (Decred Contractor Clearance) routes. See the proposal
+// below for more information about the DCC process.
+//
+// https://proposals.decred.org/proposals/fa38a35
+//
+// A new cms user must have their contractor type updated before they are able
+// to submit invoices. There are currently two ways for this to happen.
+// 1. An admin can update it manually using the CMSManageUser route.
+// 2. The contractor can undergo the DCC process. The DCC process is where
+//    the new contractor is nominated by an exising contractor then other
+//    existing contractors can support or oppose the DCC nomination. Admins
+//    currently have final say in the approval of a DCC. If a DCC is
+//    contentious, it can be put up for an all contractor vote where existing
+//    contractor votes are weighted by the amount of hours they've billed.
+//    Once a DCC has been approved, the user's ContractorType is automatically
+//    updated and they are able to submit invoices.
+//
+// testDCC runs through the full DCC process with the exception of the all
+// contractor vote for contentious DCCs. See testDCCVote() for details on the
+// all contractor vote.
+func testDCC(admin user) error {
+	fmt.Printf("Running testDCC\n")
+
+	// Create three users and make them existing contractors
+	fmt.Printf("  create existing contractors\n")
+
+	c1, err := contractorNew(admin, cms.DomainTypeDeveloper,
+		cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+	c2, err := contractorNew(admin, cms.DomainTypeDeveloper,
+		cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+	c3, err := contractorNew(admin, cms.DomainTypeDeveloper,
+		cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+
+	// Create a nominee
+	fmt.Printf("  create a user to be the nominee\n")
+
+	n1, err := userNew(admin)
+	if err != nil {
+		return err
+	}
+
+	// Create a new DCC for the nominee
+	fmt.Printf("  create a DCC for the nominee\n")
+
+	dcc, err := dccNew(*c1, n1.ID, cms.DCCTypeIssuance,
+		cms.DomainTypeDeveloper, cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+	dccToken := dcc.CensorshipRecord.Token
+
+	// Comment on the DCC
+	fmt.Printf("  comment on the DCC\n")
+
+	err = dccCommentNew(*c1, dccToken, "", randomString())
+	if err != nil {
+		return err
+	}
+	err = dccCommentNew(*c2, dccToken, "", randomString())
+	if err != nil {
+		return err
+	}
+	err = dccCommentNew(*c3, dccToken, "", randomString())
+	if err != nil {
+		return err
+	}
+
+	// Support the DCC
+	fmt.Printf("  support the DCC\n")
+
+	err = dccSupport(*c2, dccToken, dccIssuanceSupport)
+	if err != nil {
+		return err
+	}
+	err = dccSupport(*c3, dccToken, dccIssuanceSupport)
+	if err != nil {
+		return err
+	}
+
+	// Have admin approve the DCC
+	fmt.Printf("  approve the DCC\n")
+
+	err = dccSetStatus(admin, dccToken, cms.DCCStatusApproved,
+		"there was non-contentious support")
+	if err != nil {
+		return err
+	}
+
+	// Create a nominee. This time we'll reject their DCC.
+	fmt.Printf("  create a user to be the nominee\n")
+
+	n2, err := userNew(admin)
+	if err != nil {
+		return err
+	}
+
+	// Create a new DCC for the nominee
+	fmt.Printf("  create a DCC for the nominee\n")
+
+	dcc, err = dccNew(*c1, n2.ID, cms.DCCTypeIssuance,
+		cms.DomainTypeDeveloper, cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+	dccToken = dcc.CensorshipRecord.Token
+
+	// Oppose the DCC
+	fmt.Printf("  oppose the DCC\n")
+
+	err = dccSupport(*c2, dccToken, dccIssuanceOppose)
+	if err != nil {
+		return err
+	}
+	err = dccSupport(*c3, dccToken, dccIssuanceOppose)
+	if err != nil {
+		return err
+	}
+
+	// Have admin reject the DCC
+	fmt.Printf("  reject the DCC\n")
+
+	err = dccSetStatus(admin, dccToken, cms.DCCStatusRejected,
+		"there was non-contentious opposition")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("testDCC success!\n")
+
+	return nil
+}
+
+// testDCCVote tests the DCC all contractor vote routes.
+//
+// When a DCC proposal is deemed contentious by the admin, the admin can start
+// an all contractor vote for the DCC. Contractors are able to cast votes
+// proportional to the amount of time they've billed, and that has been paid,
+// over the previous 6 months. Admins still currently have final say over
+// whether to approve or reject the DCC.
+//
+// The admin starts an all contractor vote on a DCC by setting the DCC status
+// to DCCStatusAllVote.
+func testDCCVote(admin user) error {
+	fmt.Printf("Running testDCCVote\n")
+
+	// Create three users and make them existing contractors
+	fmt.Printf("  create existing contractors\n")
+
+	c1, err := contractorNew(admin, cms.DomainTypeDeveloper,
+		cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+	c2, err := contractorNew(admin, cms.DomainTypeDeveloper,
+		cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+	c3, err := contractorNew(admin, cms.DomainTypeDeveloper,
+		cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+
+	// Create a nominee
+	fmt.Printf("  create a user to be the nominee\n")
+
+	n1, err := userNew(admin)
+	if err != nil {
+		return err
+	}
+
+	// Create a new DCC for the nominee
+	fmt.Printf("  create a DCC for the nominee\n")
+
+	dcc, err := dccNew(*c1, n1.ID, cms.DCCTypeIssuance,
+		cms.DomainTypeDeveloper, cms.ContractorTypeDirect)
+	if err != nil {
+		return err
+	}
+	dccToken := dcc.CensorshipRecord.Token
+
+	// Support/oppose the DCC
+	fmt.Printf("  cast DCC votes\n")
+
+	err = dccSupport(*c2, dccToken, dccIssuanceSupport)
+	if err != nil {
+		return err
+	}
+	err = dccSupport(*c3, dccToken, dccIssuanceOppose)
+	if err != nil {
+		return err
+	}
+
+	// Start an all contractor vote for the DCC
+	err = dccSetStatus(admin, dccToken, cms.DCCStatusAllVote,
+		"support was contentious")
+	if err != nil {
+		return err
+	}
+
+	// Vote on the DCC
+	err = dccVote(*c2, dccToken, cmsplugin.DCCApprovalString)
+	if err != nil {
+		return err
+	}
+	err = dccVote(*c3, dccToken, cmsplugin.DCCDisapprovalString)
+	if err != nil {
+		return err
+	}
+
+	/*
+		// Have the admin approve the DCC
+		// This can't be done in the test run because the vote needs to
+		// have ended before the admin can change the status. This is how
+		// a DCC is ultimately decided as approved or rejected though.
+		err = dccSetStatus(admin, dccToken, cms.DCCStatusApproved,
+			"I decree it to be")
+		if err != nil {
+			return err
+		}
+	*/
+
+	fmt.Printf("testDCCVote success!\n")
+
+	return nil
+}
+
+// Execute executes the TestRun command.
+func (cmd *TestRunCmd) Execute(args []string) error {
+	const (
+		modeCMSWWW = "cmswww"
+	)
+
+	// Suppress output from cli commands
+	cfg.Silent = true
+
+	fmt.Printf("Running pre-testrun validation\n")
+
+	// Validate politeiawww setup
+	vr, err := client.Version()
+	switch {
+	case err != nil:
+		return fmt.Errorf("version: %v", err)
+	case vr.Mode != modeCMSWWW:
+		return fmt.Errorf("politeiawww is not in cmswww mode")
+	case !vr.TestNet:
+		return fmt.Errorf("politeiawww is not on testnet")
+	}
+
+	// Validate admin credentials
+	admin := user{
+		Email:    cmd.Args.AdminEmail,
+		Password: cmd.Args.AdminPassword,
+	}
+	err = login(admin)
+	if err != nil {
+		return err
+	}
+	lr, err := client.Me()
+	if err != nil {
+		return err
+	}
+	if !lr.IsAdmin {
+		return fmt.Errorf("%v is not an admin", admin.Email)
+	}
+	admin.Username = lr.Username
+
+	// Test runs
+	err = testDCC(admin)
+	if err != nil {
+		return fmt.Errorf("testDCC: %v", err)
+	}
+	err = testDCCVote(admin)
+	if err != nil {
+		return fmt.Errorf("testDCCVote: %v", err)
+	}
+
+	fmt.Printf("testrun complete!\n")
+
+	return nil
+}

--- a/politeiawww/cmd/cmswww/testrun.go
+++ b/politeiawww/cmd/cmswww/testrun.go
@@ -393,7 +393,7 @@ func invoiceSetStatus(admin user, token string, s cms.InvoiceStatusT) error {
 	return nil
 }
 
-// invoicesPays marks all of the currenlty approved invoices as paid.
+// invoicesPays marks all of the currently approved invoices as paid.
 //
 // This function returns with the admin logged out.
 func invoicesPay(admin user) error {
@@ -426,7 +426,7 @@ func dccNew(sponsor user, nomineeID string, dcct cms.DCCTypeT, dt cms.DomainType
 
 	// We can't use the NewDCCCmd here because we need the
 	// censorship token that is returned in the reply. Run
-	// the command manualy.
+	// the command manually.
 	di := cms.DCCInput{
 		Type:             dcct,
 		NomineeUserID:    nomineeID,
@@ -528,7 +528,7 @@ func dccSupport(u user, token, vote string) error {
 
 	err = logout()
 	if err != nil {
-		return fmt.Errorf("logout: %v")
+		return fmt.Errorf("logout: %v", err)
 	}
 
 	return nil
@@ -552,7 +552,7 @@ func dccStartVote(admin user, token string) error {
 
 	err = logout()
 	if err != nil {
-		return fmt.Errorf("logout: %v")
+		return fmt.Errorf("logout: %v", err)
 	}
 
 	return nil
@@ -578,7 +578,7 @@ func dccVote(u user, token, vote string) error {
 
 	err = logout()
 	if err != nil {
-		return fmt.Errorf("logout: %v")
+		return fmt.Errorf("logout: %v", err)
 	}
 
 	return nil
@@ -600,7 +600,7 @@ func dccVoteSummary(u user, token string) (*cms.VoteSummary, error) {
 
 	err = logout()
 	if err != nil {
-		return nil, fmt.Errorf("logout: %v")
+		return nil, fmt.Errorf("logout: %v", err)
 	}
 
 	return &ddr.VoteSummary, nil
@@ -630,7 +630,7 @@ func dccCommentNew(u user, token, parentID, comment string) error {
 
 	err = logout()
 	if err != nil {
-		return fmt.Errorf("logout: %v")
+		return fmt.Errorf("logout: %v", err)
 	}
 
 	return nil
@@ -652,7 +652,7 @@ func dccComments(u user, token string) ([]www.Comment, error) {
 
 	err = logout()
 	if err != nil {
-		return nil, fmt.Errorf("logout: %v")
+		return nil, fmt.Errorf("logout: %v", err)
 	}
 
 	return gcr.Comments, nil
@@ -667,7 +667,7 @@ func dccComments(u user, token string) ([]www.Comment, error) {
 // to submit invoices. There are currently two ways for this to happen.
 // 1. An admin can update it manually using the CMSManageUser route.
 // 2. The contractor can undergo the DCC process. The DCC process is where
-//    the new contractor is nominated by an exising contractor then other
+//    the new contractor is nominated by an existing contractor then other
 //    existing contractors can support or oppose the DCC nomination. Admins
 //    currently have final say in the approval of a DCC. If a DCC is
 //    contentious, it can be put up for an all contractor vote where existing

--- a/politeiawww/cmd/cmswww/testrun.go
+++ b/politeiawww/cmd/cmswww/testrun.go
@@ -107,7 +107,7 @@ func logout() error {
 // userNew returns a new cms user that has been invited and registered. The
 // user credentials are randomly generated.
 //
-// This function returns with the admin logged in.
+// This function returns with the admin logged out.
 func userNew(admin user) (*user, error) {
 	// Login the admin
 	err := login(admin)
@@ -158,10 +158,10 @@ func userNew(admin user) (*user, error) {
 	}
 	u.ID = lr.UserID
 
-	// Log the admin back in
-	err = login(admin)
+	// Log the user out
+	err = logout()
 	if err != nil {
-		return nil, fmt.Errorf("login: %v", err)
+		return nil, fmt.Errorf("logout: %v", err)
 	}
 
 	return &u, nil
@@ -170,12 +170,17 @@ func userNew(admin user) (*user, error) {
 // contractorNew creates a new user then updates the user with the given
 // contractor details.
 //
-// This function returns with the admin logged in.
+// This function returns with the admin logged out.
 func contractorNew(admin user, dt cms.DomainTypeT, ct cms.ContractorTypeT) (*user, error) {
 	// Invite and register a new user
 	u, err := userNew(admin)
 	if err != nil {
 		return nil, fmt.Errorf("userNew: %v", err)
+	}
+
+	err = login(admin)
+	if err != nil {
+		return nil, fmt.Errorf("login: %v", err)
 	}
 
 	// Update the user's contractor status
@@ -187,6 +192,11 @@ func contractorNew(admin user, dt cms.DomainTypeT, ct cms.ContractorTypeT) (*use
 	err = muc.Execute(nil)
 	if err != nil {
 		return nil, fmt.Errorf("CMSManageUserCmd: %v", err)
+	}
+
+	err = logout()
+	if err != nil {
+		return nil, fmt.Errorf("logout: %v", err)
 	}
 
 	return u, err
@@ -475,12 +485,13 @@ func dcc(token string) (*cms.DCCRecord, error) {
 
 // dccSetStatus updates the status of the given DCC.
 //
-// This function returns with the admin logged in.
+// This function returns with the admin logged out.
 func dccSetStatus(admin user, token string, st cms.DCCStatusT, reason string) error {
 	err := login(admin)
 	if err != nil {
 		return fmt.Errorf("login: %v", err)
 	}
+
 	sds := SetDCCStatusCmd{}
 	sds.Args.Token = token
 	sds.Args.Status = strconv.Itoa(int(st))
@@ -488,6 +499,11 @@ func dccSetStatus(admin user, token string, st cms.DCCStatusT, reason string) er
 	err = sds.Execute(nil)
 	if err != nil {
 		return fmt.Errorf("SetDCCStatusCmd: %v", err)
+	}
+
+	err = logout()
+	if err != nil {
+		return fmt.Errorf("logout: %v", err)
 	}
 	return nil
 }
@@ -518,7 +534,9 @@ func dccSupport(u user, token, vote string) error {
 	return nil
 }
 
-// This function returns with the admin logged in.
+// dccStartVote starts an all contractor vote for the provided DCC.
+//
+// This function returns with the admin logged out.
 func dccStartVote(admin user, token string) error {
 	err := login(admin)
 	if err != nil {
@@ -530,6 +548,11 @@ func dccStartVote(admin user, token string) error {
 	err = svc.Execute(nil)
 	if err != nil {
 		return fmt.Errorf("StartVoteCmd: %v", err)
+	}
+
+	err = logout()
+	if err != nil {
+		return fmt.Errorf("logout: %v")
 	}
 
 	return nil


### PR DESCRIPTION
This requires #1104.

This diff adds a testrun command to cmswww.

The command runs through the DCC process and the DCC vote process. Its
meant to help with testing PRs and serve an informal reference
implementation to document how some of the cms processes work. It can be
expanded in the future to include other CMS routes.

```
$ cmswww testrun admin@example.com password
Running pre-testrun validation
Running testDCC
  create existing contractors
  create a user to be the nominee
  create a DCC for the nominee: 8b5c987f5822613da6d3eef4f8ed8fe2350aab6b17f9a609bdd6c099a0a5a511
  comment on the DCC
  support the DCC
  approve the DCC
  create a user to be the nominee
  create a DCC for the nominee: 5e58d92a3d2804a3bb4d38438cab16ff7e03933949f1b438919bf47e09257f94
  oppose the DCC
  reject the DCC
testDCC success!
Running testDCCVote
  create existing contractors
  submitting invoices for contractors
  marking invoices as approved and paid
  create a user to be the nominee
  create a DCC for the nominee: b5983733a411bf2b5a8e1ab5ea1cc1ac59b6e8d3bc980e3b5eacc417a0547f13
  support/oppose DCC
  start DCC vote
  cast DCC votes
testDCCVote success!
testrun complete!
```