### PR TITLE
gitbe: Fix decredplugin post edit hook bug.

### DIFF
--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -569,7 +569,7 @@ func (g *gitBackEnd) decredPluginPostEdit(token string) error {
 	log.Tracef("decredPluginPostEdit: %v", token)
 
 	// The post edit hook gets called on both unvetted and vetted
-	// propsoals, but comments can only be made on vetted proposals.
+	// proposals, but comments can only be made on vetted proposals.
 	var destination string
 	var err error
 	if g.vettedPropExists(token) {

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -568,9 +568,15 @@ func (g *gitBackEnd) pluginBestBlock() (string, error) {
 func (g *gitBackEnd) decredPluginPostEdit(token string) error {
 	log.Tracef("decredPluginPostEdit: %v", token)
 
-	destination, err := g.flushComments(token)
-	if err != nil {
-		return err
+	// The post edit hook gets called on both unvetted and vetted
+	// propsoals, but comments can only be made on vetted proposals.
+	var destination string
+	var err error
+	if g.vettedPropExists(token) {
+		destination, err = g.flushComments(token)
+		if err != nil {
+			return err
+		}
 	}
 
 	// When destination is empty there was nothing to do


### PR DESCRIPTION
This diff fixes a bug that was recently introduced when the gitbe
UnvettedExists call was fixed. The decredplugin post-edit hook was
trying to flush the comments on unvetted proposals, but validation was
failing because comments can only be made on vetted proposals.