### PR TITLE
gitbe: Fix UnvettedExists bug.

### DIFF
--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -137,7 +137,7 @@ func setCMSPluginHook(name string, f func(string) error) {
 //
 // Must be called WITH the mutex held.
 func (g *gitBackEnd) flushDCCVotes(token string) (string, error) {
-	if !g.unvettedPropExists(token) {
+	if !g.vettedPropExists(token) {
 		return "", fmt.Errorf("unknown dcc: %v", token)
 	}
 

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -254,14 +254,6 @@ func setDecredPluginHook(name string, f func(string) error) {
 	decredPluginHooks[name] = f
 }
 
-func (g *gitBackEnd) unvettedPropExists(token string) bool {
-	tokenb, err := util.ConvertStringToken(token)
-	if err != nil {
-		return false
-	}
-	return g.UnvettedExists(tokenb)
-}
-
 func (g *gitBackEnd) vettedPropExists(token string) bool {
 	tokenb, err := util.ConvertStringToken(token)
 	if err != nil {
@@ -643,7 +635,7 @@ func (g *gitBackEnd) flushJournalsUnwind(id string) error {
 //
 // Must be called WITH the mutex held.
 func (g *gitBackEnd) flushComments(token string) (string, error) {
-	if !g.unvettedPropExists(token) {
+	if !g.vettedPropExists(token) {
 		return "", fmt.Errorf("unknown proposal: %v", token)
 	}
 
@@ -831,7 +823,7 @@ func (g *gitBackEnd) flushCommentJournals() error {
 //
 // Must be called WITH the mutex held.
 func (g *gitBackEnd) flushVotes(token string) (string, error) {
-	if !g.unvettedPropExists(token) {
+	if !g.vettedPropExists(token) {
 		return "", fmt.Errorf("unknown proposal: %v", token)
 	}
 

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2320,8 +2320,21 @@ func (g *gitBackEnd) fsck(path string) error {
 // UnvettedExists satisfies the backend interface.
 func (g *gitBackEnd) UnvettedExists(token []byte) bool {
 	log.Tracef("UnvettedExists %x", token)
-	_, err := os.Stat(pijoin(g.unvetted, hex.EncodeToString(token)))
-	return err == nil
+
+	// Unvetted records exists as branches in the unvetted repo where
+	// the branch name is the record token.
+	branches, err := g.gitBranches(g.unvetted)
+	if err != nil {
+		return false
+	}
+	t := hex.EncodeToString(token)
+	for _, v := range branches {
+		if v == t {
+			return true
+		}
+	}
+
+	return false
 }
 
 // VettedExists returns whether the given token corresponds to a record in


### PR DESCRIPTION
This diff fixes the UnvettedExists gitbe method. It was previously
checking the unvetted repo for the record on the master branch. This is
incorrect. Unvetted records are stored in the unvetted repo as branches.
Once they become vetted records then they are merged into master. The
UnvettedExists method now checks the unvetted repo branches for the
record.

It also updates a few plugin calls, which were calling the
UnvettedExists method when they should have been calling the VettedExits
method. This was not causing any issues because the UnvettedExists method
was actually returning whether the vetted record existed.