### PR TITLE
[cms] fix: show complete invoice details for admin or owner

### DIFF
--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -828,7 +828,7 @@ func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails, u *us
 	// Calculate the payout from the invoice record
 	dbInv := convertInvoiceRecordToDatabaseInvoice(invRec)
 	var reply cms.InvoiceDetailsReply
-	if !u.Admin {
+	if u.Admin || dbInv.UserID == u.ID.String() {
 		payout, err := calculatePayout(*dbInv)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
this PR closes #1277 which reported an incomplete info response from invoice details call.