### PR TITLE
tests: Move expired deadline test case to correct place

### DIFF
--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -1941,17 +1941,42 @@ func TestProcessNewProposal(t *testing.T) {
 
 	// Create a user that has paid their registration
 	// fee and has purchased proposal credits.
-	usrValid, id := newUser(t, p, true, false)
-	payRegistrationFee(t, p, usrValid)
-	addProposalCredits(t, p, usrValid, 10)
+	usr, id := newUser(t, p, true, false)
+	payRegistrationFee(t, p, usr)
+	addProposalCredits(t, p, usr, 10)
 
-	// Create a NewProposal
+	// Create a new proposal
 	f := newFileRandomMD(t)
 	np := createNewProposal(t, id, []www.File{f}, "")
 
 	// Invalid proposal
 	propInvalid := createNewProposal(t, id, []www.File{f}, "")
 	propInvalid.Signature = ""
+
+	// Expired deadline RFP proposal
+	rfpProp := newProposalRecord(t, usr, id, www.PropStatusPublic)
+	rfpToken := rfpProp.CensorshipRecord.Token
+	makeProposalRFP(t, &rfpProp, []string{}, time.Now().Unix()-p.linkByPeriodMin())
+	td.AddRecord(t, convertPropToPD(t, rfpProp))
+
+	// Set vote summary for expired deadline proposal
+	no := decredplugin.VoteOptionIDReject
+	yes := decredplugin.VoteOptionIDApprove
+	approved := []www.VoteOptionResult{
+		newVoteOptionResult(t, no, "not approve", 1, 2),
+		newVoteOptionResult(t, yes, "approve", 2, 8),
+	}
+	vsApproved := newVoteSummary(t, www.PropVoteStatusFinished, approved)
+	p.voteSummarySet(rfpToken, vsApproved)
+
+	// Set expired deadline rfp metadata and signature
+	propMetadata, _ := newProposalMetadata(t, "valid name", rfpToken, 0)
+	propExpired := createNewProposal(t, id, []www.File{f}, "")
+	propExpired.Metadata = propMetadata
+	root := merkleRoot(t, propExpired.Files, propExpired.Metadata)
+	s := id.SignMessage([]byte(root))
+	sig := hex.EncodeToString(s[:])
+	propExpired.Signature = sig
 
 	// Setup tests
 	var tests = []struct {
@@ -1966,28 +1991,36 @@ func TestProcessNewProposal(t *testing.T) {
 			usrUnpaid,
 			www.UserError{
 				ErrorCode: www.ErrorStatusUserNotPaid,
-			}},
-
+			},
+		},
 		{
 			"no proposal credits",
 			np,
 			usrNoCredits,
 			www.UserError{
 				ErrorCode: www.ErrorStatusNoProposalCredits,
-			}},
-
+			},
+		},
 		{
 			"invalid proposal",
 			propInvalid,
-			usrValid,
+			usr,
 			www.UserError{
 				ErrorCode: www.ErrorStatusInvalidSignature,
-			}},
-
+			},
+		},
+		{
+			"linkby deadline expired",
+			propExpired,
+			usr,
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidLinkTo,
+			},
+		},
 		{
 			"success",
 			np,
-			usrValid,
+			usr,
 			nil,
 		},
 	}

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -329,13 +329,6 @@ func TestValidateProposalMetadata(t *testing.T) {
 	makeProposalRFP(t, &rfpProposalNotApproved, linkFrom, linkBy)
 	d.AddRecord(t, convertPropToPD(t, rfpProposalNotApproved))
 
-	// RFP bad linkBy expired timestamp
-	rfpBadLinkBy := newProposalRecord(t, usr, id, public)
-	rfpBadLinkByToken := rfpBadLinkBy.CensorshipRecord.Token
-	badLinkBy := int64(1351700038)
-	makeProposalRFP(t, &rfpBadLinkBy, linkFrom, badLinkBy)
-	d.AddRecord(t, convertPropToPD(t, rfpBadLinkBy))
-
 	// RFP bad state
 	rfpBadState := newProposalRecord(t, usr, id, www.PropStatusNotReviewed)
 	rfpBadStateToken := rfpBadState.CensorshipRecord.Token
@@ -349,7 +342,6 @@ func TestValidateProposalMetadata(t *testing.T) {
 	}
 	vsApproved := newVoteSummary(t, www.PropVoteStatusFinished, approved)
 	p.voteSummarySet(rfpToken, vsApproved)
-	p.voteSummarySet(rfpBadLinkByToken, vsApproved)
 
 	// Not approved VoteSummary for proposal
 	notApproved := []www.VoteOptionResult{
@@ -358,7 +350,6 @@ func TestValidateProposalMetadata(t *testing.T) {
 	}
 	vsNotApproved := newVoteSummary(t, www.PropVoteStatusFinished, notApproved)
 	p.voteSummarySet(rfpTokenNotApproved, vsNotApproved)
-	p.voteSummarySet(rfpBadLinkByToken, vsApproved)
 	p.voteSummarySet(rfpBadStateToken, vsApproved)
 
 	// Metadatas to validate and test
@@ -369,8 +360,6 @@ func TestValidateProposalMetadata(t *testing.T) {
 	_, mdProposalNotRFP := newProposalMetadata(t, validName, token, 0)
 	_, mdProposalNotApproved := newProposalMetadata(t, validName,
 		rfpTokenNotApproved, 0)
-	_, mdProposalBadLinkBy := newProposalMetadata(t, validName,
-		rfpBadLinkByToken, 0)
 	_, mdProposalBadState := newProposalMetadata(t, validName,
 		rfpBadStateToken, 0)
 	_, mdProposalBothRFP := newProposalMetadata(t, validName, rfpToken,
@@ -427,14 +416,6 @@ func TestValidateProposalMetadata(t *testing.T) {
 			www.UserError{
 				ErrorCode:    www.ErrorStatusInvalidLinkTo,
 				ErrorContext: []string{"rfp proposal vote did not pass"},
-			},
-		},
-		{
-			"invalid linkTo proposal deadline is expired",
-			mdProposalBadLinkBy,
-			www.UserError{
-				ErrorCode:    www.ErrorStatusInvalidLinkTo,
-				ErrorContext: []string{"linkto proposal deadline is expired"},
 			},
 		},
 		{


### PR DESCRIPTION
This diff removes a obsolete test case that is causing travis to fail on the repo.

edit: it now adds this test case, seeing if the submission deadline of a RFP proposal is expired, to its correct place, in `TestProcessNewProposal`. 