### PR TITLE
politeiad: Update cache build process.

### DIFF
--- a/decredplugin/decredplugin.go
+++ b/decredplugin/decredplugin.go
@@ -1171,8 +1171,12 @@ func DecodeGetProposalCommentsLikesReply(payload []byte) (*GetProposalCommentsLi
 	return &gpclr, nil
 }
 
-// Inventory is used to retrieve the decred plugin inventory.
-type Inventory struct{}
+// Inventory is used to retrieve the decred plugin inventory for all versions
+// of the provided record tokens. If no tokens are provided, the decred plugin
+// inventory for all versions of all records will be returned.
+type Inventory struct {
+	Tokens []string `json:"tokens,omitempty"`
+}
 
 // EncodeInventory encodes Inventory into a JSON byte slice.
 func EncodeInventory(i Inventory) ([]byte, error) {

--- a/politeiad/backend/backend.go
+++ b/politeiad/backend/backend.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/decred/politeia/politeiad/api/v1"
+	v1 "github.com/decred/politeia/politeiad/api/v1"
 )
 
 var (
@@ -164,6 +164,12 @@ type Backend interface {
 
 	// Check if a vetted record exists
 	VettedExists([]byte) bool
+
+	// Get all unvetted record tokens
+	UnvettedTokens() ([][]byte, error)
+
+	// Get all vetted record tokens
+	VettedTokens() ([][]byte, error)
 
 	// Get unvetted record
 	GetUnvetted([]byte) (*Record, error)

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	cmsPluginIdentity  = "cmsfullidentity"
-	cmsPluginJournals  = "cmssjournals"
-	cmsPluginInventory = "cmsinventory"
+	cmsPluginIdentity    = "cmsfullidentity"
+	cmsPluginJournals    = "cmssjournals"
+	cmsPluginEnableCache = "enablecache"
 )
 
 type CastDCCVoteJournal struct {
@@ -81,13 +81,10 @@ func getCMSPlugin(testnet bool) backend.Plugin {
 		Settings: []backend.PluginSetting{},
 	}
 
-	// This setting is used to tell politeiad how to retrieve the
-	// decred plugin data that is required to build the external
-	// politeiad cache.
 	cmsPlugin.Settings = append(cmsPlugin.Settings,
 		backend.PluginSetting{
-			Key:   cmsPluginInventory,
-			Value: cmsplugin.CmdInventory,
+			Key:   cmsPluginEnableCache,
+			Value: "",
 		})
 
 	// Initialize hooks

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -38,9 +38,9 @@ import (
 const (
 	decredPluginIdentity        = "fullidentity"
 	decredPluginJournals        = "journals"
-	decredPluginInventory       = "inventory"
 	decredPluginVoteDurationMin = "votedurationmin"
 	decredPluginVoteDurationMax = "votedurationmax"
+	decredPluginEnableCache     = "enablecache"
 
 	defaultCommentIDFilename = "commentid.txt"
 	defaultCommentFilename   = "comments.journal"
@@ -178,13 +178,10 @@ func getDecredPlugin(dcrdataHost string) backend.Plugin {
 		},
 	)
 
-	// This setting is used to tell politeiad how to retrieve the
-	// decred plugin data that is required to build the external
-	// politeiad cache.
 	decredPlugin.Settings = append(decredPlugin.Settings,
 		backend.PluginSetting{
-			Key:   decredPluginInventory,
-			Value: decredplugin.CmdInventory,
+			Key:   decredPluginEnableCache,
+			Value: "",
 		})
 
 	// Initialize hooks
@@ -2309,6 +2306,8 @@ func (g *gitBackEnd) validateVoteBit(token, bit string) error {
 //
 // Functions must be called WITH the lock held.
 func (g *gitBackEnd) replayBallot(token string) error {
+	log.Debugf("replayBallot %v", token)
+
 	// Verify proposal exists, we can run this lockless
 	if !g.vettedPropExists(token) {
 		return nil
@@ -2803,201 +2802,169 @@ func (g *gitBackEnd) pluginProposalVotes(payload string) (string, error) {
 	return string(reply), nil
 }
 
-// pluginInventory returns the decred plugin inventory for all proposals.  The
-// inventory consists of comments, like comments, vote authorizations, vote
-// details, and cast votes.
-func (g *gitBackEnd) pluginInventory() (string, error) {
+// pluginInventory returns the decred plugin inventory for the specified
+// records. If no record tokens are specified then the decred plugin inventory
+// for all vetted records will be returned.
+func (g *gitBackEnd) pluginInventory(payload string) (string, error) {
 	log.Tracef("pluginInventory")
 
+	inv, err := decredplugin.DecodeInventory([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	var tokens []string
+	if len(inv.Tokens) == 0 {
+		// No records specified. Return the decred plugin data for all
+		// vetted records.
+		g.Lock()
+		tokens, err = g.getVettedTokens()
+		g.Unlock()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		// Records were specified. Only return the decred plugin data for
+		// the specified records.
+		tokens = inv.Tokens
+	}
+
+	log.Debugf("Fetching decred plugin inventory for %x record", len(tokens))
+
+	// Convert tokens to a map
+	include := make(map[string]struct{}, len(tokens))
+	for _, v := range tokens {
+		include[v] = struct{}{}
+	}
+
+	// Compile decred plugin metadata streams for all versions of the
+	// specified records.
+	var (
+		authVotes       = make([]decredplugin.AuthorizeVote, 0, len(include))
+		authVoteReplies = make([]decredplugin.AuthorizeVoteReply, 0, len(include))
+		voteTuples      = make([]decredplugin.StartVoteTuple, 0, len(include))
+	)
+	for token := range include {
+		tokenb, err := hex.DecodeString(token)
+		if err != nil {
+			return "", err
+		}
+
+		// Find the most recent vesion number for this record
+		r, err := g.GetVetted(tokenb, "")
+		if err != nil {
+			return "", fmt.Errorf("GetVetted %v version 0: %v", token, err)
+		}
+		version, err := strconv.ParseUint(r.Version, 10, 64)
+		if err != nil {
+			return "", err
+		}
+
+		// Compile decred plugin metadata streams from all versions of
+		// the record.
+		for version > 0 {
+			// Lookup record
+			r, err := g.GetVetted(tokenb, strconv.FormatUint(version, 10))
+			if err != nil {
+				return "", fmt.Errorf("GetVetted %v version %v: %v",
+					token, version, err)
+			}
+
+			// Check for decred plugin metadata streams
+			var svt decredplugin.StartVoteTuple
+			for _, v := range r.Metadata {
+				switch v.ID {
+				case decredplugin.MDStreamAuthorizeVote:
+					// Authorize vote
+					av, err := decredplugin.DecodeAuthorizeVote([]byte(v.Payload))
+					if err != nil {
+						return "", err
+					}
+					avr := decredplugin.AuthorizeVoteReply{
+						Action:        av.Action,
+						RecordVersion: r.Version,
+						Receipt:       av.Receipt,
+						Timestamp:     av.Timestamp,
+					}
+					authVotes = append(authVotes, *av)
+					authVoteReplies = append(authVoteReplies, avr)
+				case decredplugin.MDStreamVoteBits:
+					// Start vote
+					sv, err := decredplugin.DecodeStartVote([]byte(v.Payload))
+					if err != nil {
+						return "", err
+					}
+					svt.StartVote = *sv
+				case decredplugin.MDStreamVoteSnapshot:
+					// Start vote reply
+					svr, err := decredplugin.DecodeStartVoteReply([]byte(v.Payload))
+					if err != nil {
+						return "", err
+					}
+					svt.StartVoteReply = *svr
+				}
+				// Check if this record version had vote metadata
+				if svt.StartVote.Version != 0 && svt.StartVoteReply.Version != 0 {
+					voteTuples = append(voteTuples, svt)
+				}
+			}
+
+			// Decrement record version
+			version--
+		}
+	}
+
+	// Compile the journal data. This requires the lock.
 	g.Lock()
 	defer g.Unlock()
 
-	// Ensure journal has been replayed
-	if !journalsReplayed {
-		return "", backend.ErrJournalsNotReplayed
-	}
-
-	// Walk in-memory comments cache and compile all comments
-	var count int
-	for _, v := range decredPluginCommentsCache {
-		count += len(v)
-	}
-	comments := make([]decredplugin.Comment, 0, count)
-	for _, v := range decredPluginCommentsCache {
-		for _, c := range v {
-			comments = append(comments, c)
+	// Compile comments and like comments. These can be pulled from the
+	// memory caches.
+	comments := make([]decredplugin.Comment, 0, 1024)
+	likeComments := make([]decredplugin.LikeComment, 0, 1024)
+	for token := range include {
+		// Comments
+		rcomments, ok := decredPluginCommentsCache[token]
+		if !ok {
+			continue
 		}
-	}
-
-	// Walk in-memory comment likes cache and compile all
-	// comment likes
-	count = 0
-	for _, v := range decredPluginCommentsLikesCache {
-		count += len(v)
-	}
-	likes := make([]decredplugin.LikeComment, 0, count)
-	for _, v := range decredPluginCommentsLikesCache {
-		likes = append(likes, v...)
-	}
-
-	// Walk vetted repo and compile all file paths
-	paths := make([]string, 0, 2048) // PNOOMA
-	err := filepath.Walk(g.vetted,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			paths = append(paths, path)
-			return nil
-		})
-	if err != nil {
-		return "", fmt.Errorf("walk vetted: %v", err)
-	}
-
-	// Filter out the file paths for authorize vote metadata and
-	// start vote metadata
-	avPaths := make([]string, 0, len(paths))
-	svPaths := make([]string, 0, len(paths))
-	avFile := fmt.Sprintf("%02v%v", decredplugin.MDStreamAuthorizeVote,
-		defaultMDFilenameSuffix)
-	svFile := fmt.Sprintf("%02v%v", decredplugin.MDStreamVoteBits,
-		defaultMDFilenameSuffix)
-	for _, v := range paths {
-		switch filepath.Base(v) {
-		case avFile:
-			avPaths = append(avPaths, v)
-		case svFile:
-			svPaths = append(svPaths, v)
+		for _, v := range rcomments {
+			comments = append(comments, v)
 		}
+
+		// Like comments
+		lc, ok := decredPluginCommentsLikesCache[token]
+		if !ok {
+			continue
+		}
+		likeComments = append(likeComments, lc...)
 	}
 
-	// Compile all vote authorizations. We return the authorize
-	// vote data for all versions of a record, not just the latest
-	// version.
-	av := make([]decredplugin.AuthorizeVote, 0, len(avPaths))
-	avr := make([]decredplugin.AuthorizeVoteReply, 0, len(avPaths))
-	for _, v := range avPaths {
-		// Read in authorize vote file into memory
-		b, err := ioutil.ReadFile(v)
+	// Compile cast votes
+	votes := make([]decredplugin.CastVote, 0, len(include)*41000)
+	for token := range include {
+		cv, err := g.tallyVotes(token)
 		if err != nil {
-			return "", fmt.Errorf("ReadFile: %v", err)
+			return "", fmt.Errorf("tallyVotes %v: %v", token, err)
 		}
-
-		// Decode authorize vote
-		a, err := decredplugin.DecodeAuthorizeVote(b)
-		if err != nil {
-			return "", fmt.Errorf("DecodeAuthorizeVote: %v", err)
-		}
-		av = append(av, *a)
-
-		// Parse record version out of file path
-		versionDir := filepath.Dir(v)
-		version := filepath.Base(versionDir)
-
-		// Create authorize vote reply
-		avr = append(avr, decredplugin.AuthorizeVoteReply{
-			Action:        a.Action,
-			RecordVersion: version,
-			Receipt:       a.Receipt,
-			Timestamp:     a.Timestamp,
-		})
-	}
-
-	// Compile the start vote tuples. The in-memory caches that
-	// contain the vote bits and the vote snapshots are lazy
-	// loaded so we have to read vote metadata directly from disk.
-	svt := make([]decredplugin.StartVoteTuple, 0, len(decredPluginVoteCache))
-	for _, v := range svPaths {
-		// Read vote bits file into memory
-		b, err := ioutil.ReadFile(v)
-		if err != nil {
-			return "", fmt.Errorf("ReadFile %v: %v", v, err)
-		}
-
-		// Decode vote bits
-		sv, err := decredplugin.DecodeStartVote(b)
-		if err != nil {
-			return "", fmt.Errorf("DecodeStartVote: %v", err)
-		}
-
-		// Read vote snapshot file into memory
-		dir := filepath.Dir(v)
-		filename := fmt.Sprintf("%02v%v", decredplugin.MDStreamVoteSnapshot,
-			defaultMDFilenameSuffix)
-		path := filepath.Join(dir, filename)
-		b, err = ioutil.ReadFile(path)
-		if err != nil {
-			return "", fmt.Errorf("ReadFile %v: %v", path, err)
-		}
-
-		// Decode vote snapshot
-		svr, err := decredplugin.DecodeStartVoteReply(b)
-		if err != nil {
-			return "", fmt.Errorf("DecodeStartVoteReply: %v", err)
-		}
-
-		// Create start vote tuple
-		svt = append(svt, decredplugin.StartVoteTuple{
-			StartVote:      *sv,
-			StartVoteReply: *svr,
-		})
-	}
-
-	// Compile cast votes. The in-memory votes cache does not
-	// store the full cast vote struct so we need to replay the
-	// vote journals.
-
-	// Walk journals directory and tally votes for all ballot
-	// journals that are found.
-	cv := make([][]decredplugin.CastVote, 0, len(svt))
-	err = filepath.Walk(g.journals,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			if info.Name() == defaultBallotFilename {
-				token := filepath.Base(filepath.Dir(path))
-				votes, err := g.tallyVotes(token)
-				if err != nil {
-					return fmt.Errorf("tallyVotes %v: %v", token, err)
-				}
-
-				cv = append(cv, votes)
-			}
-
-			return nil
-		})
-	if err != nil {
-		return "", fmt.Errorf("walk journals: %v", err)
-	}
-
-	// Combine votes into a single slice
-	count = 0
-	for _, v := range cv {
-		count += len(v)
-	}
-	votes := make([]decredplugin.CastVote, 0, count)
-	for _, v := range cv {
-		votes = append(votes, v...)
+		votes = append(votes, cv...)
 	}
 
 	// Prepare reply
-	ir := decredplugin.InventoryReply{
+	ivr := decredplugin.InventoryReply{
 		Comments:             comments,
-		LikeComments:         likes,
-		AuthorizeVotes:       av,
-		AuthorizeVoteReplies: avr,
-		StartVoteTuples:      svt,
+		LikeComments:         likeComments,
+		AuthorizeVotes:       authVotes,
+		AuthorizeVoteReplies: authVoteReplies,
+		StartVoteTuples:      voteTuples,
 		CastVotes:            votes,
 	}
-
-	payload, err := decredplugin.EncodeInventoryReply(ir)
+	reply, err := decredplugin.EncodeInventoryReply(ivr)
 	if err != nil {
-		return "", fmt.Errorf("EncodeInventoryReply: %v", err)
+		return "", err
 	}
 
-	return string(payload), nil
+	return string(reply), nil
 }
 
 // pluginLoadVoteResults is a pass through function. CmdLoadVoteResults does

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -1790,7 +1790,7 @@ func (g *gitBackEnd) updateRecord(token []byte, mdAppend []backend.MetadataStrea
 //
 // This function is part of the interface.
 func (g *gitBackEnd) UpdateVettedRecord(token []byte, mdAppend []backend.MetadataStream, mdOverwrite []backend.MetadataStream, filesAdd []backend.File, filesDel []string) (*backend.Record, error) {
-	log.Debugf("UpdateVettedRecord %x", token)
+	log.Tracef("UpdateVettedRecord %x", token)
 	return g.updateRecord(token, mdAppend, mdOverwrite, filesAdd, filesDel,
 		true)
 }
@@ -1799,7 +1799,7 @@ func (g *gitBackEnd) UpdateVettedRecord(token []byte, mdAppend []backend.Metadat
 //
 // This function is part of the interface.
 func (g *gitBackEnd) UpdateUnvettedRecord(token []byte, mdAppend []backend.MetadataStream, mdOverwrite []backend.MetadataStream, filesAdd []backend.File, filesDel []string) (*backend.Record, error) {
-	log.Debugf("UpdateUnvettedRecord %x", token)
+	log.Tracef("UpdateUnvettedRecord %x", token)
 	return g.updateRecord(token, mdAppend, mdOverwrite, filesAdd, filesDel,
 		false)
 }
@@ -1900,7 +1900,7 @@ func (g *gitBackEnd) _updateVettedMetadata(token []byte, mdAppend []backend.Meta
 //
 // This function must be called without the lock held.
 func (g *gitBackEnd) UpdateVettedMetadata(token []byte, mdAppend []backend.MetadataStream, mdOverwrite []backend.MetadataStream) error {
-	log.Debugf("UpdateVettedMetadata: %x", token)
+	log.Tracef("UpdateVettedMetadata: %x", token)
 
 	// Send in a single metadata array to verify there are no dups.
 	allMD := append(mdAppend, mdOverwrite...)
@@ -2092,7 +2092,7 @@ func (g *gitBackEnd) updateReadme(content string) error {
 //
 // UpdateReadme satisfies the backend interface.
 func (g *gitBackEnd) UpdateReadme(content string) error {
-	log.Debugf("UpdateReadme")
+	log.Tracef("UpdateReadme")
 
 	// Lock filesystem
 	g.Lock()
@@ -2347,6 +2347,62 @@ func (g *gitBackEnd) VettedExists(token []byte) bool {
 	return err == nil
 }
 
+// UnvettedTokens returns the censorship record token of all unvetted records
+// in the backend.
+func (g *gitBackEnd) UnvettedTokens() ([][]byte, error) {
+	log.Tracef("UnvettedTokens")
+
+	g.Lock()
+	defer g.Unlock()
+	if g.shutdown {
+		return nil, backend.ErrShutdown
+	}
+
+	tokens, err := g.getUnvettedTokens()
+	if err != nil {
+		return nil, err
+	}
+
+	tokensb := make([][]byte, 0, len(tokens))
+	for _, v := range tokens {
+		b, err := hex.DecodeString(v)
+		if err != nil {
+			return nil, err
+		}
+		tokensb = append(tokensb, b)
+	}
+
+	return tokensb, nil
+}
+
+// VettedTokens returns the censorship record token of all vetted records in
+// the backend.
+func (g *gitBackEnd) VettedTokens() ([][]byte, error) {
+	log.Tracef("VettedTokens")
+
+	g.Lock()
+	defer g.Unlock()
+	if g.shutdown {
+		return nil, backend.ErrShutdown
+	}
+
+	tokens, err := g.getVettedTokens()
+	if err != nil {
+		return nil, err
+	}
+
+	tokensb := make([][]byte, 0, len(tokens))
+	for _, v := range tokens {
+		b, err := hex.DecodeString(v)
+		if err != nil {
+			return nil, err
+		}
+		tokensb = append(tokensb, b)
+	}
+
+	return tokensb, nil
+}
+
 // vettedMetadataStreamExists returns whether the given metadata stream exists.
 //
 // This function must be called with the read lock held.
@@ -2362,7 +2418,7 @@ func (g *gitBackEnd) vettedMetadataStreamExists(token []byte, mdstreamID int) bo
 //
 // GetUnvetted satisfies the backend interface.
 func (g *gitBackEnd) GetUnvetted(token []byte) (*backend.Record, error) {
-	log.Debugf("GetUnvetted %x", token)
+	log.Tracef("GetUnvetted %x", token)
 	return g.getRecordLock(token, "", g.unvetted, true)
 }
 
@@ -2370,7 +2426,7 @@ func (g *gitBackEnd) GetUnvetted(token []byte) (*backend.Record, error) {
 //
 // GetVetted satisfies the backend interface.
 func (g *gitBackEnd) GetVetted(token []byte, version string) (*backend.Record, error) {
-	log.Debugf("GetVetted %x", token)
+	log.Tracef("GetVetted %x %v", token, version)
 	return g.getRecordLock(token, version, g.vetted, true)
 }
 
@@ -2640,7 +2696,7 @@ func (g *gitBackEnd) SetVettedStatus(token []byte, status backend.MDStatusT, mdA
 // Inventory returns an inventory of vetted and unvetted records.  If
 // includeFiles is set the content is also returned.
 func (g *gitBackEnd) Inventory(vettedCount, branchCount uint, includeFiles, allVersions bool) ([]backend.Record, []backend.Record, error) {
-	log.Debugf("Inventory: %v %v %v", vettedCount, branchCount, includeFiles)
+	log.Tracef("Inventory: %v %v %v", vettedCount, branchCount, includeFiles)
 
 	// Lock filesystem
 	g.Lock()
@@ -2648,6 +2704,8 @@ func (g *gitBackEnd) Inventory(vettedCount, branchCount uint, includeFiles, allV
 	if g.shutdown {
 		return nil, nil, backend.ErrShutdown
 	}
+
+	log.Debugf("Inventory: walking vetted")
 
 	// Walk vetted, we can simply take the vetted directory and sort the
 	// entries by time.
@@ -2720,7 +2778,7 @@ func (g *gitBackEnd) Inventory(vettedCount, branchCount uint, includeFiles, allV
 //
 // GetPlugins satisfies the backend interface.
 func (g *gitBackEnd) GetPlugins() ([]backend.Plugin, error) {
-	log.Debugf("GetPlugins")
+	log.Tracef("GetPlugins")
 	return g.plugins, nil
 }
 
@@ -2730,7 +2788,7 @@ func (g *gitBackEnd) GetPlugins() ([]backend.Plugin, error) {
 //
 // Plugin satisfies the backend interface.
 func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
-	log.Debugf("Plugin: %v", command)
+	log.Tracef("Plugin: %v", command)
 	switch command {
 	case decredplugin.CmdAuthorizeVote:
 		payload, err := g.pluginAuthorizeVote(payload)
@@ -2766,7 +2824,7 @@ func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
 		payload, err := g.pluginGetProposalCommentsLikes(payload)
 		return decredplugin.CmdProposalCommentsLikes, payload, err
 	case decredplugin.CmdInventory:
-		payload, err := g.pluginInventory()
+		payload, err := g.pluginInventory(payload)
 		return decredplugin.CmdInventory, payload, err
 	case decredplugin.CmdLoadVoteResults:
 		payload, err := g.pluginLoadVoteResults()
@@ -2787,7 +2845,7 @@ func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
 //
 // Close satisfies the backend interface.
 func (g *gitBackEnd) Close() {
-	log.Debugf("Close")
+	log.Tracef("Close")
 
 	g.Lock()
 	defer g.Unlock()

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2705,8 +2705,6 @@ func (g *gitBackEnd) Inventory(vettedCount, branchCount uint, includeFiles, allV
 		return nil, nil, backend.ErrShutdown
 	}
 
-	log.Debugf("Inventory: walking vetted")
-
 	// Walk vetted, we can simply take the vetted directory and sort the
 	// entries by time.
 	files, err := ioutil.ReadDir(g.vetted)

--- a/politeiad/cache/cache.go
+++ b/politeiad/cache/cache.go
@@ -143,8 +143,7 @@ type PluginDriver interface {
 	// Setup the plugin tables
 	Setup() error
 
-	// Build the plugin tables from scratch. The given payload should
-	// provide all data necessary to build the plugin tables.
+	// Drop the existing plugin tables and rebuild them
 	Build(payload string) error
 
 	// Execute a plugin command. Some commands are executed by
@@ -196,7 +195,7 @@ type Cache interface {
 	// Setup the record cache tables
 	Setup() error
 
-	// Build the records cache from scratch
+	// Drop existing tables and rebuild them
 	Build([]Record) error
 
 	// Register a plugin with the cache
@@ -205,7 +204,7 @@ type Cache interface {
 	// Setup the database tables for a plugin
 	PluginSetup(string) error
 
-	// Build the cache for a plugin
+	// Drop existing plugin tables and rebuild them
 	PluginBuild(string, string) error
 
 	// Execute a plugin command

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -17,9 +17,12 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"syscall"
 	"time"
 
+	"github.com/decred/politeia/cmsplugin"
+	"github.com/decred/politeia/decredplugin"
 	v1 "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiad/backend"
@@ -1057,6 +1060,208 @@ func (p *politeia) addRoute(method string, route string, handler http.HandlerFun
 	p.router.StrictSlash(true).HandleFunc(route, handler).Methods(method)
 }
 
+func (p *politeia) buildCacheDecredPlugin(tokens []string) error {
+	log.Infof("Building %v plugin cache", decredplugin.ID)
+
+	// Reset the existing plugin tables
+	err := p.cache.PluginBuild(decredplugin.ID, "")
+	if err != nil {
+		return fmt.Errorf("PluginBuild: %v", err)
+	}
+
+	// Build the plugin cache for each record
+	for i, token := range tokens {
+		log.Infof("Building %v plugin cache for %v (%v/%v)",
+			decredplugin.ID, token, i+1, len(tokens))
+
+		// Get plugin data from the backend for this record
+		ri := decredplugin.Inventory{
+			Tokens: []string{token},
+		}
+		b, err := decredplugin.EncodeInventory(ri)
+		if err != nil {
+			return err
+		}
+		_, reply, err := p.backend.Plugin(decredplugin.CmdInventory, string(b))
+		if err != nil {
+			return fmt.Errorf("backend decred plugin inventory %v: %v", token, err)
+		}
+		ir, err := decredplugin.DecodeInventoryReply([]byte(reply))
+		if err != nil {
+			return err
+		}
+
+		// Build the plugin cache for this record
+
+		// Build comments
+		log.Debugf("Building comments cache (%v comments)", len(ir.Comments))
+		for _, v := range ir.Comments {
+			// Setup payloads
+			nc := decredplugin.NewComment{
+				Token:     v.Token,
+				ParentID:  v.ParentID,
+				Comment:   v.Comment,
+				Signature: v.Signature,
+				PublicKey: v.PublicKey,
+			}
+			ncr := decredplugin.NewCommentReply{
+				CommentID: v.CommentID,
+				Receipt:   v.Receipt,
+				Timestamp: v.Timestamp,
+			}
+			cmdPayload, err := decredplugin.EncodeNewComment(nc)
+			if err != nil {
+				return err
+			}
+			replyPayload, err := decredplugin.EncodeNewCommentReply(ncr)
+			if err != nil {
+				return err
+			}
+
+			// Send plugin command
+			_, err = p.cache.PluginExec(cache.PluginCommand{
+				ID:             decredplugin.ID,
+				Command:        decredplugin.CmdNewComment,
+				CommandPayload: string(cmdPayload),
+				ReplyPayload:   string(replyPayload),
+			})
+			if err != nil {
+				return fmt.Errorf("PluginExec %v %v %v: %v",
+					decredplugin.CmdNewComment, token, ncr.CommentID, err)
+			}
+		}
+
+		// Build comment likes
+		log.Debugf("Building comment likes cache (%v likes)",
+			len(ir.LikeComments))
+		for _, v := range ir.LikeComments {
+			// Setup payloads
+			cmdPayload, err := decredplugin.EncodeLikeComment(v)
+			if err != nil {
+				return err
+			}
+
+			// Send plugin command
+			_, err = p.cache.PluginExec(cache.PluginCommand{
+				ID:             decredplugin.ID,
+				Command:        decredplugin.CmdLikeComment,
+				CommandPayload: string(cmdPayload),
+			})
+			if err != nil {
+				return fmt.Errorf("PluginExec %v %v %v: %v",
+					decredplugin.CmdLikeComment, token, v.CommentID, err)
+			}
+		}
+
+		// Build vote authorizations
+		log.Debugf("Building authorize vote cache")
+		for k, v := range ir.AuthorizeVotes {
+			// Setup payloads
+			cmdPayload, err := decredplugin.EncodeAuthorizeVote(v)
+			if err != nil {
+				return err
+			}
+			avr := ir.AuthorizeVoteReplies[k]
+			replyPayload, err := decredplugin.EncodeAuthorizeVoteReply(avr)
+			if err != nil {
+				return err
+			}
+
+			// Send plugin command
+			_, err = p.cache.PluginExec(cache.PluginCommand{
+				ID:             decredplugin.ID,
+				Command:        decredplugin.CmdAuthorizeVote,
+				CommandPayload: string(cmdPayload),
+				ReplyPayload:   string(replyPayload),
+			})
+			if err != nil {
+				return fmt.Errorf("PluginExec %v %v: %v",
+					decredplugin.CmdAuthorizeVote, token, err)
+			}
+		}
+
+		// Build start votes
+		log.Debugf("Building start vote cache")
+		for _, v := range ir.StartVoteTuples {
+			// Setup payloads. The start vote payload comes in the tuple
+			// already encoded due to the start vote versioning.
+			replyPayload, err := decredplugin.EncodeStartVoteReply(v.StartVoteReply)
+			if err != nil {
+				return err
+			}
+
+			// Send plugin command
+			_, err = p.cache.PluginExec(cache.PluginCommand{
+				ID:             decredplugin.ID,
+				Command:        decredplugin.CmdStartVote,
+				CommandPayload: v.StartVote.Payload,
+				ReplyPayload:   string(replyPayload),
+			})
+			if err != nil {
+				return fmt.Errorf("PluginExec %v %v: %v",
+					decredplugin.CmdStartVote, token, err)
+			}
+		}
+
+		// Build cast votes
+		log.Debugf("Building cast votes cache (%v votes)", len(ir.CastVotes))
+		if len(ir.CastVotes) != 0 {
+			// Setup payloads
+			bl := decredplugin.Ballot{
+				Votes: ir.CastVotes,
+			}
+			cmdPayload, err := decredplugin.EncodeBallot(bl)
+			if err != nil {
+				return err
+			}
+			receipts := make([]decredplugin.CastVoteReply, 0, len(ir.CastVotes))
+			for _, v := range ir.CastVotes {
+				receipts = append(receipts, decredplugin.CastVoteReply{
+					ClientSignature: v.Signature,
+				})
+			}
+			br := decredplugin.BallotReply{
+				Receipts: receipts,
+			}
+			replyPayload, err := decredplugin.EncodeBallotReply(br)
+			if err != nil {
+				return err
+			}
+
+			// Send plugin command
+			_, err = p.cache.PluginExec(cache.PluginCommand{
+				ID:             decredplugin.ID,
+				Command:        decredplugin.CmdBallot,
+				CommandPayload: string(cmdPayload),
+				ReplyPayload:   string(replyPayload),
+			})
+			if err != nil {
+				return fmt.Errorf("PluginExec %v %v: %v",
+					decredplugin.CmdBallot, token, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *politeia) buildCacheCMSPlugin(tokens []string) error {
+	// Fetch plugin inventory
+	_, payload, err := p.backend.Plugin(cmsplugin.CmdInventory, "")
+	if err != nil {
+		return fmt.Errorf("cms plugin inventory: %v", err)
+	}
+
+	// Build plugin cache
+	err = p.cache.PluginBuild(cmsplugin.ID, payload)
+	if err != nil {
+		return fmt.Errorf("cache PluginBuild %v: %v",
+			cmsplugin.ID, err)
+	}
+
+	return nil
+}
+
 func _main() error {
 	// Load configuration and parse command line.  This function also
 	// initializes logging and configures it accordingly.
@@ -1260,54 +1465,111 @@ func _main() error {
 
 	// Build the cache
 	if p.cfg.BuildCache {
-		// Fetch all versions of all records from the inventory and
-		// use them to build the cache.
-		vetted, unvetted, err := p.backend.Inventory(0, 0, true, true)
+		// Reset cache tables
+		err = p.cache.Build([]cache.Record{})
 		if err != nil {
-			return fmt.Errorf("backend inventory: %v", err)
+			return fmt.Errorf("cache Build: %v", err)
 		}
 
-		inv := make([]cache.Record, 0, len(vetted)+len(unvetted))
-		for _, r := range vetted {
-			inv = append(inv, p.convertBackendRecordToCache(r))
+		// Build unvetted records cache
+		log.Infof("Building unvettted records cache")
+		unvetted, err := p.backend.UnvettedTokens()
+		if err != nil {
+			return fmt.Errorf("backend UnvettedTokens: %v", err)
 		}
-		for _, r := range unvetted {
-			inv = append(inv, p.convertBackendRecordToCache(r))
+		for _, token := range unvetted {
+			r, err := p.backend.GetUnvetted(token)
+			if err != nil {
+				return fmt.Errorf("backend GetUnvetted %x: %v", token, err)
+			}
+			cr := p.convertBackendRecordToCache(*r)
+			err = p.cache.NewRecord(cr)
+			if err != nil {
+				return fmt.Errorf("cache NewRecord %x: %v", token, err)
+			}
+
+			log.Debugf("Added unvetted record %x", token)
 		}
 
-		// Build the cache
-		err = p.cache.Build(inv)
+		// Build vetted records cache
+		log.Debugf("Building vetted records cache")
+		vetted, err := p.backend.VettedTokens()
 		if err != nil {
-			return fmt.Errorf("build cache: %v", err)
+			return fmt.Errorf("backend VettedTokens: %v", err)
+		}
+		for _, token := range vetted {
+			// Add the most recent version
+			r, err := p.backend.GetVetted(token, "")
+			if err != nil {
+				return fmt.Errorf("backend GetVetted %x: %v", token, err)
+			}
+			cr := p.convertBackendRecordToCache(*r)
+			err = p.cache.NewRecord(cr)
+			if err != nil {
+				return fmt.Errorf("cache NewRecord %x: %v", token, err)
+			}
+
+			log.Debugf("Added vetted record %x version %v", token, r.Version)
+
+			// Add all previous versions
+			version, err := strconv.ParseUint(r.Version, 10, 64)
+			if err != nil {
+				return err
+			}
+			version--
+			for version > 0 {
+				v := strconv.FormatUint(version, 10)
+				r, err := p.backend.GetVetted(token, v)
+				if err != nil {
+					return fmt.Errorf("backend GetVetted %x %v: %v",
+						token, v, err)
+				}
+				cr := p.convertBackendRecordToCache(*r)
+				err = p.cache.NewRecord(cr)
+				if err != nil {
+					return fmt.Errorf("cache NewRecord %x %v: %v",
+						token, v, err)
+				}
+
+				log.Debugf("Added vetted record %x version %v", token, version)
+				version--
+			}
+		}
+
+		// Compile all tokens
+		tokens := make([]string, 0, len(unvetted)+len(vetted))
+		for _, v := range unvetted {
+			tokens = append(tokens, hex.EncodeToString(v))
+		}
+		for _, v := range vetted {
+			tokens = append(tokens, hex.EncodeToString(v))
 		}
 
 		// Build the cache for plugins
-		// XXX when we create an interface for plugins we need to
-		// rethink how we're building the plugin caches. Reading the
-		// entire plugin inventory into memory is only a temporary
-		// solution.
-		for _, v := range p.plugins {
-			var cmd string
-			for _, s := range v.Settings {
-				if s.Key == "inventory" {
-					cmd = s.Value
+		for _, plugin := range p.plugins {
+			var enableCache bool
+			for _, s := range plugin.Settings {
+				if s.Key == "enablecache" {
+					enableCache = true
 				}
 			}
-			if cmd == "" {
+			if !enableCache {
 				continue
 			}
 
-			// Fetch plugin inventory
-			_, payload, err := p.backend.Plugin(cmd, "")
-			if err != nil {
-				log.Errorf("Failed to get plugin data to build cache "+
-					"plugin:%v command:%v error:%v", v.ID, cmd, err)
-			}
-
-			// Build plugin cache
-			err = p.cache.PluginBuild(v.ID, payload)
-			if err != nil {
-				return fmt.Errorf("plugin '%v' build cache: %v", v.ID, err)
+			switch plugin.ID {
+			case decredplugin.ID:
+				err := p.buildCacheDecredPlugin(tokens)
+				if err != nil {
+					return fmt.Errorf("buildCacheDecredPlugin: %v", err)
+				}
+			case cmsplugin.ID:
+				err := p.buildCacheCMSPlugin(tokens)
+				if err != nil {
+					return fmt.Errorf("buildCacheCMSPlugin: %v", err)
+				}
+			default:
+				return fmt.Errorf("cache enabled for invalid plugin '%v'", plugin.ID)
 			}
 		}
 	}


### PR DESCRIPTION
When the cache needs to be rebuilt it would use the backend `Inventory`
call to retrieve the full record inventory, including all versions of
every record, and store them in memory. This was a temporary solution
that has now started to become a problem due to the amount of data that
exists on the mainnet proposals site.

This diff adds two calls, `UnvettedTokens` and `VettedTokens` to the
backend interface that return the tokens of all unvetted and vetted
records, respectively. When the cache gets rebuilt it uses these calls
to fetch the record tokens then retrieves a single record at a time to
insert into the cache. The decred plugin cache rebuild process was
also updated to do the same thing. It retrieves the decred plugin data
and builds the decred plugin cache for each record individually.