### PR TITLE
cache: Remove decredplugin sanity check.

### DIFF
--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -1379,11 +1379,6 @@ func newProposalMetadata(r Record) (*ProposalMetadata, error) {
 		}
 	}
 
-	// Sanity check
-	if name == "" {
-		return nil, fmt.Errorf("no proposal name found")
-	}
-
 	return &ProposalMetadata{
 		Token: r.Token,
 		Name:  name,


### PR DESCRIPTION
A sanity check in the cache decred plugin was causing issues with cms so
it needed to be taken out until we've split up the plugins by
functionality.