### PR TITLE
dbutil: use user database interface

### DIFF
--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -26,6 +26,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/politeia/decredplugin"
+	"github.com/decred/politeia/mdstream"
 	"github.com/decred/politeia/politeiad/backend/gitbe"
 	"github.com/decred/politeia/politeiawww/sharedconfig"
 	"github.com/decred/politeia/politeiawww/user"
@@ -156,14 +157,6 @@ const usageMsg = `politeiawww_dbutil usage:
           Required DB flag : -cockroachdb
           Args             : <username>
 `
-
-type proposalMetadata struct {
-	Version   uint64 `json:"version"`   // Version of this struct
-	Timestamp int64  `json:"timestamp"` // Last update of proposal
-	Name      string `json:"name"`      // Generated proposal name
-	PublicKey string `json:"publickey"` // Key used for signature
-	Signature string `json:"signature"` // Signature of merkle root
-}
 
 func cmdDump() error {
 	// If email is provided, only dump that user.
@@ -386,7 +379,7 @@ func cmdStubUsers() error {
 					return err
 				}
 
-				var md proposalMetadata
+				var md mdstream.ProposalGeneralV2
 				err = json.Unmarshal(b, &md)
 				if err != nil {
 					return fmt.Errorf("proposal md: %v", err)
@@ -764,7 +757,6 @@ func _main() error {
 	switch {
 	case *level:
 		dbDir := filepath.Join(*dataDir, network)
-		// dbDir := filepath.Join(*dataDir, network, localdb.UserdbPath)
 		fmt.Printf("Database: %v\n", dbDir)
 
 		_, err := os.Stat(dbDir)
@@ -781,7 +773,6 @@ func _main() error {
 		userDB = ldb
 		defer userDB.Close()
 
-	// connects to cockroachdb by default
 	case *cockroach:
 		err := validateCockroachParams()
 		if err != nil {

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -175,7 +175,7 @@ func cmdDump() error {
 	}
 
 	err := userDB.AllUsers(func(u *user.User) {
-		fmt.Printf("Key    : %v\n", string(u.Username))
+		fmt.Printf("Key    : %v\n", u.Username)
 		fmt.Printf("Record : %v\n", spew.Sdump(u))
 	})
 	if err != nil {
@@ -470,6 +470,9 @@ func cmdMigrate() error {
 	err = ldb.AllUsers(func(u *user.User) {
 		users = append(users, *u)
 	})
+	if err != nil {
+		return fmt.Errorf("leveldb allusers request: %v", err)
+	}
 
 	// Make sure the migration went ok.
 	if len(users) == 0 {


### PR DESCRIPTION
This diff changes the approach on `politeiawww_dbutil` to use the user.Database interface instead of the *leveldb.DB Database object.

Also, changes the proposalMetadata to use the correct one imported from mdstream package

Closes #1241 