### PR TITLE
[cms] Remove invoice line items on EditInvoice

### DIFF
--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -61,6 +61,13 @@ func (c *cockroachdb) UpdateInvoice(dbInvoice *database.Invoice) error {
 	return c.recordsdb.Save(invoice).Error
 }
 
+// RemoveLineItem deletes an existing invoice line items from the database.
+func (c *cockroachdb) RemoveInvoiceLineItems(invoiceToken string) error {
+	log.Debugf("RemoveInvoiceLineItems: %v", invoiceToken)
+
+	return c.recordsdb.Where("invoice_token = ?", invoiceToken).Delete(&LineItem{}).Error
+}
+
 // Return all invoices by userid
 func (c *cockroachdb) InvoicesByUserID(userid string) ([]database.Invoice, error) {
 	log.Tracef("InvoicesByUserID")

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -43,6 +43,8 @@ type Database interface {
 	NewInvoice(*Invoice) error    // Create new invoice
 	UpdateInvoice(*Invoice) error // Update existing invoice
 
+	RemoveInvoiceLineItems(string) error // Remove invoices line items
+
 	InvoicesByUserID(string) ([]Invoice, error)
 	InvoiceByToken(string) (*Invoice, error)     // Return invoice given its token
 	InvoicesByAddress(string) ([]Invoice, error) // Return invoice by its address

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1212,6 +1212,13 @@ func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms
 		return nil, err
 	}
 
+	// Remove all existing line items for that invoice.  They will all get added
+	// back on the update below.
+	err = p.cmsDB.RemoveInvoiceLineItems(invRec.CensorshipRecord.Token)
+	if err != nil {
+		return nil, err
+	}
+
 	// Update the cmsdb
 	dbInvoice, err := convertRecordToDatabaseInvoice(pd.Record{
 		Files:            convertPropFilesFromWWW(ei.Files),


### PR DESCRIPTION
There was a bug discovered that line items that were being remove via Edit were still remaining in the cmsdatabase due to UpdateInvoice not fully updating the sub tables within.  To handle all situations we now just remove all line item rows for a particular invoice before the update occurs.  This will ensure that when the UpdateInvoice occurs only the ones included in the edit will remain.