### PR TITLE
[cms] Fix batch proposals error

### DIFF
--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -1034,7 +1034,7 @@ func (p *politeiawww) makeProposalsRequest(method string, route string, v interf
 	}
 
 	dest := cms.ProposalsMainnet
-	if !p.cfg.TestNet {
+	if p.cfg.TestNet {
 		dest = cms.ProposalsTestnet
 	}
 

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -1034,7 +1034,7 @@ func (p *politeiawww) makeProposalsRequest(method string, route string, v interf
 	}
 
 	dest := cms.ProposalsMainnet
-	if p.cfg.TestNet {
+	if !p.cfg.TestNet {
 		dest = cms.ProposalsTestnet
 	}
 
@@ -1078,15 +1078,8 @@ func (p *politeiawww) makeProposalsRequest(method string, route string, v interf
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		var pdErrorReply www.PDErrorReply
-		decoder := json.NewDecoder(r.Body)
-		if err := decoder.Decode(&pdErrorReply); err != nil {
-			return nil, err
-		}
-
-		return nil, www.PDError{
-			HTTPCode:   r.StatusCode,
-			ErrorReply: pdErrorReply,
+		return nil, www.UserError{
+			ErrorCode: www.ErrorStatusT(r.StatusCode),
 		}
 	}
 


### PR DESCRIPTION
When issuing a batch proposals pass through request for ProposalBillingSummary on mainnet, too many proposals were being requested.  We must only request below the ProposalListPageSize amount.  

So this PR chops up the list of approved invoices returned from the TokenInventory list into chunks that abide by max list page size.