### PR TITLE
[cms] Fix the update of empty user owned proposals and supervisors

### DIFF
--- a/politeiawww/user/cockroachdb/cms.go
+++ b/politeiawww/user/cockroachdb/cms.go
@@ -195,10 +195,10 @@ func (c *cockroachdb) updateCMSUser(tx *gorm.DB, nu user.UpdateCMSUser) error {
 	if nu.ContractorContact != "" {
 		cms.ContractorContact = nu.ContractorContact
 	}
-	if superVisorUserIds != "" {
+	if superVisorUserIds != "" || cms.SupervisorUserID != superVisorUserIds {
 		cms.SupervisorUserID = superVisorUserIds
 	}
-	if proposalsOwned != "" {
+	if proposalsOwned != "" || cms.ProposalsOwned != proposalsOwned {
 		cms.ProposalsOwned = proposalsOwned
 	}
 


### PR DESCRIPTION
This diff solves a misbehaviour where we couldn't set the owned proposals and supervisors id fields back to empty. Now we check the updated fields agains't the previous records to see if there was any changes, and if so, continue with the update.