### PR TITLE
[totp] Add TOTP Code check in Login

### DIFF
--- a/politeiawww/api/www/v1/api.md
+++ b/politeiawww/api/www/v1/api.md
@@ -468,6 +468,9 @@ Reply:
 Login as a user or admin.  Admin status is determined by the server based on
 the user database.  Note that Login reply is identical to Me reply.
 
+A valid TOTP code is required if user has set and verified a TOTP secret 
+key previously.
+
 **Route:** `POST /v1/login`
 
 **Params:**
@@ -476,6 +479,7 @@ the user database.  Note that Login reply is identical to Me reply.
 |-|-|-|-|
 | email | string | Email address of user that is attempting to login. | Yes |
 | password | string | Accompanying password for provided email. | Yes |
+| code | string | TOTP code based on user's TOTP secret (if verified). | No |
 
 **Results:** See the [`Login reply`](#login-reply).
 
@@ -485,6 +489,9 @@ error codes:
 - [`ErrorStatusEmailNotVerified`](#ErrorStatusEmailNotVerified)
 - [`ErrorStatusUserDeactivated`](#ErrorStatusUserDeactivated)
 - [`ErrorStatusUserLocked`](#ErrorStatusUserLocked)
+- [`ErrorStatusRequiresTOTPCode`](#ErrorStatusRequiresTOTPCode)
+- [`ErrorStatusTOTPWaitForNewCode`](#ErrorStatusTOTPWaitForNewCode)
+- [`ErrorStatusTOTPFailedValidation`](#ErrorStatusTOTPFailedValidation)
 
 **Example**
 
@@ -2799,6 +2806,8 @@ Reply:
 | <a name="ErrorStatusWrongProposalType">ErrorStatusWrongProposalType</a> | 76 | Wrong proposal type. |
 | <a name="ErrorStatusTOTPFailedValidation">ErrorStatusTOTPFailedValidation</a> | 77 | TOTP code provided doesn't failed validation with current key. |
 | <a name="ErrorStatusTOTPInvalidType">ErrorStatusTOTPInvalidType</a> | 78 | Invalid TOTP Type. |
+| <a name="ErrorStatusRequiresTOTPCode">ErrorStatusRequiresTOTPCode</a> | 79 | User has verified TOTP secret and login requires code. |
+| <a name="ErrorStatusTOTPWaitForNewCode">ErrorStatusTOTPWaitForNewCode</a> | 80 | Must wait until next TOTP code window before another login attempt. |
 
 
 ### `Proposal status codes`

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -792,7 +792,7 @@ type AbridgedUser struct {
 type Login struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
-	Code     string `json:"code,omitempty"`
+	Code     string `json:"code,omitempty"` // TOTP code based on user's TOTP secret (if verified)
 }
 
 // LoginReply is used to reply to the Login command.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -792,7 +792,7 @@ type AbridgedUser struct {
 type Login struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
-	Code     string `json:"code"`
+	Code     string `json:"code,omitempty"`
 }
 
 // LoginReply is used to reply to the Login command.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -217,8 +217,7 @@ const (
 	ErrorStatusTOTPFailedValidation        ErrorStatusT = 77
 	ErrorStatusTOTPInvalidType             ErrorStatusT = 78
 	ErrorStatusRequiresTOTPCode            ErrorStatusT = 79
-	ErrorStatusInvalidTOTPCode             ErrorStatusT = 80
-	ErrorStatusTOTPWaitForNewCode          ErrorStatusT = 81
+	ErrorStatusTOTPWaitForNewCode          ErrorStatusT = 80
 
 	// Proposal state codes
 	//
@@ -397,6 +396,8 @@ var (
 		ErrorStatusWrongProposalType:           "wrong proposal type",
 		ErrorStatusTOTPFailedValidation:        "the provided passcode does not match the saved secret key",
 		ErrorStatusTOTPInvalidType:             "invalid totp type",
+		ErrorStatusRequiresTOTPCode:            "login requires totp code",
+		ErrorStatusTOTPWaitForNewCode:          "must wait until next totp code window",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -216,6 +216,9 @@ const (
 	ErrorStatusWrongProposalType           ErrorStatusT = 76
 	ErrorStatusTOTPFailedValidation        ErrorStatusT = 77
 	ErrorStatusTOTPInvalidType             ErrorStatusT = 78
+	ErrorStatusRequiresTOTPCode            ErrorStatusT = 79
+	ErrorStatusInvalidTOTPCode             ErrorStatusT = 80
+	ErrorStatusTOTPWaitForNewCode          ErrorStatusT = 81
 
 	// Proposal state codes
 	//
@@ -788,6 +791,7 @@ type AbridgedUser struct {
 type Login struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
+	Code     string `json:"code"`
 }
 
 // LoginReply is used to reply to the Login command.

--- a/politeiawww/cmd/shared/login.go
+++ b/politeiawww/cmd/shared/login.go
@@ -13,10 +13,10 @@ import (
 // LoginCmd logs into Politeia using the specified credentials.
 type LoginCmd struct {
 	Args struct {
-		Email    string `positional-arg-name:"email"`
-		Password string `positional-arg-name:"password"`
+		Email    string `positional-arg-name:"email" required:"true"`
+		Password string `positional-arg-name:"password" required:"true"`
 		Code     string `positional-arg-name:"code"`
-	} `positional-args:"true" required:"true"`
+	} `positional-args:"true" optional:"true"`
 }
 
 // Execute executes the login command.
@@ -65,6 +65,7 @@ Login as a user or admin.
 Arguments:
 1. email      (string, required)   Email
 2. password   (string, required)   Password
+3. code       (string)             TOTP Code
 
 Result:
 {

--- a/politeiawww/cmd/shared/login.go
+++ b/politeiawww/cmd/shared/login.go
@@ -15,6 +15,7 @@ type LoginCmd struct {
 	Args struct {
 		Email    string `positional-arg-name:"email"`
 		Password string `positional-arg-name:"password"`
+		Code     string `positional-arg-name:"code"`
 	} `positional-args:"true" required:"true"`
 }
 
@@ -31,6 +32,7 @@ func (cmd *LoginCmd) Execute(args []string) error {
 	l := &v1.Login{
 		Email:    cmd.Args.Email,
 		Password: DigestSHA3(cmd.Args.Password),
+		Code:     cmd.Args.Code,
 	}
 
 	// Print request details

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -1278,7 +1278,7 @@ func (p *politeiawww) handleSetTOTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	str, err := p.processSetTOTP(st, u)
+	str, err := p.processSetTOTP(st, u, nil)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleSetTOTP: processSetTOTP %v", err)

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -1278,7 +1278,7 @@ func (p *politeiawww) handleSetTOTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	str, err := p.processSetTOTP(st, u, nil)
+	str, err := p.processSetTOTP(st, u)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleSetTOTP: processSetTOTP %v", err)

--- a/politeiawww/totp.go
+++ b/politeiawww/totp.go
@@ -37,7 +37,7 @@ func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User) (*www.SetTOTP
 	if u.TOTPSecret != "" && u.TOTPVerified {
 		valid, err := p.totpValidate(st.Code, u.TOTPSecret, time.Now())
 		if err != nil {
-			log.Debugf("error valdiating totp code %v", err)
+			log.Debugf("Error valdiating totp code %v", err)
 			return nil, www.UserError{
 				ErrorCode: www.ErrorStatusTOTPFailedValidation,
 			}
@@ -94,7 +94,7 @@ func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User) (*www.SetTOTP
 func (p *politeiawww) processVerifyTOTP(vt www.VerifyTOTP, u *user.User) (*www.VerifyTOTPReply, error) {
 	valid, err := p.totpValidate(vt.Code, u.TOTPSecret, time.Now())
 	if err != nil {
-		log.Debugf("error valdiating totp code %v", err)
+		log.Debugf("Error valdiating totp code %v", err)
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusTOTPFailedValidation,
 		}

--- a/politeiawww/totp.go
+++ b/politeiawww/totp.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"image/png"
-	"testing"
 	"time"
 
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
@@ -28,26 +27,19 @@ var (
 )
 
 // processSetTOTP attempts to set a new TOTP key based on the given TOTP type.
-func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User, t *testing.T) (*www.SetTOTPReply, error) {
+func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User) (*www.SetTOTPReply, error) {
 	log.Tracef("processSetTOTP: %v", u.ID.String())
 	// if the user already has a TOTP secret set, check the code that was given
 	// as well to see if it matches to update.
-	requestTime := time.Now()
-	code, err := p.totpGenerateCode(u.TOTPSecret, requestTime)
-	if err != nil {
-		return nil, err
-	}
 	if u.TOTPSecret != "" && u.TOTPVerified {
-		valid, err := p.totpValidate(st.Code, u.TOTPSecret, requestTime)
+		valid, err := p.totpValidate(st.Code, u.TOTPSecret, time.Now())
 		if err != nil {
-			t.Logf("error validating code %v %v %v", requestTime, st.Code, code)
 			log.Debugf("error valdiating totp code %v", err)
 			return nil, www.UserError{
 				ErrorCode: www.ErrorStatusTOTPFailedValidation,
 			}
 		}
 		if !valid {
-			t.Logf("not valid code %v %v %v", requestTime, st.Code, code)
 			return nil, www.UserError{
 				ErrorCode: www.ErrorStatusTOTPFailedValidation,
 			}

--- a/politeiawww/totp.go
+++ b/politeiawww/totp.go
@@ -11,6 +11,7 @@ import (
 
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/user"
+	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 )
 
@@ -31,7 +32,13 @@ func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User) (*www.SetTOTP
 	// if the user already has a TOTP secret set, check the code that was given
 	// as well to see if it matches to update.
 	if u.TOTPSecret != "" && u.TOTPVerified {
-		valid := totp.Validate(st.Code, u.TOTPSecret)
+		valid, err := p.totpValidate(st.Code, u.TOTPSecret, time.Now())
+		if err != nil {
+			log.Debugf("error valdiating totp code %v", err)
+			return nil, www.UserError{
+				ErrorCode: www.ErrorStatusTOTPFailedValidation,
+			}
+		}
 		if !valid {
 			return nil, www.UserError{
 				ErrorCode: www.ErrorStatusTOTPFailedValidation,
@@ -50,10 +57,8 @@ func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User) (*www.SetTOTP
 	if p.cfg.Mode == cmsWWWMode {
 		issuer = defaultCMSIssuer
 	}
-	key, err := totp.Generate(totp.GenerateOpts{
-		Issuer:      issuer,
-		AccountName: u.Username,
-	})
+	opts := p.totpGenerateOpts(issuer, u.Username)
+	key, err := totp.Generate(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +89,13 @@ func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User) (*www.SetTOTP
 // processVerifyTOTP attempts to confirm a newly set TOTP key based on the
 // given TOTP type.
 func (p *politeiawww) processVerifyTOTP(vt www.VerifyTOTP, u *user.User) (*www.VerifyTOTPReply, error) {
-	valid := totp.Validate(vt.Code, u.TOTPSecret)
+	valid, err := p.totpValidate(vt.Code, u.TOTPSecret, time.Now())
+	if err != nil {
+		log.Debugf("error valdiating totp code %v", err)
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusTOTPFailedValidation,
+		}
+	}
 	if !valid {
 		return nil, www.UserError{
 			ErrorCode: www.ErrorStatusTOTPFailedValidation,
@@ -94,10 +105,54 @@ func (p *politeiawww) processVerifyTOTP(vt www.VerifyTOTP, u *user.User) (*www.V
 	u.TOTPVerified = true
 	u.TOTPLastUpdated = append(u.TOTPLastUpdated, time.Now().Unix())
 
-	err := p.db.UserUpdate(*u)
+	err = p.db.UserUpdate(*u)
 	if err != nil {
 		return nil, err
 	}
 
 	return nil, nil
+}
+
+func (p *politeiawww) totpGenerateOpts(issuer, accountName string) totp.GenerateOpts {
+	if p.test {
+		// Set the period a totp code is valid for to 1 second when
+		// testing so the unit tests don't take forever.
+		return totp.GenerateOpts{
+			Issuer:      issuer,
+			AccountName: accountName,
+			Period:      totpTestPeriod,
+		}
+	}
+	return totp.GenerateOpts{
+		Issuer:      issuer,
+		AccountName: accountName,
+	}
+}
+
+func (p *politeiawww) totpGenerateCode(secret string, t time.Time) (string, error) {
+	if p.test {
+		// Set the period a totp code is valid for to 1 second when
+		// testing so the unit tests don't take forever.
+		return totp.GenerateCodeCustom(secret, t, totp.ValidateOpts{
+			Period:    totpTestPeriod,
+			Skew:      0,
+			Digits:    6,
+			Algorithm: otp.AlgorithmSHA1,
+		})
+	}
+	return totp.GenerateCode(secret, t)
+}
+
+func (p *politeiawww) totpValidate(code, secret string, t time.Time) (bool, error) {
+	if p.test {
+		// Set the period a totp code is valid for to 1 second when
+		// testing so the unit tests don't take forever.
+		return totp.ValidateCustom(code, secret, t, totp.ValidateOpts{
+			Period:    totpTestPeriod,
+			Skew:      0,
+			Digits:    6,
+			Algorithm: otp.AlgorithmSHA1,
+		})
+	}
+	return totp.Validate(code, secret), nil
 }

--- a/politeiawww/totp.go
+++ b/politeiawww/totp.go
@@ -18,6 +18,9 @@ import (
 const (
 	defaultPoliteiaIssuer = "politeia"
 	defaultCMSIssuer      = "cms"
+
+	// Period of totp for testing used for generating codes during tests.
+	totpTestPeriod = 1
 )
 
 var (

--- a/politeiawww/totp.go
+++ b/politeiawww/totp.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"image/png"
+	"testing"
 	"time"
 
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
@@ -27,19 +28,26 @@ var (
 )
 
 // processSetTOTP attempts to set a new TOTP key based on the given TOTP type.
-func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User) (*www.SetTOTPReply, error) {
+func (p *politeiawww) processSetTOTP(st www.SetTOTP, u *user.User, t *testing.T) (*www.SetTOTPReply, error) {
 	log.Tracef("processSetTOTP: %v", u.ID.String())
 	// if the user already has a TOTP secret set, check the code that was given
 	// as well to see if it matches to update.
+	requestTime := time.Now()
+	code, err := p.totpGenerateCode(u.TOTPSecret, requestTime)
+	if err != nil {
+		return nil, err
+	}
 	if u.TOTPSecret != "" && u.TOTPVerified {
-		valid, err := p.totpValidate(st.Code, u.TOTPSecret, time.Now())
+		valid, err := p.totpValidate(st.Code, u.TOTPSecret, requestTime)
 		if err != nil {
+			t.Logf("error validating code %v %v %v", requestTime, st.Code, code)
 			log.Debugf("error valdiating totp code %v", err)
 			return nil, www.UserError{
 				ErrorCode: www.ErrorStatusTOTPFailedValidation,
 			}
 		}
 		if !valid {
+			t.Logf("not valid code %v %v %v", requestTime, st.Code, code)
 			return nil, www.UserError{
 				ErrorCode: www.ErrorStatusTOTPFailedValidation,
 			}

--- a/politeiawww/totp.go
+++ b/politeiawww/totp.go
@@ -19,7 +19,9 @@ const (
 	defaultPoliteiaIssuer = "politeia"
 	defaultCMSIssuer      = "cms"
 
-	// Period of totp for testing used for generating codes during tests.
+	// Period (in seconds) of TOTP for testing used for generating codes during
+	// tests. A low period allows for codes to be generated and tested very
+	// quickly.
 	totpTestPeriod = 1
 )
 

--- a/politeiawww/totp_test.go
+++ b/politeiawww/totp_test.go
@@ -37,11 +37,11 @@ func TestProcessSetTOTP(t *testing.T) {
 		t.Errorf("unable to update user secret key %v", err)
 	}
 
-	code, err := p.totpGenerateCode(key.Secret(), time.Now())
+	code, err := p.totpGenerateCode(key.Secret(), time.Now().Add(500*time.Millisecond))
 	if err != nil {
 		t.Errorf("unable to generate code %v", err)
 	}
-	t.Log(code)
+
 	var tests = []struct {
 		name      string
 		params    www.SetTOTP

--- a/politeiawww/totp_test.go
+++ b/politeiawww/totp_test.go
@@ -21,10 +21,8 @@ func TestProcessSetTOTP(t *testing.T) {
 
 	alreadySetUser, _ := newUser(t, p, true, false)
 
-	key, err := totp.Generate(totp.GenerateOpts{
-		Issuer:      defaultPoliteiaIssuer,
-		AccountName: alreadySetUser.Username,
-	})
+	opts := p.totpGenerateOpts(defaultPoliteiaIssuer, alreadySetUser.Username)
+	key, err := totp.Generate(opts)
 	if err != nil {
 		t.Errorf("unable to generate secret key %v", err)
 	}
@@ -39,10 +37,11 @@ func TestProcessSetTOTP(t *testing.T) {
 		t.Errorf("unable to update user secret key %v", err)
 	}
 
-	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	code, err := p.totpGenerateCode(key.Secret(), time.Now())
 	if err != nil {
 		t.Errorf("unable to generate code %v", err)
 	}
+	t.Log(code)
 	var tests = []struct {
 		name      string
 		params    www.SetTOTP
@@ -117,10 +116,8 @@ func TestProcessVerifyTOTP(t *testing.T) {
 
 	usr, _ := newUser(t, p, true, false)
 
-	key, err := totp.Generate(totp.GenerateOpts{
-		Issuer:      defaultPoliteiaIssuer,
-		AccountName: usr.Username,
-	})
+	opts := p.totpGenerateOpts(defaultPoliteiaIssuer, usr.Username)
+	key, err := totp.Generate(opts)
 	if err != nil {
 		t.Errorf("unable to generate secret key %v", err)
 	}
@@ -135,7 +132,7 @@ func TestProcessVerifyTOTP(t *testing.T) {
 		t.Errorf("unable to update user secret key %v", err)
 	}
 
-	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	code, err := p.totpGenerateCode(key.Secret(), time.Now())
 	if err != nil {
 		t.Errorf("unable to generate code %v", err)
 	}

--- a/politeiawww/totp_test.go
+++ b/politeiawww/totp_test.go
@@ -82,7 +82,8 @@ func TestProcessSetTOTP(t *testing.T) {
 	alreadySetUser.TOTPType = int(www.TOTPTypeBasic)
 	alreadySetUser.TOTPSecret = key.Secret()
 	alreadySetUser.TOTPVerified = true
-	alreadySetUser.TOTPLastUpdated = append(alreadySetUser.TOTPLastUpdated, time.Now().Unix())
+	alreadySetUser.TOTPLastUpdated = append(alreadySetUser.TOTPLastUpdated,
+		time.Now().Unix())
 
 	err = p.db.UserUpdate(*alreadySetUser)
 	if err != nil {

--- a/politeiawww/totp_test.go
+++ b/politeiawww/totp_test.go
@@ -36,8 +36,8 @@ func TestProcessSetTOTP(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to update user secret key %v", err)
 	}
-
-	code, err := p.totpGenerateCode(key.Secret(), time.Now().Add(500*time.Millisecond))
+	requestTime := time.Now()
+	code, err := p.totpGenerateCode(key.Secret(), requestTime)
 	if err != nil {
 		t.Errorf("unable to generate code %v", err)
 	}
@@ -90,8 +90,9 @@ func TestProcessSetTOTP(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			reply, err := p.processSetTOTP(v.params, v.user)
+			reply, err := p.processSetTOTP(v.params, v.user, t)
 			if err != nil {
+				t.Logf("request time %v %v", requestTime, code)
 				got := errToStr(err)
 				want := errToStr(v.wantError)
 				if got != want {

--- a/politeiawww/totp_test.go
+++ b/politeiawww/totp_test.go
@@ -49,24 +49,6 @@ func TestProcessSetTOTP(t *testing.T) {
 		user      *user.User
 	}{
 		{
-			"error wrong type",
-			www.SetTOTP{
-				Type: www.TOTPTypeInvalid,
-			},
-			www.UserError{
-				ErrorCode: www.ErrorStatusTOTPInvalidType,
-			},
-			basicUser,
-		},
-		{
-			"success",
-			www.SetTOTP{
-				Type: www.TOTPTypeBasic,
-			},
-			nil,
-			basicUser,
-		},
-		{
 			"error already set wrong code",
 			www.SetTOTP{
 				Type: www.TOTPTypeBasic,
@@ -85,6 +67,24 @@ func TestProcessSetTOTP(t *testing.T) {
 			},
 			nil,
 			alreadySetUser,
+		},
+		{
+			"error wrong type",
+			www.SetTOTP{
+				Type: www.TOTPTypeInvalid,
+			},
+			www.UserError{
+				ErrorCode: www.ErrorStatusTOTPInvalidType,
+			},
+			basicUser,
+		},
+		{
+			"success",
+			www.SetTOTP{
+				Type: www.TOTPTypeBasic,
+			},
+			nil,
+			basicUser,
 		},
 	}
 

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -2353,24 +2353,22 @@ func (p *politeiawww) initPaywallChecker(ctx context.Context) error {
 }
 
 func (p *politeiawww) totpCheck(code string, u *user.User) error {
-	var replyError error
 	// Return error to alert that a code is required.
 	if code == "" {
 		log.Debugf("login: totp code required %v", u.Email)
-		replyError = www.UserError{
+		return www.UserError{
 			ErrorCode: www.ErrorStatusRequiresTOTPCode,
 		}
-		return replyError
 	}
 	requestTime := time.Now()
 	currentCode, err := p.totpGenerateCode(u.TOTPSecret, requestTime)
 	if err != nil {
 		log.Errorf("login: totp code generation failed %v", u.Email)
-		replyError = www.UserError{
+		return www.UserError{
 			ErrorCode: www.ErrorStatusTOTPFailedValidation,
 		}
-		return replyError
 	}
+	var replyError error
 	// Check to see if provided code matches.
 	if currentCode != code {
 		totpFails := len(u.TOTPLastFailedCodeTime)

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/decred/politeia/politeiad/api/v1/identity"
@@ -1102,7 +1101,7 @@ func (p *politeiawww) processVerifyUpdateUserKey(u *user.User, vu www.VerifyUpda
 	return u, p.db.UserUpdate(*u)
 }
 
-func (p *politeiawww) login(l www.Login, t *testing.T) loginResult {
+func (p *politeiawww) login(l www.Login) loginResult {
 	// Get user record
 	u, err := p.userByEmail(l.Email)
 	if err != nil {
@@ -1215,7 +1214,6 @@ func (p *politeiawww) login(l www.Login, t *testing.T) loginResult {
 					err:   err,
 				}
 			}
-			t.Logf("failed login attempt %v %v %v %v", requestTime, currentCode, l.Code, len(u.TOTPLastFailedCodeTime))
 			err = www.UserError{
 				ErrorCode: www.ErrorStatusTOTPFailedValidation,
 			}
@@ -1326,7 +1324,7 @@ func (p *politeiawww) processLogin(l www.Login) (*www.LoginReply, error) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		ch <- p.login(l, nil)
+		ch <- p.login(l)
 	}()
 	go func() {
 		defer wg.Done()

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -2360,87 +2360,60 @@ func (p *politeiawww) totpCheck(code string, u *user.User) error {
 			ErrorCode: www.ErrorStatusRequiresTOTPCode,
 		}
 	}
+
+	// Get the generated totp code. The provided code must match this
+	// generated code.
 	requestTime := time.Now()
 	currentCode, err := p.totpGenerateCode(u.TOTPSecret, requestTime)
 	if err != nil {
-		log.Errorf("login: totp code generation failed %v", u.Email)
-		return www.UserError{
+		return fmt.Errorf("totpGenerateCode: %v", err)
+	}
+
+	// Verify the user does not have too many failed attempts for this
+	// epoch.
+	if len(u.TOTPLastFailedCodeTime) >= totpFailedAttempts {
+		// The user has too many failed attempts. We must first verify
+		// that the failed attempts are from this epoch before this is
+		// considered to be an error. If the generated code from the
+		// failed timestamp matches the generated code from the current
+		// timestamp then we know the failures occurred during this epoch.
+		failedTS := u.TOTPLastFailedCodeTime[len(u.TOTPLastFailedCodeTime)-1]
+		oldCode, err := p.totpGenerateCode(u.TOTPSecret, time.Unix(failedTS, 0))
+		if err != nil {
+			return fmt.Errorf("totpGenerateCode: %v", err)
+		}
+		if oldCode == currentCode {
+			// The failures occurred in the same epoch which means the user
+			// has exceeded their max allowed attempts.
+			return www.UserError{
+				ErrorCode: www.ErrorStatusTOTPWaitForNewCode,
+			}
+		}
+
+		// Previous failures are not from this epoch. Clear them out.
+		u.TOTPLastFailedCodeTime = []int64{}
+	}
+
+	// Verify the provided code matches the generated code
+	var replyError error
+	if currentCode == code {
+		// The code matches. Clear out all previous failed attempts
+		// before returning.
+		u.TOTPLastFailedCodeTime = []int64{}
+	} else {
+		// The code doesn't match. Save the failure and return an error.
+		ts := requestTime.Unix()
+		u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime, ts)
+		replyError = www.UserError{
 			ErrorCode: www.ErrorStatusTOTPFailedValidation,
 		}
 	}
-	var replyError error
-	// Check to see if provided code matches.
-	if currentCode != code {
-		totpFails := len(u.TOTPLastFailedCodeTime)
-		// If this is the first time failing TOTP then just save request time
-		// and return invalid TOTP.
-		if totpFails == 0 {
-			log.Debugf("login: new totp code failure %v", u.Email)
-			u.TOTPLastFailedCodeTime = make([]int64, 0, 2)
-			u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime,
-				requestTime.Unix())
-			replyError = www.UserError{
-				ErrorCode: www.ErrorStatusTOTPFailedValidation,
-			}
-		} else {
-			// This is not the first time failing a TOTP code check, so we need
-			// to see if the failure is in the same period as the previous
-			// failure.  We generate the code from the last requested time.
-			oldCode, err := p.totpGenerateCode(u.TOTPSecret,
-				time.Unix(u.TOTPLastFailedCodeTime[totpFails-1], 0))
-			if err != nil {
-				log.Debugf("login: new totp oldcode failure %v", err)
-				// Old code was unable to be generated, but still try and save
-				// time of totp to user information.
-				u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime,
-					requestTime.Unix())
-				err = p.db.UserUpdate(*u)
-				if err != nil {
-					log.Errorf("login: user update failed %v", err)
-				}
-				return www.UserError{
-					ErrorCode: www.ErrorStatusTOTPFailedValidation,
-				}
-			}
-			// The codes match, so it's the same totp period as before.
-			// We increment the TOTPLastFailedCodeTime and check to see how
-			// many times the user has attempted then return relevant error.
-			if currentCode == oldCode {
-				log.Debugf("login: another failed window attempt %v",
-					u.Email)
-				u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime,
-					requestTime.Unix())
-				// Check to see if the user has already attempted more than
-				// 2 TOTP codes for this window.
-				if len(u.TOTPLastFailedCodeTime) > totpFailedAttempts {
-					log.Debugf("login: too many totp attempts in same "+
-						"window %v", u.Email)
-					replyError = www.UserError{
-						ErrorCode: www.ErrorStatusTOTPWaitForNewCode,
-					}
-				} else {
-					replyError = www.UserError{
-						ErrorCode: www.ErrorStatusTOTPFailedValidation,
-					}
-				}
-			} else {
-				log.Debugf("login: new totp code failure window %v", u.Email)
-				// oldCode and currentCode don't match so reset failed attempts
-				u.TOTPLastFailedCodeTime = make([]int64, 0, 2)
-				u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime,
-					requestTime.Unix())
-				replyError = www.UserError{
-					ErrorCode: www.ErrorStatusTOTPFailedValidation,
-				}
-			}
-		}
+
+	// Update the user database
+	err = p.db.UserUpdate(*u)
+	if err != nil {
+		return fmt.Errorf("UserUpdate: %v", err)
 	}
-	// Only need to update use if there was an error
-	if replyError != nil {
-		err = p.db.UserUpdate(*u)
-		if err != nil {
-			log.Errorf("totpCheck: error updating user: %v", err)
-		}
-	}
+
 	return replyError
 }

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -23,6 +23,7 @@ import (
 	"github.com/decred/politeia/politeiawww/user"
 	"github.com/decred/politeia/util"
 	"github.com/google/uuid"
+	"github.com/pquerna/otp/totp"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -1112,6 +1113,89 @@ func (p *politeiawww) login(l www.Login) loginResult {
 		}
 	}
 
+	// First check if TOTP is enabled and verified.
+	if u.TOTPVerified {
+		// return error to alert that a code is required.
+		if l.Code == "" {
+			log.Debugf("login: totp code required %v", u.Email)
+			err = www.UserError{
+				ErrorCode: www.ErrorStatusRequiresTOTPCode,
+			}
+			return loginResult{
+				reply: nil,
+				err:   err,
+			}
+		} else {
+			// Check to see if the user has already attempted more than 2
+			// TOTP codes for this window.
+			if u.TOTPFailedAttempts >= 2 {
+				log.Debugf("login: too many totp attempts in same window %v", u.Email)
+				err = www.UserError{
+					ErrorCode: www.ErrorStatusTOTPWaitForNewCode,
+				}
+				return loginResult{
+					reply: nil,
+					err:   err,
+				}
+			}
+			currentCode, err := totp.GenerateCode(u.TOTPSecret, time.Now())
+			if err != nil {
+				return loginResult{
+					reply: nil,
+					err:   err,
+				}
+			}
+			// Check to see if provided code matches.
+			if currentCode != l.Code {
+				// Code did not match, is this the first failed attempt with
+				// this code?
+				if u.TOTPLastFailedCodeTime == 0 {
+					log.Debugf("login: new totp code failure %v", u.Email)
+					u.TOTPLastFailedCodeTime = time.Now().Unix()
+					u.TOTPFailedAttempts = 1
+				} else {
+					// A code has already been generated, check to see if it
+					// matches the recently generated code.
+					oldCode, err := totp.GenerateCode(u.TOTPSecret, time.Unix(u.TOTPLastFailedCodeTime, 0))
+					if err != nil {
+						return loginResult{
+							reply: nil,
+							err:   err,
+						}
+					}
+					// The codes match, so just increment the TOTPFailedAttempts
+					// and return error.
+					if currentCode == oldCode {
+						log.Debugf("login: another failed window attempt %v", u.Email)
+						u.TOTPFailedAttempts++
+					} else {
+						log.Debugf("login: new totp code failure %v", u.Email)
+						// Code don't match so reset time to now, and failed
+						// attempts back to 1.
+						u.TOTPLastFailedCodeTime = time.Now().Unix()
+						u.TOTPFailedAttempts = 1
+					}
+				}
+
+				// Update user information with failed attempts and time.
+				err = p.db.UserUpdate(*u)
+				if err != nil {
+					return loginResult{
+						reply: nil,
+						err:   err,
+					}
+				}
+				err = www.UserError{
+					ErrorCode: www.ErrorStatusInvalidTOTPCode,
+				}
+				return loginResult{
+					reply: nil,
+					err:   err,
+				}
+			}
+		}
+	}
+
 	// Verify password
 	err = bcrypt.CompareHashAndPassword(u.HashedPassword,
 		[]byte(l.Password))
@@ -1120,6 +1204,7 @@ func (p *politeiawww) login(l www.Login) loginResult {
 		log.Debugf("login: wrong password")
 		if !userIsLocked(u.FailedLoginAttempts) {
 			u.FailedLoginAttempts++
+			u.TOTPLastFailedCodeTime = 0
 			err := p.db.UserUpdate(*u)
 			if err != nil {
 				return loginResult{

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1143,16 +1143,19 @@ func (p *politeiawww) login(l www.Login) loginResult {
 			if len(u.TOTPLastFailedCodeTime) == 0 {
 				log.Debugf("login: new totp code failure %v", u.Email)
 				u.TOTPLastFailedCodeTime = make([]int64, 0, 2)
-				u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime, requestTime.Unix())
+				u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime,
+					requestTime.Unix())
 			} else {
 				// A code has already been generated, check to see if it
 				// matches the recently generated code.
 				oldCode, err := p.totpGenerateCode(u.TOTPSecret,
-					time.Unix(u.TOTPLastFailedCodeTime[len(u.TOTPLastFailedCodeTime)-1], 0))
+					time.Unix(
+						u.TOTPLastFailedCodeTime[len(u.TOTPLastFailedCodeTime)-1], 0))
 				if err != nil {
 					log.Debugf("login: new totp oldcode failure %v", err)
 					// Update user information with failed attempts and time.
-					u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime, requestTime.Unix())
+					u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime,
+						requestTime.Unix())
 					err = p.db.UserUpdate(*u)
 					if err != nil {
 						return loginResult{
@@ -1171,13 +1174,16 @@ func (p *politeiawww) login(l www.Login) loginResult {
 				// The codes match, so just increment the TOTPFailedAttempts
 				// and return error.
 				if currentCode == oldCode {
-					log.Debugf("login: another failed window attempt %v", u.Email)
-					u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime, requestTime.Unix())
+					log.Debugf("login: another failed window attempt %v",
+						u.Email)
+					u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime,
+						requestTime.Unix())
 
-					// Check to see if the user has already attempted more than 2
-					// TOTP codes for this window.
+					// Check to see if the user has already attempted more than
+					// 2 TOTP codes for this window.
 					if len(u.TOTPLastFailedCodeTime) > totpFailedAttempts {
-						// Update user information with failed attempts and time.
+						// Update user information with failed attempts and
+						// time.
 						err = p.db.UserUpdate(*u)
 						if err != nil {
 							return loginResult{
@@ -1185,7 +1191,8 @@ func (p *politeiawww) login(l www.Login) loginResult {
 								err:   err,
 							}
 						}
-						log.Debugf("login: too many totp attempts in same window %v", u.Email)
+						log.Debugf("login: too many totp attempts in same "+
+							"window %v", u.Email)
 						err = www.UserError{
 							ErrorCode: www.ErrorStatusTOTPWaitForNewCode,
 						}
@@ -1199,7 +1206,8 @@ func (p *politeiawww) login(l www.Login) loginResult {
 					// Code don't match so reset time to now, and failed
 					// attempts back to 1.
 					u.TOTPLastFailedCodeTime = make([]int64, 0, 2)
-					u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime, requestTime.Unix())
+					u.TOTPLastFailedCodeTime = append(u.TOTPLastFailedCodeTime,
+						requestTime.Unix())
 				}
 			}
 

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -32,9 +32,6 @@ const (
 	// Number of attempts until totp locks until the next window
 	totpFailedAttempts = 2
 
-	// Period of totp for testing
-	totpTestPeriod = 1
-
 	// Route to reset password at GUI
 	ResetPasswordGuiRoute = "/password" // XXX what is this doing here?
 

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -229,10 +229,12 @@ type User struct {
 	SpentProposalCredits []ProposalCredit `json:"spentproposalcredits"`
 
 	// TOTP Secret Key and type of TOTP being used.
-	TOTPSecret      string  `json:"totpsecret"`
-	TOTPType        int     `json:"totptype"`
-	TOTPVerified    bool    `json:"totpverified"` // whether current totp secret has been verified with passcode
-	TOTPLastUpdated []int64 `json:"totplastupdated"`
+	TOTPSecret             string  `json:"totpsecret"`
+	TOTPType               int     `json:"totptype"`
+	TOTPVerified           bool    `json:"totpverified"` // whether current totp secret has been verified with passcode
+	TOTPLastUpdated        []int64 `json:"totplastupdated"`
+	TOTPFailedAttempts     int     `json:"totpfailedattempts"`
+	TOTPLastFailedCodeTime int64   `json:"totplastfailedcodetime`
 }
 
 // ActiveIdentity returns the active identity for the user if one exists.

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -231,10 +231,9 @@ type User struct {
 	// TOTP Secret Key and type of TOTP being used.
 	TOTPSecret             string  `json:"totpsecret"`
 	TOTPType               int     `json:"totptype"`
-	TOTPVerified           bool    `json:"totpverified"` // whether current totp secret has been verified with passcode
+	TOTPVerified           bool    `json:"totpverified"` // whether current totp secret has been verified with
 	TOTPLastUpdated        []int64 `json:"totplastupdated"`
-	TOTPFailedAttempts     int     `json:"totpfailedattempts"`
-	TOTPLastFailedCodeTime int64   `json:"totplastfailedcodetime`
+	TOTPLastFailedCodeTime []int64 `json:"totplastfailedcodetime"`
 }
 
 // ActiveIdentity returns the active identity for the user if one exists.

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -1194,6 +1194,18 @@ func TestLogin(t *testing.T) {
 			},
 		},
 		{
+			"error after timeout",
+			www.Login{
+				Email:    usrTOTPVerifiedTimeout.Email,
+				Password: usrTOTPVerifiedTimeoutPassword,
+				Code:     "12345",
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusTOTPFailedValidation,
+			},
+		},
+		{
 			"success after timeout",
 			www.Login{
 				Email:    usrTOTPVerifiedTimeout.Email,
@@ -1207,14 +1219,13 @@ func TestLogin(t *testing.T) {
 	// Run verified TOTP timeout tests separate since they are time dependant.
 	for _, v := range testsTOTPVerifiedTimeout {
 		t.Run(v.name, func(t *testing.T) {
-			if v.name == "success after timeout" {
+			if v.name == "error after timeout" {
 				time.Sleep(futureCodeDelay)
 			}
 			lr := p.login(v.login)
 			gotErr := errToStr(lr.err)
 			wantErr := errToStr(v.wantError)
 			if gotErr != wantErr {
-				t.Logf("failed %v %v", requestTime, code)
 				t.Errorf("got error %v, want %v",
 					gotErr, wantErr)
 			}

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -930,7 +930,7 @@ func TestLogin(t *testing.T) {
 		LastLoginTime:      0,
 	}
 
-	code, err := p.totpGenerateCode(key.Secret(), time.Now())
+	code, err := p.totpGenerateCode(key.Secret(), time.Now().Add(50*time.Millisecond))
 	if err != nil {
 		t.Errorf("unable to generate code %v", err)
 	}
@@ -944,7 +944,7 @@ func TestLogin(t *testing.T) {
 		t.Errorf("unable to generate secret key %v", err)
 	}
 
-	futureCode, err := p.totpGenerateCode(key.Secret(), time.Now().Add(1*time.Second))
+	futureCode, err := p.totpGenerateCode(key.Secret(), time.Now().Add(1*time.Second+50*time.Millisecond))
 	if err != nil {
 		t.Errorf("unable to generate future code %v", err)
 	}

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -1133,7 +1133,7 @@ func TestLogin(t *testing.T) {
 		t.Run(v.name, func(t *testing.T) {
 			// Pause for the timeout totp test
 			if v.name == "sucess after timeout" {
-				time.Sleep(1 * time.Second)
+				time.Sleep(totpTestPeriod * time.Second)
 			}
 			lr := p.login(v.login)
 			gotErr := errToStr(lr.err)

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -1004,7 +1004,8 @@ func TestLogin(t *testing.T) {
 
 	usrTOTPVerified.TOTPType = int(www.TOTPTypeBasic)
 	usrTOTPVerified.TOTPSecret = key.Secret()
-	usrTOTPVerified.TOTPLastUpdated = append(usrTOTPVerified.TOTPLastUpdated, time.Now().Unix())
+	usrTOTPVerified.TOTPLastUpdated = append(usrTOTPVerified.TOTPLastUpdated,
+		time.Now().Unix())
 	usrTOTPVerified.TOTPVerified = true
 	err = p.db.UserUpdate(*usrTOTPVerified)
 	if err != nil {
@@ -1105,21 +1106,27 @@ func TestLogin(t *testing.T) {
 	// Create TOTP Verified Timed out user
 	usrTOTPVerifiedTimeout, idTOTPTimeout := newUser(t, p, true, false)
 
-	opts = p.totpGenerateOpts(defaultPoliteiaIssuer, usrTOTPVerifiedTimeout.Username)
+	opts = p.totpGenerateOpts(defaultPoliteiaIssuer,
+		usrTOTPVerifiedTimeout.Username)
 	key, err = totp.Generate(opts)
 	if err != nil {
 		t.Errorf("unable to generate secret key %v", err)
 	}
 
-	futureCodeDelay := time.Second
-	futureCode, err := p.totpGenerateCode(key.Secret(), time.Now().Add(futureCodeDelay))
+	// Add a delay based on the set totp test period.  This will allow for
+	// testing weather or not only 2 failed totp attempts in a short period
+	// of time (as opposed to the default 60s).
+	futureCodeDelay := totpTestPeriod * time.Second
+	futureCode, err := p.totpGenerateCode(key.Secret(),
+		time.Now().Add(futureCodeDelay))
 	if err != nil {
 		t.Errorf("unable to generate future code %v", err)
 	}
 
 	usrTOTPVerifiedTimeout.TOTPType = int(www.TOTPTypeBasic)
 	usrTOTPVerifiedTimeout.TOTPSecret = key.Secret()
-	usrTOTPVerifiedTimeout.TOTPLastUpdated = append(usrTOTPVerified.TOTPLastUpdated, time.Now().Unix())
+	usrTOTPVerifiedTimeout.TOTPLastUpdated =
+		append(usrTOTPVerified.TOTPLastUpdated, time.Now().Unix())
 	usrTOTPVerifiedTimeout.TOTPVerified = true
 	err = p.db.UserUpdate(*usrTOTPVerifiedTimeout)
 	if err != nil {

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -983,61 +983,6 @@ func TestLogin(t *testing.T) {
 		wantError error
 	}{
 		{
-			"wrong email",
-			www.Login{
-				Email:    "",
-				Password: usrPassword,
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidLogin,
-			},
-		},
-		{
-			"wrong password",
-			www.Login{
-				Email:    usr.Email,
-				Password: "",
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidLogin,
-			},
-		},
-		{
-			"user not verified",
-			www.Login{
-				Email:    usrUnverified.Email,
-				Password: usrUnverifiedPassword,
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusEmailNotVerified,
-			},
-		},
-		{
-			"user deactivated",
-			www.Login{
-				Email:    usrDeactivated.Email,
-				Password: usrDeactivatedPassword,
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusUserDeactivated,
-			},
-		},
-		{
-			"user account locked",
-			www.Login{
-				Email:    usrLocked.Email,
-				Password: usrLockedPassword,
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusUserLocked,
-			},
-		},
-		{
 			"totp verified no code",
 			www.Login{
 				Email:    usrTOTPVerified.Email,
@@ -1116,6 +1061,61 @@ func TestLogin(t *testing.T) {
 			},
 			&successTOTPTimeoutReply,
 			nil,
+		},
+		{
+			"wrong email",
+			www.Login{
+				Email:    "",
+				Password: usrPassword,
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidLogin,
+			},
+		},
+		{
+			"wrong password",
+			www.Login{
+				Email:    usr.Email,
+				Password: "",
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidLogin,
+			},
+		},
+		{
+			"user not verified",
+			www.Login{
+				Email:    usrUnverified.Email,
+				Password: usrUnverifiedPassword,
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusEmailNotVerified,
+			},
+		},
+		{
+			"user deactivated",
+			www.Login{
+				Email:    usrDeactivated.Email,
+				Password: usrDeactivatedPassword,
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusUserDeactivated,
+			},
+		},
+		{
+			"user account locked",
+			www.Login{
+				Email:    usrLocked.Email,
+				Password: usrLockedPassword,
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusUserLocked,
+			},
 		},
 		{
 			"success",

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -895,86 +895,6 @@ func TestLogin(t *testing.T) {
 		LastLoginTime:      0,
 	}
 
-	// Create TOTP Verified user
-	usrTOTPVerified, idTOTP := newUser(t, p, true, false)
-
-	opts := p.totpGenerateOpts(defaultPoliteiaIssuer, usrTOTPVerified.Username)
-	key, err := totp.Generate(opts)
-	if err != nil {
-		t.Errorf("unable to generate secret key %v", err)
-	}
-
-	usrTOTPVerified.TOTPType = int(www.TOTPTypeBasic)
-	usrTOTPVerified.TOTPSecret = key.Secret()
-	usrTOTPVerified.TOTPLastUpdated = append(usrTOTPVerified.TOTPLastUpdated, time.Now().Unix())
-	usrTOTPVerified.TOTPVerified = true
-	err = p.db.UserUpdate(*usrTOTPVerified)
-	if err != nil {
-		t.Errorf("unable to update totp verified user %v", err)
-	}
-
-	usrTOTPVerifiedPassword := usrTOTPVerified.Username
-
-	// Successful TOTP user reply
-	successTOTPReply := www.LoginReply{
-		IsAdmin:            false,
-		UserID:             usrTOTPVerified.ID.String(),
-		Email:              usrTOTPVerified.Email,
-		Username:           usrTOTPVerified.Username,
-		PublicKey:          idTOTP.Public.String(),
-		PaywallAddress:     usrTOTPVerified.NewUserPaywallAddress,
-		PaywallAmount:      usrTOTPVerified.NewUserPaywallAmount,
-		PaywallTxNotBefore: usrTOTPVerified.NewUserPaywallTxNotBefore,
-		PaywallTxID:        "",
-		ProposalCredits:    0,
-		LastLoginTime:      0,
-	}
-	requestTime := time.Now()
-	code, err := p.totpGenerateCode(key.Secret(), requestTime)
-	if err != nil {
-		t.Errorf("unable to generate code %v", err)
-	}
-
-	// Create TOTP Verified Timed out user
-	usrTOTPVerifiedTimeout, idTOTPTimeout := newUser(t, p, true, false)
-
-	opts = p.totpGenerateOpts(defaultPoliteiaIssuer, usrTOTPVerifiedTimeout.Username)
-	key, err = totp.Generate(opts)
-	if err != nil {
-		t.Errorf("unable to generate secret key %v", err)
-	}
-
-	futureCode, err := p.totpGenerateCode(key.Secret(), time.Now().Add(1*time.Second+50*time.Millisecond))
-	if err != nil {
-		t.Errorf("unable to generate future code %v", err)
-	}
-
-	usrTOTPVerifiedTimeout.TOTPType = int(www.TOTPTypeBasic)
-	usrTOTPVerifiedTimeout.TOTPSecret = key.Secret()
-	usrTOTPVerifiedTimeout.TOTPLastUpdated = append(usrTOTPVerified.TOTPLastUpdated, time.Now().Unix())
-	usrTOTPVerifiedTimeout.TOTPVerified = true
-	err = p.db.UserUpdate(*usrTOTPVerifiedTimeout)
-	if err != nil {
-		t.Errorf("unable to update totp verified user %v", err)
-	}
-
-	usrTOTPVerifiedTimeoutPassword := usrTOTPVerifiedTimeout.Username
-
-	// Successful TOTP user reply
-	successTOTPTimeoutReply := www.LoginReply{
-		IsAdmin:            false,
-		UserID:             usrTOTPVerifiedTimeout.ID.String(),
-		Email:              usrTOTPVerifiedTimeout.Email,
-		Username:           usrTOTPVerifiedTimeout.Username,
-		PublicKey:          idTOTPTimeout.Public.String(),
-		PaywallAddress:     usrTOTPVerifiedTimeout.NewUserPaywallAddress,
-		PaywallAmount:      usrTOTPVerifiedTimeout.NewUserPaywallAmount,
-		PaywallTxNotBefore: usrTOTPVerifiedTimeout.NewUserPaywallTxNotBefore,
-		PaywallTxID:        "",
-		ProposalCredits:    0,
-		LastLoginTime:      0,
-	}
-
 	// Setup tests
 	var tests = []struct {
 		name      string
@@ -982,86 +902,6 @@ func TestLogin(t *testing.T) {
 		wantReply *www.LoginReply
 		wantError error
 	}{
-		{
-			"totp verified no code",
-			www.Login{
-				Email:    usrTOTPVerified.Email,
-				Password: usrTOTPVerifiedPassword,
-				Code:     "",
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusRequiresTOTPCode,
-			},
-		},
-		{
-			"totp verified wrong code",
-			www.Login{
-				Email:    usrTOTPVerified.Email,
-				Password: usrTOTPVerifiedPassword,
-				Code:     "12345",
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusTOTPFailedValidation,
-			},
-		},
-		{
-			"success totp verified",
-			www.Login{
-				Email:    usrTOTPVerified.Email,
-				Password: usrTOTPVerifiedPassword,
-				Code:     code,
-			},
-			&successTOTPReply,
-			nil,
-		},
-		{
-			"totp verified timeout first incorrect",
-			www.Login{
-				Email:    usrTOTPVerifiedTimeout.Email,
-				Password: usrTOTPVerifiedTimeoutPassword,
-				Code:     "12345",
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusTOTPFailedValidation,
-			},
-		},
-		{
-			"totp verified timeout second incorrect",
-			www.Login{
-				Email:    usrTOTPVerifiedTimeout.Email,
-				Password: usrTOTPVerifiedTimeoutPassword,
-				Code:     "12345",
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusTOTPFailedValidation,
-			},
-		},
-		{
-			"totp verified timeout third incorrect timeout",
-			www.Login{
-				Email:    usrTOTPVerifiedTimeout.Email,
-				Password: usrTOTPVerifiedTimeoutPassword,
-				Code:     "12345",
-			},
-			nil,
-			www.UserError{
-				ErrorCode: www.ErrorStatusTOTPWaitForNewCode,
-			},
-		},
-		{
-			"success after timeout",
-			www.Login{
-				Email:    usrTOTPVerifiedTimeout.Email,
-				Password: usrTOTPVerifiedTimeoutPassword,
-				Code:     futureCode,
-			},
-			&successTOTPTimeoutReply,
-			nil,
-		},
 		{
 			"wrong email",
 			www.Login{
@@ -1131,11 +971,239 @@ func TestLogin(t *testing.T) {
 	// Run tests
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			// Pause for the timeout totp test
-			if v.name == "success after timeout" {
-				time.Sleep(totpTestPeriod * time.Second)
+			lr := p.login(v.login)
+			gotErr := errToStr(lr.err)
+			wantErr := errToStr(v.wantError)
+			if gotErr != wantErr {
+				t.Errorf("got error %v, want %v",
+					gotErr, wantErr)
 			}
-			lr := p.login(v.login, t)
+
+			// If there were errors then we're done
+			if err != nil {
+				return
+			}
+
+			// Verify reply
+			diff := deep.Equal(lr.reply, v.wantReply)
+			if diff != nil {
+				t.Errorf("got/want diff:\n%v",
+					spew.Sdump(diff))
+			}
+		})
+	}
+
+	// Create TOTP Verified user
+	usrTOTPVerified, idTOTP := newUser(t, p, true, false)
+
+	opts := p.totpGenerateOpts(defaultPoliteiaIssuer, usrTOTPVerified.Username)
+	key, err := totp.Generate(opts)
+	if err != nil {
+		t.Errorf("unable to generate secret key %v", err)
+	}
+
+	usrTOTPVerified.TOTPType = int(www.TOTPTypeBasic)
+	usrTOTPVerified.TOTPSecret = key.Secret()
+	usrTOTPVerified.TOTPLastUpdated = append(usrTOTPVerified.TOTPLastUpdated, time.Now().Unix())
+	usrTOTPVerified.TOTPVerified = true
+	err = p.db.UserUpdate(*usrTOTPVerified)
+	if err != nil {
+		t.Errorf("unable to update totp verified user %v", err)
+	}
+
+	usrTOTPVerifiedPassword := usrTOTPVerified.Username
+
+	// Successful TOTP user reply
+	successTOTPReply := www.LoginReply{
+		IsAdmin:            false,
+		UserID:             usrTOTPVerified.ID.String(),
+		Email:              usrTOTPVerified.Email,
+		Username:           usrTOTPVerified.Username,
+		PublicKey:          idTOTP.Public.String(),
+		PaywallAddress:     usrTOTPVerified.NewUserPaywallAddress,
+		PaywallAmount:      usrTOTPVerified.NewUserPaywallAmount,
+		PaywallTxNotBefore: usrTOTPVerified.NewUserPaywallTxNotBefore,
+		PaywallTxID:        "",
+		ProposalCredits:    0,
+		LastLoginTime:      0,
+	}
+	requestTime := time.Now()
+	code, err := p.totpGenerateCode(key.Secret(), requestTime)
+	if err != nil {
+		t.Errorf("unable to generate code %v", err)
+	}
+
+	// Setup tests
+	var testsTOTPVerified = []struct {
+		name      string
+		login     www.Login
+		wantReply *www.LoginReply
+		wantError error
+	}{
+		{
+			"totp verified no code",
+			www.Login{
+				Email:    usrTOTPVerified.Email,
+				Password: usrTOTPVerifiedPassword,
+				Code:     "",
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusRequiresTOTPCode,
+			},
+		},
+		{
+			"totp verified wrong code",
+			www.Login{
+				Email:    usrTOTPVerified.Email,
+				Password: usrTOTPVerifiedPassword,
+				Code:     "12345",
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusTOTPFailedValidation,
+			},
+		},
+		{
+			"success totp verified",
+			www.Login{
+				Email:    usrTOTPVerified.Email,
+				Password: usrTOTPVerifiedPassword,
+				Code:     code,
+			},
+			&successTOTPReply,
+			nil,
+		},
+	}
+
+	// Run verified TOTP tests separate since they are time dependant.
+	for _, v := range testsTOTPVerified {
+		t.Run(v.name, func(t *testing.T) {
+			lr := p.login(v.login)
+			gotErr := errToStr(lr.err)
+			wantErr := errToStr(v.wantError)
+			if gotErr != wantErr {
+				t.Logf("failed %v %v", requestTime, code)
+				t.Errorf("got error %v, want %v",
+					gotErr, wantErr)
+			}
+
+			// If there were errors then we're done
+			if err != nil {
+				return
+			}
+
+			// Verify reply
+			diff := deep.Equal(lr.reply, v.wantReply)
+			if diff != nil {
+				t.Errorf("got/want diff:\n%v",
+					spew.Sdump(diff))
+			}
+		})
+	}
+
+	// Create TOTP Verified Timed out user
+	usrTOTPVerifiedTimeout, idTOTPTimeout := newUser(t, p, true, false)
+
+	opts = p.totpGenerateOpts(defaultPoliteiaIssuer, usrTOTPVerifiedTimeout.Username)
+	key, err = totp.Generate(opts)
+	if err != nil {
+		t.Errorf("unable to generate secret key %v", err)
+	}
+
+	futureCodeDelay := time.Second
+	futureCode, err := p.totpGenerateCode(key.Secret(), time.Now().Add(futureCodeDelay))
+	if err != nil {
+		t.Errorf("unable to generate future code %v", err)
+	}
+
+	usrTOTPVerifiedTimeout.TOTPType = int(www.TOTPTypeBasic)
+	usrTOTPVerifiedTimeout.TOTPSecret = key.Secret()
+	usrTOTPVerifiedTimeout.TOTPLastUpdated = append(usrTOTPVerified.TOTPLastUpdated, time.Now().Unix())
+	usrTOTPVerifiedTimeout.TOTPVerified = true
+	err = p.db.UserUpdate(*usrTOTPVerifiedTimeout)
+	if err != nil {
+		t.Errorf("unable to update totp verified user %v", err)
+	}
+
+	usrTOTPVerifiedTimeoutPassword := usrTOTPVerifiedTimeout.Username
+
+	// Successful TOTP user reply
+	successTOTPTimeoutReply := www.LoginReply{
+		IsAdmin:            false,
+		UserID:             usrTOTPVerifiedTimeout.ID.String(),
+		Email:              usrTOTPVerifiedTimeout.Email,
+		Username:           usrTOTPVerifiedTimeout.Username,
+		PublicKey:          idTOTPTimeout.Public.String(),
+		PaywallAddress:     usrTOTPVerifiedTimeout.NewUserPaywallAddress,
+		PaywallAmount:      usrTOTPVerifiedTimeout.NewUserPaywallAmount,
+		PaywallTxNotBefore: usrTOTPVerifiedTimeout.NewUserPaywallTxNotBefore,
+		PaywallTxID:        "",
+		ProposalCredits:    0,
+		LastLoginTime:      0,
+	}
+
+	// Setup tests
+	var testsTOTPVerifiedTimeout = []struct {
+		name      string
+		login     www.Login
+		wantReply *www.LoginReply
+		wantError error
+	}{
+		{
+			"totp verified timeout first incorrect",
+			www.Login{
+				Email:    usrTOTPVerifiedTimeout.Email,
+				Password: usrTOTPVerifiedTimeoutPassword,
+				Code:     "12345",
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusTOTPFailedValidation,
+			},
+		},
+		{
+			"totp verified timeout second incorrect",
+			www.Login{
+				Email:    usrTOTPVerifiedTimeout.Email,
+				Password: usrTOTPVerifiedTimeoutPassword,
+				Code:     "12345",
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusTOTPFailedValidation,
+			},
+		},
+		{
+			"totp verified timeout third incorrect timeout",
+			www.Login{
+				Email:    usrTOTPVerifiedTimeout.Email,
+				Password: usrTOTPVerifiedTimeoutPassword,
+				Code:     "12345",
+			},
+			nil,
+			www.UserError{
+				ErrorCode: www.ErrorStatusTOTPWaitForNewCode,
+			},
+		},
+		{
+			"success after timeout",
+			www.Login{
+				Email:    usrTOTPVerifiedTimeout.Email,
+				Password: usrTOTPVerifiedTimeoutPassword,
+				Code:     futureCode,
+			},
+			&successTOTPTimeoutReply,
+			nil,
+		},
+	}
+	// Run verified TOTP timeout tests separate since they are time dependant.
+	for _, v := range testsTOTPVerifiedTimeout {
+		t.Run(v.name, func(t *testing.T) {
+			if v.name == "success after timeout" {
+				time.Sleep(futureCodeDelay)
+			}
+			lr := p.login(v.login)
 			gotErr := errToStr(lr.err)
 			wantErr := errToStr(v.wantError)
 			if gotErr != wantErr {

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -929,8 +929,8 @@ func TestLogin(t *testing.T) {
 		ProposalCredits:    0,
 		LastLoginTime:      0,
 	}
-
-	code, err := p.totpGenerateCode(key.Secret(), time.Now().Add(50*time.Millisecond))
+	requestTime := time.Now()
+	code, err := p.totpGenerateCode(key.Secret(), requestTime)
 	if err != nil {
 		t.Errorf("unable to generate code %v", err)
 	}
@@ -1135,11 +1135,11 @@ func TestLogin(t *testing.T) {
 			if v.name == "success after timeout" {
 				time.Sleep(totpTestPeriod * time.Second)
 			}
-			lr := p.login(v.login)
+			lr := p.login(v.login, t)
 			gotErr := errToStr(lr.err)
 			wantErr := errToStr(v.wantError)
 			if gotErr != wantErr {
-				t.Log(v.login)
+				t.Logf("failed %v %v", requestTime, code)
 				t.Errorf("got error %v, want %v",
 					gotErr, wantErr)
 			}

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -1108,7 +1108,7 @@ func TestLogin(t *testing.T) {
 			},
 		},
 		{
-			"sucess after timeout",
+			"success after timeout",
 			www.Login{
 				Email:    usrTOTPVerifiedTimeout.Email,
 				Password: usrTOTPVerifiedTimeoutPassword,
@@ -1132,7 +1132,7 @@ func TestLogin(t *testing.T) {
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
 			// Pause for the timeout totp test
-			if v.name == "sucess after timeout" {
+			if v.name == "success after timeout" {
 				time.Sleep(totpTestPeriod * time.Second)
 			}
 			lr := p.login(v.login)

--- a/politeiawww/user_test.go
+++ b/politeiawww/user_test.go
@@ -1042,7 +1042,7 @@ func TestLogin(t *testing.T) {
 			},
 			nil,
 			www.UserError{
-				ErrorCode: www.ErrorStatusInvalidTOTPCode,
+				ErrorCode: www.ErrorStatusTOTPFailedValidation,
 			},
 		},
 		{


### PR DESCRIPTION
~Requires https://github.com/decred/politeia/pull/1210~

This PR adds the ability to have users Login with TOTP if they have verified a TOTP Secret.

Currently, if a user has verified a TOTP then they will be told they need a code to be entered along with their username/password.  This code must match before the hashed password is compare against what is saved in the database.

According to the implemented security measures here, we will only allow 2 failed TOTP codes to be submitted for a givien epoch.  Any subsequent request will fail with a `ErrorStatusTOTPWaitForNewCode`