### PR TITLE
piwww: Update editproposal command.

### DIFF
--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -62,7 +62,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		return shared.ErrUserIdentityNotFound
 	}
 
-	// Rfp & linkby flags conflict
+	// RFP & linkby flags conflict
 	if cmd.RFP && cmd.LinkBy != 0 {
 		return errEditProposalRfpAndLinkbyFound
 	}

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/decred/politeia/politeiad/api/v1/mime"
+
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 	"github.com/decred/politeia/util"
@@ -70,6 +71,17 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		}
 
 		md = b.Bytes()
+
+		// Check if cachedpropsoal got a linkto
+		// Get proposal
+		pdr, err := client.ProposalDetails(cmd.Args.Token,
+			&v1.ProposalsDetails{})
+		if err != nil {
+			return err
+		}
+		if pdr.Proposal.LinkTo != "" {
+			cmd.LinkTo = pdr.Proposal.LinkTo
+		}
 	} else {
 		// Read markdown file into memory and convert to type File
 		fpath := util.CleanAndExpandPath(mdFile)

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -118,10 +118,12 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		if err != nil {
 			return err
 		}
-		if pdr.Proposal.Name != "" {
+		// If name or linkto not provided
+		// use existing metadata
+		if pdr.Proposal.Name != "" && cmd.Name == "" {
 			cmd.Name = pdr.Proposal.Name
 		}
-		if pdr.Proposal.LinkTo != "" {
+		if pdr.Proposal.LinkTo != "" && cmd.LinkTo == "" {
 			cmd.LinkTo = pdr.Proposal.LinkTo
 		}
 

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -133,6 +133,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 
 		files = append(files, f)
 	}
+
 	// Setup metadata
 	var pm v1.ProposalMetadata
 

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -62,14 +62,12 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		return shared.ErrUserIdentityNotFound
 	}
 
-	// Both rfp & linkby flags used
-	// throw error
+	// Rfp & linkby flags conflict
 	if cmd.RFP && cmd.LinkBy != 0 {
 		return errEditProposalRfpAndLinkbyFound
 	}
 
-	// Both random & name flags used
-	// throw error
+	// Random & name flags conflict
 	if cmd.Random && cmd.Name != "" {
 		return errEditProposalRandomAndNameFound
 	}
@@ -137,29 +135,27 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 	// Setup metadata
 	var pm v1.ProposalMetadata
 
-	// Use existing metadata flag is true
-	// fetch record and pre-fill data
 	if cmd.UseMd {
 		pdr, err := client.ProposalDetails(cmd.Args.Token,
 			&v1.ProposalsDetails{})
 		if err != nil {
 			return err
 		}
+		// Prefill exisitng metadata
 		pm.Name = pdr.Proposal.Name
 		pm.LinkTo = pdr.Proposal.LinkTo
 		pm.LinkBy = pdr.Proposal.LinkBy
 	}
 	if cmd.Random {
-		// generate random name
+		// Generate random name
 		r, err := util.Random(v1.PolicyMinProposalNameLength)
 		if err != nil {
 			return err
 		}
 		pm.Name = hex.EncodeToString(r)
 	}
-	// If RFP flag is true
-	// set linkby to a month from now
 	if cmd.RFP {
+		// Set linkby to a month from now
 		pm.LinkBy = time.Now().Add(time.Hour * 24 * 30).Unix()
 	}
 	if cmd.Name != "" {

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -141,7 +141,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		if err != nil {
 			return err
 		}
-		// Prefill exisitng metadata
+		// Prefill existing metadata
 		pm.Name = pdr.Proposal.Name
 		pm.LinkTo = pdr.Proposal.LinkTo
 		pm.LinkBy = pdr.Proposal.LinkBy

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -124,7 +124,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 	// Setup metadata
 	pm := v1.ProposalMetadata{}
 
-	// Use exisitng metadata flag is true
+	// Use existing metadata flag is true
 	// fetch record and pre-fill data
 	if cmd.Usemd {
 		pdr, err := client.ProposalDetails(cmd.Args.Token,

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/decred/politeia/politeiad/api/v1/mime"
-
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 	"github.com/decred/politeia/util"
@@ -24,15 +23,28 @@ import (
 // EditProposalCmd edits an existing proposal.
 type EditProposalCmd struct {
 	Args struct {
-		Token       string   `positional-arg-name:"token" required:"true"` // Censorship token
-		Markdown    string   `positional-arg-name:"markdownfile"`          // Proposal MD file
-		Attachments []string `positional-arg-name:"attachmentfiles"`       // Proposal attachments
+		Token       string   `positional-arg-name:"token" required:"true"`
+		Markdown    string   `positional-arg-name:"markdownfile"`
+		Attachments []string `positional-arg-name:"attachmentfiles"`
 	} `positional-args:"true" optional:"true"`
-	Random bool   `long:"random" optional:"true"` // Generate random proposal data
 	Name   string `long:"name" optional:"true"`
-	RFP    bool   `long:"rfp" optional:"true"`    // Insert a LinkBy timestamp to indicate an RFP
-	LinkTo string `long:"linkto" optional:"true"` // Censorship token of prop to link to
-	LinkBy int64  `long:"linkby" optional:"true"` // UNIX timestamp of RFP deadline
+	LinkTo string `long:"linkto" optional:"true"`
+	LinkBy int64  `long:"linkby" optional:"true"`
+
+	// Random can be used in place of editing proposal name & data. When
+	// specified, random proposal name & data will be created and submitted.
+	Random bool `long:"random" optional:"true"`
+
+	// RFP is a flag that is intended to make editing an RFP easier
+	// by calculating and inserting a linkby timestamp automatically
+	// instead of having to pass in a specific timestamp using the
+	// --linkby flag.
+	RFP bool `long:"rfp" optional:"true"`
+
+	// Usemd is a flag that is intended to make editing propsoal metadata easier
+	// by using exisiting proposal metadata values instead of having to pass in
+	// specific values
+	Usemd bool `long:"usemd" optional:"true"`
 }
 
 // Execute executes the edit proposal command.
@@ -40,7 +52,6 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 	token := cmd.Args.Token
 	mdFile := cmd.Args.Markdown
 	attachmentFiles := cmd.Args.Attachments
-	var pm v1.ProposalMetadata
 
 	if !cmd.Random && mdFile == "" {
 		return errProposalMDNotFound
@@ -111,56 +122,56 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		files = append(files, f)
 	}
 	// Setup metadata
-	if cmd.Random {
-		// Check if cachedpropsoal got a linkto
-		// Get proposal
+	pm := v1.ProposalMetadata{}
+
+	// Use exisitng metadata flag is true
+	// fetch record and pre-fill data
+	if cmd.Usemd {
 		pdr, err := client.ProposalDetails(cmd.Args.Token,
 			&v1.ProposalsDetails{})
 		if err != nil {
 			return err
 		}
-		// If name or linkto not provided
-		// use existing metadata
-		if pdr.Proposal.Name != "" && cmd.Name == "" {
-			cmd.Name = pdr.Proposal.Name
+		pm.Name = pdr.Proposal.Name
+		if pdr.Proposal.LinkTo != "" {
+			pm.LinkTo = pdr.Proposal.LinkTo
 		}
-		if pdr.Proposal.LinkTo != "" && cmd.LinkTo == "" {
-			cmd.LinkTo = pdr.Proposal.LinkTo
+		if pdr.Proposal.LinkBy != 0 {
+			pm.LinkBy = pdr.Proposal.LinkBy
 		}
-		if pdr.Proposal.LinkBy != 0 && cmd.LinkBy == 0 {
-			cmd.LinkBy = pdr.Proposal.LinkBy
+	}
+	if cmd.Random {
+		// Both random & name flags used
+		// throw error
+		if cmd.Name != "" {
+			return errEditProposalRandomAndNameFound
 		}
 
-		pm = v1.ProposalMetadata{
-			Name:   cmd.Name,
-			LinkTo: cmd.LinkTo,
-			LinkBy: cmd.LinkBy,
+		// generate random name
+		r, err := util.Random(v1.PolicyMinProposalNameLength)
+		if err != nil {
+			return err
 		}
-	} else {
-		if cmd.Name == "" {
-			r, err := util.Random(v1.PolicyMinProposalNameLength)
-			if err != nil {
-				return err
-			}
-			cmd.Name = hex.EncodeToString(r)
-		}
-		pm = v1.ProposalMetadata{
-			Name: cmd.Name,
-		}
-		if cmd.RFP {
-			if cmd.LinkBy != 0 {
-				pm.LinkBy = cmd.LinkBy
-			} else {
-				// If not provided, set linkby to a month from now
-				pm.LinkBy = time.Now().Add(time.Hour * 24 * 30).Unix()
-			}
-		}
-		if cmd.LinkTo != "" {
-			pm.LinkTo = cmd.LinkTo
-		}
+		pm.Name = hex.EncodeToString(r)
+	}
+	// If RFP flag is true
+	// set linkby to a month from now
+	if cmd.RFP {
+		// Both rfp & linkby flags used
+		// throw error
 		if cmd.LinkBy != 0 {
-			pm.LinkBy = cmd.LinkBy
+			return errEditProposalRfpAndLinkbyFound
 		}
+		pm.LinkBy = time.Now().Add(time.Hour * 24 * 30).Unix()
+	}
+	if cmd.Name != "" {
+		pm.Name = cmd.Name
+	}
+	if cmd.LinkBy != 0 {
+		pm.LinkBy = cmd.LinkBy
+	}
+	if cmd.LinkTo != "" {
+		pm.LinkTo = cmd.LinkTo
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {
@@ -224,12 +235,19 @@ Arguments:
 3. attachmentfiles   (string, optional)   Attachments 
 
 Flags:
-  --random   (bool, optional)    Generate a random proposal to submit
-  --rfp      (bool, optional)    Make the proposal an RFP by inserting a LinkBy timestamp into the
-                                 proposal data JSON file. The LinkBy timestamp is set to be one
-                                 week from the current time.
-  --linkto   (string, optional)  Token of an existing public proposal to link to. The token is
-                                 used to populate the LinkTo field in the proposal data JSON file.
+  --random   (bool, optional)   Generate a random proposal name & files to submit.
+								If this flag is used then the markdown file 
+								argument is no longer required and any provided files will be
+                              	ignored.
+  --usemd    (bool, optional)   Use the existing metadata if value isn't provided explicitly.
+  --name   (string, optional)   The name of the proposal
+  --linkto (string, optional)   Token of an existing public proposal to link to. The token is
+								used to populate the LinkTo field in the proposal data JSON file.
+  --linkby  (int64, optional)   UNIX timestamp of RFP deadline.
+  --rfp      (bool, optional)   Make the proposal an RFP by inserting a LinkBy timestamp into the
+                                proposal data JSON file. The LinkBy timestamp is set to be one
+								month from the current time.
+								This is intended to be used in place of --linkby.
 
 Request:
 {

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -43,6 +43,12 @@ var (
 	errProposalMDNotFound = errors.New("proposal markdown file not " +
 		"found; you must either provide a markdown file or use the " +
 		"flag --random")
+	// errEditProposalRandomAndNameFound is emitted when both --name
+	// and --random flags found in editproposal command
+	errEditProposalRandomAndNameFound = errors.New("Please use either --random or --name")
+	// errEditProposalRfpAndLinkbyFound is emitted when both --rfp
+	// and --linkby flags found in editproposal command
+	errEditProposalRfpAndLinkbyFound = errors.New("Please use either --rfp or --linby")
 )
 
 type piwww struct {

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -45,10 +45,13 @@ var (
 		"flag --random")
 	// errEditProposalRandomAndNameFound is emitted when both --name
 	// and --random flags found in editproposal command
-	errEditProposalRandomAndNameFound = errors.New("Please use either --random or --name")
+	errEditProposalRandomAndNameFound = errors.New("--random and --name " +
+		"can't be used together, as --random generates a random name")
 	// errEditProposalRfpAndLinkbyFound is emitted when both --rfp
 	// and --linkby flags found in editproposal command
-	errEditProposalRfpAndLinkbyFound = errors.New("Please use either --rfp or --linby")
+	errEditProposalRfpAndLinkbyFound = errors.New("--rfp and --linkby can't " +
+		"be used together, as --rfp sets the linkby one month " +
+		"from now")
 )
 
 type piwww struct {

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1770,12 +1770,6 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		}
 	}
 
-	// if cached propsoal includes linkto & new proposal doesn't
-	// then use cached proposal linkto
-	if cachedProp.LinkTo != "" && pm.LinkTo == "" {
-		pm.LinkTo = cachedProp.LinkTo
-	}
-
 	// politeiad only includes files in its merkle root calc, not the
 	// metadata streams. This is why we include the ProposalMetadata
 	// as a politeiad file.

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -1770,6 +1770,12 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		}
 	}
 
+	// if cached propsoal includes linkto & new proposal doesn't
+	// then use cached proposal linkto
+	if cachedProp.LinkTo != "" && pm.LinkTo == "" {
+		pm.LinkTo = cachedProp.LinkTo
+	}
+
 	// politeiad only includes files in its merkle root calc, not the
 	// metadata streams. This is why we include the ProposalMetadata
 	// as a politeiad file.


### PR DESCRIPTION
This diff introduces new flags: `usemd` & `linkby` to the editproposal command & adjusts the help message accordingly.
When `usemd` provided existing metadata then used as starting point and can be overwritten by providing specific value flags.
In addition, it prevents users from misusing the flags and throwing new errors when:
 - `--random` is used with `--name`.
 - `--rfp` is used with `--linkby`.

Closes #1196 