### PR TITLE
cms: validate subrate and subuserid for labor invoice lineitems

### DIFF
--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -676,6 +676,16 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 							ErrorCode: cms.ErrorStatusInvalidLaborExpense,
 						}
 					}
+					if lineInput.SubRate != 0 {
+						return www.UserError{
+							ErrorCode: cms.ErrorStatusInvoiceInvalidRate,
+						}
+					}
+					if lineInput.SubUserID != "" {
+						return www.UserError{
+							ErrorCode: cms.ErrorStatusInvalidSubUserIDLineItem,
+						}
+					}
 				case cms.LineItemTypeExpense:
 					fallthrough
 				case cms.LineItemTypeMisc:


### PR DESCRIPTION
This diff adds validators for invoice SubRate and SubUserIDs on labor invoice lineitems. Basically, a Labor type lineitem shouldn't be allowed to receive both subrate and subuserid info.