### PR TITLE
[cms] Typo in DCC support template

### DIFF
--- a/politeiawww/templates.go
+++ b/politeiawww/templates.go
@@ -288,7 +288,7 @@ Contractor Management System
 const templateNewDCCSupportOpposeRaw = `
 A DCC has received new support or opposition.
 
-{.Link}}
+{{.Link}}
 
 Regards,
 Contractor Management System


### PR DESCRIPTION
Link wasn't rendering without double bracket.