### PR TITLE
Cache requests made to proposals

### DIFF
--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -938,7 +938,7 @@ func (p *politeiawww) handleStartVoteDCC(w http.ResponseWriter, r *http.Request)
 func (p *politeiawww) handlePassThroughTokenInventory(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handlePassThroughTokenInventory")
 
-	data, err := p.makePropsoalsRequestCached(http.MethodGet, www.RouteTokenInventory, nil, "1h")
+	data, err := p.makeProposalsRequestCached(http.MethodGet, www.RouteTokenInventory, nil, "1h")
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handlePassThroughTokenInventory: makeProposalsRequest: %v", err)
@@ -960,7 +960,7 @@ func (p *politeiawww) handlePassThroughBatchProposals(w http.ResponseWriter, r *
 		return
 	}
 
-	data, err := p.makePropsoalsRequestCached(http.MethodPost, www.RouteBatchProposals, bp, "1h")
+	data, err := p.makeProposalsRequestCached(http.MethodPost, www.RouteBatchProposals, bp, "1h")
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handlePassThroughBatchProposals: makeProposalsRequest: %v", err)
@@ -1016,11 +1016,11 @@ func (p *politeiawww) handleProposalBillingDetails(w http.ResponseWriter, r *htt
 	util.RespondWithJSON(w, http.StatusOK, svr)
 }
 
-// makePropsoalsRequestCached takes the same inputs as makeProposalsRequest
+// makeProposalsRequestCached takes the same inputs as makeProposalsRequest
 // plus a time parsed string "cacheTime" that determines how long a response is
 // cached. This function is only to be used if the data being processed is not
 // time sensitive and not user specific.
-func (p *politeiawww) makePropsoalsRequestCached(method string, route string, v interface{}, cacheTime string) ([]byte, error) {
+func (p *politeiawww) makeProposalsRequestCached(method string, route string, v interface{}, cacheTime string) ([]byte, error) {
 	var (
 		requestBody []byte
 		err         error

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -1016,11 +1016,11 @@ func (p *politeiawww) handleProposalBillingDetails(w http.ResponseWriter, r *htt
 	util.RespondWithJSON(w, http.StatusOK, svr)
 }
 
-// makePropsoalsRequestCached passes a request to makeProposalsRequest
-// and caches a valid result.  It takes the same inputs as
-// makeProposalsRequest plus a time parsed string "cachetime"
-// which determines how long a response is cached.
-func (p *politeiawww) makePropsoalsRequestCached(method string, route string, v interface{}, cachetime string) ([]byte, error) {
+// makePropsoalsRequestCached takes the same inputs as makeProposalsRequest
+// plus a time parsed string "cacheTime" that determines how long a response is
+// cached. This function is only to be used if the data being processed is not
+// time sensitive.
+func (p *politeiawww) makePropsoalsRequestCached(method string, route string, v interface{}, cacheTime string) ([]byte, error) {
 	var (
 		requestBody []byte
 		err         error
@@ -1038,11 +1038,11 @@ func (p *politeiawww) makePropsoalsRequestCached(method string, route string, v 
 		dest = cms.ProposalsTestnet
 	}
 
-	// Set cache_route and pass route to makeProposalsRequest
-	cache_route := dest + "/api/v1" + route
+	// Set cacheRoute and pass route to makeProposalsRequest
+	cacheRoute := dest + "/api/v1" + route
 
 	// Check cache and return if found.
-	content := p.memorycache.get(cache_route + string(requestBody))
+	content := p.memorycache.get(cacheRoute + string(requestBody))
 	if content != nil {
 		return content, nil
 	}
@@ -1051,7 +1051,7 @@ func (p *politeiawww) makePropsoalsRequestCached(method string, route string, v 
 
 	// Set cache if no errors.
 	if err == nil {
-		p.memorycache.set(cache_route+string(requestBody), response, cachetime)
+		p.memorycache.set(cacheRoute+string(requestBody), response, cacheTime)
 	}
 	return response, err
 

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -1016,9 +1016,10 @@ func (p *politeiawww) handleProposalBillingDetails(w http.ResponseWriter, r *htt
 	util.RespondWithJSON(w, http.StatusOK, svr)
 }
 
-// makePropsoalsRequestCached passes a request to makeProposalsRequest and caches a valid result. It takes the same inputs as
-// makeProposalsRequest plus a time parsed string "cachetime" which determines how long a response is cached.
-
+// makePropsoalsRequestCached passes a request to makeProposalsRequest
+// and caches a valid result.  It takes the same inputs as
+// makeProposalsRequest plus a time parsed string "cachetime"
+// which determines how long a response is cached.
 func (p *politeiawww) makePropsoalsRequestCached(method string, route string, v interface{}, cachetime string) ([]byte, error) {
 	var (
 		requestBody []byte
@@ -1037,7 +1038,7 @@ func (p *politeiawww) makePropsoalsRequestCached(method string, route string, v 
 		dest = cms.ProposalsTestnet
 	}
 
-	// Store in cache_route as to not messup the route being passed to makeProposalsRequest.
+	// Set cache_route and pass route to makeProposalsRequest
 	cache_route := dest + "/api/v1" + route
 
 	// Check cache and return if found.

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -1019,7 +1019,7 @@ func (p *politeiawww) handleProposalBillingDetails(w http.ResponseWriter, r *htt
 // makePropsoalsRequestCached takes the same inputs as makeProposalsRequest
 // plus a time parsed string "cacheTime" that determines how long a response is
 // cached. This function is only to be used if the data being processed is not
-// time sensitive.
+// time sensitive and not user specific.
 func (p *politeiawww) makePropsoalsRequestCached(method string, route string, v interface{}, cacheTime string) ([]byte, error) {
 	var (
 		requestBody []byte

--- a/politeiawww/cmswww.go
+++ b/politeiawww/cmswww.go
@@ -1047,7 +1047,7 @@ func (p *politeiawww) makeProposalsRequest(method string, route string, v interf
 
 	route = dest + "/api/v1" + route
 
-	content := p.memorycache.Get(route)
+	content := p.memorycache.Get(route + string(requestBody))
 	if content != nil {
 		return content, nil
 	} else {
@@ -1096,7 +1096,7 @@ func (p *politeiawww) makeProposalsRequest(method string, route string, v interf
 		}
 
 		responseBody = util.ConvertBodyToByteArray(r.Body, false)
-		p.memorycache.Set(route, responseBody, "1h")
+		p.memorycache.Set(route+string(requestBody), responseBody, "1h")
 		return responseBody, nil
 	}
 }

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1895,7 +1895,7 @@ func parseInvoiceInput(files []www.File) (*cms.InvoiceInput, error) {
 func (p *politeiawww) processProposalBillingSummary(pbs cms.ProposalBillingSummary) (*cms.ProposalBillingSummaryReply, error) {
 	reply := &cms.ProposalBillingSummaryReply{}
 
-	data, err := p.makePropsoalsRequestCached(http.MethodGet, www.RouteTokenInventory, nil, "1h")
+	data, err := p.makeProposalsRequestCached(http.MethodGet, www.RouteTokenInventory, nil, "1h")
 	if err != nil {
 		return nil, err
 	}
@@ -1921,7 +1921,7 @@ func (p *politeiawww) processProposalBillingSummary(pbs cms.ProposalBillingSumma
 				Tokens: approvedProposals[startOffset:i],
 			}
 
-			data, err := p.makePropsoalsRequestCached(http.MethodPost, www.RouteBatchProposals, bp, "1h")
+			data, err := p.makeProposalsRequestCached(http.MethodPost, www.RouteBatchProposals, bp, "1h")
 			if err != nil {
 				return nil, err
 			}
@@ -2031,7 +2031,7 @@ func (p *politeiawww) processProposalBillingDetails(pbd cms.ProposalBillingDetai
 		invRecs = append(invRecs, invRec)
 	}
 
-	data, err := p.makePropsoalsRequestCached(http.MethodGet, "/proposals/"+pbd.Token, nil, "1h")
+	data, err := p.makeProposalsRequestCached(http.MethodGet, "/proposals/"+pbd.Token, nil, "1h")
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1895,7 +1895,7 @@ func parseInvoiceInput(files []www.File) (*cms.InvoiceInput, error) {
 func (p *politeiawww) processProposalBillingSummary(pbs cms.ProposalBillingSummary) (*cms.ProposalBillingSummaryReply, error) {
 	reply := &cms.ProposalBillingSummaryReply{}
 
-	data, err := p.makeProposalsRequest(http.MethodGet, www.RouteTokenInventory, nil)
+	data, err := p.makePropsoalsRequestCached(http.MethodGet, www.RouteTokenInventory, nil, "1h")
 	if err != nil {
 		return nil, err
 	}
@@ -1921,7 +1921,7 @@ func (p *politeiawww) processProposalBillingSummary(pbs cms.ProposalBillingSumma
 				Tokens: approvedProposals[startOffset:i],
 			}
 
-			data, err := p.makeProposalsRequest(http.MethodPost, www.RouteBatchProposals, bp)
+			data, err := p.makePropsoalsRequestCached(http.MethodPost, www.RouteBatchProposals, bp, "1h")
 			if err != nil {
 				return nil, err
 			}
@@ -2031,7 +2031,7 @@ func (p *politeiawww) processProposalBillingDetails(pbd cms.ProposalBillingDetai
 		invRecs = append(invRecs, invRec)
 	}
 
-	data, err := p.makeProposalsRequest(http.MethodGet, "/proposals/"+pbd.Token, nil)
+	data, err := p.makePropsoalsRequestCached(http.MethodGet, "/proposals/"+pbd.Token, nil, "1h")
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/memorycache.go
+++ b/politeiawww/memorycache.go
@@ -34,8 +34,8 @@ func (p *politeiawww) newStorage() *storage {
 
 // get a cached content by key.
 func (s *storage) get(key string) []byte {
-	s.RLock()
-	defer s.RUnlock()
+	s.Lock()
+	defer s.Unlock()
 
 	item := s.items[key]
 	if item.expired() {
@@ -47,8 +47,8 @@ func (s *storage) get(key string) []byte {
 
 // set a cached content by key.
 func (s *storage) set(key string, content []byte, duration string) {
-	s.RLock()
-	defer s.RUnlock()
+	s.Lock()
+	defer s.Unlock()
 
 	d, _ := time.ParseDuration(duration)
 

--- a/politeiawww/memorycache.go
+++ b/politeiawww/memorycache.go
@@ -34,8 +34,8 @@ func (p *politeiawww) newStorage() *storage {
 
 // get a cached content by key.
 func (s *storage) get(key string) []byte {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	item := s.items[key]
 	if item.expired() {

--- a/politeiawww/memorycache.go
+++ b/politeiawww/memorycache.go
@@ -50,7 +50,11 @@ func (s *storage) set(key string, content []byte, duration string) {
 	s.Lock()
 	defer s.Unlock()
 
-	d, _ := time.ParseDuration(duration)
+	d, err := time.ParseDuration(duration)
+	if err != nil {
+		log.Errorf("Memorycache set: %v", err)
+		return
+	}
 
 	s.items[key] = item{
 		Content:    content,

--- a/politeiawww/memorycache.go
+++ b/politeiawww/memorycache.go
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+// Copyright (c) 2017 Guilherme Oenning
+// https://github.com/goenning/go-cache-demo/blob/master/LICENSE
+
 package main
 
 import (

--- a/politeiawww/memorycache.go
+++ b/politeiawww/memorycache.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// Item is a cached reference
+type Item struct {
+	Content    []byte
+	Expiration int64
+}
+
+//Storage mechanism for caching strings in memory
+type Storage struct {
+	items map[string]Item
+	mu    *sync.RWMutex
+}
+
+// Expired returns true if the item has expired.
+func (item Item) Expired() bool {
+	if item.Expiration == 0 {
+		return false
+	}
+	return time.Now().UnixNano() > item.Expiration
+}
+
+//NewStorage creates a new in memory storage
+func (p *politeiawww) NewStorage() *Storage {
+	return &Storage{
+		items: make(map[string]Item),
+		mu:    &sync.RWMutex{},
+	}
+}
+
+//Get a cached content by key
+func (s Storage) Get(key string) []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	item := s.items[key]
+	if item.Expired() {
+		delete(s.items, key)
+		return nil
+	}
+	return item.Content
+}
+
+//Set a cached content by key
+func (s Storage) Set(key string, content []byte, duration string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	d, _ := time.ParseDuration(duration)
+
+	s.items[key] = Item{
+		Content:    content,
+		Expiration: time.Now().Add(d).UnixNano(),
+	}
+}

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -87,9 +87,10 @@ func (w *wsContext) isAuthenticated() bool {
 
 // politeiawww application context.
 type politeiawww struct {
-	cfg      *config
-	router   *mux.Router
-	sessions sessions.Store
+	cfg         *config
+	router      *mux.Router
+	sessions    sessions.Store
+	memorycache *Storage
 
 	ws    map[string]map[string]*wsContext // [uuid][]*context
 	wsMtx sync.RWMutex

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -90,7 +90,7 @@ type politeiawww struct {
 	cfg         *config
 	router      *mux.Router
 	sessions    sessions.Store
-	memorycache *Storage
+	memorycache *storage
 
 	ws    map[string]map[string]*wsContext // [uuid][]*context
 	wsMtx sync.RWMutex

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -684,6 +684,9 @@ func _main() error {
 		}()
 	}
 
+	// Setup memorycache
+	p.memorycache = p.NewStorage()
+
 	// Tell user we are ready to go.
 	log.Infof("Start of day")
 

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -685,7 +685,7 @@ func _main() error {
 	}
 
 	// Setup memorycache
-	p.memorycache = p.NewStorage()
+	p.memorycache = p.newStorage()
 
 	// Tell user we are ready to go.
 	log.Infof("Start of day")


### PR DESCRIPTION
Adds a (1 hour.  make longer ?) cache to the makeProposalsRequest calls.  Since its the same data being pulled again and again this should make for a faster UX. 

based off of https://github.com/goenning/go-cache-demo/blob/master/cache/memory/cache.go