### PR TITLE
tests: Add unit tests to RFP-related functions

### DIFF
--- a/politeiad/cache/testcache/decred.go
+++ b/politeiad/cache/testcache/decred.go
@@ -223,7 +223,7 @@ func (c *testcache) findLinkedFrom(token string) ([]string, error) {
 	// provided token.
 	for _, allVersions := range c.records {
 		// Get the latest version of the proposal
-		r := allVersions[string(len(allVersions))]
+		r := allVersions[strconv.Itoa(len(allVersions))]
 
 		// Extract LinkTo from the ProposalMetadata file
 		for _, f := range r.Files {

--- a/politeiad/testpoliteiad/decred.go
+++ b/politeiad/testpoliteiad/decred.go
@@ -157,6 +157,9 @@ func (p *TestPoliteiad) startVoteRunoff(payload string) (string, error) {
 	p.startVotesRunoffReplies[svr.Token] = response
 
 	svrReply, err := decred.EncodeStartVoteRunoffReply(response)
+	if err != nil {
+		return "", err
+	}
 
 	return string(svrReply), nil
 }

--- a/politeiad/testpoliteiad/decred.go
+++ b/politeiad/testpoliteiad/decred.go
@@ -93,11 +93,81 @@ func (p *TestPoliteiad) startVote(payload string) (string, error) {
 	return string(svrb), nil
 }
 
+func (p *TestPoliteiad) startVoteRunoff(payload string) (string, error) {
+	svr, err := decred.DecodeStartVoteRunoff([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	// Store authorize votes
+	avReply := make(map[string]decred.AuthorizeVoteReply)
+	for _, av := range svr.AuthorizeVotes {
+		r, err := p.record(av.Token)
+		if err != nil {
+			return "", err
+		}
+		// Fill client data
+		s := p.identity.SignMessage([]byte(av.Signature))
+		av.Version = decred.VersionAuthorizeVote
+		av.Receipt = hex.EncodeToString(s[:])
+		av.Timestamp = time.Now().Unix()
+		av.Version = decred.VersionAuthorizeVote
+
+		// Store
+		_, ok := p.authorizeVotes[av.Token]
+		if !ok {
+			p.authorizeVotes[av.Token] = make(map[string]decred.AuthorizeVote)
+		}
+		p.authorizeVotes[av.Token][r.Version] = av
+
+		// Prepare response
+		avr := decred.AuthorizeVoteReply{
+			Action:        av.Action,
+			RecordVersion: r.Version,
+			Receipt:       av.Receipt,
+			Timestamp:     av.Timestamp,
+		}
+		avReply[av.Token] = avr
+	}
+
+	// Store start votes
+	svReply := decred.StartVoteReply{}
+	for _, sv := range svr.StartVotes {
+		sv.Version = decred.VersionStartVote
+		p.startVotes[sv.Vote.Token] = sv
+		// Prepare response
+		endHeight := bestBlock + sv.Vote.Duration
+		svReply.Version = decred.VersionStartVoteReply
+		svReply.StartBlockHeight = strconv.FormatUint(uint64(bestBlock), 10)
+		svReply.EndHeight = strconv.FormatUint(uint64(endHeight), 10)
+		svReply.EligibleTickets = []string{}
+	}
+
+	// Store start vote runoff
+	p.startVotesRunoff[svr.Token] = *svr
+
+	response := decred.StartVoteRunoffReply{
+		AuthorizeVoteReplies: avReply,
+		StartVoteReply:       svReply,
+	}
+
+	p.startVotesRunoffReplies[svr.Token] = response
+
+	svrReply, err := decred.EncodeStartVoteRunoffReply(response)
+
+	return string(svrReply), nil
+}
+
 // decredExec executes the passed in plugin command.
 func (p *TestPoliteiad) decredExec(pc v1.PluginCommand) (string, error) {
 	switch pc.Command {
 	case decred.CmdStartVote:
 		return p.startVote(pc.Payload)
+	case decred.CmdStartVoteRunoff:
+		return p.startVoteRunoff(pc.Payload)
 	case decred.CmdAuthorizeVote:
 		return p.authorizeVote(pc.Payload)
 	case decred.CmdBestBlock:

--- a/politeiad/testpoliteiad/testpoliteiad.go
+++ b/politeiad/testpoliteiad/testpoliteiad.go
@@ -41,6 +41,7 @@ type TestPoliteiad struct {
 
 	URL            string // Base url of form http://ipaddr:port
 	PublicIdentity *identity.PublicIdentity
+	FullIdentity   *identity.FullIdentity
 
 	identity *identity.FullIdentity
 	server   *httptest.Server
@@ -481,6 +482,7 @@ func New(t *testing.T, c cache.Cache) *TestPoliteiad {
 
 	// Init context
 	p := TestPoliteiad{
+		FullIdentity:     id,
 		PublicIdentity:   &id.Public,
 		identity:         id,
 		cache:            c,

--- a/politeiawww/events.go
+++ b/politeiawww/events.go
@@ -535,11 +535,7 @@ func (e *EventManager) _register(eventType EventT, listenerToAdd chan interface{
 		e.Listeners = make(map[EventT][]chan interface{})
 	}
 
-	if _, ok := e.Listeners[eventType]; ok {
-		e.Listeners[eventType] = append(e.Listeners[eventType], listenerToAdd)
-	} else {
-		e.Listeners[eventType] = []chan interface{}{listenerToAdd}
-	}
+	e.Listeners[eventType] = append(e.Listeners[eventType], listenerToAdd)
 }
 
 // _unregister removes the given listener channel for the given event type.

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -2698,8 +2698,6 @@ func validateStartVote(sv www2.StartVote, u user.User, pr www.ProposalRecord, vs
 	dsv := convertStartVoteV2ToDecred(sv)
 	err = dsv.VerifySignature()
 	if err != nil {
-		fmt.Println("err")
-		fmt.Println(err)
 		log.Debugf("validateStartVote: VerifySignature: %v", err)
 		return www.UserError{
 			ErrorCode: www.ErrorStatusInvalidSignature,

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -2698,6 +2698,8 @@ func validateStartVote(sv www2.StartVote, u user.User, pr www.ProposalRecord, vs
 	dsv := convertStartVoteV2ToDecred(sv)
 	err = dsv.VerifySignature()
 	if err != nil {
+		fmt.Println("err")
+		fmt.Println(err)
 		log.Debugf("validateStartVote: VerifySignature: %v", err)
 		return www.UserError{
 			ErrorCode: www.ErrorStatusInvalidSignature,
@@ -2738,7 +2740,6 @@ func validateStartVoteStandard(sv www2.StartVote, u user.User, pr www.ProposalRe
 	}
 
 	// The remaining validation is specific to a VoteTypeStandard.
-
 	switch {
 	case sv.Vote.Type != www2.VoteTypeStandard:
 		// Not a standard vote
@@ -2832,7 +2833,7 @@ func validateStartVoteRunoff(sv www2.StartVote, u user.User, pr www.ProposalReco
 
 	case !isRFPSubmission(pr):
 		// The proposal is not an RFP submission
-		e := fmt.Sprintf("%v in not an rfp submission", token)
+		e := fmt.Sprintf("%v is not an rfp submission", token)
 		return www.UserError{
 			ErrorCode:    www.ErrorStatusWrongProposalType,
 			ErrorContext: []string{e},

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -2448,7 +2448,7 @@ func validateAuthorizeVote(av www.AuthorizeVote, u user.User, pr www.ProposalRec
 	return nil
 }
 
-// validateAuthorizeVoteRunoff validates the authorize vote for a proposal that
+// validateAuthorizeVoteStandard validates the authorize vote for a proposal that
 // is participating in a standard vote. A UserError is returned if any of the
 // validation fails.
 func validateAuthorizeVoteStandard(av www.AuthorizeVote, u user.User, pr www.ProposalRecord, vs www.VoteSummary) error {

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -3026,7 +3026,7 @@ func (p *politeiawww) processStartVoteRunoffV2(sv www2.StartVoteRunoff, u *user.
 		}
 	}
 	if len(auths) == 0 {
-		e := fmt.Sprintf("start votes and authorize votes cannot be empty")
+		e := "start votes and authorize votes cannot be empty"
 		return nil, www.UserError{
 			ErrorCode:    www.ErrorStatusInvalidRunoffVote,
 			ErrorContext: []string{e},

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -243,14 +243,13 @@ func TestVoteIsApproved(t *testing.T) {
 		newVoteOptionResult(t, no, "not approve", 1, 2),
 		newVoteOptionResult(t, yes, "approve", 2, 8),
 	}
-	vsVoteNotFinished :=
-		newVoteSummary(t, www.PropVoteStatusAuthorized, emptyResults)
-	vsQuorumNotMet :=
-		newVoteSummary(t, www.PropVoteStatusFinished, badQuorumResults)
-	vsPassPercentageNotMet :=
-		newVoteSummary(t, www.PropVoteStatusFinished, badPassPercentageResults)
-	vsApproved :=
-		newVoteSummary(t, www.PropVoteStatusFinished, approvedResults)
+	vsVoteNotFinished := newVoteSummary(t, www.PropVoteStatusAuthorized,
+		emptyResults)
+	vsQuorumNotMet := newVoteSummary(t, www.PropVoteStatusFinished,
+		badQuorumResults)
+	vsPassPercentageNotMet := newVoteSummary(t, www.PropVoteStatusFinished,
+		badPassPercentageResults)
+	vsApproved := newVoteSummary(t, www.PropVoteStatusFinished, approvedResults)
 
 	var tests = []struct {
 		name    string
@@ -368,27 +367,23 @@ func TestValidateProposalMetadata(t *testing.T) {
 	_, mdInvalidLinkTo := newProposalMetadata(t, validName, invalidToken, 0)
 	_, mdProposalNotFound := newProposalMetadata(t, validName, rToken, 0)
 	_, mdProposalNotRFP := newProposalMetadata(t, validName, token, 0)
-	_, mdProposalNotApproved :=
-		newProposalMetadata(t, validName, rfpTokenNotApproved, 0)
-	_, mdProposalBadLinkBy :=
-		newProposalMetadata(t, validName, rfpBadLinkByToken, 0)
-	_, mdProposalBadState :=
-		newProposalMetadata(t, validName, rfpBadStateToken, 0)
-	_, mdProposalBothRFP :=
-		newProposalMetadata(t, validName, rfpToken, time.Now().Unix())
+	_, mdProposalNotApproved := newProposalMetadata(t, validName,
+		rfpTokenNotApproved, 0)
+	_, mdProposalBadLinkBy := newProposalMetadata(t, validName,
+		rfpBadLinkByToken, 0)
+	_, mdProposalBadState := newProposalMetadata(t, validName,
+		rfpBadStateToken, 0)
+	_, mdProposalBothRFP := newProposalMetadata(t, validName, rfpToken,
+		time.Now().Unix())
 	// LinkBy validations
-	_, mdLinkByMin :=
-		newProposalMetadata(t, validName, "", 100)
-	_, mdLinkByMax :=
-		newProposalMetadata(t, validName, "", time.Now().Unix()+7777000)
-	linkByMinError :=
-		fmt.Sprintf("linkby period cannot be shorter than %v seconds",
-			p.linkByPeriodMin())
-	linkByMaxError :=
-		fmt.Sprintf("linkby period cannot be greater than %v seconds",
-			p.linkByPeriodMax())
-	_, mdSuccess :=
-		newProposalMetadata(t, validName, rfpToken, 0)
+	_, mdLinkByMin := newProposalMetadata(t, validName, "", 100)
+	_, mdLinkByMax := newProposalMetadata(t, validName, "",
+		time.Now().Unix()+7777000)
+	linkByMinError := fmt.Sprintf("linkby period cannot be shorter than %v"+
+		" seconds", p.linkByPeriodMin())
+	linkByMaxError := fmt.Sprintf("linkby period cannot be greater than %v"+
+		" seconds", p.linkByPeriodMax())
+	_, mdSuccess := newProposalMetadata(t, validName, rfpToken, 0)
 
 	var tests = []struct {
 		name      string
@@ -1464,7 +1459,8 @@ func TestValidateStartVoteStandard(t *testing.T) {
 	sv := newStartVote(t, token, 1, minDuration, www2.VoteTypeStandard, id)
 
 	// Invalid vote type
-	svInvalidType := newStartVote(t, token, 1, minDuration, www2.VoteTypeRunoff, id)
+	svInvalidType := newStartVote(t, token, 1, minDuration,
+		www2.VoteTypeRunoff, id)
 	svInvalidType.Vote.Type = www2.VoteTypeRunoff
 
 	// RFP proposal linkBy less than min
@@ -1647,7 +1643,8 @@ func TestValidateStartVoteRunoff(t *testing.T) {
 
 	sv := newStartVote(t, token, 1, minDuration, www2.VoteTypeRunoff, id)
 
-	svInvalidType := newStartVote(t, token, 1, minDuration, www2.VoteTypeStandard, id)
+	svInvalidType := newStartVote(t, token, 1, minDuration,
+		www2.VoteTypeStandard, id)
 
 	var tests = []struct {
 		name string
@@ -1788,7 +1785,8 @@ func TestFilterProposals(t *testing.T) {
 		input []www.ProposalRecord
 		want  []www.ProposalRecord
 	}{
-		{"filter by State",
+		{
+			"filter by State",
 			proposalsFilter{
 				StateMap: map[www.PropStateT]bool{
 					www.PropStateUnvetted: true,
@@ -1802,7 +1800,8 @@ func TestFilterProposals(t *testing.T) {
 			},
 		},
 
-		{"filter by UserID",
+		{
+			"filter by UserID",
 			proposalsFilter{
 				UserID: "1",
 				StateMap: map[www.PropStateT]bool{
@@ -1816,8 +1815,8 @@ func TestFilterProposals(t *testing.T) {
 				*props[1],
 			},
 		},
-
-		{"filter by Before",
+		{
+			"filter by Before",
 			proposalsFilter{
 				Before: props[3].CensorshipRecord.Token,
 				StateMap: map[www.PropStateT]bool{
@@ -1833,7 +1832,8 @@ func TestFilterProposals(t *testing.T) {
 			},
 		},
 
-		{"filter by After",
+		{
+			"filter by After",
 			proposalsFilter{
 				After: props[3].CensorshipRecord.Token,
 				StateMap: map[www.PropStateT]bool{
@@ -1849,7 +1849,8 @@ func TestFilterProposals(t *testing.T) {
 			},
 		},
 
-		{"unsorted proposals",
+		{
+			"unsorted proposals",
 			proposalsFilter{
 				StateMap: map[www.PropStateT]bool{
 					www.PropStateUnvetted: true,
@@ -1940,24 +1941,36 @@ func TestProcessNewProposal(t *testing.T) {
 		usr  *user.User
 		want error
 	}{
-		{"unpaid registration fee", np, usrUnpaid,
+		{
+			"unpaid registration fee",
+			np,
+			usrUnpaid,
 			www.UserError{
 				ErrorCode: www.ErrorStatusUserNotPaid,
 			}},
 
-		{"no proposal credits", np, usrNoCredits,
+		{
+			"no proposal credits",
+			np,
+			usrNoCredits,
 			www.UserError{
 				ErrorCode: www.ErrorStatusNoProposalCredits,
 			}},
 
-		{"invalid proposal",
+		{
+			"invalid proposal",
 			propInvalid,
 			usrValid,
 			www.UserError{
 				ErrorCode: www.ErrorStatusInvalidSignature,
 			}},
 
-		{"success", np, usrValid, nil},
+		{
+			"success",
+			np,
+			usrValid,
+			nil,
+		},
 	}
 
 	// Run tests
@@ -2243,7 +2256,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 		// This is an admin route so it can be assumed that the
 		// user has been validated and is an admin.
 
-		{"no change message for censored", admin,
+		{
+			"no change message for censored",
+			admin,
 			www.SetProposalStatus{
 				Token:          tokenNotReviewed,
 				ProposalStatus: www.PropStatusCensored,
@@ -2254,7 +2269,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				ErrorCode: www.ErrorStatusChangeMessageCannotBeBlank,
 			}},
 
-		{"no change message for abandoned", admin,
+		{
+			"no change message for abandoned",
+			admin,
 			www.SetProposalStatus{
 				Token:          tokenPublic,
 				ProposalStatus: www.PropStatusAbandoned,
@@ -2265,7 +2282,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				ErrorCode: www.ErrorStatusChangeMessageCannotBeBlank,
 			}},
 
-		{"invalid public key", admin,
+		{
+			"invalid public key",
+			admin,
 			www.SetProposalStatus{
 				Token:          tokenNotReviewed,
 				ProposalStatus: www.PropStatusPublic,
@@ -2276,7 +2295,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidSigningKey,
 			}},
 
-		{"invalid signature", admin,
+		{
+			"invalid signature",
+			admin,
 			www.SetProposalStatus{
 				Token:          tokenNotReviewed,
 				ProposalStatus: www.PropStatusPublic,
@@ -2287,7 +2308,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidSignature,
 			}},
 
-		{"invalid proposal token", admin,
+		{
+			"invalid proposal token",
+			admin,
 			www.SetProposalStatus{
 				Token:          tokenNotFound,
 				ProposalStatus: www.PropStatusPublic,
@@ -2298,7 +2321,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			}},
 
-		{"invalid status change", admin,
+		{
+			"invalid status change",
+			admin,
 			www.SetProposalStatus{
 				Token:               tokenNotReviewed,
 				ProposalStatus:      www.PropStatusAbandoned,
@@ -2309,8 +2334,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 			www.UserError{
 				ErrorCode: www.ErrorStatusInvalidPropStatusTransition,
 			}},
-
-		{"unvetted success", admin,
+		{
+			"unvetted success",
+			admin,
 			www.SetProposalStatus{
 				Token:          tokenNotReviewed,
 				ProposalStatus: www.PropStatusPublic,
@@ -2318,7 +2344,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				PublicKey:      admin.PublicKey(),
 			}, nil},
 
-		{"vote already authorized", admin,
+		{
+			"vote already authorized",
+			admin,
 			www.SetProposalStatus{
 				Token:               tokenVoteAuthorized,
 				ProposalStatus:      www.PropStatusAbandoned,
@@ -2330,7 +2358,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				ErrorCode: www.ErrorStatusWrongVoteStatus,
 			}},
 
-		{"vote already started", admin,
+		{
+			"vote already started",
+			admin,
 			www.SetProposalStatus{
 				Token:               tokenVoteStarted,
 				ProposalStatus:      www.PropStatusAbandoned,
@@ -2342,7 +2372,9 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				ErrorCode: www.ErrorStatusWrongVoteStatus,
 			}},
 
-		{"vetted success", admin,
+		{
+			"vetted success",
+			admin,
 			www.SetProposalStatus{
 				Token:               tokenPublic,
 				ProposalStatus:      www.PropStatusAbandoned,
@@ -2397,7 +2429,8 @@ func TestProcessAllVetted(t *testing.T) {
 		av   www.GetAllVetted
 		want error
 	}{
-		{"before token not hex",
+		{
+			"before token not hex",
 			www.GetAllVetted{
 				Before: tokenNotHex,
 			},
@@ -2405,7 +2438,8 @@ func TestProcessAllVetted(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			},
 		},
-		{"before token invalid length short",
+		{
+			"before token invalid length short",
 			www.GetAllVetted{
 				Before: tokenShort,
 			},
@@ -2413,7 +2447,8 @@ func TestProcessAllVetted(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			},
 		},
-		{"before token invalid length long",
+		{
+			"before token invalid length long",
 			www.GetAllVetted{
 				Before: tokenLong,
 			},
@@ -2421,7 +2456,8 @@ func TestProcessAllVetted(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			},
 		},
-		{"after token not hex",
+		{
+			"after token not hex",
 			www.GetAllVetted{
 				After: tokenNotHex,
 			},
@@ -2429,7 +2465,8 @@ func TestProcessAllVetted(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			},
 		},
-		{"after token invalid length short",
+		{
+			"after token invalid length short",
 			www.GetAllVetted{
 				After: tokenShort,
 			},
@@ -2437,7 +2474,8 @@ func TestProcessAllVetted(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			},
 		},
-		{"after token invalid length long",
+		{
+			"after token invalid length long",
 			www.GetAllVetted{
 				After: tokenLong,
 			},
@@ -2445,13 +2483,15 @@ func TestProcessAllVetted(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			},
 		},
-		{"valid before token",
+		{
+			"valid before token",
 			www.GetAllVetted{
 				Before: tokenValid,
 			},
 			nil,
 		},
-		{"valid after token",
+		{
+			"valid after token",
 			www.GetAllVetted{
 				After: tokenValid,
 			},
@@ -2576,10 +2616,12 @@ func TestProcessStartVoteV2(t *testing.T) {
 	}
 	rToken := hex.EncodeToString(randomToken)
 
-	svInvalidToken := newStartVote(t, token, 1, minDuration, www2.VoteTypeStandard, id)
+	svInvalidToken := newStartVote(t, token, 1, minDuration,
+		www2.VoteTypeStandard, id)
 	svInvalidToken.Vote.Token = ""
 
-	svRandomToken := newStartVote(t, token, 1, minDuration, www2.VoteTypeStandard, id)
+	svRandomToken := newStartVote(t, token, 1, minDuration,
+		www2.VoteTypeStandard, id)
 	svRandomToken.Vote.Token = rToken
 
 	var tests = []struct {
@@ -2670,7 +2712,8 @@ func TestProcessStartVoteRunoffV2(t *testing.T) {
 
 	makeProposalRFP(t, &rfpProposal, []string{}, linkBy)
 	makeProposalRFPSubmissions(t, rfpSubmissions, linkTo)
-	makeProposalRFPSubmissions(t, []*www.ProposalRecord{&extraProposalSubmission}, extraToken)
+	makeProposalRFPSubmissions(t, []*www.ProposalRecord{&extraProposalSubmission},
+		extraToken)
 
 	badRFPProposal := newProposalRecord(t, usr, id, public)
 
@@ -2743,7 +2786,8 @@ func TestProcessStartVoteRunoffV2(t *testing.T) {
 	svInvalidToken := []www2.StartVote{
 		sub1SvInvalid,
 	}
-	svRunoffInvalidToken := newStartVoteRunoff(t, token, avInvalidToken, svInvalidToken)
+	svRunoffInvalidToken := newStartVoteRunoff(t, token, avInvalidToken,
+		svInvalidToken)
 
 	// Proposal submission record not found
 	randomToken, err := util.Random(pd.TokenSize)

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -390,6 +390,16 @@ func newVoteSummary(t *testing.T, s www.PropVoteStatusT, rs []www.VoteOptionResu
 	}
 }
 
+func newVoteOptionV2(t *testing.T, id, desc string, bits uint64) www2.VoteOption {
+	t.Helper()
+
+	return www2.VoteOption{
+		Id:          id,
+		Description: desc,
+		Bits:        bits,
+	}
+}
+
 func newVoteOptionResult(t *testing.T, id, desc string, bits, votes uint64) www.VoteOptionResult {
 	t.Helper()
 
@@ -1476,38 +1486,20 @@ func TestValidateAuthorizeVoteRunoff(t *testing.T) {
 }
 
 func TestValidateVoteOptions(t *testing.T) {
+	approve := decredplugin.VoteOptionIDApprove
+	reject := decredplugin.VoteOptionIDReject
 	invalidVoteOption := []www2.VoteOption{
-		{
-			Id:          "wrong",
-			Description: "",
-			Bits:        0,
-		},
+		newVoteOptionV2(t, "wrong", "", 0),
 	}
 	missingReject := []www2.VoteOption{
-		{
-			Id:          decredplugin.VoteOptionIDApprove,
-			Description: "",
-			Bits:        0,
-		},
+		newVoteOptionV2(t, approve, "", 0),
 	}
 	missingApprove := []www2.VoteOption{
-		{
-			Id:          decredplugin.VoteOptionIDReject,
-			Description: "",
-			Bits:        1,
-		},
+		newVoteOptionV2(t, reject, "", 1),
 	}
 	valid := []www2.VoteOption{
-		{
-			Id:          decredplugin.VoteOptionIDApprove,
-			Description: "approve",
-			Bits:        0,
-		},
-		{
-			Id:          decredplugin.VoteOptionIDReject,
-			Description: "reject",
-			Bits:        1,
-		},
+		newVoteOptionV2(t, approve, "", 0),
+		newVoteOptionV2(t, reject, "", 1),
 	}
 	var tests = []struct {
 		name string

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -1069,30 +1069,24 @@ func TestValidateVoteOptions(t *testing.T) {
 			"invalid vote option",
 			invalidVoteOption,
 			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidVoteOptions,
-				ErrorContext: []string{
-					fmt.Sprintf("invalid vote option id 'wrong'"),
-				},
+				ErrorCode:    www.ErrorStatusInvalidVoteOptions,
+				ErrorContext: []string{"invalid vote option id 'wrong'"},
 			},
 		},
 		{
 			"missing reject vote option",
 			missingReject,
 			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidVoteOptions,
-				ErrorContext: []string{
-					fmt.Sprintf("missing vote option id 'no'"),
-				},
+				ErrorCode:    www.ErrorStatusInvalidVoteOptions,
+				ErrorContext: []string{"missing vote option id 'no'"},
 			},
 		},
 		{
 			"missing approve vote option",
 			missingApprove,
 			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidVoteOptions,
-				ErrorContext: []string{
-					fmt.Sprintf("missing vote option id 'yes'"),
-				},
+				ErrorCode:    www.ErrorStatusInvalidVoteOptions,
+				ErrorContext: []string{"missing vote option id 'yes'"},
 			},
 		},
 		{

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -343,6 +343,8 @@ func newFileRandomMD(t *testing.T) www.File {
 }
 
 func newStartVote(t *testing.T, token string, proposalVersion uint32, vt www2.VoteT, id *identity.FullIdentity) www2.StartVote {
+	t.Helper()
+
 	vote := www2.Vote{
 		Token:            token,
 		ProposalVersion:  proposalVersion,
@@ -378,6 +380,8 @@ func newStartVote(t *testing.T, token string, proposalVersion uint32, vt www2.Vo
 }
 
 func newStartVoteCmd(t *testing.T, token string, proposalVersion uint32, id *identity.FullIdentity) pd.PluginCommand {
+	t.Helper()
+
 	sv := newStartVote(t, token, proposalVersion, www2.VoteTypeStandard, id)
 	dsv := convertStartVoteV2ToDecred(sv)
 	payload, err := decredplugin.EncodeStartVoteV2(dsv)
@@ -399,7 +403,31 @@ func newStartVoteCmd(t *testing.T, token string, proposalVersion uint32, id *ide
 	}
 }
 
-func newAuthorizeVote(token, version, action string, id *identity.FullIdentity) www.AuthorizeVote {
+func newStartVoteRunoff(t *testing.T, tk string, avs []www2.AuthorizeVote, svs []www2.StartVote) www2.StartVoteRunoff {
+	t.Helper()
+
+	return www2.StartVoteRunoff{
+		Token:          tk,
+		AuthorizeVotes: avs,
+		StartVotes:     svs,
+	}
+}
+
+func newAuthorizeVoteV2(t *testing.T, token, version, action string, id *identity.FullIdentity) www2.AuthorizeVote {
+	t.Helper()
+
+	sig := id.SignMessage([]byte(token + version + action))
+	return www2.AuthorizeVote{
+		Token:     token,
+		Action:    action,
+		PublicKey: hex.EncodeToString(id.Public.Key[:]),
+		Signature: hex.EncodeToString(sig[:]),
+	}
+}
+
+func newAuthorizeVote(t *testing.T, token, version, action string, id *identity.FullIdentity) www.AuthorizeVote {
+	t.Helper()
+
 	sig := id.SignMessage([]byte(token + version + action))
 	return www.AuthorizeVote{
 		Action:    action,
@@ -410,7 +438,9 @@ func newAuthorizeVote(token, version, action string, id *identity.FullIdentity) 
 }
 
 func newAuthorizeVoteCmd(t *testing.T, token, version, action string, id *identity.FullIdentity) pd.PluginCommand {
-	av := newAuthorizeVote(token, version, action, id)
+	t.Helper()
+
+	av := newAuthorizeVote(t, token, version, action, id)
 	dav := convertAuthorizeVoteToDecred(av)
 	payload, err := decredplugin.EncodeAuthorizeVote(dav)
 	if err != nil {
@@ -494,6 +524,8 @@ func newProposalRecord(t *testing.T, u *user.User, id *identity.FullIdentity, s 
 }
 
 func newProposalMetadata(t *testing.T, name, linkto string, linkby int64) ([]www.Metadata, www.ProposalMetadata) {
+	t.Helper()
+
 	if name == "" {
 		// Generate a random name if none was given
 		name = proposalNameRandom(t)
@@ -563,6 +595,7 @@ func makeProposalRFP(t *testing.T, pr *www.ProposalRecord, linkedfrom []string, 
 
 func makeProposalRFPSubmissions(t *testing.T, prs []*www.ProposalRecord, linkto string) {
 	t.Helper()
+
 	for _, pr := range prs {
 		md, _ := newProposalMetadata(t, pr.Name, linkto, 0)
 		pr.LinkTo = linkto

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -342,15 +342,15 @@ func newFileRandomMD(t *testing.T) www.File {
 	}
 }
 
-func newStartVote(t *testing.T, token string, proposalVersion uint32, vt www2.VoteT, id *identity.FullIdentity) www2.StartVote {
+func newStartVote(t *testing.T, token string, v uint32, d uint32, vt www2.VoteT, id *identity.FullIdentity) www2.StartVote {
 	t.Helper()
 
 	vote := www2.Vote{
 		Token:            token,
-		ProposalVersion:  proposalVersion,
+		ProposalVersion:  v,
 		Type:             vt,
 		Mask:             0x03, // bit 0 no, bit 1 yes
-		Duration:         2016,
+		Duration:         d,
 		QuorumPercentage: 20,
 		PassPercentage:   60,
 		Options: []www2.VoteOption{
@@ -379,10 +379,10 @@ func newStartVote(t *testing.T, token string, proposalVersion uint32, vt www2.Vo
 	}
 }
 
-func newStartVoteCmd(t *testing.T, token string, proposalVersion uint32, id *identity.FullIdentity) pd.PluginCommand {
+func newStartVoteCmd(t *testing.T, token string, proposalVersion uint32, d uint32, id *identity.FullIdentity) pd.PluginCommand {
 	t.Helper()
 
-	sv := newStartVote(t, token, proposalVersion, www2.VoteTypeStandard, id)
+	sv := newStartVote(t, token, proposalVersion, d, www2.VoteTypeStandard, id)
 	dsv := convertStartVoteV2ToDecred(sv)
 	payload, err := decredplugin.EncodeStartVoteV2(dsv)
 	if err != nil {

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -172,10 +172,11 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 
 	// Setup config
 	cfg := &config{
-		DataDir:       dataDir,
-		PaywallAmount: 1e7,
-		PaywallXpub:   "tpubVobLtToNtTq6TZNw4raWQok35PRPZou53vegZqNubtBTJMMFmuMpWybFCfweJ52N8uZJPZZdHE5SRnBBuuRPfC5jdNstfKjiAs8JtbYG9jx",
-		TestNet:       true,
+		DataDir:         dataDir,
+		PaywallAmount:   1e7,
+		PaywallXpub:     "tpubVobLtToNtTq6TZNw4raWQok35PRPZou53vegZqNubtBTJMMFmuMpWybFCfweJ52N8uZJPZZdHE5SRnBBuuRPfC5jdNstfKjiAs8JtbYG9jx",
+		TestNet:         true,
+		VoteDurationMin: 2016,
 	}
 
 	// Setup database

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -342,11 +342,11 @@ func newFileRandomMD(t *testing.T) www.File {
 	}
 }
 
-func newStartVote(t *testing.T, token string, proposalVersion uint32, id *identity.FullIdentity) www2.StartVote {
+func newStartVote(t *testing.T, token string, proposalVersion uint32, vt www2.VoteT, id *identity.FullIdentity) www2.StartVote {
 	vote := www2.Vote{
 		Token:            token,
 		ProposalVersion:  proposalVersion,
-		Type:             www2.VoteTypeStandard,
+		Type:             vt,
 		Mask:             0x03, // bit 0 no, bit 1 yes
 		Duration:         2016,
 		QuorumPercentage: 20,
@@ -378,7 +378,7 @@ func newStartVote(t *testing.T, token string, proposalVersion uint32, id *identi
 }
 
 func newStartVoteCmd(t *testing.T, token string, proposalVersion uint32, id *identity.FullIdentity) pd.PluginCommand {
-	sv := newStartVote(t, token, proposalVersion, id)
+	sv := newStartVote(t, token, proposalVersion, www2.VoteTypeStandard, id)
 	dsv := convertStartVoteV2ToDecred(sv)
 	payload, err := decredplugin.EncodeStartVoteV2(dsv)
 	if err != nil {
@@ -628,6 +628,7 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 		PaywallXpub:     "tpubVobLtToNtTq6TZNw4raWQok35PRPZou53vegZqNubtBTJMMFmuMpWybFCfweJ52N8uZJPZZdHE5SRnBBuuRPfC5jdNstfKjiAs8JtbYG9jx",
 		TestNet:         true,
 		VoteDurationMin: 2016,
+		VoteDurationMax: 4032,
 	}
 
 	// Setup database

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -5,18 +5,33 @@
 package main
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
 	"io/ioutil"
+	"math/rand"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrtime/merkle"
+	"github.com/decred/politeia/decredplugin"
+	"github.com/decred/politeia/mdstream"
+	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
+	"github.com/decred/politeia/politeiad/api/v1/mime"
 	"github.com/decred/politeia/politeiad/cache/testcache"
 	"github.com/decred/politeia/politeiad/testpoliteiad"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
+	www2 "github.com/decred/politeia/politeiawww/api/www/v2"
 	"github.com/decred/politeia/politeiawww/user"
 	"github.com/decred/politeia/politeiawww/user/localdb"
 	"github.com/decred/politeia/util"
@@ -71,6 +86,152 @@ func addProposalCredits(t *testing.T, p *politeiawww, u *user.User, quantity int
 	err := p.db.UserUpdate(*u)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func proposalNameRandom(t *testing.T) string {
+	r, err := util.Random(www.PolicyMinProposalNameLength)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(r)
+}
+
+// merkleRoot returns a hex encoded merkle root of the passed in files and
+// metadata.
+func merkleRoot(t *testing.T, files []www.File, metadata []www.Metadata) string {
+	t.Helper()
+
+	digests := make([]*[sha256.Size]byte, 0, len(files))
+	for _, f := range files {
+		// Compute file digest
+		b, err := base64.StdEncoding.DecodeString(f.Payload)
+		if err != nil {
+			t.Fatalf("decode payload for file %v: %v",
+				f.Name, err)
+		}
+		digest := util.Digest(b)
+
+		// Compare against digest that came with the file
+		d, ok := util.ConvertDigest(f.Digest)
+		if !ok {
+			t.Fatalf("invalid digest: file:%v digest:%v",
+				f.Name, f.Digest)
+		}
+		if !bytes.Equal(digest, d[:]) {
+			t.Fatalf("digests do not match for file %v",
+				f.Name)
+		}
+
+		// Digest is valid
+		digests = append(digests, &d)
+	}
+
+	for _, v := range metadata {
+		b, err := base64.StdEncoding.DecodeString(v.Payload)
+		if err != nil {
+			t.Fatalf("decode payload for metadata %v: %v",
+				v.Hint, err)
+		}
+		digest := util.Digest(b)
+		d, ok := util.ConvertDigest(v.Digest)
+		if !ok {
+			t.Fatalf("invalid digest: metadata:%v digest:%v",
+				v.Hint, v.Digest)
+		}
+		if !bytes.Equal(digest, d[:]) {
+			t.Fatalf("digests do not match for metadata %v",
+				v.Hint)
+		}
+
+		// Digest is valid
+		digests = append(digests, &d)
+	}
+
+	// Compute merkle root
+	return hex.EncodeToString(merkle.Root(digests)[:])
+}
+
+// createFilePNG creates a File that contains a png image.  The png image is
+// blank by default but can be filled in with random rgb colors by setting the
+// addColor parameter to true.  The png without color will be ~3kB.  The png
+// with color will be ~2MB.
+func createFilePNG(t *testing.T, addColor bool) *www.File {
+	t.Helper()
+
+	b := new(bytes.Buffer)
+	img := image.NewRGBA(image.Rect(0, 0, 1000, 500))
+
+	// Fill in the pixels with random rgb colors in order to
+	// increase the size of the image. This is used to create an
+	// image that exceeds the maximum image size policy.
+	if addColor {
+		r := rand.New(rand.NewSource(255))
+		for y := 0; y < img.Bounds().Max.Y-1; y++ {
+			for x := 0; x < img.Bounds().Max.X-1; x++ {
+				a := uint8(r.Float32() * 255)
+				rgb := uint8(r.Float32() * 255)
+				img.SetRGBA(x, y, color.RGBA{rgb, rgb, rgb, a})
+			}
+		}
+	}
+
+	err := png.Encode(b, img)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Generate a random name
+	r, err := util.Random(8)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	return &www.File{
+		Name:    hex.EncodeToString(r) + ".png",
+		MIME:    mime.DetectMimeType(b.Bytes()),
+		Digest:  hex.EncodeToString(util.Digest(b.Bytes())),
+		Payload: base64.StdEncoding.EncodeToString(b.Bytes()),
+	}
+}
+
+// createFileMD creates a File that contains a markdown file.  The markdown
+// file is filled with randomly generated data.
+func createFileMD(t *testing.T, size int) *www.File {
+	t.Helper()
+
+	var b bytes.Buffer
+	r, err := util.Random(size)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	b.WriteString(base64.StdEncoding.EncodeToString(r) + "\n")
+
+	return &www.File{
+		Name:    www.PolicyIndexFilename,
+		MIME:    http.DetectContentType(b.Bytes()),
+		Digest:  hex.EncodeToString(util.Digest(b.Bytes())),
+		Payload: base64.StdEncoding.EncodeToString(b.Bytes()),
+	}
+}
+
+// createNewProposal computes the merkle root of the given files, signs the
+// merkle root with the given identity then returns a NewProposal object.
+func createNewProposal(t *testing.T, id *identity.FullIdentity, files []www.File, title string) *www.NewProposal {
+	t.Helper()
+
+	// Setup metadata
+	metadata, _ := newProposalMetadata(t, title, "", 0)
+
+	// Compute and sign merkle root
+	m := merkleRoot(t, files, metadata)
+	sig := id.SignMessage([]byte(m))
+
+	return &www.NewProposal{
+		Files:     files,
+		Metadata:  metadata,
+		PublicKey: hex.EncodeToString(id.Public.Key[:]),
+		Signature: hex.EncodeToString(sig[:]),
 	}
 }
 
@@ -156,6 +317,296 @@ func newUser(t *testing.T, p *politeiawww, isVerified, isAdmin bool) (*user.User
 	}
 
 	return usr, fid
+}
+
+// newFileRandomMD returns a File with the name index.md that contains random
+// base64 text.
+func newFileRandomMD(t *testing.T) www.File {
+	t.Helper()
+
+	var b bytes.Buffer
+	// Add ten lines of random base64 text.
+	for i := 0; i < 10; i++ {
+		r, err := util.Random(32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.WriteString(base64.StdEncoding.EncodeToString(r) + "\n")
+	}
+
+	return www.File{
+		Name:    "index.md",
+		MIME:    mime.DetectMimeType(b.Bytes()),
+		Digest:  hex.EncodeToString(util.Digest(b.Bytes())),
+		Payload: base64.StdEncoding.EncodeToString(b.Bytes()),
+	}
+}
+
+func newStartVote(t *testing.T, token string, proposalVersion uint32, id *identity.FullIdentity) www2.StartVote {
+	vote := www2.Vote{
+		Token:            token,
+		ProposalVersion:  proposalVersion,
+		Type:             www2.VoteTypeStandard,
+		Mask:             0x03, // bit 0 no, bit 1 yes
+		Duration:         2016,
+		QuorumPercentage: 20,
+		PassPercentage:   60,
+		Options: []www2.VoteOption{
+			{
+				Id:          "no",
+				Description: "Don't approve proposal",
+				Bits:        0x01,
+			},
+			{
+				Id:          "yes",
+				Description: "Approve proposal",
+				Bits:        0x02,
+			},
+		},
+	}
+	vb, err := json.Marshal(vote)
+	if err != nil {
+		t.Fatalf("marshal vote failed: %v %v", err, vote)
+	}
+	msg := hex.EncodeToString(util.Digest(vb))
+	sig := id.SignMessage([]byte(msg))
+	return www2.StartVote{
+		Vote:      vote,
+		PublicKey: hex.EncodeToString(id.Public.Key[:]),
+		Signature: hex.EncodeToString(sig[:]),
+	}
+}
+
+func newStartVoteCmd(t *testing.T, token string, proposalVersion uint32, id *identity.FullIdentity) pd.PluginCommand {
+	sv := newStartVote(t, token, proposalVersion, id)
+	dsv := convertStartVoteV2ToDecred(sv)
+	payload, err := decredplugin.EncodeStartVoteV2(dsv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        decredplugin.ID,
+		Command:   decredplugin.CmdStartVote,
+		CommandID: decredplugin.CmdStartVote + " " + sv.Vote.Token,
+		Payload:   string(payload),
+	}
+}
+
+func newAuthorizeVote(token, version, action string, id *identity.FullIdentity) www.AuthorizeVote {
+	sig := id.SignMessage([]byte(token + version + action))
+	return www.AuthorizeVote{
+		Action:    action,
+		Token:     token,
+		Signature: hex.EncodeToString(sig[:]),
+		PublicKey: hex.EncodeToString(id.Public.Key[:]),
+	}
+}
+
+func newAuthorizeVoteCmd(t *testing.T, token, version, action string, id *identity.FullIdentity) pd.PluginCommand {
+	av := newAuthorizeVote(token, version, action, id)
+	dav := convertAuthorizeVoteToDecred(av)
+	payload, err := decredplugin.EncodeAuthorizeVote(dav)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        decredplugin.ID,
+		Command:   decredplugin.CmdAuthorizeVote,
+		CommandID: decredplugin.CmdAuthorizeVote + " " + av.Token,
+		Payload:   string(payload),
+	}
+}
+
+func newProposalRecord(t *testing.T, u *user.User, id *identity.FullIdentity, s www.PropStatusT) www.ProposalRecord {
+	t.Helper()
+
+	f := newFileRandomMD(t)
+	files := []www.File{f}
+	name := proposalNameRandom(t)
+	metadata, _ := newProposalMetadata(t, name, "", 0)
+	m := merkleRoot(t, files, metadata)
+	sig := id.SignMessage([]byte(m))
+
+	var (
+		publishedAt int64
+		censoredAt  int64
+		abandonedAt int64
+		changeMsg   string
+	)
+
+	switch s {
+	case www.PropStatusCensored:
+		changeMsg = "did not adhere to guidelines"
+		censoredAt = time.Now().Unix()
+	case www.PropStatusPublic:
+		publishedAt = time.Now().Unix()
+	case www.PropStatusAbandoned:
+		changeMsg = "no activity"
+		publishedAt = time.Now().Unix()
+		abandonedAt = time.Now().Unix()
+	}
+
+	tokenb, err := util.Random(pd.TokenSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The token is typically generated in politeiad. This function
+	// generates the token locally to make setting up tests easier.
+	// The censorship record signature is left intentionally blank.
+	return www.ProposalRecord{
+		Name:                name,
+		State:               convertPropStatusToState(s),
+		Status:              s,
+		Timestamp:           time.Now().Unix(),
+		UserId:              u.ID.String(),
+		Username:            u.Username,
+		PublicKey:           u.PublicKey(),
+		Signature:           hex.EncodeToString(sig[:]),
+		NumComments:         0,
+		Version:             "1",
+		StatusChangeMessage: changeMsg,
+		PublishedAt:         publishedAt,
+		CensoredAt:          censoredAt,
+		AbandonedAt:         abandonedAt,
+		Files:               files,
+		Metadata:            metadata,
+		CensorshipRecord: www.CensorshipRecord{
+			Token:     hex.EncodeToString(tokenb),
+			Merkle:    m,
+			Signature: "",
+		},
+	}
+}
+
+func newProposalMetadata(t *testing.T, name, linkto string, linkby int64) ([]www.Metadata, www.ProposalMetadata) {
+	if name == "" {
+		// Generate a random name if none was given
+		name = proposalNameRandom(t)
+	}
+	pm := www.ProposalMetadata{
+		Name:   name,
+		LinkTo: linkto,
+		LinkBy: linkby,
+	}
+	pmb, err := json.Marshal(pm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := []www.Metadata{
+		{
+			Digest:  hex.EncodeToString(util.Digest(pmb)),
+			Hint:    www.HintProposalMetadata,
+			Payload: base64.StdEncoding.EncodeToString(pmb),
+		},
+	}
+	return md, pm
+}
+
+func newVoteSummary(t *testing.T, s www.PropVoteStatusT, rs []www.VoteOptionResult) www.VoteSummary {
+	t.Helper()
+
+	return www.VoteSummary{
+		Status:           s,
+		EligibleTickets:  10,
+		QuorumPercentage: 30,
+		PassPercentage:   60,
+		Results:          rs,
+	}
+}
+
+func newVoteOptionV2(t *testing.T, id, desc string, bits uint64) www2.VoteOption {
+	t.Helper()
+
+	return www2.VoteOption{
+		Id:          id,
+		Description: desc,
+		Bits:        bits,
+	}
+}
+
+func newVoteOptionResult(t *testing.T, id, desc string, bits, votes uint64) www.VoteOptionResult {
+	t.Helper()
+
+	return www.VoteOptionResult{
+		Option: www.VoteOption{
+			Id:          id,
+			Description: desc,
+			Bits:        bits,
+		},
+		VotesReceived: votes,
+	}
+}
+
+func makeProposalRFP(t *testing.T, pr *www.ProposalRecord, linkedfrom []string, linkby int64) {
+	t.Helper()
+
+	md, _ := newProposalMetadata(t, pr.Name, "", linkby)
+	pr.LinkBy = linkby
+	pr.LinkedFrom = linkedfrom
+	pr.Metadata = md
+}
+
+func makeProposalRFPSubmissions(t *testing.T, prs []*www.ProposalRecord, linkto string) {
+	t.Helper()
+	for _, pr := range prs {
+		md, _ := newProposalMetadata(t, pr.Name, linkto, 0)
+		pr.LinkTo = linkto
+		pr.Metadata = md
+	}
+}
+
+func convertPropToPD(t *testing.T, p www.ProposalRecord) pd.Record {
+	t.Helper()
+
+	// Attach ProposalMetadata as a politeiad file
+	files := convertPropFilesFromWWW(p.Files)
+	for _, v := range p.Metadata {
+		switch v.Hint {
+		case www.HintProposalMetadata:
+			files = append(files, convertFileFromMetadata(v))
+		}
+	}
+
+	// Create a ProposalGeneralV2 mdstream
+	md, err := mdstream.EncodeProposalGeneralV2(
+		mdstream.ProposalGeneralV2{
+			Version:   mdstream.VersionProposalGeneral,
+			Timestamp: time.Now().Unix(),
+			PublicKey: p.PublicKey,
+			Signature: p.Signature,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mdStreams := []pd.MetadataStream{{
+		ID:      mdstream.IDProposalGeneral,
+		Payload: string(md),
+	}}
+
+	return pd.Record{
+		Status:           convertPropStatusFromWWW(p.Status),
+		Timestamp:        p.Timestamp,
+		Version:          p.Version,
+		Metadata:         mdStreams,
+		CensorshipRecord: convertPropCensorFromWWW(p.CensorshipRecord),
+		Files:            files,
+	}
 }
 
 // newTestPoliteiawww returns a new politeiawww context that is setup for


### PR DESCRIPTION
This diff aims to increase test coverage to functions related to the RFP process recently merged in the repo. Besides adding proposal tests, this diff moves test helper functions (`new...`) to `testing.go` for better modularity.

Tests added:
```
TestValidateProposalMetadata
TestValidateAuthorizeVote
TestValidateStartVote
TestProcessAuthorizeVote
TestProcessStartVoteV2
TestProcessStartVoteRunoffV2
```

Smaller tests added:
```
TestIsRFP
TestIsRFPSubmission
TestIsProposalAuthor
TestVoteIsApproved
TestValidateVoteOptions
TestValidateVoteBit
TestValidateAuthorizeVoteStandard
TestValidateAuthorizeVoteRunoff
TestValidateStartVoteStandard
TestValidateStartVoteRunoff
```

If any of the smaller tests added are deemed to make the code brittle and hard to change, let me know and I can remove or modify them.
