### PR TITLE
[cms] Update AdminInvoices to Invoices

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -15,7 +15,7 @@ server side notifications.  It does not render HTML.
     - [`New invoice`](#new-invoice)
     - [`User invoices`](#user-invoices)
     - [`Set invoice status`](#set-invoice-status)
-    - [`Admin invoices`](#admin-invoices)
+    - [`Invoices`](#invoices)
     - [`Edit invoice`](#edit-invoice)
     - [`Generate payouts`](#generate-payouts)
     - [`Support/Oppose DCC`](#supportoppose-dcc)
@@ -321,21 +321,36 @@ Reply:
 }
 ```
 
-### `Admin invoices`
+### `Invoices`
 
-Retrieve a page of invoices given the month and year and status.
+This request allows administrators or invoice owners to have full view of any 
+of their past invoices.  Users of the same domain may be able to see limited
+information from the invoices.  This will allow for inter-domain checks and
+auditing of invoices.  All private infomation will be hidden to non-admins or
+invoice owners (rates, expenses, payouts, address, locations etc).  This will be
+merely used to audit hours billed.
 
-Note: This call requires admin privileges.
+There are a few optional parameters that are available to ease searching:
+Month/Year will return all the invoices submitted for that month, Status
+will return all invoices of that status. UserID will only return invoices that
+are owned by that userid and start time/end time will return all invoices that
+were submitted in that date range.  Note: There is a max page size for date
+range requests.
 
-**Route:** `POST /v1/admin/invoices`
+
+**Route:** `POST /v1/invoices`
 
 **Params:**
 
 | Parameter | Type | Description | Required |
 |-|-|-|-|
-| month | int16 | An optional filter that can be set (along with year) to return invoices from a given month, from 1 to 12. | |
-| year | int16 | An optional filter that can be set (along with month) to return invoices from a given year. | |
-| status | int64 | An optional filter for the list; this should be an [invoice status](#invoice-status-codes). | |
+| month | int16 | An optional filter that can be set (along with year) to return invoices from a given month, from 1 to 12. | No |
+| year | int16 | An optional filter that can be set (along with month) to return invoices from a given year. | No |
+| status | int64 | An optional filter for the list; this should be an [invoice status](#invoice-status-codes). | No |
+| starttime | int64 | An optional filter that can be set with endtime for date range of submitted invoices. | No |
+| endtime | int64 | An optional filter that can be set with starttime for date range of submitted invoices. | No |
+| userid | int64 | An optional filter that can be set to return invoices that only match the provided userid. | No |
+
 
 **Results:**
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -181,6 +181,11 @@ const (
 	// summaries.
 	ProposalBillingListPageSize = 50
 
+	// InvoiceListPageSize is the maximum number of invoices returned by the
+	// Invoices request, the date range should just be updated to return them
+	// all.
+	InvoiceListPageSize = 50
+
 	ErrorStatusMalformedName                  www.ErrorStatusT = 1001
 	ErrorStatusMalformedLocation              www.ErrorStatusT = 1002
 	ErrorStatusInvoiceNotFound                www.ErrorStatusT = 1003

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -539,11 +539,15 @@ type UserInvoicesReply struct {
 	Invoices []InvoiceRecord `json:"invoices"`
 }
 
-// AdminInvoices is used to get all invoices from all users
+// AdminInvoices is used to get all invoices from all users (if no userid is
+// given).
 type AdminInvoices struct {
-	Month  uint16         `json:"month"`  // Month of Invoice
-	Year   uint16         `json:"year"`   // Year of Invoice
-	Status InvoiceStatusT `json:"status"` // Current status of invoice
+	Month     uint16         `json:"month"`  // Month of Invoice
+	Year      uint16         `json:"year"`   // Year of Invoice
+	Status    InvoiceStatusT `json:"status"` // Current status of invoice
+	UserID    string         `json:"userid"` // User ID for invoices to return
+	StartTime int64          `json:"start"`  // Start time for range
+	EndTime   int64          `json:"end"`    // End time for range
 }
 
 // AdminInvoicesReply is used to reply to an admin invoices command.

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -551,8 +551,8 @@ type Invoices struct {
 	Year      uint16         `json:"year"`   // Year of Invoice
 	Status    InvoiceStatusT `json:"status"` // Current status of invoice
 	UserID    string         `json:"userid"` // User ID for invoices to return
-	StartTime int64          `json:"start"`  // Start time for range
-	EndTime   int64          `json:"end"`    // End time for range
+	StartTime int64          `json:"start"`  // Start time for range of invoice submission
+	EndTime   int64          `json:"end"`    // End time for range of invoice submission
 }
 
 // InvoicesReply is used to reply to an admin invoices command.

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -42,7 +42,7 @@ const (
 	RouteVoteDetailsDCC         = "/dcc/votedetails"
 	RouteActiveVotesDCC         = "/dcc/activevotes"
 	RouteStartVoteDCC           = "/dcc/startvote"
-	RouteAdminInvoices          = "/admin/invoices"
+	RouteInvoices               = "/invoices"
 	RouteManageCMSUser          = "/admin/managecms"
 	RouteAdminUserInvoices      = "/admin/userinvoices"
 	RouteGeneratePayouts        = "/admin/generatepayouts"
@@ -539,9 +539,9 @@ type UserInvoicesReply struct {
 	Invoices []InvoiceRecord `json:"invoices"`
 }
 
-// AdminInvoices is used to get all invoices from all users (if no userid is
+// Invoices is used to get all invoices from all users (if no userid is
 // given).
-type AdminInvoices struct {
+type Invoices struct {
 	Month     uint16         `json:"month"`  // Month of Invoice
 	Year      uint16         `json:"year"`   // Year of Invoice
 	Status    InvoiceStatusT `json:"status"` // Current status of invoice
@@ -550,8 +550,8 @@ type AdminInvoices struct {
 	EndTime   int64          `json:"end"`    // End time for range
 }
 
-// AdminInvoicesReply is used to reply to an admin invoices command.
-type AdminInvoicesReply struct {
+// InvoicesReply is used to reply to an admin invoices command.
+type InvoicesReply struct {
 	Invoices []InvoiceRecord `json:"invoices"`
 }
 

--- a/politeiawww/cmd/cmswww/admininvoices.go
+++ b/politeiawww/cmd/cmswww/admininvoices.go
@@ -7,12 +7,12 @@ package main
 import (
 	"fmt"
 
-	"github.com/decred/politeia/politeiawww/api/cms/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/cms/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 )
 
-// AdminInvoicesCmd gets all invoices by month/year and/or status.
-type AdminInvoicesCmd struct {
+// InvoicesCmd gets all invoices by month/year and/or status.
+type InvoicesCmd struct {
 	Args struct {
 		Month  int `long:"month"`
 		Year   int `long:"year"`
@@ -21,7 +21,7 @@ type AdminInvoicesCmd struct {
 }
 
 // Execute executes the admin invoices command.
-func (cmd *AdminInvoicesCmd) Execute(args []string) error {
+func (cmd *InvoicesCmd) Execute(args []string) error {
 	// Get server public key
 	vr, err := client.Version()
 	if err != nil {
@@ -29,8 +29,8 @@ func (cmd *AdminInvoicesCmd) Execute(args []string) error {
 	}
 
 	// Get admin invoices
-	uir, err := client.AdminInvoices(
-		&v1.AdminInvoices{
+	uir, err := client.Invoices(
+		&v1.Invoices{
 			Month:  uint16(cmd.Args.Month),
 			Year:   uint16(cmd.Args.Year),
 			Status: v1.InvoiceStatusT(cmd.Args.Status),

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -56,7 +56,6 @@ type cmswww struct {
 
 	// Commands
 	ActiveVotes            ActiveVotesCmd            `command:"activevotes" description:"(user) get the dccs that are being voted on"`
-	AdminInvoices          AdminInvoicesCmd          `command:"admininvoices" description:"(admin)  get all invoices (optional by month/year and/or status)"`
 	BatchProposals         shared.BatchProposalsCmd  `command:"batchproposals" description:"(user)   retrieve a set of proposals"`
 	CensorComment          shared.CensorCommentCmd   `command:"censorcomment" description:"(admin)  censor a comment"`
 	ChangePassword         shared.ChangePasswordCmd  `command:"changepassword" description:"(user)   change the password for the logged in user"`
@@ -74,6 +73,7 @@ type cmswww struct {
 	InviteNewUser          InviteNewUserCmd          `command:"invite" description:"(admin)  invite a new user"`
 	InvoiceDetails         InvoiceDetailsCmd         `command:"invoicedetails" description:"(public) get the details of a proposal"`
 	InvoicePayouts         InvoicePayoutsCmd         `command:"invoicepayouts" description:"(admin)  generate paid invoice list for a given date range"`
+	Invoices               InvoicesCmd               `command:"invoices" description:"(user)  get all invoices (optional with optional parameters)"`
 	Login                  shared.LoginCmd           `command:"login" description:"(public) login to Politeia"`
 	Logout                 shared.LogoutCmd          `command:"logout" description:"(public) logout of Politeia"`
 	CMSManageUser          CMSManageUserCmd          `command:"cmsmanageuser" description:"(admin)  edit certain properties of the specified user"`

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -944,19 +944,19 @@ func (c *Client) ProposalBillingSummary(pbd *cms.ProposalBillingSummary) (*cms.P
 	return &pbdr, nil
 }
 
-// AdminInvoices retrieves invoices base on possible field set in the request
+// Invoices retrieves invoices base on possible field set in the request
 // month/year and/or status
-func (c *Client) AdminInvoices(ai *cms.AdminInvoices) (*cms.AdminInvoicesReply, error) {
+func (c *Client) Invoices(ai *cms.Invoices) (*cms.InvoicesReply, error) {
 	responseBody, err := c.makeRequest(http.MethodPost,
-		cms.APIRoute, cms.RouteAdminInvoices, ai)
+		cms.APIRoute, cms.RouteInvoices, ai)
 	if err != nil {
 		return nil, err
 	}
 
-	var air cms.AdminInvoicesReply
+	var air cms.InvoicesReply
 	err = json.Unmarshal(responseBody, &air)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal AdminInvoicesReply: %v", err)
+		return nil, fmt.Errorf("unmarshal InvoicesReply: %v", err)
 	}
 
 	if c.cfg.Verbose {

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -344,7 +344,7 @@ func (c *cockroachdb) ExchangeRate(month, year int) (*database.ExchangeRate, err
 func (c *cockroachdb) InvoicesByDateRangeStatus(start, end int64, status int) ([]database.Invoice, error) {
 	log.Debugf("InvoicesByDateRangeStatus: %v %v", time.Unix(start, 0),
 		time.Unix(end, 0))
-	// Get all invoice changes of PAID status within date range.
+	// Get all invoice changes of given status within date range.
 	invoiceChanges := make([]InvoiceChange, 0, 1024) // PNOOMA
 	err := c.recordsdb.
 		Where("new_status = ? AND "+
@@ -390,10 +390,12 @@ func (c *cockroachdb) InvoicesByDateRangeStatus(start, end int64, status int) ([
 func (c *cockroachdb) InvoicesByDateRange(start, end int64) ([]database.Invoice, error) {
 	log.Debugf("InvoicesByDateRange: %v %v", time.Unix(start, 0),
 		time.Unix(end, 0))
-	// Get all invoice changes of PAID status within date range.
+	// Get all invoice changes of NEW status within date range.
 	invoiceChanges := make([]InvoiceChange, 0, 1024) // PNOOMA
 	err := c.recordsdb.
-		Where("timestamp BETWEEN ? AND ?",
+		Where("new_status = ? AND"+
+			"timestamp BETWEEN ? AND ?",
+			v1.InvoiceStatusNew,
 			time.Unix(start, 0),
 			time.Unix(end, 0)).
 		Find(&invoiceChanges).

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -53,7 +53,8 @@ type Database interface {
 	InvoicesByMonthYear(uint16, uint16) ([]Invoice, error)            // Returns all invoice by month, year
 	InvoicesByStatus(int) ([]Invoice, error)                          // Returns all invoices by status
 	InvoicesAll() ([]Invoice, error)                                  // Returns all invoices
-	InvoicesByDateRangeStatus(int64, int64, int) ([]*Invoice, error)  // Returns all paid invoice line items from range provided
+	InvoicesByDateRangeStatus(int64, int64, int) ([]Invoice, error)   // Returns all paid invoice line items from range provided
+	InvoicesByDateRange(int64, int64) ([]Invoice, error)              // Returns all invoices from range provided
 	InvoicesByLineItemsProposalToken(string) ([]*Invoice, error)      // Returns all Invoices with paid line item information based on proposal token.
 
 	// ExchangeRate functions

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -228,7 +228,14 @@ func (p *politeiawww) handleAdminInvoices(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	reply, err := p.processAdminInvoices(ai)
+	user, err := p.getSessionUser(w, r)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"handleAdminInvoices: getSessionUser %v", err)
+		return
+	}
+
+	reply, err := p.processAdminInvoices(ai, user)
 	if err != nil {
 		RespondWithError(w, r, 0, "handleAdminInvoices: processAdminInvoices %v", err)
 		return
@@ -1133,6 +1140,9 @@ func (p *politeiawww) setCMSWWWRoutes() {
 	p.addRoute(http.MethodGet, cms.APIRoute,
 		cms.RouteUserInvoices, p.handleUserInvoices,
 		permissionLogin)
+	p.addRoute(http.MethodPost, cms.APIRoute,
+		cms.RouteAdminInvoices, p.handleAdminInvoices,
+		permissionLogin)
 	p.addRoute(http.MethodGet, cms.APIRoute,
 		cms.RouteInvoiceComments, p.handleInvoiceComments,
 		permissionLogin)
@@ -1197,9 +1207,6 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		permissionAdmin)
 	p.addRoute(http.MethodPost, www.PoliteiaWWWAPIRoute,
 		www.RouteCensorComment, p.handleCensorComment,
-		permissionAdmin)
-	p.addRoute(http.MethodPost, cms.APIRoute,
-		cms.RouteAdminInvoices, p.handleAdminInvoices,
 		permissionAdmin)
 	p.addRoute(http.MethodPost, cms.APIRoute,
 		cms.RouteSetInvoiceStatus, p.handleSetInvoiceStatus,

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -215,14 +215,14 @@ func (p *politeiawww) handleSetInvoiceStatus(w http.ResponseWriter, r *http.Requ
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
 
-// handleAdminInvoices handles the request to get all of the  of a new contractor by an
+// handleInvoices handles the request to get all of the  of a new contractor by an
 // administrator for the Contractor Management System.
-func (p *politeiawww) handleAdminInvoices(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("handleAdminInvoices")
-	var ai cms.AdminInvoices
+func (p *politeiawww) handleInvoices(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleInvoices")
+	var ai cms.Invoices
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&ai); err != nil {
-		RespondWithError(w, r, 0, "handleAdminInvoices: unmarshal", www.UserError{
+		RespondWithError(w, r, 0, "handleInvoices: unmarshal", www.UserError{
 			ErrorCode: www.ErrorStatusInvalidInput,
 		})
 		return
@@ -231,13 +231,13 @@ func (p *politeiawww) handleAdminInvoices(w http.ResponseWriter, r *http.Request
 	user, err := p.getSessionUser(w, r)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"handleAdminInvoices: getSessionUser %v", err)
+			"handleInvoices: getSessionUser %v", err)
 		return
 	}
 
-	reply, err := p.processAdminInvoices(ai, user)
+	reply, err := p.processInvoices(ai, user)
 	if err != nil {
-		RespondWithError(w, r, 0, "handleAdminInvoices: processAdminInvoices %v", err)
+		RespondWithError(w, r, 0, "handleInvoices: processInvoices %v", err)
 		return
 	}
 
@@ -304,7 +304,7 @@ func (p *politeiawww) handleGeneratePayouts(w http.ResponseWriter, r *http.Reque
 
 	reply, err := p.processGeneratePayouts(gp, user)
 	if err != nil {
-		RespondWithError(w, r, 0, "handleGeneratePayouts: processAdminInvoices %v", err)
+		RespondWithError(w, r, 0, "handleGeneratePayouts: processGeneratePayouts %v", err)
 		return
 	}
 
@@ -1141,7 +1141,7 @@ func (p *politeiawww) setCMSWWWRoutes() {
 		cms.RouteUserInvoices, p.handleUserInvoices,
 		permissionLogin)
 	p.addRoute(http.MethodPost, cms.APIRoute,
-		cms.RouteAdminInvoices, p.handleAdminInvoices,
+		cms.RouteInvoices, p.handleInvoices,
 		permissionLogin)
 	p.addRoute(http.MethodGet, cms.APIRoute,
 		cms.RouteInvoiceComments, p.handleInvoiceComments,

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -835,8 +835,8 @@ func convertRecordFilesToWWW(f []pd.File) []www.File {
 	return files
 }
 
-func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) *cms.InvoiceRecord {
-	invRec := &cms.InvoiceRecord{}
+func convertDatabaseInvoiceToInvoiceRecord(dbInvoice cmsdatabase.Invoice) cms.InvoiceRecord {
+	invRec := cms.InvoiceRecord{}
 	invRec.Status = dbInvoice.Status
 	invRec.Timestamp = dbInvoice.Timestamp
 	invRec.UserID = dbInvoice.UserID
@@ -1800,4 +1800,20 @@ func convertStartVoteToCMS(sv cms.StartVote) cmsplugin.StartVote {
 		Signature: sv.Signature,
 	}
 
+}
+
+func filterDomainInvoice(inv *cms.InvoiceRecord) cms.InvoiceRecord {
+	inv.Files = nil
+	inv.Input.ContractorContact = ""
+	inv.Input.ContractorLocation = ""
+	inv.Input.ContractorName = ""
+	inv.Input.ContractorRate = 0
+
+	for i, li := range inv.Input.LineItems {
+		li.Expenses = 0
+		li.SubRate = 0
+		inv.Input.LineItems[i] = li
+	}
+
+	return *inv
 }

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1473,8 +1473,20 @@ func (p *politeiawww) processInvoices(ai cms.Invoices, u *user.User) (*cms.UserI
 		return nil, err
 	}
 
+	// Sort returned invoices by time submitted
+	sort.Slice(dbInvs, func(a, b int) bool {
+		return dbInvs[a].Timestamp < dbInvs[b].Timestamp
+	})
+
 	invRecs := make([]cms.InvoiceRecord, 0, len(dbInvs))
 	for _, v := range dbInvs {
+		// Only return up to max page size if start time and end time are
+		// provided.
+		if (ai.StartTime != 0 && ai.EndTime != 0) &&
+			len(invRecs) > cms.InvoiceListPageSize {
+			break
+		}
+
 		invoiceUser, err := p.getCMSUserByIDRaw(u.ID.String())
 		if err != nil {
 			return nil, err

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1397,10 +1397,10 @@ func (p *politeiawww) processAdminUserInvoices(aui cms.AdminUserInvoices) (*cms.
 	return &reply, nil
 }
 
-// processAdminInvoices fetches all invoices that are currently stored in the
+// processInvoices fetches all invoices that are currently stored in the
 // cmsdb for an administrator, based on request fields (month/year and/or status).
-func (p *politeiawww) processAdminInvoices(ai cms.AdminInvoices, u *user.User) (*cms.UserInvoicesReply, error) {
-	log.Tracef("processAdminInvoices")
+func (p *politeiawww) processInvoices(ai cms.Invoices, u *user.User) (*cms.UserInvoicesReply, error) {
+	log.Tracef("processInvoices")
 
 	// Make sure month AND year are set, if any.
 	if (ai.Month == 0 && ai.Year != 0) || (ai.Month != 0 && ai.Year == 0) {
@@ -1955,7 +1955,7 @@ func (p *politeiawww) processProposalBillingDetails(pbd cms.ProposalBillingDetai
 			return nil, err
 		}
 		totalSpent += int64(payout.Total)
-		invRecs = append(invRecs, *convertDatabaseInvoiceToInvoiceRecord(*dbInv))
+		invRecs = append(invRecs, convertDatabaseInvoiceToInvoiceRecord(*dbInv))
 	}
 
 	data, err := p.makeProposalsRequest(http.MethodGet, "/proposals/"+pbd.Token, nil)


### PR DESCRIPTION
This PR changes the existing `AdminInvoices` request to the more open `Invoices`.  

`Invoices` now is allowed to be accessed by any user instead of just administrators.  Users may access invoices from their set domain.  Private information concerning payouts, addresses, location etc is scrubbed if the requesting user isn't the invoice owner or an administrator.

This PR also adds 3 new params to the Invoices request. StartTime, EndTime and UserID.

- UserID if set will return only invoices that were created by that UserID.

- StartTime and EndTIme will return invoices in the range given. But note that these params can only be used when Month/Year are empty otherwise an Error will be returned.