### PR TITLE
[cms] Add params to AdminInvoices request

### DIFF
--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -532,11 +532,15 @@ type UserInvoicesReply struct {
 	Invoices []InvoiceRecord `json:"invoices"`
 }
 
-// AdminInvoices is used to get all invoices from all users
+// AdminInvoices is used to get all invoices from all users (if no userid is
+// given).
 type AdminInvoices struct {
-	Month  uint16         `json:"month"`  // Month of Invoice
-	Year   uint16         `json:"year"`   // Year of Invoice
-	Status InvoiceStatusT `json:"status"` // Current status of invoice
+	Month     uint16         `json:"month"`  // Month of Invoice
+	Year      uint16         `json:"year"`   // Year of Invoice
+	Status    InvoiceStatusT `json:"status"` // Current status of invoice
+	UserID    string         `json:"userid"` // User ID for invoices to return
+	StartTime int64          `json:"start"`  // Start time for range
+	EndTime   int64          `json:"end"`    // End time for range
 }
 
 // AdminInvoicesReply is used to reply to an admin invoices command.

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -53,7 +53,8 @@ type Database interface {
 	InvoicesByMonthYear(uint16, uint16) ([]Invoice, error)            // Returns all invoice by month, year
 	InvoicesByStatus(int) ([]Invoice, error)                          // Returns all invoices by status
 	InvoicesAll() ([]Invoice, error)                                  // Returns all invoices
-	InvoicesByDateRangeStatus(int64, int64, int) ([]*Invoice, error)  // Returns all paid invoice line items from range provided
+	InvoicesByDateRangeStatus(int64, int64, int) ([]Invoice, error)   // Returns all paid invoice line items from range provided
+	InvoicesByDateRange(int64, int64) ([]Invoice, error)              // Returns all invoices from range provided
 	InvoicesByLineItemsProposalToken(string) ([]*Invoice, error)      // Returns all Invoices with paid line item information based on proposal token.
 
 	// ExchangeRate functions


### PR DESCRIPTION
This PR adds 3 new params to the AdminInvoices request.  StartTime, EndTime and UserID.

UserID if set will return only invoices that were created by that UserID.

StartTime and EndTIme will return invoices in the range given.  But note that these params can only be used when Month/Year are empty otherwise an Error will be returned.