### PR TITLE
piwww: Add RFP process to testrun command.

### DIFF
--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1480,6 +1480,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 			fmt.Printf("  RFP approved successfully\n")
 			// Create 4 RFP submissions.
 			// 1 Unreviewd
+			fmt.Println("  Create unreviewed RFP submission")
 			np, err = newProposal(false, token)
 			if err != nil {
 				return err

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1490,6 +1490,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 				return err
 			}
 			// 2 Public
+			fmt.Println("  Create 2 more submissions & make them public")
 			np, err = newProposal(false, token)
 			if err != nil {
 				return err

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1474,7 +1474,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 		time.Sleep(sleepInterval)
 	}
 	if !vs.Approved {
-		fmt.Println(" RFP rejected")
+		fmt.Println("  RFP rejected")
 	} else {
 		return fmt.Errorf("RFP approved? %v, want false",
 			vs.Approved)
@@ -1497,12 +1497,16 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 
 	// Create another RFP
-	fmt.Println(" Create another RFP")
+	fmt.Println("  Create another RFP")
+	np, err = newRFPProposal()
+	if err != nil {
+		return err
+	}
 	npr, err = client.NewProposal(np)
 	if err != nil {
 		return err
 	}
-	token = rpr.CensorshipRecord.Token
+	token = npr.CensorshipRecord.Token
 
 	// Make second RFP public
 	fmt.Printf("  Set RFP status: not reviewed to public\n")

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1335,7 +1335,8 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	// RFP routes
 	fmt.Println("Running RFP routes")
 
-	// Login with admin and make the proposal public
+	// Login with admin to create an RFP
+	// and make the proposal public.
 	fmt.Printf("  Login admin\n")
 	err = login(admin.email, admin.password)
 	if err != nil {
@@ -1448,15 +1449,24 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 
 	if !noDcrwallet {
-		// RFP Vote results
-		fmt.Printf("  Vote results\n")
-		vrr, err = client.VoteResults(token)
-		if err != nil {
-			return err
+		// Wait to RFP to finish voting
+		for {
+			vsr, err := client.VoteStatus(token)
+			if err != nil {
+				return err
+			}
+
+			// RFP voting period has ended
+			// proceed with tests
+			if vsr.Status == v1.PropVoteStatusFinished {
+				break
+			}
+
+			fmt.Printf("  RFP voting still going on...\n")
+			time.Sleep(sleepInterval)
 		}
-		fmt.Println(vrr)
-		// TODO: poll voteReults tell vote is done, then create submissions and start run off vote :)
 	}
+	fmt.Println("RFP voting finished!")
 
 	// Logout
 	fmt.Printf("  Logout\n")

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -45,11 +45,22 @@ func login(email, password string) error {
 	return lc.Execute(nil)
 }
 
+// newRFPProposal is a wrapper func which creates a RFP by calling newProposal
+func newRFPProposal() (*v1.NewProposal, error) {
+	return newProposal(true, "")
+}
+
+// newSubmissionProposal is a wrapper func which creates a RFP submission by
+// calling newProposal func with a given linkto token.
+func newSubmissionProposal(linkto string) (*v1.NewProposal, error) {
+	return newProposal(false, linkto)
+}
+
 // newProposal returns a NewProposal object contains randonly generated
-// markdown text and a signature from the logged in user, if given RFP
+// markdown text and a signature from the logged in user, if given `rfp`
 // bool is true it creates an RFP.
-// If given linkto it creates a RFP submission.
-func newProposal(RFP bool, linkto string) (*v1.NewProposal, error) {
+// If given `linkto` it creates a RFP submission.
+func newProposal(rfp bool, linkto string) (*v1.NewProposal, error) {
 	md, err := createMDFile()
 	if err != nil {
 		return nil, fmt.Errorf("create MD file: %v", err)
@@ -59,7 +70,7 @@ func newProposal(RFP bool, linkto string) (*v1.NewProposal, error) {
 	pm := v1.ProposalMetadata{
 		Name: "Some proposal name",
 	}
-	if RFP {
+	if rfp {
 		pm.LinkBy = time.Now().Add(time.Hour * 24 * 30).Unix()
 	}
 	if linkto != "" {
@@ -1356,7 +1367,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Create RFP
 	fmt.Println("  Create RFP")
-	np, err = newProposal(true, "")
+	np, err = newRFPProposal()
 	if err != nil {
 		return err
 	}
@@ -1481,7 +1492,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 			// Create 4 RFP submissions.
 			// 1 Unreviewd
 			fmt.Println("  Create unreviewed RFP submission")
-			np, err = newProposal(false, token)
+			np, err = newSubmissionProposal(token)
 			if err != nil {
 				return err
 			}
@@ -1491,7 +1502,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 			}
 			// 2 Public
 			fmt.Println("  Create 2 more submissions & make them public")
-			np, err = newProposal(false, token)
+			np, err = newSubmissionProposal(token)
 			if err != nil {
 				return err
 			}
@@ -1509,7 +1520,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 			if err != nil {
 				return err
 			}
-			np, err = newProposal(false, token)
+			np, err = newSubmissionProposal(token)
 			if err != nil {
 				return err
 			}
@@ -1529,7 +1540,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 			}
 			// 1 Abandoned, first make public
 			// then abandon
-			np, err = newProposal(false, token)
+			np, err = newSubmissionProposal(token)
 			if err != nil {
 				return err
 			}

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1574,6 +1574,18 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 				return err
 			}
 			if !dcrwalletFailed {
+				// Try cast votes on abandoned & expect error
+				fmt.Println("  Try casting votes on abandoned RFP submission")
+				_, err = castVotes(thirdstoken, vsr.OptionsResult[0].Option.Id)
+				if err != nil {
+					switch {
+					case strings.Contains(err.Error(), "proposal not found"):
+						fmt.Println("  Casting votes on abandoned submission failed as expected")
+					default:
+						return err
+					}
+				}
+
 				// Wait to runoff vote finish
 				var vs v1.VoteSummary
 				for vs.Status != v1.PropVoteStatusFinished {

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -56,6 +56,12 @@ func newSubmissionProposal(linkto string) (*v1.NewProposal, error) {
 	return newProposal(false, linkto)
 }
 
+// newNormalProposal is a wrapper func which creates a proposal by calling
+// newProposal
+func newNormalProposal() (*v1.NewProposal, error) {
+	return newProposal(false, "")
+}
+
 // newProposal returns a NewProposal object contains randonly generated
 // markdown text and a signature from the logged in user, if given `rfp`
 // bool is true it creates an RFP.
@@ -183,11 +189,6 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-
-	// As we rely on votedurationmin to be set to something reasonable
-	// in order to approve an RFP & it's submssion.
-	// We validate it's value before any test
-	// XXXX: continue here.
 
 	// Create user and verify email
 	b, err := util.Random(int(policy.MinPasswordLength))
@@ -398,7 +399,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Submit new proposal
 	fmt.Printf("  New proposal\n")
-	np, err := newProposal(false, "")
+	np, err := newNormalProposal()
 	if err != nil {
 		return err
 	}
@@ -734,7 +735,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 		unreviewedPropToken string
 	)
 
-	np, err = newProposal(false, "")
+	np, err = newNormalProposal()
 	if err != nil {
 		return err
 	}
@@ -744,7 +745,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 	notReviewed1 = npr.CensorshipRecord.Token
 
-	np, err = newProposal(false, "")
+	np, err = newNormalProposal()
 	if err != nil {
 		return err
 	}
@@ -754,7 +755,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 	notReviewed2 = npr.CensorshipRecord.Token
 
-	np, err = newProposal(false, "")
+	np, err = newNormalProposal()
 	if err != nil {
 		return err
 	}
@@ -772,7 +773,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 	unreviewedChanges1 = npr.CensorshipRecord.Token
 
-	np, err = newProposal(false, "")
+	np, err = newNormalProposal()
 	if err != nil {
 		return err
 	}
@@ -790,7 +791,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 	unreviewedChanges2 = npr.CensorshipRecord.Token
 
-	np, err = newProposal(false, "")
+	np, err = newNormalProposal()
 	if err != nil {
 		return err
 	}
@@ -1116,7 +1117,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	fmt.Printf("  Submitting a page of proposals to test vetted route\n")
 	for i := 0; i < v1.ProposalListPageSize; i++ {
-		np, err = newProposal(false, "")
+		np, err = newNormalProposal()
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1373,7 +1373,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 
 	// Create RFP
-	fmt.Println("  Create a RFP, start vote & wait untill it's rejected")
+	fmt.Println("  Create a RFP")
 	np, err = newRFPProposal()
 	if err != nil {
 		return err
@@ -1662,7 +1662,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 				if err != nil {
 					switch {
 					case strings.Contains(err.Error(), "proposal not found"):
-						fmt.Println("  Casting votes on abandoned submission failed as expected")
+						fmt.Println("  Casting votes on abandoned submission failed")
 					default:
 						return err
 					}

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1439,7 +1439,8 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	fmt.Printf("  Start RFP vote\n")
 	svc = StartVoteCmd{}
 	svc.Args.Token = token
-	svc.Args.Duration = 1
+	// use policy's min vote duration
+	svc.Args.Duration = policy.MinVoteDuration
 	svc.Args.PassPercentage = "0"
 	svc.Args.QuorumPercentage = "0"
 	err = svc.Execute(nil)
@@ -1580,7 +1581,8 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 			fmt.Printf("  Start RFP submissions runoff vote\n")
 			svrc := StartVoteRunoffCmd{}
 			svrc.Args.TokenRFP = token
-			svrc.Args.Duration = 1
+			// use policy's min vote duration
+			svrc.Args.Duration = policy.MinVoteDuration
 			svrc.Args.PassPercentage = "0"
 			svrc.Args.QuorumPercentage = "0"
 			err = svrc.Execute(nil)

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1351,22 +1351,22 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Create RFP
 	fmt.Println("  Create RFP")
-	nrfp, err := newProposal(true)
+	np, err = newProposal(true)
 	if err != nil {
 		return err
 	}
-	rnpr, err := client.NewProposal(nrfp)
+	npr, err = client.NewProposal(np)
 	if err != nil {
 		return err
 	}
 
 	// Verify RFP censorship record
 	rpr := v1.ProposalRecord{
-		Files:            nrfp.Files,
-		Metadata:         nrfp.Metadata,
-		PublicKey:        nrfp.PublicKey,
-		Signature:        nrfp.Signature,
-		CensorshipRecord: rnpr.CensorshipRecord,
+		Files:            np.Files,
+		Metadata:         np.Metadata,
+		PublicKey:        np.PublicKey,
+		Signature:        np.Signature,
+		CensorshipRecord: npr.CensorshipRecord,
 	}
 	err = shared.VerifyProposal(rpr, version.PubKey)
 	if err != nil {

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -1450,16 +1450,12 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	svc = StartVoteCmd{}
 	svc.Args.Token = token
 	svc.Args.Duration = policy.MinVoteDuration
-	svc.Args.PassPercentage = "0"
-	svc.Args.QuorumPercentage = "0"
+	svc.Args.PassPercentage = "1"
+	svc.Args.QuorumPercentage = "1"
 	err = svc.Execute(nil)
 	if err != nil {
 		return err
 	}
-
-	// Cast RFP votes
-	fmt.Printf("  Cast 'No' votes\n")
-	dcrwalletFailed, err = castVotes(token, vsr.OptionsResult[1].Option.Id)
 
 	// Wait to RFP to finish voting
 	var vs v1.VoteSummary

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -10,8 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/decred/dcrwallet/rpc/walletrpc"
 	"github.com/decred/politeia/decredplugin"
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
@@ -88,7 +90,8 @@ func newProposal(RFP bool) (*v1.NewProposal, error) {
 func (cmd *TestRunCmd) Execute(args []string) error {
 	const (
 		// sleepInterval is the time to wait in between requests
-		// when polling politeiawww for paywall tx confirmations.
+		// when polling politeiawww for paywall tx confirmations
+		// or RFP vote results.
 		sleepInterval = 15 * time.Second
 
 		// Comment actions
@@ -416,6 +419,13 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 		return err
 	}
 
+	// Update user key
+	fmt.Printf("  Update user key\n")
+	err = uukc.Execute(nil)
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("  Set proposal status: public\n")
 	spsc := SetProposalStatusCmd{}
 	spsc.Args.Token = token
@@ -704,8 +714,8 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 		// We don't need these now but will need
 		// them when we test the public routes.
-		// censoredPropToken   string
-		// unreviewedPropToken string
+		censoredPropToken   string
+		unreviewedPropToken string
 	)
 
 	np, err = newProposal(false)
@@ -775,7 +785,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	// We don't use this proposal for testing the set
 	// proposal status routes, but will need it when
 	// we are testing the public routes.
-	// unreviewedPropToken = npr.CensorshipRecord.Token
+	unreviewedPropToken = npr.CensorshipRecord.Token
 
 	// Log back in with admin
 	fmt.Printf("  Login admin\n")
@@ -829,7 +839,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	// Save this token. We will need it when
 	// we test the public routes.
-	// censoredPropToken = spsc.Args.Token
+	censoredPropToken = spsc.Args.Token
 
 	// Set proposal status - not reviewed to public
 	fmt.Printf("  Set proposal status: not reviewed to public\n")
@@ -969,358 +979,358 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	}
 
 	// Public routes
-	// fmt.Printf("Running public routes\n")
+	fmt.Printf("Running public routes\n")
 
-	// // Me failure
-	// _, err = client.Me()
-	// if err == nil {
-	// 	return fmt.Errorf("admin should be logged out")
-	// }
+	// Me failure
+	_, err = client.Me()
+	if err == nil {
+		return fmt.Errorf("admin should be logged out")
+	}
 
-	// // Proposal details
-	// fmt.Printf("  Proposal details\n")
-	// pdr, err = client.ProposalDetails(token, nil)
-	// if err != nil {
-	// 	return err
-	// }
+	// Proposal details
+	fmt.Printf("  Proposal details\n")
+	pdr, err = client.ProposalDetails(token, nil)
+	if err != nil {
+		return err
+	}
 
-	// if pdr.Proposal.Version != "2" {
-	// 	return fmt.Errorf("proposal details version got %v, want 2",
-	// 		pdr.Proposal.Version)
-	// }
+	if pdr.Proposal.Version != "2" {
+		return fmt.Errorf("proposal details version got %v, want 2",
+			pdr.Proposal.Version)
+	}
 
-	// // Proposal details version
-	// fmt.Printf("  Proposal details version\n")
-	// pdr, err = client.ProposalDetails(token,
-	// 	&v1.ProposalsDetails{
-	// 		Version: "1",
-	// 	})
-	// if err != nil {
-	// 	return err
-	// }
+	// Proposal details version
+	fmt.Printf("  Proposal details version\n")
+	pdr, err = client.ProposalDetails(token,
+		&v1.ProposalsDetails{
+			Version: "1",
+		})
+	if err != nil {
+		return err
+	}
 
-	// if pdr.Proposal.Version != "1" {
-	// 	return fmt.Errorf("proposal details version got %v, want 1",
-	// 		pdr.Proposal.Version)
-	// }
+	if pdr.Proposal.Version != "1" {
+		return fmt.Errorf("proposal details version got %v, want 1",
+			pdr.Proposal.Version)
+	}
 
-	// // Proposal details - unreviewed
-	// fmt.Printf("  Proposal details: unreviewed proposal\n")
-	// pdr, err = client.ProposalDetails(unreviewedPropToken, nil)
-	// if err != nil {
-	// 	return err
-	// }
+	// Proposal details - unreviewed
+	fmt.Printf("  Proposal details: unreviewed proposal\n")
+	pdr, err = client.ProposalDetails(unreviewedPropToken, nil)
+	if err != nil {
+		return err
+	}
 
-	// switch {
-	// case pdr.Proposal.Name != "":
-	// 	return fmt.Errorf("proposal name should be empty string")
+	switch {
+	case pdr.Proposal.Name != "":
+		return fmt.Errorf("proposal name should be empty string")
 
-	// case len(pdr.Proposal.Files) != 0:
-	// 	return fmt.Errorf("proposal files should not be included")
-	// }
+	case len(pdr.Proposal.Files) != 0:
+		return fmt.Errorf("proposal files should not be included")
+	}
 
-	// // Proposal details - censored
-	// fmt.Printf("  Proposal details: censored proposal\n")
-	// pdr, err = client.ProposalDetails(censoredPropToken, nil)
-	// if err != nil {
-	// 	return err
-	// }
+	// Proposal details - censored
+	fmt.Printf("  Proposal details: censored proposal\n")
+	pdr, err = client.ProposalDetails(censoredPropToken, nil)
+	if err != nil {
+		return err
+	}
 
-	// switch {
-	// case pdr.Proposal.Name != "":
-	// 	return fmt.Errorf("proposal name should be empty string")
+	switch {
+	case pdr.Proposal.Name != "":
+		return fmt.Errorf("proposal name should be empty string")
 
-	// case len(pdr.Proposal.Files) != 0:
-	// 	return fmt.Errorf("proposal files should not be included")
+	case len(pdr.Proposal.Files) != 0:
+		return fmt.Errorf("proposal files should not be included")
 
-	// case pdr.Proposal.CensoredAt == 0:
-	// 	return fmt.Errorf("proposal should have a CensoredAt timestamp")
-	// }
+	case pdr.Proposal.CensoredAt == 0:
+		return fmt.Errorf("proposal should have a CensoredAt timestamp")
+	}
 
-	// // Proposal comments
-	// fmt.Printf("  Get comments\n")
-	// gcr, err = client.GetComments(token)
-	// if err != nil {
-	// 	return err
-	// }
+	// Proposal comments
+	fmt.Printf("  Get comments\n")
+	gcr, err = client.GetComments(token)
+	if err != nil {
+		return err
+	}
 
-	// if len(gcr.Comments) != 2 {
-	// 	return fmt.Errorf("num comments got %v, want 2",
-	// 		len(gcr.Comments))
-	// }
+	if len(gcr.Comments) != 2 {
+		return fmt.Errorf("num comments got %v, want 2",
+			len(gcr.Comments))
+	}
 
-	// c0 := gcr.Comments[0]
-	// c1 := gcr.Comments[1]
-	// switch {
-	// case c0.CommentID != "1":
-	// 	return fmt.Errorf("comment ID got %v, want 1",
-	// 		c0.CommentID)
+	c0 := gcr.Comments[0]
+	c1 := gcr.Comments[1]
+	switch {
+	case c0.CommentID != "1":
+		return fmt.Errorf("comment ID got %v, want 1",
+			c0.CommentID)
 
-	// case c0.Upvotes != 0:
-	// 	return fmt.Errorf("comment %v result up votes got %v, want 0",
-	// 		c0.CommentID, c0.Upvotes)
+	case c0.Upvotes != 0:
+		return fmt.Errorf("comment %v result up votes got %v, want 0",
+			c0.CommentID, c0.Upvotes)
 
-	// case c0.Downvotes != 1:
-	// 	return fmt.Errorf("comment %v result down votes got %v, want 1",
-	// 		c0.CommentID, c0.Downvotes)
+	case c0.Downvotes != 1:
+		return fmt.Errorf("comment %v result down votes got %v, want 1",
+			c0.CommentID, c0.Downvotes)
 
-	// case c0.ResultVotes != -1:
-	// 	return fmt.Errorf("comment %v result vote score got %v, want -1",
-	// 		c0.CommentID, c0.Downvotes)
+	case c0.ResultVotes != -1:
+		return fmt.Errorf("comment %v result vote score got %v, want -1",
+			c0.CommentID, c0.Downvotes)
 
-	// case c1.CommentID != "2":
-	// 	return fmt.Errorf("comment ID got %v, want 2",
-	// 		c1.CommentID)
+	case c1.CommentID != "2":
+		return fmt.Errorf("comment ID got %v, want 2",
+			c1.CommentID)
 
-	// case c1.Comment != "":
-	// 	return fmt.Errorf("censored comment text got '%v', want ''",
-	// 		c1.Comment)
+	case c1.Comment != "":
+		return fmt.Errorf("censored comment text got '%v', want ''",
+			c1.Comment)
 
-	// case !c1.Censored:
-	// 	return fmt.Errorf("censored comment not marked as censored")
-	// }
+	case !c1.Censored:
+		return fmt.Errorf("censored comment not marked as censored")
+	}
 
-	// // Vetted proposals. We need to submit a page of proposals and
-	// // make them public first in order to test the vetted route.
-	// fmt.Printf("  Login admin\n")
-	// err = login(admin.email, admin.password)
-	// if err != nil {
-	// 	return err
-	// }
+	// Vetted proposals. We need to submit a page of proposals and
+	// make them public first in order to test the vetted route.
+	fmt.Printf("  Login admin\n")
+	err = login(admin.email, admin.password)
+	if err != nil {
+		return err
+	}
 
-	// fmt.Printf("  Submitting a page of proposals to test vetted route\n")
-	// for i := 0; i < v1.ProposalListPageSize; i++ {
-	// 	np, err = newProposal(false)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	_, err = client.NewProposal(np)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
+	fmt.Printf("  Submitting a page of proposals to test vetted route\n")
+	for i := 0; i < v1.ProposalListPageSize; i++ {
+		np, err = newProposal(false)
+		if err != nil {
+			return err
+		}
+		_, err = client.NewProposal(np)
+		if err != nil {
+			return err
+		}
+	}
 
-	// fmt.Printf("  Token inventory\n")
-	// tir, err := client.TokenInventory()
-	// if err != nil {
-	// 	return err
-	// }
+	fmt.Printf("  Token inventory\n")
+	tir, err := client.TokenInventory()
+	if err != nil {
+		return err
+	}
 
-	// fmt.Printf("  Batch proposals\n")
-	// bpr, err := client.BatchProposals(&v1.BatchProposals{
-	// 	Tokens: tir.Unreviewed[:v1.ProposalListPageSize],
-	// })
-	// if err != nil {
-	// 	return err
-	// }
+	fmt.Printf("  Batch proposals\n")
+	bpr, err := client.BatchProposals(&v1.BatchProposals{
+		Tokens: tir.Unreviewed[:v1.ProposalListPageSize],
+	})
+	if err != nil {
+		return err
+	}
 
-	// fmt.Printf("  Making unvetted proposals public\n")
-	// for _, v := range bpr.Proposals {
-	// 	spsc := SetProposalStatusCmd{}
-	// 	spsc.Args.Token = v.CensorshipRecord.Token
-	// 	spsc.Args.Status = strconv.Itoa(int(v1.PropStatusPublic))
-	// 	err = spsc.Execute(nil)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
+	fmt.Printf("  Making unvetted proposals public\n")
+	for _, v := range bpr.Proposals {
+		spsc := SetProposalStatusCmd{}
+		spsc.Args.Token = v.CensorshipRecord.Token
+		spsc.Args.Status = strconv.Itoa(int(v1.PropStatusPublic))
+		err = spsc.Execute(nil)
+		if err != nil {
+			return err
+		}
+	}
 
-	// fmt.Printf("  Logout\n")
-	// lc = shared.LogoutCmd{}
-	// err = lc.Execute(nil)
-	// if err != nil {
-	// 	return err
-	// }
+	fmt.Printf("  Logout\n")
+	lc = shared.LogoutCmd{}
+	err = lc.Execute(nil)
+	if err != nil {
+		return err
+	}
 
-	// fmt.Printf("  Vetted\n")
-	// gavr, err := client.GetAllVetted(&v1.GetAllVetted{})
-	// if err != nil {
-	// 	return err
-	// }
+	fmt.Printf("  Vetted\n")
+	gavr, err := client.GetAllVetted(&v1.GetAllVetted{})
+	if err != nil {
+		return err
+	}
 
-	// if len(gavr.Proposals) != v1.ProposalListPageSize {
-	// 	return fmt.Errorf("proposals page size got %v, want %v",
-	// 		len(gavr.Proposals), v1.ProposalListPageSize)
-	// }
+	if len(gavr.Proposals) != v1.ProposalListPageSize {
+		return fmt.Errorf("proposals page size got %v, want %v",
+			len(gavr.Proposals), v1.ProposalListPageSize)
+	}
 
-	// for _, v := range gavr.Proposals {
-	// 	err = shared.VerifyProposal(v, version.PubKey)
-	// 	if err != nil {
-	// 		return fmt.Errorf("verify proposal failed %v: %v",
-	// 			v.CensorshipRecord.Token, err)
-	// 	}
-	// }
+	for _, v := range gavr.Proposals {
+		err = shared.VerifyProposal(v, version.PubKey)
+		if err != nil {
+			return fmt.Errorf("verify proposal failed %v: %v",
+				v.CensorshipRecord.Token, err)
+		}
+	}
 
-	// // User details
-	// fmt.Printf("  User details\n")
-	// udr, err := client.UserDetails(user.ID)
-	// if err != nil {
-	// 	return err
-	// }
+	// User details
+	fmt.Printf("  User details\n")
+	udr, err := client.UserDetails(user.ID)
+	if err != nil {
+		return err
+	}
 
-	// if udr.User.ID != user.ID {
-	// 	return fmt.Errorf("user ID got %v, want %v",
-	// 		udr.User.ID, user.ID)
-	// }
+	if udr.User.ID != user.ID {
+		return fmt.Errorf("user ID got %v, want %v",
+			udr.User.ID, user.ID)
+	}
 
-	// // User proposals
-	// fmt.Printf("  User proposals\n")
-	// upr, err := client.UserProposals(
-	// 	&v1.UserProposals{
-	// 		UserId: user.ID,
-	// 	})
-	// if err != nil {
-	// 	return err
-	// }
+	// User proposals
+	fmt.Printf("  User proposals\n")
+	upr, err := client.UserProposals(
+		&v1.UserProposals{
+			UserId: user.ID,
+		})
+	if err != nil {
+		return err
+	}
 
-	// // userPropCount is the total number of proposals that we've
-	// // submitted with the test user during the test run that are
-	// // public.
-	// userPropCount := 3
-	// if upr.NumOfProposals != userPropCount {
-	// 	return fmt.Errorf("user proposal count got %v, want %v",
-	// 		upr.NumOfProposals, userPropCount)
-	// }
+	// userPropCount is the total number of proposals that we've
+	// submitted with the test user during the test run that are
+	// public.
+	userPropCount := 3
+	if upr.NumOfProposals != userPropCount {
+		return fmt.Errorf("user proposal count got %v, want %v",
+			upr.NumOfProposals, userPropCount)
+	}
 
-	// for _, v := range upr.Proposals {
-	// 	err := shared.VerifyProposal(v, version.PubKey)
-	// 	if err != nil {
-	// 		return fmt.Errorf("verify proposal failed %v: %v",
-	// 			v.CensorshipRecord.Token, err)
-	// 	}
-	// }
+	for _, v := range upr.Proposals {
+		err := shared.VerifyProposal(v, version.PubKey)
+		if err != nil {
+			return fmt.Errorf("verify proposal failed %v: %v",
+				v.CensorshipRecord.Token, err)
+		}
+	}
 
-	// // Vote details
-	// fmt.Printf("  Vote details\n")
-	// vdr, err := client.VoteDetailsV2(token)
-	// if err != nil {
-	// 	return err
-	// }
-	// switch vdr.Version {
-	// case 2:
-	// 	// Validate signature
-	// 	vote, err := decredplugin.DecodeVoteV2([]byte(vdr.Vote))
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	dsv := decredplugin.StartVoteV2{
-	// 		PublicKey: vdr.PublicKey,
-	// 		Vote:      *vote,
-	// 		Signature: vdr.Signature,
-	// 	}
-	// 	err = dsv.VerifySignature()
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// default:
-	// 	return fmt.Errorf("unknown start vote version %v", vdr.Version)
-	// }
+	// Vote details
+	fmt.Printf("  Vote details\n")
+	vdr, err := client.VoteDetailsV2(token)
+	if err != nil {
+		return err
+	}
+	switch vdr.Version {
+	case 2:
+		// Validate signature
+		vote, err := decredplugin.DecodeVoteV2([]byte(vdr.Vote))
+		if err != nil {
+			return err
+		}
+		dsv := decredplugin.StartVoteV2{
+			PublicKey: vdr.PublicKey,
+			Vote:      *vote,
+			Signature: vdr.Signature,
+		}
+		err = dsv.VerifySignature()
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown start vote version %v", vdr.Version)
+	}
 
-	// // Vote status
-	// fmt.Printf("  Vote status\n")
-	// vsr, err = client.VoteStatus(token)
-	// if err != nil {
-	// 	return err
-	// }
+	// Vote status
+	fmt.Printf("  Vote status\n")
+	vsr, err = client.VoteStatus(token)
+	if err != nil {
+		return err
+	}
 
-	// if vsr.Status != v1.PropVoteStatusStarted {
-	// 	return fmt.Errorf("vote status got %v, want %v",
-	// 		vsr.Status, v1.PropVoteStatusStarted)
-	// }
+	if vsr.Status != v1.PropVoteStatusStarted {
+		return fmt.Errorf("vote status got %v, want %v",
+			vsr.Status, v1.PropVoteStatusStarted)
+	}
 
-	// // Active votes
-	// fmt.Printf("  Active votes\n")
-	// avr, err := client.ActiveVotes()
-	// if err != nil {
-	// 	return err
-	// }
+	// Active votes
+	fmt.Printf("  Active votes\n")
+	avr, err := client.ActiveVotes()
+	if err != nil {
+		return err
+	}
 
-	// var found bool
-	// for _, v := range avr.Votes {
-	// 	if v.Proposal.CensorshipRecord.Token == token {
-	// 		found = true
-	// 	}
-	// }
-	// if !found {
-	// 	return fmt.Errorf("proposal %v not found in active votes",
-	// 		token)
-	// }
+	var found bool
+	for _, v := range avr.Votes {
+		if v.Proposal.CensorshipRecord.Token == token {
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("proposal %v not found in active votes",
+			token)
+	}
 
-	// // Cast votes
-	// fmt.Printf("  Cast votes\n")
-	// var skipCastVotes bool
-	// var vc VoteCmd
-	// vc.Args.Token = token
-	// vc.Args.VoteID = vsr.OptionsResult[0].Option.Id
-	// err = vc.Execute(nil)
-	// if err != nil {
-	// 	switch {
-	// 	case strings.Contains(err.Error(), "connection refused"):
-	// 		// User is not running a dcrwallet instance locally.
-	// 		// This is ok. Print a warning and continue.
-	// 		fmt.Printf("  WARNING: could not connect to dcrwallet; " +
-	// 			"skipping cast votes\n")
-	// 		skipCastVotes = true
+	// Cast votes
+	fmt.Printf("  Cast votes\n")
+	var skipCastVotes bool
+	var vc VoteCmd
+	vc.Args.Token = token
+	vc.Args.VoteID = vsr.OptionsResult[0].Option.Id
+	err = vc.Execute(nil)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "connection refused"):
+			// User is not running a dcrwallet instance locally.
+			// This is ok. Print a warning and continue.
+			fmt.Printf("  WARNING: could not connect to dcrwallet; " +
+				"skipping cast votes\n")
+			skipCastVotes = true
 
-	// 	case strings.Contains(err.Error(), "no eligible tickets"):
-	// 		// User doesn't have any eligible tickets. This is ok.
-	// 		// Print a warning and continue.
-	// 		fmt.Printf("  WARNING: user has no elibigle tickets; " +
-	// 			"skipping cast votes\n")
-	// 		skipCastVotes = true
+		case strings.Contains(err.Error(), "no eligible tickets"):
+			// User doesn't have any eligible tickets. This is ok.
+			// Print a warning and continue.
+			fmt.Printf("  WARNING: user has no elibigle tickets; " +
+				"skipping cast votes\n")
+			skipCastVotes = true
 
-	// 	default:
-	// 		return err
-	// 	}
-	// }
+		default:
+			return err
+		}
+	}
 
-	// // Find how many votes the user cast so that
-	// // we can compare it against the vote results.
-	// var voteCount int
-	// if !skipCastVotes {
-	// 	// Get proposal vote details
-	// 	var pvt v1.ProposalVoteTuple
-	// 	for _, v := range avr.Votes {
-	// 		if v.Proposal.CensorshipRecord.Token == token {
-	// 			pvt = v
-	// 			break
-	// 		}
-	// 	}
+	// Find how many votes the user cast so that
+	// we can compare it against the vote results.
+	var voteCount int
+	if !skipCastVotes {
+		// Get proposal vote details
+		var pvt v1.ProposalVoteTuple
+		for _, v := range avr.Votes {
+			if v.Proposal.CensorshipRecord.Token == token {
+				pvt = v
+				break
+			}
+		}
 
-	// 	// Get the number of eligible tickets the user had
-	// 	ticketPool, err := convertTicketHashes(pvt.StartVoteReply.EligibleTickets)
-	// 	if err != nil {
-	// 		return err
-	// 	}
+		// Get the number of eligible tickets the user had
+		ticketPool, err := convertTicketHashes(pvt.StartVoteReply.EligibleTickets)
+		if err != nil {
+			return err
+		}
 
-	// 	err = client.LoadWalletClient()
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	defer client.Close()
+		err = client.LoadWalletClient()
+		if err != nil {
+			return err
+		}
+		defer client.Close()
 
-	// 	ctr, err := client.CommittedTickets(
-	// 		&walletrpc.CommittedTicketsRequest{
-	// 			Tickets: ticketPool,
-	// 		})
-	// 	if err != nil {
-	// 		return err
-	// 	}
+		ctr, err := client.CommittedTickets(
+			&walletrpc.CommittedTicketsRequest{
+				Tickets: ticketPool,
+			})
+		if err != nil {
+			return err
+		}
 
-	// 	voteCount = len(ctr.TicketAddresses)
-	// }
+		voteCount = len(ctr.TicketAddresses)
+	}
 
-	// // Vote results
-	// fmt.Printf("  Vote results\n")
-	// vrr, err := client.VoteResults(token)
-	// if err != nil {
-	// 	return err
-	// }
+	// Vote results
+	fmt.Printf("  Vote results\n")
+	vrr, err := client.VoteResults(token)
+	if err != nil {
+		return err
+	}
 
-	// if len(vrr.CastVotes) != voteCount {
-	// 	return fmt.Errorf("num cast votes got %v, want %v",
-	// 		len(vrr.CastVotes), voteCount)
-	// }
+	if len(vrr.CastVotes) != voteCount {
+		return fmt.Errorf("num cast votes got %v, want %v",
+			len(vrr.CastVotes), voteCount)
+	}
 
 	// RFP routes
 	fmt.Println("Running RFP routes")
@@ -1367,6 +1377,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	token = rpr.CensorshipRecord.Token
 	fmt.Printf("  RFP submitted: %v\n", token)
 
+	// Make RFP public
 	fmt.Printf("  Set RFP status: not reviewed to public\n")
 	spsc = SetProposalStatusCmd{}
 	spsc.Args.Token = token
@@ -1384,6 +1395,75 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	if pdr.Proposal.Status != v1.PropStatusPublic {
 		return fmt.Errorf("RFP status got %v, want %v",
 			pdr.Proposal.Status, v1.PropStatusPublic)
+	}
+
+	// Authorize vote
+	fmt.Printf("  Authorize vote: authorize\n")
+	avc = AuthorizeVoteCmd{}
+	avc.Args.Token = token
+	avc.Args.Action = decredplugin.AuthVoteActionAuthorize
+	err = avc.Execute(nil)
+	if err != nil {
+		return err
+	}
+
+	// Start RFP vote
+	fmt.Printf("  Start vote\n")
+	svc = StartVoteCmd{}
+	svc.Args.Token = token
+	svc.Args.Duration = 1
+	svc.Args.PassPercentage = "0"
+	svc.Args.QuorumPercentage = "0"
+	err = svc.Execute(nil)
+	if err != nil {
+		return err
+	}
+
+	// Cast RFP votes
+	fmt.Printf("  Cast RFP votes\n")
+	var noDcrwallet bool
+	vc = VoteCmd{}
+	vc.Args.Token = token
+	vc.Args.VoteID = vsr.OptionsResult[0].Option.Id
+	err = vc.Execute(nil)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "connection refused"):
+			// User is not running a dcrwallet instance locally.
+			// This is ok. Print a warning and continue.
+			fmt.Printf("  WARNING: could not connect to dcrwallet; " +
+				"skipping RFP tests\n")
+			noDcrwallet = true
+
+		case strings.Contains(err.Error(), "no eligible tickets"):
+			// User doesn't have any eligible tickets. This is ok.
+			// Print a warning and continue.
+			fmt.Printf("  WARNING: user has no elibigle tickets; " +
+				"skipping RFP tests\n")
+			noDcrwallet = true
+
+		default:
+			return err
+		}
+	}
+
+	if !noDcrwallet {
+		// RFP Vote results
+		fmt.Printf("  Vote results\n")
+		vrr, err = client.VoteResults(token)
+		if err != nil {
+			return err
+		}
+		fmt.Println(vrr)
+		// TODO: poll voteReults tell vote is done, then create submissions and start run off vote :)
+	}
+
+	// Logout
+	fmt.Printf("  Logout\n")
+	lc = shared.LogoutCmd{}
+	err = lc.Execute(nil)
+	if err != nil {
+		return err
 	}
 
 	// Websockets

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -177,6 +177,11 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 		return err
 	}
 
+	// As we rely on votedurationmin to be set to something reasonable
+	// in order to approve an RFP & it's submssion.
+	// We validate it's value before any test
+	// XXXX: continue here.
+
 	// Create user and verify email
 	b, err := util.Random(int(policy.MinPasswordLength))
 	if err != nil {


### PR DESCRIPTION
This diff adds the RFP process to `piwww testrun` command.

It covers the following commands:
 - Create RFP
 - Make RFP public
 - Authorize it for vote
 - Start vote on RFP
 - Cast RFP votes
 - Wait until RFP votes is done
 - Create 4 RFP submissions:
   - 1 Unreviewed
   - 2 Public
   - 1 Abandoned
 - Start runoff vote
 - Cast first public submission votes
 - Wait until runoff vote is done
 - Ensure first submission was approved.

And the following failures/edge cases as @lukebp suggested:

 - Attempting to submit an RFP submission before the RFP vote has been approved.
 - Submit an RFP, have the vote fail, attempt to submit an RFP submission to failed rfp.
 - Attempting to vote on the abandoned proposal submission during runoff vote.


Closes #1190 