### PR TITLE
cache: Fix LinkedFrom bugs.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -1340,8 +1340,9 @@ func DecodeLoadVoteResultsReply(payload []byte) (*LoadVoteResultsReply, error) {
 
 // LinkedFrom returns a map[token][]token that contains the linked from list
 // for each of the given proposal tokens. A linked from list is a list of all
-// the proposals that have linked to a given proposal using the LinkTo field
-// in the ProposalMetadata mdstream.
+// the proposals that have linked to a given proposal using the LinkTo field in
+// the ProposalMetadata mdstream. If a token does not correspond to an actual
+// proposal then it will not be included in the returned map.
 type LinkedFrom struct {
 	Tokens []string `json:"tokens"`
 }

--- a/politeiad/cache/cockroachdb/cockroachdb.go
+++ b/politeiad/cache/cockroachdb/cockroachdb.go
@@ -48,6 +48,23 @@ type cockroachdb struct {
 	plugins   map[string]cache.PluginDriver // [pluginID]PluginDriver
 }
 
+// recordExists returns whether a record exists for the provided token and
+// version.
+func recordExists(db *gorm.DB, token string, version string) (bool, error) {
+	var r Record
+	err := db.Where("key = ?", token+version).Find(&r).Error
+	if err == gorm.ErrRecordNotFound {
+		// Record doesn't exist
+		return false, nil
+	} else if err != nil {
+		// All other errors
+		return false, err
+	}
+
+	// Record exists
+	return true, nil
+}
+
 func (c *cockroachdb) newRecord(tx *gorm.DB, r Record) error {
 	// Insert record
 	err := tx.Create(&r).Error


### PR DESCRIPTION
This diff fixes two different bugs in the decred plugin linkedfrom
command.

1. Passed in tokens were being returned in the reply map even if they
   did not correspond to an actual proposal.
2. The query was searching for all proposals that had their linkedto
   field set to the provided token. The cache stores all version of a
   proposal so the query was returning all versions when it should have
   just been returning the most recent version.
