### PR TITLE
www: Add dedicated router port for admin routes

### DIFF
--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -28,6 +28,7 @@ const (
 	RoutePolicy                   = "/policy"
 	RouteSecret                   = "/secret"
 	RouteLogin                    = "/login"
+	RouteLoginAdmin               = "/loginadmin"
 	RouteLogout                   = "/logout"
 	RouteUserMe                   = "/user/me"
 	RouteUserDetails              = "/user/{userid:[0-9a-zA-Z-]{36}}"
@@ -211,6 +212,7 @@ const (
 	ErrorStatusInvalidLinkBy               ErrorStatusT = 74
 	ErrorStatusInvalidRunoffVote           ErrorStatusT = 75
 	ErrorStatusWrongProposalType           ErrorStatusT = 76
+	ErrorStatusLoginAttemptWrongHost       ErrorStatusT = 77
 
 	// Proposal state codes
 	//
@@ -285,6 +287,12 @@ const (
 	NotificationEmailAdminProposalVoteAuthorized EmailNotificationT = 1 << 6
 	NotificationEmailCommentOnMyProposal         EmailNotificationT = 1 << 7
 	NotificationEmailCommentOnMyComment          EmailNotificationT = 1 << 8
+
+	// Default network config
+	DefaultMainnetPort      = "4443"
+	DefaultTestnetPort      = "4443"
+	DefaultMainnetAdminPort = "1433"
+	DefaultTestnetAdminPort = "1433"
 )
 
 var (
@@ -383,6 +391,7 @@ var (
 		ErrorStatusInvalidLinkBy:               "invalid proposal linkby",
 		ErrorStatusInvalidRunoffVote:           "invalid runoff vote",
 		ErrorStatusWrongProposalType:           "wrong proposal type",
+		ErrorStatusLoginAttemptWrongHost:       "admin login attempt on wrong host",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -74,6 +74,7 @@ type piwww struct {
 	Inventory          InventoryCmd             `command:"inventory" description:"(public) get the proposals that are being voted on"`
 	LikeComment        LikeCommentCmd           `command:"likecomment" description:"(user)   upvote/downvote a comment"`
 	Login              shared.LoginCmd          `command:"login" description:"(public) login to Politeia"`
+	LoginAdmin         shared.LoginAdminCmd     `command:"loginadmin" description:"(admin) login to Politeia with an admin account"`
 	Logout             shared.LogoutCmd         `command:"logout" description:"(public) logout of Politeia"`
 	ManageUser         shared.ManageUserCmd     `command:"manageuser" description:"(admin)  edit certain properties of the specified user"`
 	Me                 shared.MeCmd             `command:"me" description:"(user)   get user details for the logged in user"`

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -77,7 +77,7 @@ func (p *politeiawww) isLoggedInAsAdmin(f http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// logging logs all incoming commands before calling the next funxtion.
+// logging logs all incoming commands before calling the next function.
 //
 // NOTE: LOGGING WILL LOG PASSWORDS IF TRACING IS ENABLED.
 func logging(f http.HandlerFunc) http.HandlerFunc {

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -86,9 +86,10 @@ func (w *wsContext) isAuthenticated() bool {
 
 // politeiawww application context.
 type politeiawww struct {
-	cfg      *config
-	router   *mux.Router
-	sessions sessions.Store
+	cfg         *config
+	router      *mux.Router
+	adminRouter *mux.Router
+	sessions    sessions.Store
 
 	ws    map[string]map[string]*wsContext // [uuid][]*context
 	wsMtx sync.RWMutex

--- a/politeiawww/testing.go
+++ b/politeiawww/testing.go
@@ -693,6 +693,7 @@ func newTestPoliteiawww(t *testing.T) (*politeiawww, func()) {
 		cache:           testcache.New(),
 		params:          &chaincfg.TestNet3Params,
 		router:          mux.NewRouter(),
+		adminRouter:     mux.NewRouter(),
 		sessions:        NewSessionStore(db, sessionMaxAge, cookieKey),
 		smtp:            smtp,
 		test:            true,


### PR DESCRIPTION
This diff lays the work for the integration of authpf for admins on pi. Major changes are:

- all routes enabled on `:1433`, the admin port
- only non-admin routes enabled on `:4443`, the normal port
- admin logins made on `:4443` are rejected with `ErrorStatusLoginAttemptWrongHost`
- normal logins made on `:1433` are rejected with `ErrorStatusLoginAttemptWrongHost`

Another change is that `piwww` now saves the `isAdmin` property on the on-disk user data file, alongside with the username. This way we can set the appropriate host port depending on the logged in user when the cli is used. Besides that, `piwww` adds a `loginadmin` command, which hits the admin port instead of the normal port. With the `login` and `loginadmin` commands we set the data we need on the on-disk user file.

Closes #945