### PR TITLE
totp: Add reset totp to admin db tool

### DIFF
--- a/politeiawww/cmd/politeiawww_dbutil/README.md
+++ b/politeiawww/cmd/politeiawww_dbutil/README.md
@@ -79,6 +79,13 @@ You can specify the following options:
           Required DB flag : -cockroachdb
           Args             : <username>
 
+      -resettotp
+          Reset a user's totp settings in case they are locked out and 
+          confirm identity. 
+          Required DB flag : -leveldb or -cockroachdb
+          LevelDB args     : <email>
+          CockroachDB args : <username>
+
 ### Examples
 
 Mainnet example:

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -742,8 +742,7 @@ func levelResetTOTP(email string) error {
 		return err
 	}
 
-	fmt.Printf("User with email '%v' totp reset "+
-		"to %v\n", email)
+	fmt.Printf("User with email '%v' totp reset\n", email)
 
 	return nil
 }

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -155,7 +155,7 @@ const usageMsg = `politeiawww_dbutil usage:
     -verifyidentities
           Verify a user's identities do not violate any politeia rules. Invalid
           identities are fixed.
-		  Required DB flag : -cockroachdb
+          Required DB flag : -cockroachdb
 
     -resettotp
           Reset a user's totp settings in case they are locked out and 

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -160,7 +160,7 @@ const usageMsg = `politeiawww_dbutil usage:
     -resettotp
           Reset a user's totp settings in case they are locked out and 
           confirm identity. 
-		  Required DB flag : -leveldb or -cockroachdb
+          Required DB flag : -leveldb or -cockroachdb
           LevelDB args     : <email>
           CockroachDB args : <username>
 `

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -81,6 +81,7 @@ var (
 	migrate          = flag.Bool("migrate", false, "")
 	createKey        = flag.Bool("createkey", false, "")
 	verifyIdentities = flag.Bool("verifyidentities", false, "")
+	resetTotp        = flag.Bool("resettotp", false, "")
 
 	network string // Mainnet or testnet3
 	// XXX ldb should be abstracted away. dbutil commands should use
@@ -151,11 +152,17 @@ const usageMsg = `politeiawww_dbutil usage:
           Required DB flag : None
           Args             : None
 
-     -verifyidentities
+    -verifyidentities
           Verify a user's identities do not violate any politeia rules. Invalid
           identities are fixed.
-          Required DB flag : -cockroachdb
-          Args             : <username>
+		  Required DB flag : -cockroachdb
+
+    -resettotp
+          Reset a user's totp settings in case they are locked out and 
+          confirm identity. 
+		  Required DB flag : -leveldb or -cockroachdb
+          LevelDB args     : <email>
+          CockroachDB args : <username>
 `
 
 func cmdDump() error {
@@ -709,6 +716,76 @@ func cmdVerifyIdentities() error {
 	return nil
 }
 
+func levelResetTOTP(email string) error {
+	b, err := ldb.Get([]byte(email), nil)
+	if err != nil {
+		return fmt.Errorf("user email '%v' not found", email)
+	}
+
+	u, err := user.DecodeUser(b)
+	if err != nil {
+		return err
+	}
+
+	u.TOTPLastUpdated = nil
+	u.TOTPSecret = ""
+	u.TOTPType = 0
+	u.TOTPVerified = false
+
+	b, err = user.EncodeUser(*u)
+	if err != nil {
+		return err
+	}
+
+	err = ldb.Put([]byte(email), b, nil)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("User with email '%v' totp reset "+
+		"to %v\n", email)
+
+	return nil
+}
+
+func cockroachResetTOTP(username string) error {
+	u, err := userDB.UserGetByUsername(username)
+	if err != nil {
+		return err
+	}
+
+	u.TOTPLastUpdated = nil
+	u.TOTPSecret = ""
+	u.TOTPType = 0
+	u.TOTPVerified = false
+
+	err = userDB.UserUpdate(*u)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("User with username '%v' reset totp\n", username)
+
+	return nil
+}
+
+func cmdResetTOTP() error {
+	args := flag.Args()
+	if len(args) != 1 {
+		return fmt.Errorf("invalid number of arguments; want <username>, got %v",
+			args)
+	}
+
+	switch {
+	case *level:
+		return levelResetTOTP(args[0])
+	case *cockroach:
+		return cockroachResetTOTP(args[0])
+	}
+
+	return nil
+}
+
 func _main() error {
 	flag.Parse()
 
@@ -730,7 +807,7 @@ func _main() error {
 	}
 
 	switch {
-	case *addCredits || *setAdmin || *stubUsers:
+	case *addCredits || *setAdmin || *stubUsers || *resetTotp:
 		// These commands must be run with -cockroachdb or -leveldb
 		if !*level && !*cockroach {
 			return fmt.Errorf("missing database flag; must use " +
@@ -808,6 +885,8 @@ func _main() error {
 		return cmdCreateKey()
 	case *verifyIdentities:
 		return cmdVerifyIdentities()
+	case *resetTotp:
+		return cmdResetTOTP()
 	default:
 		fmt.Printf("invalid command\n")
 		flag.Usage()

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -716,38 +716,14 @@ func cmdVerifyIdentities() error {
 	return nil
 }
 
-func levelResetTOTP(email string) error {
-	b, err := ldb.Get([]byte(email), nil)
-	if err != nil {
-		return fmt.Errorf("user email '%v' not found", email)
+func cmdResetTOTP() error {
+	args := flag.Args()
+	if len(args) != 1 {
+		return fmt.Errorf("invalid number of arguments; want <username>, got %v",
+			args)
 	}
 
-	u, err := user.DecodeUser(b)
-	if err != nil {
-		return err
-	}
-
-	u.TOTPLastUpdated = nil
-	u.TOTPSecret = ""
-	u.TOTPType = 0
-	u.TOTPVerified = false
-
-	b, err = user.EncodeUser(*u)
-	if err != nil {
-		return err
-	}
-
-	err = ldb.Put([]byte(email), b, nil)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("User with email '%v' totp reset\n", email)
-
-	return nil
-}
-
-func cockroachResetTOTP(username string) error {
+	username := args[0]
 	u, err := userDB.UserGetByUsername(username)
 	if err != nil {
 		return err
@@ -764,23 +740,6 @@ func cockroachResetTOTP(username string) error {
 	}
 
 	fmt.Printf("User with username '%v' reset totp\n", username)
-
-	return nil
-}
-
-func cmdResetTOTP() error {
-	args := flag.Args()
-	if len(args) != 1 {
-		return fmt.Errorf("invalid number of arguments; want <username>, got %v",
-			args)
-	}
-
-	switch {
-	case *level:
-		return levelResetTOTP(args[0])
-	case *cockroach:
-		return cockroachResetTOTP(args[0])
-	}
 
 	return nil
 }


### PR DESCRIPTION
This adds a basic reset of TOTP credentials to the politeiawww_dbutil tool.  This should only be necessary for extreme cases,
but will be more convenient than have to alter the db by hand and more secure than having an admin command available in www.