### PR TITLE
gitbe: Set vote duration as a plugin setting.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -41,8 +41,11 @@ const (
 	MDStreamVoteBits         = 14 // Vote bits and mask
 	MDStreamVoteSnapshot     = 15 // Vote tickets and start/end parameters
 
-	VoteDurationMin = 2016 // Minimum vote duration (in blocks)
-	VoteDurationMax = 4032 // Maximum vote duration (in blocks)
+	// Vote duration requirements for proposal votes (in blocks)
+	VoteDurationMinMainnet = 2016
+	VoteDurationMaxMainnet = 4032
+	VoteDurationMinTestnet = 0
+	VoteDurationMaxTestnet = 4032
 
 	// Authorize vote actions
 	AuthVoteActionAuthorize = "authorize" // Authorize a proposal vote

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2784,6 +2784,21 @@ func New(anp *chaincfg.Params, root string, dcrtimeHost string, gitPath string, 
 	if err != nil {
 		return nil, err
 	}
+
+	// Setup decred plugin settings
+	var voteDurationMin, voteDurationMax string
+	switch anp.Name {
+	case chaincfg.MainNetParams.Name:
+		voteDurationMin = strconv.Itoa(decredplugin.VoteDurationMinMainnet)
+		voteDurationMax = strconv.Itoa(decredplugin.VoteDurationMaxMainnet)
+	case chaincfg.TestNet3Params.Name:
+		voteDurationMin = strconv.Itoa(decredplugin.VoteDurationMinTestnet)
+		voteDurationMax = strconv.Itoa(decredplugin.VoteDurationMaxTestnet)
+	default:
+		return nil, fmt.Errorf("unknown chaincfg params '%v'", anp.Name)
+	}
+	setDecredPluginSetting(decredPluginVoteDurationMin, voteDurationMin)
+	setDecredPluginSetting(decredPluginVoteDurationMax, voteDurationMax)
 	setDecredPluginSetting(decredPluginIdentity, string(idJSON))
 	setDecredPluginSetting(decredPluginJournals, g.journals)
 	setDecredPluginHook(PluginPostHookEdit, g.decredPluginPostEdit)


### PR DESCRIPTION
This diff adds the vote duration min/max as a plugin setting to the
gitbe decred plugin. This allows the min/max to be lowered when on
testnet to make testing easier.

politeiawww already allows this.