### PR TITLE
multi: add context to multiple APIs

### DIFF
--- a/politeiawww/cmd/piwww/newuser.go
+++ b/politeiawww/cmd/piwww/newuser.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 
@@ -27,7 +28,7 @@ type NewUserCmd struct {
 }
 
 // Execute executes the new user command.
-func (cmd *NewUserCmd) Execute(args []string) error {
+func (cmd *NewUserCmd) Execute(ctx context.Context, args []string) error {
 	email := cmd.Args.Email
 	username := cmd.Args.Username
 	password := cmd.Args.Password
@@ -141,7 +142,7 @@ func (cmd *NewUserCmd) Execute(args []string) error {
 		faucet := SendFaucetTxCmd{}
 		faucet.Args.Address = lr.PaywallAddress
 		faucet.Args.Amount = lr.PaywallAmount
-		err = faucet.Execute(nil)
+		err = faucet.Execute(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmd/piwww/sendfaucettx.go
+++ b/politeiawww/cmd/piwww/sendfaucettx.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/decred/politeia/util"
@@ -21,7 +22,7 @@ type SendFaucetTxCmd struct {
 }
 
 // Execute executes the send faucet tx command.
-func (cmd *SendFaucetTxCmd) Execute(args []string) error {
+func (cmd *SendFaucetTxCmd) Execute(ctx context.Context, args []string) error {
 	address := cmd.Args.Address
 	atoms := cmd.Args.Amount
 	dcr := float64(atoms) / 1e8
@@ -31,7 +32,7 @@ func (cmd *SendFaucetTxCmd) Execute(args []string) error {
 			dcr, address)
 	}
 
-	txID, err := util.PayWithTestnetFaucet(cfg.FaucetHost, address, atoms,
+	txID, err := util.PayWithTestnetFaucet(ctx, cfg.FaucetHost, address, atoms,
 		cmd.Args.OverrideToken)
 	if err != nil {
 		return err

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -230,13 +231,14 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 	fmt.Printf("Creating user: %v\n", email)
 
+	ctx := context.Background()
 	nuc := NewUserCmd{
 		Verify: true,
 	}
 	nuc.Args.Email = email
 	nuc.Args.Username = username
 	nuc.Args.Password = password
-	err = nuc.Execute(nil)
+	err = nuc.Execute(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -287,7 +289,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 
 		// Pay user registration fee
 		fmt.Printf("  Paying user registration fee\n")
-		txID, err := util.PayWithTestnetFaucet(cfg.FaucetHost,
+		txID, err := util.PayWithTestnetFaucet(ctx, cfg.FaucetHost,
 			lr.PaywallAddress, lr.PaywallAmount, "")
 		if err != nil {
 			return err
@@ -336,7 +338,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 		fmt.Printf("  Purchasing %v proposal credits\n", numCredits)
 
 		atoms := ppdr.CreditPrice * uint64(numCredits)
-		txID, err := util.PayWithTestnetFaucet(cfg.FaucetHost,
+		txID, err := util.PayWithTestnetFaucet(ctx, cfg.FaucetHost,
 			ppdr.PaywallAddress, atoms, "")
 		if err != nil {
 			return err

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -76,7 +76,7 @@ func (p *politeiawww) handleNewInvoice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reply, err := p.processNewInvoice(ni, user)
+	reply, err := p.processNewInvoice(r.Context(), ni, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleNewInvoice: processNewInvoice %v", err)
@@ -204,7 +204,7 @@ func (p *politeiawww) handleSetInvoiceStatus(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	reply, err := p.processSetInvoiceStatus(sis, user)
+	reply, err := p.processSetInvoiceStatus(r.Context(), sis, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleSetInvoiceStatus: processSetInvoiceStatus %v", err)
@@ -269,7 +269,7 @@ func (p *politeiawww) handleEditInvoice(w http.ResponseWriter, r *http.Request) 
 
 	log.Debugf("handleEditInvoice: %v", ei.Token)
 
-	epr, err := p.processEditInvoice(ei, user)
+	epr, err := p.processEditInvoice(r.Context(), ei, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleEditInvoice: processEditInvoice %v", err)
@@ -333,7 +333,7 @@ func (p *politeiawww) handleNewCommentInvoice(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	cr, err := p.processNewCommentInvoice(sc, user)
+	cr, err := p.processNewCommentInvoice(r.Context(), sc, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleNewCommentInvoice: processNewCommentInvoice: %v", err)
@@ -381,7 +381,7 @@ func (p *politeiawww) handleInvoiceExchangeRate(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	ierr, err := p.processInvoiceExchangeRate(ier)
+	ierr, err := p.processInvoiceExchangeRate(r.Context(), ier)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleInvoiceExchangeRate: processNewCommentInvoice: %v", err)
@@ -435,7 +435,7 @@ func (p *politeiawww) handlePayInvoices(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	reply, err := p.processPayInvoices(user)
+	reply, err := p.processPayInvoices(r.Context(), user)
 	if err != nil {
 		RespondWithError(w, r, 0, "handlePayInvoices: processPayInvoices %v",
 			err)
@@ -582,7 +582,7 @@ func (p *politeiawww) handleNewDCC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ndr, err := p.processNewDCC(nd, u)
+	ndr, err := p.processNewDCC(r.Context(), nd, u)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleNewDCC: processNewDCC: %v", err)
@@ -609,7 +609,7 @@ func (p *politeiawww) handleDCCDetails(w http.ResponseWriter, r *http.Request) {
 	pathParams := mux.Vars(r)
 	gd.Token = pathParams["token"]
 
-	gdr, err := p.processDCCDetails(gd)
+	gdr, err := p.processDCCDetails(r.Context(), gd)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleDCCDetails: processDCCDetails: %v", err)
@@ -667,7 +667,7 @@ func (p *politeiawww) handleSupportOpposeDCC(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	sdr, err := p.processSupportOpposeDCC(sd, u)
+	sdr, err := p.processSupportOpposeDCC(r.Context(), sd, u)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleSupportOpposeDCC: processSupportOpposeDCC: %v", err)
@@ -698,7 +698,7 @@ func (p *politeiawww) handleNewCommentDCC(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	cr, err := p.processNewCommentDCC(sc, user)
+	cr, err := p.processNewCommentDCC(r.Context(), sc, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleNewCommentDCC: processNewCommentDCC: %v", err)
@@ -751,7 +751,7 @@ func (p *politeiawww) handleSetDCCStatus(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	adr, err := p.processSetDCCStatus(ad, u)
+	adr, err := p.processSetDCCStatus(r.Context(), ad, u)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleSetDCCStatus: processSetDCCStatus: %v", err)
@@ -851,7 +851,7 @@ func (p *politeiawww) handleCastVoteDCC(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	cvr, err := p.processCastVoteDCC(cv, u)
+	cvr, err := p.processCastVoteDCC(r.Context(), cv, u)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleCastVoteDCC: processCastVoteDCC: %v", err)
@@ -873,7 +873,7 @@ func (p *politeiawww) handleVoteDetailsDCC(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	vdr, err := p.processVoteDetailsDCC(vd.Token)
+	vdr, err := p.processVoteDetailsDCC(r.Context(), vd.Token)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleVoteDetailsDCC: processVoteDetailsDCC: %v", err)
@@ -887,7 +887,7 @@ func (p *politeiawww) handleVoteDetailsDCC(w http.ResponseWriter, r *http.Reques
 func (p *politeiawww) handleActiveVoteDCC(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleActiveVoteDCC")
 
-	avr, err := p.processActiveVoteDCC()
+	avr, err := p.processActiveVoteDCC(r.Context())
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleActiveVoteDCC: processActiveVoteDCC %v", err)
@@ -925,7 +925,7 @@ func (p *politeiawww) handleStartVoteDCC(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	svr, err := p.processStartVoteDCC(sv, user)
+	svr, err := p.processStartVoteDCC(r.Context(), sv, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleStartVoteDCC: processStartVoteDCC %v", err)

--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -194,7 +195,7 @@ func validateComment(c www.NewComment) error {
 
 // processNewComment sends a new comment decred plugin command to politeaid
 // then fetches the new comment from the cache and returns it.
-func (p *politeiawww) processNewComment(nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
+func (p *politeiawww) processNewComment(ctx context.Context, nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
 	log.Tracef("processNewComment: %v %v", nc.Token, u.ID)
 
 	// Make sure token is valid and not a prefix
@@ -251,11 +252,11 @@ func (p *politeiawww) processNewComment(nc www.NewComment, u *user.User) (*www.N
 	}
 
 	// Ensure proposal voting has not ended
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
 	}
-	vs, err := p.voteSummaryGet(nc.Token, bb)
+	vs, err := p.voteSummaryGet(ctx, nc.Token, bb)
 	if err != nil {
 		return nil, fmt.Errorf("voteSummaryGet: %v", err)
 	}
@@ -302,7 +303,7 @@ func (p *politeiawww) processNewComment(nc www.NewComment, u *user.User) (*www.N
 	}
 
 	// Send polieiad request
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -349,7 +350,7 @@ func (p *politeiawww) processNewComment(nc www.NewComment, u *user.User) (*www.N
 
 // processNewCommentInvoice sends a new comment decred plugin command to politeaid
 // then fetches the new comment from the cache and returns it.
-func (p *politeiawww) processNewCommentInvoice(nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
+func (p *politeiawww) processNewCommentInvoice(ctx context.Context, nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
 	log.Tracef("processNewComment: %v %v", nc.Token, u.ID)
 
 	ir, err := p.getInvoice(nc.Token)
@@ -418,7 +419,7 @@ func (p *politeiawww) processNewCommentInvoice(nc www.NewComment, u *user.User) 
 	}
 
 	// Send polieiad request
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -473,7 +474,7 @@ func (p *politeiawww) processNewCommentInvoice(nc www.NewComment, u *user.User) 
 }
 
 // processLikeComment processes an upvote/downvote on a comment.
-func (p *politeiawww) processLikeComment(lc www.LikeComment, u *user.User) (*www.LikeCommentReply, error) {
+func (p *politeiawww) processLikeComment(ctx context.Context, lc www.LikeComment, u *user.User) (*www.LikeCommentReply, error) {
 	log.Debugf("processLikeComment: %v %v %v", lc.Token, lc.CommentID, u.ID)
 
 	// Make sure token is valid and not a prefix
@@ -523,11 +524,11 @@ func (p *politeiawww) processLikeComment(lc www.LikeComment, u *user.User) (*www
 	}
 
 	// Ensure proposal voting has not ended
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
 	}
-	vs, err := p.voteSummaryGet(pr.CensorshipRecord.Token, bb)
+	vs, err := p.voteSummaryGet(ctx, pr.CensorshipRecord.Token, bb)
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +588,7 @@ func (p *politeiawww) processLikeComment(lc www.LikeComment, u *user.User) (*www
 	}
 
 	// Send plugin command to politeiad
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -630,7 +631,7 @@ func (p *politeiawww) processLikeComment(lc www.LikeComment, u *user.User) (*www
 
 // processCensorComment sends a censor comment decred plugin command to
 // politeiad then returns the censor comment receipt.
-func (p *politeiawww) processCensorComment(cc www.CensorComment, u *user.User) (*www.CensorCommentReply, error) {
+func (p *politeiawww) processCensorComment(ctx context.Context, cc www.CensorComment, u *user.User) (*www.CensorCommentReply, error) {
 	log.Tracef("processCensorComment: %v: %v", cc.Token, cc.CommentID)
 
 	// Make sure token is valid and not a prefix
@@ -674,11 +675,11 @@ func (p *politeiawww) processCensorComment(cc www.CensorComment, u *user.User) (
 	}
 
 	// Ensure proposal voting has not ended
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getBestBlock: %v", err)
 	}
-	vs, err := p.voteSummaryGet(cc.Token, bb)
+	vs, err := p.voteSummaryGet(ctx, cc.Token, bb)
 	if err != nil {
 		return nil, err
 	}
@@ -710,7 +711,7 @@ func (p *politeiawww) processCensorComment(cc www.CensorComment, u *user.User) (
 	}
 
 	// Send plugin request
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -79,7 +80,7 @@ func createSponsorStatementRegex() string {
 	return buf.String()
 }
 
-func (p *politeiawww) processNewDCC(nd cms.NewDCC, u *user.User) (*cms.NewDCCReply, error) {
+func (p *politeiawww) processNewDCC(ctx context.Context, nd cms.NewDCC, u *user.User) (*cms.NewDCCReply, error) {
 	reply := &cms.NewDCCReply{}
 
 	err := p.validateDCC(nd, u)
@@ -146,7 +147,7 @@ func (p *politeiawww) processNewDCC(nd cms.NewDCC, u *user.User) (*cms.NewDCCRep
 	}
 
 	// Send the newrecord politeiad request
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.NewRecordRoute, n)
 	if err != nil {
 		return nil, err
@@ -202,7 +203,7 @@ func (p *politeiawww) processNewDCC(nd cms.NewDCC, u *user.User) (*cms.NewDCCRep
 	}
 
 	// Send SetUnvettedStatus request to politeiad
-	responseBody, err = p.makeRequest(http.MethodPost,
+	responseBody, err = p.makeRequest(ctx, http.MethodPost,
 		pd.SetUnvettedStatusRoute, sus)
 	if err != nil {
 		return nil, err
@@ -479,14 +480,14 @@ func (p *politeiawww) getDCC(token string) (*cms.DCCRecord, error) {
 	return &i, nil
 }
 
-func (p *politeiawww) processDCCDetails(gd cms.DCCDetails) (*cms.DCCDetailsReply, error) {
+func (p *politeiawww) processDCCDetails(ctx context.Context, gd cms.DCCDetails) (*cms.DCCDetailsReply, error) {
 	log.Tracef("processDCCDetails: %v", gd.Token)
-	vdr, err := p.cmsVoteDetails(gd.Token)
+	vdr, err := p.cmsVoteDetails(ctx, gd.Token)
 	if err != nil {
 		return nil, err
 	}
 
-	vsr, err := p.cmsVoteSummary(gd.Token)
+	vsr, err := p.cmsVoteSummary(ctx, gd.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -552,7 +553,7 @@ func (p *politeiawww) processGetDCCs(gds cms.GetDCCs) (*cms.GetDCCsReply, error)
 	}, nil
 }
 
-func (p *politeiawww) processSupportOpposeDCC(sd cms.SupportOpposeDCC, u *user.User) (*cms.SupportOpposeDCCReply, error) {
+func (p *politeiawww) processSupportOpposeDCC(ctx context.Context, sd cms.SupportOpposeDCC, u *user.User) (*cms.SupportOpposeDCCReply, error) {
 	log.Tracef("processSupportOpposeDCC: %v %v", sd.Token, u.ID)
 
 	// The submitted Vote in the request must either be "aye" or "nay"
@@ -643,7 +644,7 @@ func (p *politeiawww) processSupportOpposeDCC(sd cms.SupportOpposeDCC, u *user.U
 		},
 	}
 
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.UpdateVettedMetadataRoute, pdCommand)
 	if err != nil {
 		return nil, err
@@ -682,7 +683,7 @@ func stringInSlice(arr []string, str string) bool {
 
 // processNewCommentDCC sends a new comment decred plugin command to politeaid
 // then fetches the new comment from the cache and returns it.
-func (p *politeiawww) processNewCommentDCC(nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
+func (p *politeiawww) processNewCommentDCC(ctx context.Context, nc www.NewComment, u *user.User) (*www.NewCommentReply, error) {
 	log.Tracef("processNewCommentDCC: %v %v", nc.Token, u.ID)
 
 	// Validate comment
@@ -756,7 +757,7 @@ func (p *politeiawww) processNewCommentDCC(nc www.NewComment, u *user.User) (*ww
 	}
 
 	// Send polieiad request
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -851,7 +852,7 @@ func (p *politeiawww) getDCCComments(token string) ([]www.Comment, error) {
 	return comments, nil
 }
 
-func (p *politeiawww) processSetDCCStatus(sds cms.SetDCCStatus, u *user.User) (*cms.SetDCCStatusReply, error) {
+func (p *politeiawww) processSetDCCStatus(ctx context.Context, sds cms.SetDCCStatus, u *user.User) (*cms.SetDCCStatusReply, error) {
 	log.Tracef("processSetDCCStatus: %v", u.PublicKey())
 
 	// Ensure the provided public key is the user's active key.
@@ -884,14 +885,14 @@ func (p *politeiawww) processSetDCCStatus(sds cms.SetDCCStatus, u *user.User) (*
 	}
 
 	// Validate vote status
-	vsr, err := p.cmsVoteSummary(sds.Token)
+	vsr, err := p.cmsVoteSummary(ctx, sds.Token)
 	if err != nil {
 		return nil, err
 	}
 
 	// Only allow voting on All Vote DCC proposals
 	// Get vote summary to check vote status
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -939,7 +940,7 @@ func (p *politeiawww) processSetDCCStatus(sds cms.SetDCCStatus, u *user.User) (*
 		},
 	}
 
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.UpdateVettedMetadataRoute, pdCommand)
 	if err != nil {
 		return nil, err
@@ -1027,10 +1028,10 @@ func dccStatusInSlice(arr []cms.DCCStatusT, status cms.DCCStatusT) bool {
 	return false
 }
 
-func (p *politeiawww) processCastVoteDCC(cv cms.CastVote, u *user.User) (*cms.CastVoteReply, error) {
+func (p *politeiawww) processCastVoteDCC(ctx context.Context, cv cms.CastVote, u *user.User) (*cms.CastVoteReply, error) {
 	log.Tracef("processCastVoteDCC: %v", u.PublicKey())
 
-	vdr, err := p.cmsVoteDetails(cv.Token)
+	vdr, err := p.cmsVoteDetails(ctx, cv.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -1053,7 +1054,7 @@ func (p *politeiawww) processCastVoteDCC(cv cms.CastVote, u *user.User) (*cms.Ca
 	// Only allow voting on All Vote DCC proposals
 	// Get vote summary to check vote status
 
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1083,7 +1084,7 @@ func (p *politeiawww) processCastVoteDCC(cv cms.CastVote, u *user.User) (*cms.Ca
 		Payload:   string(payload),
 	}
 
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -1111,11 +1112,11 @@ func (p *politeiawww) processCastVoteDCC(cv cms.CastVote, u *user.User) (*cms.Ca
 	return convertCastVoteReplyToCMS(pluginCastVoteReply), nil
 }
 
-func (p *politeiawww) processVoteDetailsDCC(token string) (*cms.VoteDetailsReply, error) {
+func (p *politeiawww) processVoteDetailsDCC(ctx context.Context, token string) (*cms.VoteDetailsReply, error) {
 	log.Tracef("processVoteDetailsDCC: %v", token)
 
 	// Validate vote status
-	dvdr, err := p.cmsVoteDetails(token)
+	dvdr, err := p.cmsVoteDetails(ctx, token)
 	if err != nil {
 		if err == cmsdatabase.ErrDCCNotFound {
 			err = www.UserError{
@@ -1141,7 +1142,7 @@ func (p *politeiawww) processVoteDetailsDCC(token string) (*cms.VoteDetailsReply
 
 // cmsVoteDetails sends the cms plugin votedetails command to the gitbe
 // and returns the vote details for the passed in proposal.
-func (p *politeiawww) cmsVoteDetails(token string) (*cmsplugin.VoteDetailsReply, error) {
+func (p *politeiawww) cmsVoteDetails(ctx context.Context, token string) (*cmsplugin.VoteDetailsReply, error) {
 	// Setup plugin command
 	vd := cmsplugin.VoteDetails{
 		Token: token,
@@ -1160,7 +1161,7 @@ func (p *politeiawww) cmsVoteDetails(token string) (*cmsplugin.VoteDetailsReply,
 		Command:   cmsplugin.CmdVoteDetails,
 		Payload:   string(payload),
 	}
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -1187,7 +1188,7 @@ func (p *politeiawww) cmsVoteDetails(token string) (*cmsplugin.VoteDetailsReply,
 
 // cmsVoteSummary provides the current tally of a given DCC proposal based on
 // the provided token.
-func (p *politeiawww) cmsVoteSummary(token string) (*cmsplugin.VoteSummaryReply, error) {
+func (p *politeiawww) cmsVoteSummary(ctx context.Context, token string) (*cmsplugin.VoteSummaryReply, error) {
 	// Setup plugin command
 	vs := cmsplugin.VoteSummary{
 		Token: token,
@@ -1206,7 +1207,7 @@ func (p *politeiawww) cmsVoteSummary(token string) (*cmsplugin.VoteSummaryReply,
 		Command:   cmsplugin.CmdVoteSummary,
 		Payload:   string(payload),
 	}
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -1231,7 +1232,7 @@ func (p *politeiawww) cmsVoteSummary(token string) (*cmsplugin.VoteSummaryReply,
 	return vsr, nil
 }
 
-func (p *politeiawww) processActiveVoteDCC() (*cms.ActiveVoteReply, error) {
+func (p *politeiawww) processActiveVoteDCC(ctx context.Context) (*cms.ActiveVoteReply, error) {
 	log.Tracef("processActiveVoteDCC")
 
 	// Request full record inventory from backend
@@ -1246,7 +1247,7 @@ func (p *politeiawww) processActiveVoteDCC() (*cms.ActiveVoteReply, error) {
 		AllVersions:  true,
 	}
 
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.InventoryRoute, pdCommand)
 	if err != nil {
 		return nil, err
@@ -1266,7 +1267,7 @@ func (p *politeiawww) processActiveVoteDCC() (*cms.ActiveVoteReply, error) {
 	}
 	vetted := pdReply.Vetted
 
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1276,7 +1277,7 @@ func (p *politeiawww) processActiveVoteDCC() (*cms.ActiveVoteReply, error) {
 		for _, m := range r.Metadata {
 			switch m.ID {
 			case mdstream.IDDCCGeneral:
-				vs, err := p.cmsVoteSummary(r.CensorshipRecord.Token)
+				vs, err := p.cmsVoteSummary(ctx, r.CensorshipRecord.Token)
 				if err != nil {
 					log.Errorf("processActiveVotes: error pull cmsVoteSummary "+
 						"%v %v", r.CensorshipRecord.Token, err)
@@ -1298,7 +1299,7 @@ func (p *politeiawww) processActiveVoteDCC() (*cms.ActiveVoteReply, error) {
 	vt := make([]cms.VoteTuple, 0, len(dccs))
 	for _, v := range dccs {
 		// Get vote details from gitbe
-		vdr, err := p.cmsVoteDetails(v.CensorshipRecord.Token)
+		vdr, err := p.cmsVoteDetails(ctx, v.CensorshipRecord.Token)
 		if err != nil {
 			return nil, fmt.Errorf("decredVoteDetails %v: %v",
 				v.CensorshipRecord.Token, err)
@@ -1383,7 +1384,7 @@ func (p *politeiawww) getDCCs(tokens []string) (map[string]cms.DCCRecord, error)
 
 // processStartVoteV2 starts the voting period on a proposal using the provided
 // v2 StartVote.
-func (p *politeiawww) processStartVoteDCC(sv cms.StartVote, u *user.User) (*cms.StartVoteReply, error) {
+func (p *politeiawww) processStartVoteDCC(ctx context.Context, sv cms.StartVote, u *user.User) (*cms.StartVoteReply, error) {
 	log.Tracef("processStartVoteDCC %v", sv.Vote.Token)
 
 	// Sanity check
@@ -1479,7 +1480,7 @@ func (p *politeiawww) processStartVoteDCC(sv cms.StartVote, u *user.User) (*cms.
 	}
 
 	// Validate vote status
-	vsr, err := p.cmsVoteSummary(sv.Vote.Token)
+	vsr, err := p.cmsVoteSummary(ctx, sv.Vote.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -1487,7 +1488,7 @@ func (p *politeiawww) processStartVoteDCC(sv cms.StartVote, u *user.User) (*cms.
 	// Only allow voting on All Vote DCC proposals
 	// Get vote summary to check vote status
 
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1526,7 +1527,7 @@ func (p *politeiawww) processStartVoteDCC(sv cms.StartVote, u *user.User) (*cms.
 		CommandID: cmsplugin.CmdStartVote + " " + sv.Vote.Token,
 		Payload:   string(payload),
 	}
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -336,7 +337,7 @@ func (p *politeiawww) decredTokenInventory(bestBlock uint64, includeUnvetted boo
 }
 
 // decredLoadVoteResults sends the loadvotesummaries command to politeiad.
-func (p *politeiawww) decredLoadVoteResults(bestBlock uint64) (*decredplugin.LoadVoteResultsReply, error) {
+func (p *politeiawww) decredLoadVoteResults(ctx context.Context, bestBlock uint64) (*decredplugin.LoadVoteResultsReply, error) {
 	// Setup plugin command
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -360,7 +361,7 @@ func (p *politeiawww) decredLoadVoteResults(bestBlock uint64) (*decredplugin.Loa
 	}
 
 	// Send plugin command to politeiad
-	respBody, err := p.makeRequest(http.MethodPost,
+	respBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -264,7 +265,7 @@ func validateContact(contact string) error {
 }
 
 // processNewInvoice tries to submit a new invoice to politeiad.
-func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.NewInvoiceReply, error) {
+func (p *politeiawww) processNewInvoice(ctx context.Context, ni cms.NewInvoice, u *user.User) (*cms.NewInvoiceReply, error) {
 	log.Tracef("processNewInvoice")
 
 	cmsUser, err := p.getCMSUserByIDRaw(u.ID.String())
@@ -362,7 +363,7 @@ func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.N
 	}
 
 	// Send the newrecord politeiad request
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.NewRecordRoute, n)
 	if err != nil {
 		return nil, err
@@ -419,7 +420,7 @@ func (p *politeiawww) processNewInvoice(ni cms.NewInvoice, u *user.User) (*cms.N
 	}
 
 	// Send SetUnvettedStatus request to politeiad
-	responseBody, err = p.makeRequest(http.MethodPost,
+	responseBody, err = p.makeRequest(ctx, http.MethodPost,
 		pd.SetUnvettedStatusRoute, sus)
 	if err != nil {
 		return nil, err
@@ -860,7 +861,7 @@ func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails, u *us
 }
 
 // processSetInvoiceStatus updates the status of the specified invoice.
-func (p *politeiawww) processSetInvoiceStatus(sis cms.SetInvoiceStatus, u *user.User) (*cms.SetInvoiceStatusReply, error) {
+func (p *politeiawww) processSetInvoiceStatus(ctx context.Context, sis cms.SetInvoiceStatus, u *user.User) (*cms.SetInvoiceStatusReply, error) {
 	log.Tracef("processSetInvoiceStatus")
 
 	invRec, err := p.getInvoice(sis.Token)
@@ -926,7 +927,7 @@ func (p *politeiawww) processSetInvoiceStatus(sis cms.SetInvoiceStatus, u *user.
 		},
 	}
 
-	responseBody, err := p.makeRequest(http.MethodPost, pd.UpdateVettedMetadataRoute, pdCommand)
+	responseBody, err := p.makeRequest(ctx, http.MethodPost, pd.UpdateVettedMetadataRoute, pdCommand)
 	if err != nil {
 		return nil, err
 	}
@@ -1047,7 +1048,7 @@ func statusInSlice(arr []cms.InvoiceStatusT, status cms.InvoiceStatusT) bool {
 }
 
 // processEditInvoice attempts to edit a proposal on politeiad.
-func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms.EditInvoiceReply, error) {
+func (p *politeiawww) processEditInvoice(ctx context.Context, ei cms.EditInvoice, u *user.User) (*cms.EditInvoiceReply, error) {
 	log.Tracef("processEditInvoice %v", ei.Token)
 
 	invRec, err := p.getInvoice(ei.Token)
@@ -1177,7 +1178,7 @@ func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms
 	}
 
 	// Send politeiad request
-	responseBody, err := p.makeRequest(http.MethodPost, pd.UpdateVettedRoute, e)
+	responseBody, err := p.makeRequest(ctx, http.MethodPost, pd.UpdateVettedRoute, e)
 	if err != nil {
 		return nil, err
 	}
@@ -1223,7 +1224,7 @@ func (p *politeiawww) processEditInvoice(ei cms.EditInvoice, u *user.User) (*cms
 	}
 
 	var updateMetaReply pd.UpdateVettedMetadataReply
-	responseBody, err = p.makeRequest(http.MethodPost,
+	responseBody, err = p.makeRequest(ctx, http.MethodPost,
 		pd.UpdateVettedMetadataRoute, pdCommand)
 	if err != nil {
 		return nil, err
@@ -1641,7 +1642,7 @@ func (p *politeiawww) getInvoiceComments(token string) ([]www.Comment, error) {
 
 // processPayInvoices looks for all approved invoices and then goes about
 // changing their statuses' to paid.
-func (p *politeiawww) processPayInvoices(u *user.User) (*cms.PayInvoicesReply, error) {
+func (p *politeiawww) processPayInvoices(ctx context.Context, u *user.User) (*cms.PayInvoicesReply, error) {
 	log.Tracef("processPayInvoices")
 
 	dbInvs, err := p.cmsDB.InvoicesByStatus(int(cms.InvoiceStatusApproved))
@@ -1679,7 +1680,7 @@ func (p *politeiawww) processPayInvoices(u *user.User) (*cms.PayInvoicesReply, e
 			},
 		}
 
-		responseBody, err := p.makeRequest(http.MethodPost,
+		responseBody, err := p.makeRequest(ctx, http.MethodPost,
 			pd.UpdateVettedMetadataRoute, pdCommand)
 		if err != nil {
 			return nil, err

--- a/politeiawww/paywall.go
+++ b/politeiawww/paywall.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -57,7 +58,7 @@ func (p *politeiawww) paywallIsEnabled() bool {
 // paywall pool have received a payment.  If so, proposal credits are created
 // for the user, the user database is updated, and the user is removed from
 // the paywall pool.
-func (p *politeiawww) checkForProposalPayments(pool map[uuid.UUID]paywallPoolMember) (bool, []uuid.UUID) {
+func (p *politeiawww) checkForProposalPayments(ctx context.Context, pool map[uuid.UUID]paywallPoolMember) (bool, []uuid.UUID) {
 	var userIDsToRemove []uuid.UUID
 
 	// In theory poolMember could be raced during this call. In practice
@@ -95,7 +96,7 @@ func (p *politeiawww) checkForProposalPayments(pool map[uuid.UUID]paywallPoolMem
 			continue
 		}
 
-		tx, err := p.verifyProposalPayment(u)
+		tx, err := p.verifyProposalPayment(ctx, u)
 		if err != nil {
 			if err == user.ErrShutdown {
 				// The database is shutdown, so stop the thread.
@@ -131,21 +132,21 @@ func (p *politeiawww) checkForProposalPayments(pool map[uuid.UUID]paywallPoolMem
 	return true, userIDsToRemove
 }
 
-func (p *politeiawww) checkForPayments() {
+func (p *politeiawww) checkForPayments(ctx context.Context) {
 	for {
 		// Removing pool members from the pool while in the middle of
 		// polling can cause a race to occur in checkForProposalPayments.
 		userPaywallsToCheck := p.createUserPaywallPoolCopy()
 
 		// Check new user payments.
-		shouldContinue, userIDsToRemove := p.checkForUserPayments(userPaywallsToCheck)
+		shouldContinue, userIDsToRemove := p.checkForUserPayments(ctx, userPaywallsToCheck)
 		if !shouldContinue {
 			return
 		}
 		p.removeUsersFromPool(userIDsToRemove, paywallTypeUser)
 
 		// Check proposal payments.
-		shouldContinue, userIDsToRemove = p.checkForProposalPayments(userPaywallsToCheck)
+		shouldContinue, userIDsToRemove = p.checkForProposalPayments(ctx, userPaywallsToCheck)
 		if !shouldContinue {
 			return
 		}
@@ -205,7 +206,7 @@ func (p *politeiawww) generateProposalPaywall(u *user.User) (*user.ProposalPaywa
 // verifyPropoposalPayment checks whether a payment has been sent to the
 // user's proposal paywall address. Proposal credits are created and added to
 // the user's account if the payment meets the minimum requirements.
-func (p *politeiawww) verifyProposalPayment(u *user.User) (*util.TxDetails, error) {
+func (p *politeiawww) verifyProposalPayment(ctx context.Context, u *user.User) (*util.TxDetails, error) {
 	paywall := p.mostRecentProposalPaywall(u)
 
 	// If a TxID exists, the payment has already been verified.
@@ -214,7 +215,7 @@ func (p *politeiawww) verifyProposalPayment(u *user.User) (*util.TxDetails, erro
 	}
 
 	// Fetch txs sent to paywall address
-	txs, err := util.FetchTxsForAddress(paywall.Address, p.dcrdataHostHTTP())
+	txs, err := util.FetchTxsForAddress(ctx, paywall.Address, p.dcrdataHostHTTP())
 	if err != nil {
 		return nil, fmt.Errorf("FetchTxsForAddress %v: %v",
 			paywall.Address, err)

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -235,7 +236,7 @@ func (p *politeiawww) linkByValidate(linkBy int64) error {
 // that is applicable to both new proposals and proposal edits. Additional
 // validation is done in processNewProposal and processEditProposal that is
 // specific to that action only.
-func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
+func (p *politeiawww) validateProposalMetadata(ctx context.Context, pm www.ProposalMetadata) error {
 	// Validate Name
 	if !isValidProposalName(pm.Name) {
 		return www.UserError{
@@ -267,11 +268,11 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 		if err != nil {
 			return err
 		}
-		bb, err := p.getBestBlock()
+		bb, err := p.getBestBlock(ctx)
 		if err != nil {
 			return err
 		}
-		vs, err := p.voteSummaryGet(pm.LinkTo, bb)
+		vs, err := p.voteSummaryGet(ctx, pm.LinkTo, bb)
 		if err != nil {
 			return err
 		}
@@ -313,7 +314,7 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 // validateProposal ensures that the given new proposal meets the api policy
 // requirements. If a proposal data file exists (currently optional) then it is
 // parsed and a ProposalMetadata is returned.
-func (p *politeiawww) validateProposal(np www.NewProposal, u *user.User) (*www.ProposalMetadata, error) {
+func (p *politeiawww) validateProposal(ctx context.Context, np www.NewProposal, u *user.User) (*www.ProposalMetadata, error) {
 	if len(np.Files) == 0 {
 		return nil, www.UserError{
 			ErrorCode:    www.ErrorStatusProposalMissingFiles,
@@ -536,7 +537,7 @@ func (p *politeiawww) validateProposal(np www.NewProposal, u *user.User) (*www.P
 	}
 
 	// Validate ProposalMetadata
-	err := p.validateProposalMetadata(*pm)
+	err := p.validateProposalMetadata(ctx, *pm)
 	if err != nil {
 		return nil, err
 	}
@@ -1009,7 +1010,7 @@ func (p *politeiawww) getPropComments(token string) ([]www.Comment, error) {
 // proposal record was found.
 //
 // This function must be called WITHOUT read/write lock held.
-func (p *politeiawww) voteSummariesGet(tokens []string, bestBlock uint64) (map[string]www.VoteSummary, error) {
+func (p *politeiawww) voteSummariesGet(ctx context.Context, tokens []string, bestBlock uint64) (map[string]www.VoteSummary, error) {
 	voteSummaries := make(map[string]www.VoteSummary)
 	tokensToLookup := make([]string, 0, len(tokens))
 
@@ -1045,7 +1046,7 @@ func (p *politeiawww) voteSummariesGet(tokens []string, bestBlock uint64) (map[s
 			if err == cache.ErrRecordNotFound {
 				// There are missing entries in the VoteResults
 				// cache table. Load them.
-				_, err := p.decredLoadVoteResults(bestBlock)
+				_, err := p.decredLoadVoteResults(ctx, bestBlock)
 				if err != nil {
 					return nil, err
 				}
@@ -1117,8 +1118,8 @@ func (p *politeiawww) voteSummarySet(token string, voteSummary www.VoteSummary) 
 // correspond to a proposal.
 //
 // This function must be called WITHOUT the read/write lock held.
-func (p *politeiawww) voteSummaryGet(token string, bestBlock uint64) (*www.VoteSummary, error) {
-	s, err := p.voteSummariesGet([]string{token}, bestBlock)
+func (p *politeiawww) voteSummaryGet(ctx context.Context, token string, bestBlock uint64) (*www.VoteSummary, error) {
+	s, err := p.voteSummariesGet(ctx, []string{token}, bestBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -1130,7 +1131,7 @@ func (p *politeiawww) voteSummaryGet(token string, bestBlock uint64) (*www.VoteS
 }
 
 // processNewProposal tries to submit a new proposal to politeiad.
-func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*www.NewProposalReply, error) {
+func (p *politeiawww) processNewProposal(ctx context.Context, np www.NewProposal, user *user.User) (*www.NewProposalReply, error) {
 	log.Tracef("processNewProposal")
 
 	// Pay up sucker!
@@ -1146,7 +1147,7 @@ func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*
 		}
 	}
 
-	pm, err := p.validateProposal(np, user)
+	pm, err := p.validateProposal(ctx, np, user)
 	if err != nil {
 		return nil, err
 	}
@@ -1218,7 +1219,7 @@ func (p *politeiawww) processNewProposal(np www.NewProposal, user *user.User) (*
 	}
 
 	// Send politeiad request
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.NewRecordRoute, n)
 	if err != nil {
 		return nil, err
@@ -1320,7 +1321,7 @@ func (p *politeiawww) processProposalDetails(propDetails www.ProposalsDetails, u
 
 // processBatchVoteSummary returns the vote summaries for the provided list
 // of proposals.
-func (p *politeiawww) processBatchVoteSummary(batchVoteSummary www.BatchVoteSummary) (*www.BatchVoteSummaryReply, error) {
+func (p *politeiawww) processBatchVoteSummary(ctx context.Context, batchVoteSummary www.BatchVoteSummary) (*www.BatchVoteSummaryReply, error) {
 	log.Tracef("processBatchVoteSummary")
 
 	if len(batchVoteSummary.Tokens) > www.ProposalListPageSize {
@@ -1337,12 +1338,12 @@ func (p *politeiawww) processBatchVoteSummary(batchVoteSummary www.BatchVoteSumm
 		}
 	}
 
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	summaries, err := p.voteSummariesGet(batchVoteSummary.Tokens, bb)
+	summaries, err := p.voteSummariesGet(ctx, batchVoteSummary.Tokens, bb)
 	if err != nil {
 		return nil, err
 	}
@@ -1472,7 +1473,7 @@ func verifyStatusChange(current, next www.PropStatusT) error {
 }
 
 // processSetProposalStatus changes the status of an existing proposal.
-func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *user.User) (*www.SetProposalStatusReply, error) {
+func (p *politeiawww) processSetProposalStatus(ctx context.Context, sps www.SetProposalStatus, u *user.User) (*www.SetProposalStatusReply, error) {
 	log.Tracef("processSetProposalStatus %v", sps.Token)
 
 	// Make sure token is valid and not a prefix
@@ -1579,7 +1580,7 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 		}
 
 		// Send unvetted status change request
-		responseBody, err := p.makeRequest(http.MethodPost,
+		responseBody, err := p.makeRequest(ctx, http.MethodPost,
 			pd.SetUnvettedStatusRoute, sus)
 		if err != nil {
 			return nil, err
@@ -1597,11 +1598,11 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 		// Vetted status change
 
 		// Ensure voting has not been started or authorized yet
-		bb, err := p.getBestBlock()
+		bb, err := p.getBestBlock(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("getBestBlock: %v", err)
 		}
-		vs, err := p.voteSummaryGet(pr.CensorshipRecord.Token, bb)
+		vs, err := p.voteSummaryGet(ctx, pr.CensorshipRecord.Token, bb)
 		if err != nil {
 			return nil, err
 		}
@@ -1632,7 +1633,7 @@ func (p *politeiawww) processSetProposalStatus(sps www.SetProposalStatus, u *use
 		}
 
 		// Send vetted status change request
-		responseBody, err := p.makeRequest(http.MethodPost,
+		responseBody, err := p.makeRequest(ctx, http.MethodPost,
 			pd.SetVettedStatusRoute, svs)
 		if err != nil {
 			return nil, err
@@ -1699,7 +1700,7 @@ func filesToDel(filesOld []www.File, filesNew []www.File) []string {
 }
 
 // processEditProposal attempts to edit a proposal on politeiad.
-func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*www.EditProposalReply, error) {
+func (p *politeiawww) processEditProposal(ctx context.Context, ep www.EditProposal, u *user.User) (*www.EditProposalReply, error) {
 	log.Tracef("processEditProposal %v", ep.Token)
 
 	// Make sure token is valid and not a prefix
@@ -1736,11 +1737,11 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 	}
 
 	// Validate proposal vote status
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
-	vs, err := p.voteSummaryGet(ep.Token, bb)
+	vs, err := p.voteSummaryGet(ctx, ep.Token, bb)
 	if err != nil {
 		return nil, err
 	}
@@ -1762,7 +1763,7 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 		Signature: ep.Signature,
 	}
 
-	pm, err := p.validateProposal(np, u)
+	pm, err := p.validateProposal(ctx, np, u)
 	if err != nil {
 		return nil, err
 	}
@@ -1844,7 +1845,7 @@ func (p *politeiawww) processEditProposal(ep www.EditProposal, u *user.User) (*w
 	}
 
 	// Send politeiad request
-	responseBody, err := p.makeRequest(http.MethodPost, pdRoute, e)
+	responseBody, err := p.makeRequest(ctx, http.MethodPost, pdRoute, e)
 	if err != nil {
 		return nil, err
 	}
@@ -2026,7 +2027,7 @@ func (p *politeiawww) getVoteStatusReply(token string) (*www.VoteStatusReply, bo
 	return &voteStatusReply, true
 }
 
-func (p *politeiawww) voteStatusReply(token string, bestBlock uint64) (*www.VoteStatusReply, error) {
+func (p *politeiawww) voteStatusReply(ctx context.Context, token string, bestBlock uint64) (*www.VoteStatusReply, error) {
 	cachedVsr, ok := p.getVoteStatusReply(token)
 
 	if ok {
@@ -2036,7 +2037,7 @@ func (p *politeiawww) voteStatusReply(token string, bestBlock uint64) (*www.Vote
 
 	// Vote status wasn't in the memory cache
 	// so fetch it from the cache database.
-	vs, err := p.voteSummaryGet(token, bestBlock)
+	vs, err := p.voteSummaryGet(ctx, token, bestBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -2072,7 +2073,7 @@ func (p *politeiawww) voteStatusReply(token string, bestBlock uint64) (*www.Vote
 }
 
 // processVoteStatus returns the vote status for a given proposal
-func (p *politeiawww) processVoteStatus(token string) (*www.VoteStatusReply, error) {
+func (p *politeiawww) processVoteStatus(ctx context.Context, token string) (*www.VoteStatusReply, error) {
 	log.Tracef("ProcessProposalVotingStatus: %v", token)
 
 	// Make sure token is valid and not a prefix
@@ -2101,13 +2102,13 @@ func (p *politeiawww) processVoteStatus(token string) (*www.VoteStatusReply, err
 	}
 
 	// Get best block
-	bestBlock, err := p.getBestBlock()
+	bestBlock, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("bestBlock: %v", err)
 	}
 
 	// Get vote status
-	vsr, err := p.voteStatusReply(token, bestBlock)
+	vsr, err := p.voteStatusReply(ctx, token, bestBlock)
 	if err != nil {
 		return nil, fmt.Errorf("voteStatusReply: %v", err)
 	}
@@ -2116,12 +2117,12 @@ func (p *politeiawww) processVoteStatus(token string) (*www.VoteStatusReply, err
 }
 
 // processGetAllVoteStatus returns the vote status of all public proposals.
-func (p *politeiawww) processGetAllVoteStatus() (*www.GetAllVoteStatusReply, error) {
+func (p *politeiawww) processGetAllVoteStatus(ctx context.Context) (*www.GetAllVoteStatusReply, error) {
 	log.Tracef("processGetAllVoteStatus")
 
 	// We need to determine best block height here in order
 	// to set the voting status
-	bestBlock, err := p.getBestBlock()
+	bestBlock, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("bestBlock: %v", err)
 	}
@@ -2141,7 +2142,7 @@ func (p *politeiawww) processGetAllVoteStatus() (*www.GetAllVoteStatusReply, err
 		}
 
 		// Get vote status for proposal
-		vs, err := p.voteStatusReply(v.CensorshipRecord.Token, bestBlock)
+		vs, err := p.voteStatusReply(ctx, v.CensorshipRecord.Token, bestBlock)
 		if err != nil {
 			return nil, fmt.Errorf("voteStatusReply: %v", err)
 		}
@@ -2154,15 +2155,15 @@ func (p *politeiawww) processGetAllVoteStatus() (*www.GetAllVoteStatusReply, err
 	}, nil
 }
 
-func (p *politeiawww) processActiveVote() (*www.ActiveVoteReply, error) {
+func (p *politeiawww) processActiveVote(ctx context.Context) (*www.ActiveVoteReply, error) {
 	log.Tracef("processActiveVote")
 
 	// Fetch proposals that are actively being voted on
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
-	tir, err := p.tokenInventory(bb, false)
+	tir, err := p.tokenInventory(ctx, bb, false)
 	if err != nil {
 		return nil, err
 	}
@@ -2302,7 +2303,7 @@ func (p *politeiawww) processVoteResults(token string) (*www.VoteResultsReply, e
 }
 
 // processCastVotes handles the www.Ballot call
-func (p *politeiawww) processCastVotes(ballot *www.Ballot) (*www.BallotReply, error) {
+func (p *politeiawww) processCastVotes(ctx context.Context, ballot *www.Ballot) (*www.BallotReply, error) {
 	log.Tracef("processCastVotes")
 
 	challenge, err := util.Random(pd.ChallengeSize)
@@ -2332,7 +2333,7 @@ func (p *politeiawww) processCastVotes(ballot *www.Ballot) (*www.BallotReply, er
 		Payload:   string(payload),
 	}
 
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -2537,7 +2538,7 @@ func validateAuthorizeVoteRunoff(av www.AuthorizeVote, u user.User, pr www.Propo
 
 // processAuthorizeVote sends the authorizevote command to decred plugin to
 // indicate that a proposal has been finalized and is ready to be voted on.
-func (p *politeiawww) processAuthorizeVote(av www.AuthorizeVote, u *user.User) (*www.AuthorizeVoteReply, error) {
+func (p *politeiawww) processAuthorizeVote(ctx context.Context, av www.AuthorizeVote, u *user.User) (*www.AuthorizeVoteReply, error) {
 	log.Tracef("processAuthorizeVote %v", av.Token)
 
 	// Make sure token is valid and not a prefix
@@ -2558,11 +2559,11 @@ func (p *politeiawww) processAuthorizeVote(av www.AuthorizeVote, u *user.User) (
 		}
 		return nil, err
 	}
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
-	vs, err := p.voteSummaryGet(av.Token, bb)
+	vs, err := p.voteSummaryGet(ctx, av.Token, bb)
 	if err != nil {
 		return nil, err
 	}
@@ -2592,7 +2593,7 @@ func (p *politeiawww) processAuthorizeVote(av www.AuthorizeVote, u *user.User) (
 	}
 
 	// Send authorizevote plugin request
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -2852,7 +2853,7 @@ func validateStartVoteRunoff(sv www2.StartVote, u user.User, pr www.ProposalReco
 // processStartVoteV2 starts the voting period on a proposal using the provided
 // v2 StartVote. Proposals that are RFP submissions cannot use this route. They
 // must sue the StartVoteRunoff route.
-func (p *politeiawww) processStartVoteV2(sv www2.StartVote, u *user.User) (*www2.StartVoteReply, error) {
+func (p *politeiawww) processStartVoteV2(ctx context.Context, sv www2.StartVote, u *user.User) (*www2.StartVoteReply, error) {
 	log.Tracef("processStartVoteV2 %v", sv.Vote.Token)
 
 	// Sanity check
@@ -2876,11 +2877,11 @@ func (p *politeiawww) processStartVoteV2(sv www2.StartVote, u *user.User) (*www2
 		}
 		return nil, err
 	}
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
-	vs, err := p.voteSummaryGet(sv.Vote.Token, bb)
+	vs, err := p.voteSummaryGet(ctx, sv.Vote.Token, bb)
 	if err != nil {
 		return nil, err
 	}
@@ -2908,7 +2909,7 @@ func (p *politeiawww) processStartVoteV2(sv www2.StartVote, u *user.User) (*www2
 		CommandID: decredplugin.CmdStartVote + " " + sv.Vote.Token,
 		Payload:   string(payload),
 	}
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -2982,7 +2983,7 @@ func voteIsApproved(vs www.VoteSummary) bool {
 // non-abandoned RFP submissions for the provided RFP token. If politeiad fails
 // to start the voting period on any of the RFP submissions, all work is
 // unwound and an error is returned.
-func (p *politeiawww) processStartVoteRunoffV2(sv www2.StartVoteRunoff, u *user.User) (*www2.StartVoteRunoffReply, error) {
+func (p *politeiawww) processStartVoteRunoffV2(ctx context.Context, sv www2.StartVoteRunoff, u *user.User) (*www2.StartVoteRunoffReply, error) {
 	log.Tracef("processStartVoteRunoffV2 %v", sv.Token)
 
 	// Sanity check
@@ -2990,7 +2991,7 @@ func (p *politeiawww) processStartVoteRunoffV2(sv www2.StartVoteRunoff, u *user.
 		return nil, fmt.Errorf("user is not an admin")
 	}
 
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -3054,7 +3055,7 @@ func (p *politeiawww) processStartVoteRunoffV2(sv www2.StartVoteRunoff, u *user.
 			}
 			return nil, err
 		}
-		vs, err := p.voteSummaryGet(token, bb)
+		vs, err := p.voteSummaryGet(ctx, token, bb)
 		if err != nil {
 			return nil, err
 		}
@@ -3190,7 +3191,7 @@ func (p *politeiawww) processStartVoteRunoffV2(sv www2.StartVoteRunoff, u *user.
 	}
 
 	// Send plugin command
-	responseBody, err := p.makeRequest(http.MethodPost,
+	responseBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {
 		return nil, err
@@ -3239,7 +3240,7 @@ func (p *politeiawww) processStartVoteRunoffV2(sv www2.StartVoteRunoff, u *user.
 // load it before retrying the token inventory call. Since politeiawww only has
 // read access to the cache, loading the VoteResults table requires using a
 // politeiad decredplugin command.
-func (p *politeiawww) tokenInventory(bestBlock uint64, isAdmin bool) (*www.TokenInventoryReply, error) {
+func (p *politeiawww) tokenInventory(ctx context.Context, bestBlock uint64, isAdmin bool) (*www.TokenInventoryReply, error) {
 	var done bool
 	var r www.TokenInventoryReply
 	for retries := 0; !done && retries <= 1; retries++ {
@@ -3251,7 +3252,7 @@ func (p *politeiawww) tokenInventory(bestBlock uint64, isAdmin bool) (*www.Token
 			if err == cache.ErrRecordNotFound {
 				// There are missing entries in the vote
 				// results cache table. Load them.
-				_, err := p.decredLoadVoteResults(bestBlock)
+				_, err := p.decredLoadVoteResults(ctx, bestBlock)
 				if err != nil {
 					return nil, err
 				}
@@ -3271,15 +3272,15 @@ func (p *politeiawww) tokenInventory(bestBlock uint64, isAdmin bool) (*www.Token
 
 // processTokenInventory returns the tokens of all proposals in the inventory,
 // categorized by stage of the voting process.
-func (p *politeiawww) processTokenInventory(isAdmin bool) (*www.TokenInventoryReply, error) {
+func (p *politeiawww) processTokenInventory(ctx context.Context, isAdmin bool) (*www.TokenInventoryReply, error) {
 	log.Tracef("processTokenInventory")
 
-	bb, err := p.getBestBlock()
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return p.tokenInventory(bb, isAdmin)
+	return p.tokenInventory(ctx, bb, isAdmin)
 }
 
 // processVoteDetailsV2 returns the vote details for the given proposal token.
@@ -3339,12 +3340,12 @@ func (p *politeiawww) processVoteDetailsV2(token string) (*www2.VoteDetailsReply
 
 // initLoadVoteResults is used to send the LoadVoteResults decred plugin command
 // to the cache on www startup.
-func (p *politeiawww) initVoteResults() error {
-	bb, err := p.getBestBlock()
+func (p *politeiawww) initVoteResults(ctx context.Context) error {
+	bb, err := p.getBestBlock(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = p.decredLoadVoteResults(bb)
+	_, err = p.decredLoadVoteResults(ctx, bb)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/proposals_test.go
+++ b/politeiawww/proposals_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"reflect"
@@ -446,9 +447,10 @@ func TestValidateProposalMetadata(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := p.validateProposalMetadata(test.metadata)
+			err := p.validateProposalMetadata(ctx, test.metadata)
 			got := errToStr(err)
 			want := errToStr(test.want)
 			if got != want {
@@ -692,9 +694,10 @@ func TestValidateProposal(t *testing.T) {
 	}
 
 	// Run test cases
+	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := p.validateProposal(test.newProposal, test.user)
+			_, err := p.validateProposal(ctx, test.newProposal, test.user)
 			got := errToStr(err)
 			want := errToStr(test.want)
 			if got != want {
@@ -1832,9 +1835,10 @@ func TestProcessNewProposal(t *testing.T) {
 	}
 
 	// Run tests
+	ctx := context.Background()
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			npr, err := p.processNewProposal(*v.np, v.usr)
+			npr, err := p.processNewProposal(ctx, *v.np, v.usr)
 			got := errToStr(err)
 			want := errToStr(v.want)
 
@@ -1986,9 +1990,10 @@ func TestProcessEditProposal(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			_, err := p.processEditProposal(v.editProp, v.user)
+			_, err := p.processEditProposal(ctx, v.editProp, v.user)
 			got := errToStr(err)
 			want := errToStr(v.wantError)
 
@@ -2095,7 +2100,8 @@ func TestProcessSetProposalStatus(t *testing.T) {
 			PublicKey:      admin.PublicKey(),
 		}
 
-		_, err := p.processSetProposalStatus(sps, admin)
+		ctx := context.Background()
+		_, err := p.processSetProposalStatus(ctx, sps, admin)
 		got := errToStr(err)
 		want := www.ErrorStatus[www.ErrorStatusReviewerAdminEqualsAuthor]
 		if got != want {
@@ -2243,9 +2249,10 @@ func TestProcessSetProposalStatus(t *testing.T) {
 	}
 
 	// Run tests
+	ctx := context.Background()
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			reply, err := p.processSetProposalStatus(v.sps, v.usr)
+			reply, err := p.processSetProposalStatus(ctx, v.sps, v.usr)
 			got := errToStr(err)
 			want := errToStr(v.want)
 			if got != want {
@@ -2429,9 +2436,10 @@ func TestProcessAuthorizeVote(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			reply, err := p.processAuthorizeVote(v.av, v.user)
+			reply, err := p.processAuthorizeVote(ctx, v.av, v.user)
 			got := errToStr(err)
 			want := errToStr(v.wantErr)
 
@@ -2518,9 +2526,10 @@ func TestProcessStartVoteV2(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			_, err := p.processStartVoteV2(v.sv, v.user)
+			_, err := p.processStartVoteV2(ctx, v.sv, v.user)
 			got := errToStr(err)
 			want := errToStr(v.wantErr)
 			if got != want {
@@ -2776,9 +2785,10 @@ func TestProcessStartVoteRunoffV2(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := p.processStartVoteRunoffV2(test.sv, test.user)
+			_, err := p.processStartVoteRunoffV2(ctx, test.sv, test.user)
 			got := errToStr(err)
 			want := errToStr(test.want)
 			if got != want {

--- a/politeiawww/userwww.go
+++ b/politeiawww/userwww.go
@@ -499,7 +499,7 @@ func (p *politeiawww) handleVerifyUserPayment(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	vuptr, err := p.processVerifyUserPayment(user, vupt)
+	vuptr, err := p.processVerifyUserPayment(r.Context(), user, vupt)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleVerifyUserPayment: processVerifyUserPayment %v",
@@ -614,7 +614,7 @@ func (p *politeiawww) handleUserPaymentsRescan(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	reply, err := p.processUserPaymentsRescan(upr)
+	reply, err := p.processUserPaymentsRescan(r.Context(), upr)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleUserPaymentsRescan: processUserPaymentsRescan:  %v",


### PR DESCRIPTION
This uses the http request's context while processing.  If a visitor closes the http connection, we should stop processing.