### PR TITLE
cache: Performance improvements for vote results

### DIFF
--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -684,9 +684,6 @@ func (d *decred) voteSummaries(tokens []string, bestBlock uint64) (map[string]de
 		}
 	}
 
-	// Update best block
-	d.bestBlockSet(bestBlock)
-
 	return summaries, nil
 }
 

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -230,9 +230,6 @@ func (d *decred) voteResultsMissing(bestBlock uint64) ([]string, []string, error
 		runoff = append(runoff, token)
 	}
 
-	// Update best block
-	d.bestBlockSet(bestBlock)
-
 	return standard, runoff, nil
 }
 
@@ -519,6 +516,9 @@ func (d *decred) voteResultsLoad(bestBlock uint64) error {
 
 		done[pm.LinkTo] = struct{}{}
 	}
+
+	// Keep track of block used to update the table.
+	d.bestBlockSet(bestBlock)
 
 	return nil
 }

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -185,12 +185,12 @@ func (d *decred) voteResultsMissing(bestBlock uint64) ([]string, []string, error
 	// Find standard vote proposals that have finished voting but
 	// have not yet been added to the VoteResults table.
 	q := `SELECT start_votes.token
-			FROM start_votes
-			LEFT OUTER JOIN vote_results
-			  ON start_votes.token = vote_results.token
-			  WHERE start_votes.end_height <= ?
-			  AND start_votes.Type = ?
-			  AND vote_results.token IS NULL`
+        FROM start_votes
+        LEFT OUTER JOIN vote_results
+          ON start_votes.token = vote_results.token
+          WHERE start_votes.end_height <= ?
+          AND start_votes.Type = ?
+          AND vote_results.token IS NULL`
 	rows, err := d.recordsdb.Raw(q, bestBlock,
 		int(decredplugin.VoteTypeStandard)).Rows()
 	if err != nil {

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -973,6 +973,7 @@ func (p *politeiawww) setupPiDcrdataWSSubs() error {
 					m.Block.Height)
 				bb := uint64(m.Block.Height)
 				p.updateBestBlock(bb)
+				// Keep VoteResults table updated with received best block
 				_, err = p.decredLoadVoteResults(bb)
 				if err != nil {
 					log.Errorf("decredLoadVoteResults: %v", err)

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -971,7 +971,13 @@ func (p *politeiawww) setupPiDcrdataWSSubs() error {
 			case *exptypes.WebsocketBlock:
 				log.Debugf("wsDcrdata message WebsocketBlock(height=%v)",
 					m.Block.Height)
-				p.updateBestBlock(uint64(m.Block.Height))
+				bb := uint64(m.Block.Height)
+				p.updateBestBlock(bb)
+				_, err = p.decredLoadVoteResults(bb)
+				if err != nil {
+					log.Errorf("decredLoadVoteResults: %v", err)
+					return
+				}
 			case *pstypes.HangUp:
 				log.Infof("Dcrdata has hung up. Will reconnect.")
 				err = p.resetPiDcrdataWSSubs()

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -977,7 +977,6 @@ func (p *politeiawww) setupPiDcrdataWSSubs() error {
 				_, err = p.decredLoadVoteResults(bb)
 				if err != nil {
 					log.Errorf("decredLoadVoteResults: %v", err)
-					return
 				}
 			case *pstypes.HangUp:
 				log.Infof("Dcrdata has hung up. Will reconnect.")

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -3336,3 +3336,18 @@ func (p *politeiawww) processVoteDetailsV2(token string) (*www2.VoteDetailsReply
 
 	return vdr, nil
 }
+
+// initLoadVoteResults is used to send the LoadVoteResults decred plugin command
+// to the cache on www startup.
+func (p *politeiawww) initLoadVoteResults() error {
+	bb, err := p.getBestBlock()
+	if err != nil {
+		return err
+	}
+	_, err = p.decredLoadVoteResults(bb)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -3339,7 +3339,7 @@ func (p *politeiawww) processVoteDetailsV2(token string) (*www2.VoteDetailsReply
 
 // initLoadVoteResults is used to send the LoadVoteResults decred plugin command
 // to the cache on www startup.
-func (p *politeiawww) initLoadVoteResults() error {
+func (p *politeiawww) initVoteResults() error {
 	bb, err := p.getBestBlock()
 	if err != nil {
 		return err

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -445,13 +445,19 @@ func _main() error {
 		return fmt.Errorf("initCommentScore: %v", err)
 	}
 
-	// Set up the code that checks for paywall payments.
+	// Setup VoteResults cache table
+	err = p.initLoadVoteResults()
+	if err != nil {
+		return err
+	}
+
+	// Setup the code that checks for paywall payments.
 	if p.cfg.Mode == "piwww" {
+		p.initEventManager()
 		err = p.initPaywallChecker()
 		if err != nil {
 			return err
 		}
-		p.initEventManager()
 	} else if p.cfg.Mode == "cmswww" {
 		p.initCMSEventManager()
 	}

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -446,18 +446,19 @@ func _main() error {
 	}
 
 	// Setup VoteResults cache table
-	err = p.initLoadVoteResults()
+	log.Infof("Loading vote results cache table")
+	err = p.initVoteResults()
 	if err != nil {
 		return err
 	}
 
 	// Setup the code that checks for paywall payments.
 	if p.cfg.Mode == "piwww" {
-		p.initEventManager()
 		err = p.initPaywallChecker()
 		if err != nil {
 			return err
 		}
+		p.initEventManager()
 	} else if p.cfg.Mode == "cmswww" {
 		p.initCMSEventManager()
 	}


### PR DESCRIPTION
This diff implements three performance improvements for the vote results cache table.

- Keep track of the best block used to update the vote results table, and only update it again if a new best block is received.
- `LoadVoteResults` command on www startup.
- `LoadVoteResults` command whenever a new best block comes along in dcrdata ws connection.

closes #1221 