### PR TITLE
Return proper error when using token prefix

### DIFF
--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -199,6 +199,14 @@ func validateComment(c www.NewComment) error {
 func (p *politeiawww) processNewComment(nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
 	log.Tracef("processNewComment: %v %v", nc.Token, u.ID)
 
+	// Make sure token is valid and not a prefix
+	if !isTokenValid(nc.Token) {
+		return nil, www.UserError{
+			ErrorCode:    www.ErrorStatusInvalidCensorshipToken,
+			ErrorContext: []string{nc.Token},
+		}
+	}
+
 	// Pay up sucker!
 	if !p.HasUserPaid(u) {
 		return nil, www.UserError{
@@ -470,6 +478,14 @@ func (p *politeiawww) processNewCommentInvoice(nc www.NewComment, u *user.User) 
 func (p *politeiawww) processLikeComment(lc www.LikeComment, u *user.User) (*www.LikeCommentReply, error) {
 	log.Debugf("processLikeComment: %v %v %v", lc.Token, lc.CommentID, u.ID)
 
+	// Make sure token is valid and not a prefix
+	if !isTokenValid(lc.Token) {
+		return nil, www.UserError{
+			ErrorCode:    www.ErrorStatusInvalidCensorshipToken,
+			ErrorContext: []string{lc.Token},
+		}
+	}
+
 	// Pay up sucker!
 	if !p.HasUserPaid(u) {
 		return nil, www.UserError{
@@ -618,6 +634,14 @@ func (p *politeiawww) processLikeComment(lc www.LikeComment, u *user.User) (*www
 // politeiad then returns the censor comment receipt.
 func (p *politeiawww) processCensorComment(cc www.CensorComment, u *user.User) (*www.CensorCommentReply, error) {
 	log.Tracef("processCensorComment: %v: %v", cc.Token, cc.CommentID)
+
+	// Make sure token is valid and not a prefix
+	if !isTokenValid(cc.Token) {
+		return nil, www.UserError{
+			ErrorCode:    www.ErrorStatusInvalidCensorshipToken,
+			ErrorContext: []string{cc.Token},
+		}
+	}
 
 	// Ensure the public key is the user's active key
 	if cc.PublicKey != u.PublicKey() {

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -979,13 +979,13 @@ func TestProcessEditProposal(t *testing.T) {
 		wantError error
 	}{
 		{
-			"proposal not found",
+			"invalid proposal token",
 			usr,
 			www.EditProposal{
 				Token: "invalid-token",
 			},
 			www.UserError{
-				ErrorCode: www.ErrorStatusProposalNotFound,
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			},
 		},
 		{
@@ -1293,7 +1293,7 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				ErrorCode: www.ErrorStatusInvalidSignature,
 			}},
 
-		{"proposal not found", admin,
+		{"invalid proposal token", admin,
 			www.SetProposalStatus{
 				Token:          tokenNotFound,
 				ProposalStatus: www.PropStatusPublic,
@@ -1301,7 +1301,7 @@ func TestProcessSetProposalStatus(t *testing.T) {
 				PublicKey:      admin.PublicKey(),
 			},
 			www.UserError{
-				ErrorCode: www.ErrorStatusProposalNotFound,
+				ErrorCode: www.ErrorStatusInvalidCensorshipToken,
 			}},
 
 		{"invalid status change", admin,

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -635,6 +635,14 @@ func (p *politeiawww) processEditUser(eu *www.EditUser, user *user.User) (*www.E
 func (p *politeiawww) processUserCommentsLikes(user *user.User, token string) (*www.UserCommentsLikesReply, error) {
 	log.Tracef("processUserCommentsLikes: %v %v", user.ID, token)
 
+	// Make sure token is valid and not a prefix
+	if !isTokenValid(token) {
+		return nil, www.UserError{
+			ErrorCode:    www.ErrorStatusInvalidCensorshipToken,
+			ErrorContext: []string{token},
+		}
+	}
+
 	// Fetch all like comments for the proposal
 	dlc, err := p.decredPropCommentLikes(token)
 	if err != nil {


### PR DESCRIPTION
This diff adds a check on the routes that receive a proposal token. This check verifies if the token is valid and not in the prefix short form.

Closes #1206 