### PR TITLE
[cms] Add Version to InvoiceDetails request

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -452,7 +452,8 @@ type InvoiceRecord struct {
 
 // InvoiceDetails is used to retrieve a invoice by it's token.
 type InvoiceDetails struct {
-	Token string `json:"token"` // Censorship token
+	Token   string `json:"token"`             // Censorship token
+	Version string `json:"version,omitempty"` // Invoice version
 }
 
 // InvoiceDetailsReply is used to reply to a invoice details command.

--- a/politeiawww/cmd/cmswww/invoicedetails.go
+++ b/politeiawww/cmd/cmswww/invoicedetails.go
@@ -7,13 +7,15 @@ package main
 import (
 	"fmt"
 
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
 // InvoiceDetailsCmd retrieves the details of a invoice.
 type InvoiceDetailsCmd struct {
 	Args struct {
-		Token string `positional-arg-name:"token" required:"true"` // Censorship token
+		Token   string `positional-arg-name:"token" required:"true"` // Censorship token
+		Version string `positional-arg-name:"version"`               // Proposal version
 	} `positional-args:"true"`
 }
 
@@ -26,7 +28,10 @@ func (cmd *InvoiceDetailsCmd) Execute(args []string) error {
 	}
 
 	// Get invoice
-	idr, err := client.InvoiceDetails(cmd.Args.Token)
+	idr, err := client.InvoiceDetails(cmd.Args.Token,
+		&v1.InvoiceDetails{
+			Version: cmd.Args.Version,
+		})
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/cmswww/testrun.go
+++ b/politeiawww/cmd/cmswww/testrun.go
@@ -369,7 +369,7 @@ func invoiceSetStatus(admin user, token string, s cms.InvoiceStatusT) error {
 
 	// Get the most recent version of the DCC to pull the version
 	// from it.
-	idr, err := client.InvoiceDetails(token)
+	idr, err := client.InvoiceDetails(token, nil)
 	if err != nil {
 		return fmt.Errorf("InvoiceDetails: %v", err)
 	}

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -1759,9 +1759,9 @@ func (c *Client) ResendVerification(rv www.ResendVerification) (*www.ResendVerif
 }
 
 // InvoiceDetails retrieves the specified invoice.
-func (c *Client) InvoiceDetails(token string) (*cms.InvoiceDetailsReply, error) {
+func (c *Client) InvoiceDetails(token string, id *cms.InvoiceDetails) (*cms.InvoiceDetailsReply, error) {
 	route := "/invoices/" + token
-	responseBody, err := c.makeRequest(http.MethodGet, cms.APIRoute, route, nil)
+	responseBody, err := c.makeRequest(http.MethodGet, cms.APIRoute, route, id)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -789,7 +789,15 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails, u *user.User) (*cms.InvoiceDetailsReply, error) {
 	log.Tracef("processInvoiceDetails")
 
-	invRec, err := p.getInvoice(invDetails.Token)
+	// Version is an optional query param. Fetch latest version
+	// when query param is not specified.
+	var invRec *cms.InvoiceRecord
+	var err error
+	if invDetails.Version == "" {
+		invRec, err = p.getInvoice(invDetails.Token)
+	} else {
+		invRec, err = p.getInvoiceVersion(invDetails.Token, invDetails.Version)
+	}
 	if err != nil {
 		if err == cache.ErrRecordNotFound {
 			err = www.UserError{
@@ -1279,6 +1287,30 @@ func (p *politeiawww) getInvoice(token string) (*cms.InvoiceRecord, error) {
 	if err != nil {
 		return nil, err
 	}
+	i := convertInvoiceFromCache(*r)
+
+	// Fill in userID and username fields
+	u, err := p.db.UserGetByPubKey(i.PublicKey)
+	if err != nil {
+		log.Errorf("getInvoice: getUserByPubKey: token:%v "+
+			"pubKey:%v err:%v", token, i.PublicKey, err)
+	} else {
+		i.UserID = u.ID.String()
+		i.Username = u.Username
+	}
+
+	return &i, nil
+}
+
+// getInvoiceVersion gets a specific version of an invoice from the cache.
+func (p *politeiawww) getInvoiceVersion(token, version string) (*cms.InvoiceRecord, error) {
+	log.Tracef("getInvoiceVersion: %v %v", token, version)
+
+	r, err := p.cache.RecordVersion(token, version)
+	if err != nil {
+		return nil, err
+	}
+
 	i := convertInvoiceFromCache(*r)
 
 	// Fill in userID and username fields


### PR DESCRIPTION
Now administrators will be able to view all the versions of an invoice after edits completed by a contractor.  

This works in the exact same manner as ProposalDetails request.  It's an optional field, when populated, request that version of the token provided.  If empty it will the return the most recent change.  