### PR TITLE
politeiawww: Fix linkto expiration bug.

### DIFF
--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -2479,8 +2479,10 @@ func validateAuthorizeVoteStandard(av www.AuthorizeVote, u user.User, pr www.Pro
 	// standard votes.
 	switch {
 	case isRFPSubmission(pr):
-		// Wrong validation function used. Fail with a 500.
-		return fmt.Errorf("proposal is a runoff vote submission")
+		return www.UserError{
+			ErrorCode:    www.ErrorStatusWrongProposalType,
+			ErrorContext: []string{"proposal is an rfp submission"},
+		}
 	case pr.PublicKey != av.PublicKey:
 		// User is not the author. First make sure the author didn't
 		// submit the proposal using an old identity.

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -942,7 +942,9 @@ func TestValidateAuthorizeVoteStandard(t *testing.T) {
 			*usr,
 			prop,
 			www.VoteSummary{},
-			fmt.Errorf("proposal is a runoff vote submission"),
+			www.UserError{
+				ErrorCode: www.ErrorStatusWrongProposalType,
+			},
 		},
 		{
 			"not proposal author",


### PR DESCRIPTION
This diff fixes a bug that was causing proposal edits to be rejected if
the linkto deadline had expired. New RFP submissions should be rejected
once the linkby deadline has expired, but edits to existing submissions
are allowed.