### PR TITLE
www: Add proposal category feature

### DIFF
--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -15,6 +15,7 @@ import (
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
 )
 
@@ -143,10 +144,10 @@ func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 // merkle root, thus causing an error where the client calculated merkle root
 // if different than the politeiad calculated merkle root.
 type ProposalMetadata struct {
-	Name     string `json:"name"`               // Proposal name
-	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
-	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
-	Category string `json:"category,omitempty"` // Proposal category
+	Name     string       `json:"name"`               // Proposal name
+	LinkTo   string       `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64        `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category v1.CategoryT `json:"category,omitempty"` // Proposal category
 }
 
 // EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -15,7 +15,6 @@ import (
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
-	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
 )
 
@@ -144,10 +143,10 @@ func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 // merkle root, thus causing an error where the client calculated merkle root
 // if different than the politeiad calculated merkle root.
 type ProposalMetadata struct {
-	Name     string        `json:"name"`               // Proposal name
-	LinkTo   string        `json:"linkto,omitempty"`   // Token of proposal to link to
-	LinkBy   int64         `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
-	Category www.CategoryT `json:"category,omitempty"` // Proposal category
+	Name     string `json:"name"`               // Proposal name
+	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category string `json:"category,omitempty"` // Proposal category
 }
 
 // EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -143,9 +143,10 @@ func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 // merkle root, thus causing an error where the client calculated merkle root
 // if different than the politeiad calculated merkle root.
 type ProposalMetadata struct {
-	Name   string `json:"name"`             // Proposal name
-	LinkTo string `json:"linkto,omitempty"` // Token of proposal to link to
-	LinkBy int64  `json:"linkby,omitempty"` // UNIX timestamp of RFP deadline
+	Name     string `json:"name"`               // Proposal name
+	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category string `json:"category,omitempty"` // Proposal category
 }
 
 // EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -15,7 +15,7 @@ import (
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
-	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
+	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
 )
 
@@ -144,10 +144,10 @@ func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 // merkle root, thus causing an error where the client calculated merkle root
 // if different than the politeiad calculated merkle root.
 type ProposalMetadata struct {
-	Name     string       `json:"name"`               // Proposal name
-	LinkTo   string       `json:"linkto,omitempty"`   // Token of proposal to link to
-	LinkBy   int64        `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
-	Category v1.CategoryT `json:"category,omitempty"` // Proposal category
+	Name     string        `json:"name"`               // Proposal name
+	LinkTo   string        `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64         `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category www.CategoryT `json:"category,omitempty"` // Proposal category
 }
 
 // EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -1822,10 +1822,11 @@ func proposalMetadataNew(r Record) (*ProposalMetadata, error) {
 	}
 
 	return &ProposalMetadata{
-		Token:  r.Token,
-		Name:   name,
-		LinkTo: pm.LinkTo,
-		LinkBy: pm.LinkBy,
+		Token:    r.Token,
+		Name:     name,
+		LinkTo:   pm.LinkTo,
+		LinkBy:   pm.LinkBy,
+		Category: pm.Category,
 	}, nil
 }
 

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -90,7 +90,7 @@ type ProposalMetadata struct {
 	Name     string `gorm:"not null"`    // Proposal name
 	LinkTo   string `gorm:""`            // Token of proposal to link to
 	LinkBy   int64  `gorm:""`            // UNIX timestamp of RFP deadline
-	Category int    `gorm:""`            // Proposal category
+	Category string `gorm:""`            // Proposal category
 }
 
 // Comment represents a record comment, including all of the server side

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -86,10 +86,11 @@ func (Record) TableName() string {
 //
 // This is a decred plugin model.
 type ProposalMetadata struct {
-	Token  string `gorm:"primary_key"` // Censorship token
-	Name   string `gorm:"not null"`    // Proposal name
-	LinkTo string `gorm:""`            // Token of proposal to link to
-	LinkBy int64  `gorm:""`            // UNIX timestamp of RFP deadline
+	Token    string `gorm:"primary_key"` // Censorship token
+	Name     string `gorm:"not null"`    // Proposal name
+	LinkTo   string `gorm:""`            // Token of proposal to link to
+	LinkBy   int64  `gorm:""`            // UNIX timestamp of RFP deadline
+	Category string `gorm:""`            // Proposal category
 }
 
 // Comment represents a record comment, including all of the server side

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -90,7 +90,7 @@ type ProposalMetadata struct {
 	Name     string `gorm:"not null"`    // Proposal name
 	LinkTo   string `gorm:""`            // Token of proposal to link to
 	LinkBy   int64  `gorm:""`            // UNIX timestamp of RFP deadline
-	Category string `gorm:""`            // Proposal category
+	Category int    `gorm:""`            // Proposal category
 }
 
 // Comment represents a record comment, including all of the server side

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -211,6 +211,7 @@ const (
 	ErrorStatusInvalidLinkBy               ErrorStatusT = 74
 	ErrorStatusInvalidRunoffVote           ErrorStatusT = 75
 	ErrorStatusWrongProposalType           ErrorStatusT = 76
+	ErrorStatusInvalidProposalCategory     ErrorStatusT = 77
 
 	// Proposal state codes
 	//
@@ -299,6 +300,16 @@ var (
 	PolicyUsernameSupportedChars = []string{
 		"a-z", "0-9", ".", ",", ":", ";", "-", "@", "+", "(", ")", "_"}
 
+	// PolicyProposalCategories describes the valid categories a user can define
+	// for a proposal
+	PolicyProposalCategories = []string{
+		"development",
+		"marketing",
+		"research",
+		"design",
+		"documentation",
+	}
+
 	// PoliteiaWWWAPIRoute is the prefix to the API route
 	PoliteiaWWWAPIRoute = fmt.Sprintf("/v%v", PoliteiaWWWAPIVersion)
 
@@ -383,6 +394,7 @@ var (
 		ErrorStatusInvalidLinkBy:               "invalid proposal linkby",
 		ErrorStatusInvalidRunoffVote:           "invalid runoff vote",
 		ErrorStatusWrongProposalType:           "wrong proposal type",
+		ErrorStatusInvalidProposalCategory:     "invalid proposal category",
 	}
 
 	// PropStatus converts propsal status codes to human readable text
@@ -444,9 +456,10 @@ const (
 // proposal submission and before the proposal vote is started to ensure that
 // the RFP submissions have sufficient time to be submitted.
 type ProposalMetadata struct {
-	Name   string `json:"name"`             // Proposal name
-	LinkTo string `json:"linkto,omitempty"` // Token of proposal to link to
-	LinkBy int64  `json:"linkby,omitempty"` // UNIX timestamp of RFP deadline
+	Name     string `json:"name"`               // Proposal name
+	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category string `json:"category,omitempty"` // Proposal category
 }
 
 // Metadata describes user specified metadata.
@@ -510,6 +523,7 @@ type ProposalRecord struct {
 	LinkTo              string      `json:"linkto,omitempty"`              // Token of linked parent proposal
 	LinkBy              int64       `json:"linkby,omitempty"`              // UNIX timestamp of RFP deadline
 	LinkedFrom          []string    `json:"linkedfrom,omitempty"`          // Tokens of public props that have linked to this this prop
+	Category            string      `json:"category,omitempty"`            // Proposal category
 
 	Files            []File           `json:"files"`
 	Metadata         []Metadata       `json:"metadata"`
@@ -960,6 +974,7 @@ type PolicyReply struct {
 	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
 	MinVoteDuration            uint32   `json:"minvoteduration"`
 	MaxVoteDuration            uint32   `json:"maxvoteduration"`
+	ProposalCategories         []string `json:"proposalcategories"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -17,7 +17,6 @@ type PropVoteStatusT int
 type UserManageActionT int
 type EmailNotificationT int
 type VoteT int
-type CategoryT int
 
 const (
 	PoliteiaWWWAPIVersion = 1 // API version this backend understands
@@ -287,17 +286,6 @@ const (
 	NotificationEmailAdminProposalVoteAuthorized EmailNotificationT = 1 << 6
 	NotificationEmailCommentOnMyProposal         EmailNotificationT = 1 << 7
 	NotificationEmailCommentOnMyComment          EmailNotificationT = 1 << 8
-
-	// Category types
-	//
-	// These types are defined based on the available categories a contractor
-	// can select for completed work on CMS invoices
-	CategoryInvalid       CategoryT = 0
-	CategoryDevelopment   CategoryT = 1
-	CategoryMarketing     CategoryT = 2
-	CategoryResearch      CategoryT = 3
-	CategoryDesign        CategoryT = 4
-	CategoryDocumentation CategoryT = 5
 )
 
 var (
@@ -314,12 +302,12 @@ var (
 
 	// PolicyProposalCategories describes the valid categories a user can define
 	// for a proposal
-	PolicyProposalCategories = map[CategoryT]string{
-		CategoryDevelopment:   "development",
-		CategoryMarketing:     "marketing",
-		CategoryResearch:      "research",
-		CategoryDesign:        "design",
-		CategoryDocumentation: "documentation",
+	PolicyProposalCategories = []string{
+		"development",
+		"marketing",
+		"research",
+		"design",
+		"documentation",
 	}
 
 	// PoliteiaWWWAPIRoute is the prefix to the API route
@@ -468,10 +456,10 @@ const (
 // proposal submission and before the proposal vote is started to ensure that
 // the RFP submissions have sufficient time to be submitted.
 type ProposalMetadata struct {
-	Name     string    `json:"name"`               // Proposal name
-	LinkTo   string    `json:"linkto,omitempty"`   // Token of proposal to link to
-	LinkBy   int64     `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
-	Category CategoryT `json:"category,omitempty"` // Proposal category
+	Name     string `json:"name"`               // Proposal name
+	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category string `json:"category,omitempty"` // Proposal category
 }
 
 // Metadata describes user specified metadata.
@@ -535,7 +523,7 @@ type ProposalRecord struct {
 	LinkTo              string      `json:"linkto,omitempty"`              // Token of linked parent proposal
 	LinkBy              int64       `json:"linkby,omitempty"`              // UNIX timestamp of RFP deadline
 	LinkedFrom          []string    `json:"linkedfrom,omitempty"`          // Tokens of public props that have linked to this this prop
-	Category            CategoryT   `json:"category,omitempty"`            // Proposal category
+	Category            string      `json:"category,omitempty"`            // Proposal category
 
 	Files            []File           `json:"files"`
 	Metadata         []Metadata       `json:"metadata"`
@@ -962,31 +950,31 @@ type Policy struct{}
 // PolicyReply is used to reply to the policy command. It returns
 // the file upload restrictions set for Politeia.
 type PolicyReply struct {
-	MinPasswordLength          uint                 `json:"minpasswordlength"`
-	MinUsernameLength          uint                 `json:"minusernamelength"`
-	MaxUsernameLength          uint                 `json:"maxusernamelength"`
-	UsernameSupportedChars     []string             `json:"usernamesupportedchars"`
-	ProposalListPageSize       uint                 `json:"proposallistpagesize"`
-	UserListPageSize           uint                 `json:"userlistpagesize"`
-	MaxImages                  uint                 `json:"maximages"`
-	MaxImageSize               uint                 `json:"maximagesize"`
-	MaxMDs                     uint                 `json:"maxmds"`
-	MaxMDSize                  uint                 `json:"maxmdsize"`
-	ValidMIMETypes             []string             `json:"validmimetypes"`
-	MinProposalNameLength      uint                 `json:"minproposalnamelength"`
-	MaxProposalNameLength      uint                 `json:"maxproposalnamelength"`
-	PaywallEnabled             bool                 `json:"paywallenabled"`
-	ProposalNameSupportedChars []string             `json:"proposalnamesupportedchars"`
-	MaxCommentLength           uint                 `json:"maxcommentlength"`
-	BackendPublicKey           string               `json:"backendpublickey"`
-	TokenPrefixLength          int                  `json:"tokenprefixlength"`
-	BuildInformation           []string             `json:"buildinformation"`
-	IndexFilename              string               `json:"indexfilename"`
-	MinLinkByPeriod            int64                `json:"minlinkbyperiod"`
-	MaxLinkByPeriod            int64                `json:"maxlinkbyperiod"`
-	MinVoteDuration            uint32               `json:"minvoteduration"`
-	MaxVoteDuration            uint32               `json:"maxvoteduration"`
-	ProposalCategories         map[CategoryT]string `json:"proposalcategories"`
+	MinPasswordLength          uint     `json:"minpasswordlength"`
+	MinUsernameLength          uint     `json:"minusernamelength"`
+	MaxUsernameLength          uint     `json:"maxusernamelength"`
+	UsernameSupportedChars     []string `json:"usernamesupportedchars"`
+	ProposalListPageSize       uint     `json:"proposallistpagesize"`
+	UserListPageSize           uint     `json:"userlistpagesize"`
+	MaxImages                  uint     `json:"maximages"`
+	MaxImageSize               uint     `json:"maximagesize"`
+	MaxMDs                     uint     `json:"maxmds"`
+	MaxMDSize                  uint     `json:"maxmdsize"`
+	ValidMIMETypes             []string `json:"validmimetypes"`
+	MinProposalNameLength      uint     `json:"minproposalnamelength"`
+	MaxProposalNameLength      uint     `json:"maxproposalnamelength"`
+	PaywallEnabled             bool     `json:"paywallenabled"`
+	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
+	MaxCommentLength           uint     `json:"maxcommentlength"`
+	BackendPublicKey           string   `json:"backendpublickey"`
+	TokenPrefixLength          int      `json:"tokenprefixlength"`
+	BuildInformation           []string `json:"buildinformation"`
+	IndexFilename              string   `json:"indexfilename"`
+	MinLinkByPeriod            int64    `json:"minlinkbyperiod"`
+	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
+	MinVoteDuration            uint32   `json:"minvoteduration"`
+	MaxVoteDuration            uint32   `json:"maxvoteduration"`
+	ProposalCategories         []string `json:"proposalcategories"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -300,16 +300,6 @@ var (
 	PolicyUsernameSupportedChars = []string{
 		"a-z", "0-9", ".", ",", ":", ";", "-", "@", "+", "(", ")", "_"}
 
-	// PolicyProposalCategories describes the valid categories a user can define
-	// for a proposal
-	PolicyProposalCategories = []string{
-		"development",
-		"marketing",
-		"research",
-		"design",
-		"documentation",
-	}
-
 	// PoliteiaWWWAPIRoute is the prefix to the API route
 	PoliteiaWWWAPIRoute = fmt.Sprintf("/v%v", PoliteiaWWWAPIVersion)
 

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -289,6 +289,9 @@ const (
 	NotificationEmailCommentOnMyComment          EmailNotificationT = 1 << 8
 
 	// Category types
+	//
+	// These types are defined based on the available categories a contractor
+	// can select for completed work on CMS invoices
 	CategoryInvalid       CategoryT = 0
 	CategoryDevelopment   CategoryT = 1
 	CategoryMarketing     CategoryT = 2
@@ -959,31 +962,31 @@ type Policy struct{}
 // PolicyReply is used to reply to the policy command. It returns
 // the file upload restrictions set for Politeia.
 type PolicyReply struct {
-	MinPasswordLength          uint     `json:"minpasswordlength"`
-	MinUsernameLength          uint     `json:"minusernamelength"`
-	MaxUsernameLength          uint     `json:"maxusernamelength"`
-	UsernameSupportedChars     []string `json:"usernamesupportedchars"`
-	ProposalListPageSize       uint     `json:"proposallistpagesize"`
-	UserListPageSize           uint     `json:"userlistpagesize"`
-	MaxImages                  uint     `json:"maximages"`
-	MaxImageSize               uint     `json:"maximagesize"`
-	MaxMDs                     uint     `json:"maxmds"`
-	MaxMDSize                  uint     `json:"maxmdsize"`
-	ValidMIMETypes             []string `json:"validmimetypes"`
-	MinProposalNameLength      uint     `json:"minproposalnamelength"`
-	MaxProposalNameLength      uint     `json:"maxproposalnamelength"`
-	PaywallEnabled             bool     `json:"paywallenabled"`
-	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
-	MaxCommentLength           uint     `json:"maxcommentlength"`
-	BackendPublicKey           string   `json:"backendpublickey"`
-	TokenPrefixLength          int      `json:"tokenprefixlength"`
-	BuildInformation           []string `json:"buildinformation"`
-	IndexFilename              string   `json:"indexfilename"`
-	MinLinkByPeriod            int64    `json:"minlinkbyperiod"`
-	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
-	MinVoteDuration            uint32   `json:"minvoteduration"`
-	MaxVoteDuration            uint32   `json:"maxvoteduration"`
-	ProposalCategories         []string `json:"proposalcategories"`
+	MinPasswordLength          uint                 `json:"minpasswordlength"`
+	MinUsernameLength          uint                 `json:"minusernamelength"`
+	MaxUsernameLength          uint                 `json:"maxusernamelength"`
+	UsernameSupportedChars     []string             `json:"usernamesupportedchars"`
+	ProposalListPageSize       uint                 `json:"proposallistpagesize"`
+	UserListPageSize           uint                 `json:"userlistpagesize"`
+	MaxImages                  uint                 `json:"maximages"`
+	MaxImageSize               uint                 `json:"maximagesize"`
+	MaxMDs                     uint                 `json:"maxmds"`
+	MaxMDSize                  uint                 `json:"maxmdsize"`
+	ValidMIMETypes             []string             `json:"validmimetypes"`
+	MinProposalNameLength      uint                 `json:"minproposalnamelength"`
+	MaxProposalNameLength      uint                 `json:"maxproposalnamelength"`
+	PaywallEnabled             bool                 `json:"paywallenabled"`
+	ProposalNameSupportedChars []string             `json:"proposalnamesupportedchars"`
+	MaxCommentLength           uint                 `json:"maxcommentlength"`
+	BackendPublicKey           string               `json:"backendpublickey"`
+	TokenPrefixLength          int                  `json:"tokenprefixlength"`
+	BuildInformation           []string             `json:"buildinformation"`
+	IndexFilename              string               `json:"indexfilename"`
+	MinLinkByPeriod            int64                `json:"minlinkbyperiod"`
+	MaxLinkByPeriod            int64                `json:"maxlinkbyperiod"`
+	MinVoteDuration            uint32               `json:"minvoteduration"`
+	MaxVoteDuration            uint32               `json:"maxvoteduration"`
+	ProposalCategories         map[CategoryT]string `json:"proposalcategories"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -17,6 +17,7 @@ type PropVoteStatusT int
 type UserManageActionT int
 type EmailNotificationT int
 type VoteT int
+type CategoryT int
 
 const (
 	PoliteiaWWWAPIVersion = 1 // API version this backend understands
@@ -286,6 +287,14 @@ const (
 	NotificationEmailAdminProposalVoteAuthorized EmailNotificationT = 1 << 6
 	NotificationEmailCommentOnMyProposal         EmailNotificationT = 1 << 7
 	NotificationEmailCommentOnMyComment          EmailNotificationT = 1 << 8
+
+	// Category types
+	CategoryInvalid       CategoryT = 0
+	CategoryDevelopment   CategoryT = 1
+	CategoryMarketing     CategoryT = 2
+	CategoryResearch      CategoryT = 3
+	CategoryDesign        CategoryT = 4
+	CategoryDocumentation CategoryT = 5
 )
 
 var (
@@ -302,12 +311,12 @@ var (
 
 	// PolicyProposalCategories describes the valid categories a user can define
 	// for a proposal
-	PolicyProposalCategories = []string{
-		"development",
-		"marketing",
-		"research",
-		"design",
-		"documentation",
+	PolicyProposalCategories = map[CategoryT]string{
+		CategoryDevelopment:   "development",
+		CategoryMarketing:     "marketing",
+		CategoryResearch:      "research",
+		CategoryDesign:        "design",
+		CategoryDocumentation: "documentation",
 	}
 
 	// PoliteiaWWWAPIRoute is the prefix to the API route
@@ -456,10 +465,10 @@ const (
 // proposal submission and before the proposal vote is started to ensure that
 // the RFP submissions have sufficient time to be submitted.
 type ProposalMetadata struct {
-	Name     string `json:"name"`               // Proposal name
-	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
-	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
-	Category string `json:"category,omitempty"` // Proposal category
+	Name     string    `json:"name"`               // Proposal name
+	LinkTo   string    `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64     `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category CategoryT `json:"category,omitempty"` // Proposal category
 }
 
 // Metadata describes user specified metadata.
@@ -523,7 +532,7 @@ type ProposalRecord struct {
 	LinkTo              string      `json:"linkto,omitempty"`              // Token of linked parent proposal
 	LinkBy              int64       `json:"linkby,omitempty"`              // UNIX timestamp of RFP deadline
 	LinkedFrom          []string    `json:"linkedfrom,omitempty"`          // Tokens of public props that have linked to this this prop
-	Category            string      `json:"category,omitempty"`            // Proposal category
+	Category            CategoryT   `json:"category,omitempty"`            // Proposal category
 
 	Files            []File           `json:"files"`
 	Metadata         []Metadata       `json:"metadata"`

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -169,7 +169,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		pm.LinkTo = cmd.LinkTo
 	}
 	if cmd.Category != "" {
-		pm.Category = cmd.Category
+		// pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/decred/politeia/politeiad/api/v1/mime"
@@ -170,24 +169,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		pm.LinkTo = cmd.LinkTo
 	}
 	if cmd.Category != "" {
-		// Create inverse categories map from policy used on validation
-		PropCategories := make(map[string]v1.CategoryT)
-		for k, v := range v1.PolicyProposalCategories {
-			PropCategories[v] = k
-		}
-		// Parse proposal category. Accepts either the numeric category
-		// code or the human readable equivalent
-		c, err := strconv.ParseUint(cmd.Category, 10, 32)
-		if err == nil {
-			// Numeric category code found
-			pm.Category = v1.CategoryT(c)
-		} else if c, ok := PropCategories[cmd.Category]; ok {
-			// Human readable category found
-			pm.Category = c
-		} else {
-			return fmt.Errorf("Invalid proposal category '%v'. Please check "+
-				"policy for further guidance.", pm.Category)
-		}
+		pm.Category = cmd.Category
 	}
 
 	pmb, err := json.Marshal(pm)

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -27,9 +27,10 @@ type EditProposalCmd struct {
 		Markdown    string   `positional-arg-name:"markdownfile"`
 		Attachments []string `positional-arg-name:"attachmentfiles"`
 	} `positional-args:"true" optional:"true"`
-	Name   string `long:"name" optional:"true"`
-	LinkTo string `long:"linkto" optional:"true"`
-	LinkBy int64  `long:"linkby" optional:"true"`
+	Name     string `long:"name" optional:"true"`
+	LinkTo   string `long:"linkto" optional:"true"`
+	LinkBy   int64  `long:"linkby" optional:"true"`
+	Category string `long:"category" optional:"true"`
 
 	// Random can be used in place of editing proposal name & data. When
 	// specified, random proposal name & data will be created and submitted.
@@ -166,6 +167,9 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 	}
 	if cmd.LinkTo != "" {
 		pm.LinkTo = cmd.LinkTo
+	}
+	if cmd.Category != "" {
+		pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -26,9 +26,10 @@ type NewProposalCmd struct {
 		Markdown    string   `positional-arg-name:"markdownfile"`
 		Attachments []string `positional-arg-name:"attachmentfiles"`
 	} `positional-args:"true" optional:"true"`
-	Name   string `long:"name" optional:"true"`
-	LinkTo string `long:"linkto" optional:"true"`
-	LinkBy int64  `long:"linkby" optional:"true"`
+	Name     string `long:"name" optional:"true"`
+	LinkTo   string `long:"linkto" optional:"true"`
+	LinkBy   int64  `long:"linkby" optional:"true"`
+	Category string `long:"category" optional:"true"`
 
 	// Random can be used in place of submitting proposal files. When
 	// specified, random proposal data will be created and submitted.
@@ -144,6 +145,9 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		Name:   cmd.Name,
 		LinkTo: cmd.LinkTo,
 		LinkBy: cmd.LinkBy,
+	}
+	if cmd.Category != "" {
+		pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -26,10 +26,10 @@ type NewProposalCmd struct {
 		Markdown    string   `positional-arg-name:"markdownfile"`
 		Attachments []string `positional-arg-name:"attachmentfiles"`
 	} `positional-args:"true" optional:"true"`
-	Name     string `long:"name" optional:"true"`
-	LinkTo   string `long:"linkto" optional:"true"`
-	LinkBy   int64  `long:"linkby" optional:"true"`
-	Category string `long:"category" optional:"true"`
+	Name     string       `long:"name" optional:"true"`
+	LinkTo   string       `long:"linkto" optional:"true"`
+	LinkBy   int64        `long:"linkby" optional:"true"`
+	Category v1.CategoryT `long:"category" optional:"true"` // Proposal category
 
 	// Random can be used in place of submitting proposal files. When
 	// specified, random proposal data will be created and submitted.
@@ -146,7 +146,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		LinkTo: cmd.LinkTo,
 		LinkBy: cmd.LinkBy,
 	}
-	if cmd.Category != "" {
+	if cmd.Category != 0 {
 		pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/decred/politeia/politeiad/api/v1/mime"
@@ -148,24 +147,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		LinkBy: cmd.LinkBy,
 	}
 	if cmd.Category != "" {
-		// Create inverse categories map from policy for validation
-		PropCategories := make(map[string]v1.CategoryT)
-		for k, v := range v1.PolicyProposalCategories {
-			PropCategories[v] = k
-		}
-		// Parse proposal category. Accepts either the numeric category
-		// code or the human readable equivalent
-		c, err := strconv.ParseUint(cmd.Category, 10, 32)
-		if err == nil {
-			// Numeric category code found
-			pm.Category = v1.CategoryT(c)
-		} else if c, ok := PropCategories[cmd.Category]; ok {
-			// Human readable category found
-			pm.Category = c
-		} else {
-			return fmt.Errorf("Invalid proposal category '%v'. Please check "+
-				"policy for further guidance.", pm.Category)
-		}
+		pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {

--- a/politeiawww/config.go
+++ b/politeiawww/config.go
@@ -79,11 +79,18 @@ const (
 )
 
 var (
-	defaultHTTPSKeyFile  = filepath.Join(sharedconfig.DefaultHomeDir, "https.key")
-	defaultHTTPSCertFile = filepath.Join(sharedconfig.DefaultHomeDir, "https.cert")
-	defaultRPCCertFile   = filepath.Join(sharedconfig.DefaultHomeDir, "rpc.cert")
-	defaultCookieKeyFile = filepath.Join(sharedconfig.DefaultHomeDir, "cookie.key")
-	defaultLogDir        = filepath.Join(sharedconfig.DefaultHomeDir, defaultLogDirname)
+	defaultHTTPSKeyFile       = filepath.Join(sharedconfig.DefaultHomeDir, "https.key")
+	defaultHTTPSCertFile      = filepath.Join(sharedconfig.DefaultHomeDir, "https.cert")
+	defaultRPCCertFile        = filepath.Join(sharedconfig.DefaultHomeDir, "rpc.cert")
+	defaultCookieKeyFile      = filepath.Join(sharedconfig.DefaultHomeDir, "cookie.key")
+	defaultLogDir             = filepath.Join(sharedconfig.DefaultHomeDir, defaultLogDirname)
+	defaultProposalCategories = []string{
+		"development",
+		"marketing",
+		"research",
+		"design",
+		"documentation",
+	}
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -142,6 +149,7 @@ type config struct {
 	SMTPSkipVerify           bool   `long:"smtpskipverify" description:"Skip SMTP TLS cert verification. Will only skip if SMTPCert is empty"`
 	SMTPCert                 string `long:"smtpcert" description:"File containing the smtp certificate file"`
 	SystemCerts              *x509.CertPool
+	ProposalCategories       []string `long:"proposalcategories" description:"Available proposal categories (comma-separated)"`
 }
 
 // serviceOptions defines the configuration options for the rpc as a service
@@ -854,6 +862,13 @@ func loadConfig() (*config, []string, error) {
 		if cfg.SMTPSkipVerify {
 			log.Warnf("SMTPCert has been set so SMTPSkipVerify is being disregarded.")
 		}
+	}
+
+	// Parse comma-separated proposal categories
+	if len(cfg.ProposalCategories) != 0 {
+		cfg.ProposalCategories = strings.Split(cfg.ProposalCategories[0], ",")
+	} else {
+		cfg.ProposalCategories = defaultProposalCategories
 	}
 
 	return &cfg, remainingArgs, nil

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -534,6 +534,7 @@ func convertPropFromCache(r cache.Record) (*www.ProposalRecord, error) {
 		LinkTo:              pm.LinkTo,
 		LinkBy:              pm.LinkBy,
 		LinkedFrom:          []string{},
+		Category:            pm.Category,
 		Files:               files,
 		Metadata:            metadata,
 		CensorshipRecord: www.CensorshipRecord{

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -366,7 +366,7 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		MaxLinkByPeriod:            p.linkByPeriodMax(),
 		MinVoteDuration:            p.cfg.VoteDurationMin,
 		MaxVoteDuration:            p.cfg.VoteDurationMax,
-		ProposalCategories:         www.PolicyProposalCategories,
+		ProposalCategories:         p.cfg.ProposalCategories,
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -366,6 +366,7 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		MaxLinkByPeriod:            p.linkByPeriodMax(),
 		MinVoteDuration:            p.cfg.VoteDurationMin,
 		MaxVoteDuration:            p.cfg.VoteDurationMax,
+		ProposalCategories:         www.PolicyProposalCategories,
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -308,11 +308,17 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 	}
 
 	// Validate Category
-	if pm.Category != 0 {
-		_, ok := www.PolicyProposalCategories[pm.Category]
+	if pm.Category != "" {
+		ok := false
+		for _, c := range www.PolicyProposalCategories {
+			if c == pm.Category {
+				ok = true
+			}
+		}
 		if !ok {
 			return www.UserError{
-				ErrorCode: www.ErrorStatusInvalidProposalCategory,
+				ErrorCode:    www.ErrorStatusInvalidProposalCategory,
+				ErrorContext: []string{pm.Category},
 			}
 		}
 	}

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -307,6 +307,22 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 		}
 	}
 
+	// Validate Category
+	if pm.Category != "" {
+		ok := false
+		for _, c := range www.PolicyProposalCategories {
+			if c == pm.Category {
+				ok = true
+			}
+		}
+		if !ok {
+			return www.UserError{
+				ErrorCode:    www.ErrorStatusInvalidProposalCategory,
+				ErrorContext: []string{pm.Category},
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -308,17 +308,11 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 	}
 
 	// Validate Category
-	if pm.Category != "" {
-		ok := false
-		for _, c := range www.PolicyProposalCategories {
-			if c == pm.Category {
-				ok = true
-			}
-		}
+	if pm.Category != 0 {
+		_, ok := www.PolicyProposalCategories[pm.Category]
 		if !ok {
 			return www.UserError{
-				ErrorCode:    www.ErrorStatusInvalidProposalCategory,
-				ErrorContext: []string{pm.Category},
+				ErrorCode: www.ErrorStatusInvalidProposalCategory,
 			}
 		}
 	}

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -310,7 +310,7 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 	// Validate Category
 	if pm.Category != "" {
 		ok := false
-		for _, c := range www.PolicyProposalCategories {
+		for _, c := range p.cfg.ProposalCategories {
 			if c == pm.Category {
 				ok = true
 			}


### PR DESCRIPTION
This diff adds a user-defined metadata regarding a category for the proposal. Valid categories are pre-defined in www's api and returned by the policy call.

Closes #1192  