### PR TITLE
[www] Add Proposal Budget and Duration metadata

### DIFF
--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -148,6 +148,8 @@ type ProposalMetadata struct {
 	LinkTo   string        `json:"linkto,omitempty"`   // Token of proposal to link to
 	LinkBy   int64         `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
 	Category www.CategoryT `json:"category,omitempty"` // Proposal category
+	Duration int64         `json:"duration"`           // Duration of proposal (in seconds)
+	Budget   int64         `json:"budget"`             // Budget of proposal (in US cents)
 }
 
 // EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -15,6 +15,7 @@ import (
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
 )
 
@@ -143,10 +144,10 @@ func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 // merkle root, thus causing an error where the client calculated merkle root
 // if different than the politeiad calculated merkle root.
 type ProposalMetadata struct {
-	Name     string `json:"name"`               // Proposal name
-	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
-	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
-	Category string `json:"category,omitempty"` // Proposal category
+	Name     string       `json:"name"`               // Proposal name
+	LinkTo   string       `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64        `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category v1.CategoryT `json:"category,omitempty"` // Proposal category
 }
 
 // EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -143,9 +143,10 @@ func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 // merkle root, thus causing an error where the client calculated merkle root
 // if different than the politeiad calculated merkle root.
 type ProposalMetadata struct {
-	Name   string `json:"name"`             // Proposal name
-	LinkTo string `json:"linkto,omitempty"` // Token of proposal to link to
-	LinkBy int64  `json:"linkby,omitempty"` // UNIX timestamp of RFP deadline
+	Name     string `json:"name"`               // Proposal name
+	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category string `json:"category,omitempty"` // Proposal category
 }
 
 // EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.

--- a/mdstream/mdstream.go
+++ b/mdstream/mdstream.go
@@ -15,7 +15,7 @@ import (
 	pd "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
-	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
+	www "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
 )
 
@@ -144,10 +144,10 @@ func DecodeProposalGeneralV2(payload []byte) (*ProposalGeneralV2, error) {
 // merkle root, thus causing an error where the client calculated merkle root
 // if different than the politeiad calculated merkle root.
 type ProposalMetadata struct {
-	Name     string       `json:"name"`               // Proposal name
-	LinkTo   string       `json:"linkto,omitempty"`   // Token of proposal to link to
-	LinkBy   int64        `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
-	Category v1.CategoryT `json:"category,omitempty"` // Proposal category
+	Name     string        `json:"name"`               // Proposal name
+	LinkTo   string        `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64         `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category www.CategoryT `json:"category,omitempty"` // Proposal category
 }
 
 // EncodeProposalMetadata encodes a ProposalMetadata into a JSON byte slice.

--- a/politeiad/cache/cockroachdb/decred.go
+++ b/politeiad/cache/cockroachdb/decred.go
@@ -1822,10 +1822,11 @@ func proposalMetadataNew(r Record) (*ProposalMetadata, error) {
 	}
 
 	return &ProposalMetadata{
-		Token:  r.Token,
-		Name:   name,
-		LinkTo: pm.LinkTo,
-		LinkBy: pm.LinkBy,
+		Token:    r.Token,
+		Name:     name,
+		LinkTo:   pm.LinkTo,
+		LinkBy:   pm.LinkBy,
+		Category: pm.Category,
 	}, nil
 }
 

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -86,10 +86,11 @@ func (Record) TableName() string {
 //
 // This is a decred plugin model.
 type ProposalMetadata struct {
-	Token  string `gorm:"primary_key"` // Censorship token
-	Name   string `gorm:"not null"`    // Proposal name
-	LinkTo string `gorm:""`            // Token of proposal to link to
-	LinkBy int64  `gorm:""`            // UNIX timestamp of RFP deadline
+	Token    string `gorm:"primary_key"` // Censorship token
+	Name     string `gorm:"not null"`    // Proposal name
+	LinkTo   string `gorm:""`            // Token of proposal to link to
+	LinkBy   int64  `gorm:""`            // UNIX timestamp of RFP deadline
+	Category string `gorm:""`            // Proposal category
 }
 
 // Comment represents a record comment, including all of the server side

--- a/politeiad/cache/cockroachdb/models.go
+++ b/politeiad/cache/cockroachdb/models.go
@@ -90,7 +90,7 @@ type ProposalMetadata struct {
 	Name     string `gorm:"not null"`    // Proposal name
 	LinkTo   string `gorm:""`            // Token of proposal to link to
 	LinkBy   int64  `gorm:""`            // UNIX timestamp of RFP deadline
-	Category string `gorm:""`            // Proposal category
+	Category int    `gorm:""`            // Proposal category
 }
 
 // Comment represents a record comment, including all of the server side

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -216,6 +216,7 @@ const (
 	ErrorStatusWrongProposalType           ErrorStatusT = 76
 	ErrorStatusTOTPFailedValidation        ErrorStatusT = 77
 	ErrorStatusTOTPInvalidType             ErrorStatusT = 78
+	ErrorStatusInvalidProposalCategory     ErrorStatusT = 79
 
 	// Proposal state codes
 	//
@@ -308,6 +309,16 @@ var (
 	PolicyUsernameSupportedChars = []string{
 		"a-z", "0-9", ".", ",", ":", ";", "-", "@", "+", "(", ")", "_"}
 
+	// PolicyProposalCategories describes the valid categories a user can define
+	// for a proposal
+	PolicyProposalCategories = []string{
+		"development",
+		"marketing",
+		"research",
+		"design",
+		"documentation",
+	}
+
 	// PoliteiaWWWAPIRoute is the prefix to the API route
 	PoliteiaWWWAPIRoute = fmt.Sprintf("/v%v", PoliteiaWWWAPIVersion)
 
@@ -394,6 +405,7 @@ var (
 		ErrorStatusWrongProposalType:           "wrong proposal type",
 		ErrorStatusTOTPFailedValidation:        "the provided passcode does not match the saved secret key",
 		ErrorStatusTOTPInvalidType:             "invalid totp type",
+		ErrorStatusInvalidProposalCategory:     "invalid proposal category",
 	}
 
 	// PropStatus converts propsal status codes to human readable text
@@ -455,9 +467,10 @@ const (
 // proposal submission and before the proposal vote is started to ensure that
 // the RFP submissions have sufficient time to be submitted.
 type ProposalMetadata struct {
-	Name   string `json:"name"`             // Proposal name
-	LinkTo string `json:"linkto,omitempty"` // Token of proposal to link to
-	LinkBy int64  `json:"linkby,omitempty"` // UNIX timestamp of RFP deadline
+	Name     string `json:"name"`               // Proposal name
+	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category string `json:"category,omitempty"` // Proposal category
 }
 
 // Metadata describes user specified metadata.
@@ -521,6 +534,7 @@ type ProposalRecord struct {
 	LinkTo              string      `json:"linkto,omitempty"`              // Token of linked parent proposal
 	LinkBy              int64       `json:"linkby,omitempty"`              // UNIX timestamp of RFP deadline
 	LinkedFrom          []string    `json:"linkedfrom,omitempty"`          // Tokens of public props that have linked to this this prop
+	Category            string      `json:"category,omitempty"`            // Proposal category
 
 	Files            []File           `json:"files"`
 	Metadata         []Metadata       `json:"metadata"`
@@ -971,6 +985,7 @@ type PolicyReply struct {
 	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
 	MinVoteDuration            uint32   `json:"minvoteduration"`
 	MaxVoteDuration            uint32   `json:"maxvoteduration"`
+	ProposalCategories         []string `json:"proposalcategories"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -483,6 +483,8 @@ type ProposalMetadata struct {
 	LinkTo   string    `json:"linkto,omitempty"`   // Token of proposal to link to
 	LinkBy   int64     `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
 	Category CategoryT `json:"category,omitempty"` // Proposal category
+	Duration int64     `json:"duration"`           // Duration of proposal (in seconds)
+	Budget   int64     `json:"budget"`             // Budget of proposal (in US cents)
 }
 
 // Metadata describes user specified metadata.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -138,6 +138,9 @@ const (
 	// for the routes that return lists of users
 	UserListPageSize = 20
 
+	// PolicyMaxProposalDuration is the max time a proposal can run (in seconds)
+	PolicyMaxProposalDuration = 60 * 60 * 24 * 7 * 52 * 2 // 60s * 60m * 24h * 7d * 52w * 2y = 2 Years in seconds
+
 	// Error status codes
 	ErrorStatusInvalid                     ErrorStatusT = 0
 	ErrorStatusInvalidPassword             ErrorStatusT = 1
@@ -218,6 +221,8 @@ const (
 	ErrorStatusTOTPFailedValidation        ErrorStatusT = 77
 	ErrorStatusTOTPInvalidType             ErrorStatusT = 78
 	ErrorStatusInvalidProposalCategory     ErrorStatusT = 79
+	ErrorStatusInvalidProposalDuration     ErrorStatusT = 80
+	ErrorStatusInvalidProposalBudget       ErrorStatusT = 81
 
 	// Proposal state codes
 	//
@@ -418,6 +423,8 @@ var (
 		ErrorStatusTOTPFailedValidation:        "the provided passcode does not match the saved secret key",
 		ErrorStatusTOTPInvalidType:             "invalid totp type",
 		ErrorStatusInvalidProposalCategory:     "invalid proposal category",
+		ErrorStatusInvalidProposalDuration:     "invalid proposal duration",
+		ErrorStatusInvalidProposalBudget:       "invalid proposal budget",
 	}
 
 	// PropStatus converts propsal status codes to human readable text

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -298,6 +298,9 @@ const (
 	TOTPTypeBasic   TOTPMethodT = 1
 
 	// Category types
+	//
+	// These types are defined based on the available categories a contractor
+	// can select for completed work on CMS invoices
 	CategoryInvalid       CategoryT = 0
 	CategoryDevelopment   CategoryT = 1
 	CategoryMarketing     CategoryT = 2
@@ -970,31 +973,31 @@ type Policy struct{}
 // PolicyReply is used to reply to the policy command. It returns
 // the file upload restrictions set for Politeia.
 type PolicyReply struct {
-	MinPasswordLength          uint     `json:"minpasswordlength"`
-	MinUsernameLength          uint     `json:"minusernamelength"`
-	MaxUsernameLength          uint     `json:"maxusernamelength"`
-	UsernameSupportedChars     []string `json:"usernamesupportedchars"`
-	ProposalListPageSize       uint     `json:"proposallistpagesize"`
-	UserListPageSize           uint     `json:"userlistpagesize"`
-	MaxImages                  uint     `json:"maximages"`
-	MaxImageSize               uint     `json:"maximagesize"`
-	MaxMDs                     uint     `json:"maxmds"`
-	MaxMDSize                  uint     `json:"maxmdsize"`
-	ValidMIMETypes             []string `json:"validmimetypes"`
-	MinProposalNameLength      uint     `json:"minproposalnamelength"`
-	MaxProposalNameLength      uint     `json:"maxproposalnamelength"`
-	PaywallEnabled             bool     `json:"paywallenabled"`
-	ProposalNameSupportedChars []string `json:"proposalnamesupportedchars"`
-	MaxCommentLength           uint     `json:"maxcommentlength"`
-	BackendPublicKey           string   `json:"backendpublickey"`
-	TokenPrefixLength          int      `json:"tokenprefixlength"`
-	BuildInformation           []string `json:"buildinformation"`
-	IndexFilename              string   `json:"indexfilename"`
-	MinLinkByPeriod            int64    `json:"minlinkbyperiod"`
-	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
-	MinVoteDuration            uint32   `json:"minvoteduration"`
-	MaxVoteDuration            uint32   `json:"maxvoteduration"`
-	ProposalCategories         []string `json:"proposalcategories"`
+	MinPasswordLength          uint                 `json:"minpasswordlength"`
+	MinUsernameLength          uint                 `json:"minusernamelength"`
+	MaxUsernameLength          uint                 `json:"maxusernamelength"`
+	UsernameSupportedChars     []string             `json:"usernamesupportedchars"`
+	ProposalListPageSize       uint                 `json:"proposallistpagesize"`
+	UserListPageSize           uint                 `json:"userlistpagesize"`
+	MaxImages                  uint                 `json:"maximages"`
+	MaxImageSize               uint                 `json:"maximagesize"`
+	MaxMDs                     uint                 `json:"maxmds"`
+	MaxMDSize                  uint                 `json:"maxmdsize"`
+	ValidMIMETypes             []string             `json:"validmimetypes"`
+	MinProposalNameLength      uint                 `json:"minproposalnamelength"`
+	MaxProposalNameLength      uint                 `json:"maxproposalnamelength"`
+	PaywallEnabled             bool                 `json:"paywallenabled"`
+	ProposalNameSupportedChars []string             `json:"proposalnamesupportedchars"`
+	MaxCommentLength           uint                 `json:"maxcommentlength"`
+	BackendPublicKey           string               `json:"backendpublickey"`
+	TokenPrefixLength          int                  `json:"tokenprefixlength"`
+	BuildInformation           []string             `json:"buildinformation"`
+	IndexFilename              string               `json:"indexfilename"`
+	MinLinkByPeriod            int64                `json:"minlinkbyperiod"`
+	MaxLinkByPeriod            int64                `json:"maxlinkbyperiod"`
+	MinVoteDuration            uint32               `json:"minvoteduration"`
+	MaxVoteDuration            uint32               `json:"maxvoteduration"`
+	ProposalCategories         map[CategoryT]string `json:"proposalcategories"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -18,6 +18,7 @@ type UserManageActionT int
 type EmailNotificationT int
 type VoteT int
 type TOTPMethodT int
+type CategoryT int
 
 const (
 	PoliteiaWWWAPIVersion = 1 // API version this backend understands
@@ -295,6 +296,14 @@ const (
 	// Time-base one time password types
 	TOTPTypeInvalid TOTPMethodT = 0 // Invalid TOTP type
 	TOTPTypeBasic   TOTPMethodT = 1
+
+	// Category types
+	CategoryInvalid       CategoryT = 0
+	CategoryDevelopment   CategoryT = 1
+	CategoryMarketing     CategoryT = 2
+	CategoryResearch      CategoryT = 3
+	CategoryDesign        CategoryT = 4
+	CategoryDocumentation CategoryT = 5
 )
 
 var (
@@ -311,12 +320,12 @@ var (
 
 	// PolicyProposalCategories describes the valid categories a user can define
 	// for a proposal
-	PolicyProposalCategories = []string{
-		"development",
-		"marketing",
-		"research",
-		"design",
-		"documentation",
+	PolicyProposalCategories = map[CategoryT]string{
+		CategoryDevelopment:   "development",
+		CategoryMarketing:     "marketing",
+		CategoryResearch:      "research",
+		CategoryDesign:        "design",
+		CategoryDocumentation: "documentation",
 	}
 
 	// PoliteiaWWWAPIRoute is the prefix to the API route
@@ -467,10 +476,10 @@ const (
 // proposal submission and before the proposal vote is started to ensure that
 // the RFP submissions have sufficient time to be submitted.
 type ProposalMetadata struct {
-	Name     string `json:"name"`               // Proposal name
-	LinkTo   string `json:"linkto,omitempty"`   // Token of proposal to link to
-	LinkBy   int64  `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
-	Category string `json:"category,omitempty"` // Proposal category
+	Name     string    `json:"name"`               // Proposal name
+	LinkTo   string    `json:"linkto,omitempty"`   // Token of proposal to link to
+	LinkBy   int64     `json:"linkby,omitempty"`   // UNIX timestamp of RFP deadline
+	Category CategoryT `json:"category,omitempty"` // Proposal category
 }
 
 // Metadata describes user specified metadata.
@@ -534,7 +543,7 @@ type ProposalRecord struct {
 	LinkTo              string      `json:"linkto,omitempty"`              // Token of linked parent proposal
 	LinkBy              int64       `json:"linkby,omitempty"`              // UNIX timestamp of RFP deadline
 	LinkedFrom          []string    `json:"linkedfrom,omitempty"`          // Tokens of public props that have linked to this this prop
-	Category            string      `json:"category,omitempty"`            // Proposal category
+	Category            CategoryT   `json:"category,omitempty"`            // Proposal category
 
 	Files            []File           `json:"files"`
 	Metadata         []Metadata       `json:"metadata"`

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -169,7 +169,7 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 		pm.LinkTo = cmd.LinkTo
 	}
 	if cmd.Category != "" {
-		pm.Category = cmd.Category
+		// pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {

--- a/politeiawww/cmd/piwww/editproposal.go
+++ b/politeiawww/cmd/piwww/editproposal.go
@@ -27,9 +27,10 @@ type EditProposalCmd struct {
 		Markdown    string   `positional-arg-name:"markdownfile"`
 		Attachments []string `positional-arg-name:"attachmentfiles"`
 	} `positional-args:"true" optional:"true"`
-	Name   string `long:"name" optional:"true"`
-	LinkTo string `long:"linkto" optional:"true"`
-	LinkBy int64  `long:"linkby" optional:"true"`
+	Name     string `long:"name" optional:"true"`
+	LinkTo   string `long:"linkto" optional:"true"`
+	LinkBy   int64  `long:"linkby" optional:"true"`
+	Category string `long:"category" optional:"true"`
 
 	// Random can be used in place of editing proposal name & data. When
 	// specified, random proposal name & data will be created and submitted.
@@ -166,6 +167,9 @@ func (cmd *EditProposalCmd) Execute(args []string) error {
 	}
 	if cmd.LinkTo != "" {
 		pm.LinkTo = cmd.LinkTo
+	}
+	if cmd.Category != "" {
+		pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -26,9 +26,10 @@ type NewProposalCmd struct {
 		Markdown    string   `positional-arg-name:"markdownfile"`
 		Attachments []string `positional-arg-name:"attachmentfiles"`
 	} `positional-args:"true" optional:"true"`
-	Name   string `long:"name" optional:"true"`
-	LinkTo string `long:"linkto" optional:"true"`
-	LinkBy int64  `long:"linkby" optional:"true"`
+	Name     string `long:"name" optional:"true"`
+	LinkTo   string `long:"linkto" optional:"true"`
+	LinkBy   int64  `long:"linkby" optional:"true"`
+	Category string `long:"category" optional:"true"`
 
 	// Random can be used in place of submitting proposal files. When
 	// specified, random proposal data will be created and submitted.
@@ -144,6 +145,9 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		Name:   cmd.Name,
 		LinkTo: cmd.LinkTo,
 		LinkBy: cmd.LinkBy,
+	}
+	if cmd.Category != "" {
+		pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)
 	if err != nil {

--- a/politeiawww/cmd/piwww/newproposal.go
+++ b/politeiawww/cmd/piwww/newproposal.go
@@ -26,10 +26,10 @@ type NewProposalCmd struct {
 		Markdown    string   `positional-arg-name:"markdownfile"`
 		Attachments []string `positional-arg-name:"attachmentfiles"`
 	} `positional-args:"true" optional:"true"`
-	Name     string `long:"name" optional:"true"`
-	LinkTo   string `long:"linkto" optional:"true"`
-	LinkBy   int64  `long:"linkby" optional:"true"`
-	Category string `long:"category" optional:"true"`
+	Name     string       `long:"name" optional:"true"`
+	LinkTo   string       `long:"linkto" optional:"true"`
+	LinkBy   int64        `long:"linkby" optional:"true"`
+	Category v1.CategoryT `long:"category" optional:"true"` // Proposal category
 
 	// Random can be used in place of submitting proposal files. When
 	// specified, random proposal data will be created and submitted.
@@ -146,7 +146,7 @@ func (cmd *NewProposalCmd) Execute(args []string) error {
 		LinkTo: cmd.LinkTo,
 		LinkBy: cmd.LinkBy,
 	}
-	if cmd.Category != "" {
+	if cmd.Category != 0 {
 		pm.Category = cmd.Category
 	}
 	pmb, err := json.Marshal(pm)

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -534,6 +534,7 @@ func convertPropFromCache(r cache.Record) (*www.ProposalRecord, error) {
 		LinkTo:              pm.LinkTo,
 		LinkBy:              pm.LinkBy,
 		LinkedFrom:          []string{},
+		Category:            pm.Category,
 		Files:               files,
 		Metadata:            metadata,
 		CensorshipRecord: www.CensorshipRecord{

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -366,6 +366,7 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		MaxLinkByPeriod:            p.linkByPeriodMax(),
 		MinVoteDuration:            p.cfg.VoteDurationMin,
 		MaxVoteDuration:            p.cfg.VoteDurationMax,
+		ProposalCategories:         www.PolicyProposalCategories,
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -319,12 +319,22 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 
 	// Validate Duration
 	if pm.Duration != 0 {
+		if pm.Duration < 0 || pm.Duration > www.PolicyMaxProposalDuration {
+			return www.UserError{
+				ErrorCode: www.ErrorStatusInvalidProposalDuration,
+			}
+		}
 
 	}
 
 	// Validate Budget
 	if pm.Budget != 0 {
-
+		// Currently no upper bound, only checking if it's above 0
+		if pm.Budget < 0 {
+			return www.UserError{
+				ErrorCode: www.ErrorStatusInvalidProposalBudget,
+			}
+		}
 	}
 
 	return nil

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -307,6 +307,22 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 		}
 	}
 
+	// Validate Category
+	if pm.Category != "" {
+		ok := false
+		for _, c := range www.PolicyProposalCategories {
+			if c == pm.Category {
+				ok = true
+			}
+		}
+		if !ok {
+			return www.UserError{
+				ErrorCode:    www.ErrorStatusInvalidProposalCategory,
+				ErrorContext: []string{pm.Category},
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -317,6 +317,16 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 		}
 	}
 
+	// Validate Duration
+	if pm.Duration != 0 {
+
+	}
+
+	// Validate Budget
+	if pm.Budget != 0 {
+
+	}
+
 	return nil
 }
 

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -308,17 +308,11 @@ func (p *politeiawww) validateProposalMetadata(pm www.ProposalMetadata) error {
 	}
 
 	// Validate Category
-	if pm.Category != "" {
-		ok := false
-		for _, c := range www.PolicyProposalCategories {
-			if c == pm.Category {
-				ok = true
-			}
-		}
+	if pm.Category != 0 {
+		_, ok := www.PolicyProposalCategories[pm.Category]
 		if !ok {
 			return www.UserError{
-				ErrorCode:    www.ErrorStatusInvalidProposalCategory,
-				ErrorContext: []string{pm.Category},
+				ErrorCode: www.ErrorStatusInvalidProposalCategory,
 			}
 		}
 	}


### PR DESCRIPTION
Requires #1214 

This diff adds budget and duration fields to the `ProposalMetadata`. 

These will serve as guidelines for future billing against the proposal.  Upon completion of the duration the proposal may not be billed against or if the budget has been exceeded by previous invoices, there may be no more billing against that proposal.

These 2 fields are currently optional.  Budget is stored as US cents, Duration in seconds.
If populated, budget must be greater than 0 and has no upper limit.  If populated, duration must be greater than 0 and less than 2 years (`PolicyMaxProposalDuration`).