### PR TITLE
[cms] Replace DCC cache usage with direct gitbe implementation

### DIFF
--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -20,8 +20,7 @@ const (
 	CmdCastVote          = "castdccvote"
 	CmdInventory         = "cmsinventory"
 	CmdVoteSummary       = "votedccsummary"
-	CmdLoadVoteResults   = "loaddccvoteresults"
-	CmdDCCVotes          = "dccvotes"
+	CmdDCCVoteResults    = "dccvoteresults"
 	MDStreamVoteBits     = 16 // Vote bits and mask
 	MDStreamVoteSnapshot = 17 // Vote tickets and start/end parameters
 

--- a/cmsplugin/cmsplugin.go
+++ b/cmsplugin/cmsplugin.go
@@ -21,6 +21,7 @@ const (
 	CmdInventory         = "cmsinventory"
 	CmdVoteSummary       = "votedccsummary"
 	CmdLoadVoteResults   = "loaddccvoteresults"
+	CmdDCCVotes          = "dccvotes"
 	MDStreamVoteBits     = 16 // Vote bits and mask
 	MDStreamVoteSnapshot = 17 // Vote tickets and start/end parameters
 

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -1156,11 +1156,11 @@ nodata:
 	return string(reply), nil
 }
 
-// pluginDCCVotes tallies all votes for a dcc. We can run the tally
+// pluginDCCVoteResults tallies all votes for a dcc. We can run the tally
 // unlocked and just replay the journal. If the replay becomes an issue we
 // could cache it. The Vote that is returned does have to be locked.
-func (g *gitBackEnd) pluginDCCVotes(payload string) (string, error) {
-	log.Tracef("pluginDCCVotes: %v", payload)
+func (g *gitBackEnd) pluginDCCVoteResults(payload string) (string, error) {
+	log.Tracef("pluginDCCVoteResults: %v", payload)
 
 	vote, err := cmsplugin.DecodeVoteResults([]byte(payload))
 	if err != nil {
@@ -1361,15 +1361,4 @@ func (g *gitBackEnd) pluginCMSInventory() (string, error) {
 	}
 
 	return string(payload), nil
-}
-
-// pluginLoadDCCVoteResults is a pass through function. CmdLoadDCCVoteResults does
-// not require any work to be performed in gitBackEnd.
-func (g *gitBackEnd) pluginLoadDCCVoteResults() (string, error) {
-	r := cmsplugin.LoadVoteResultsReply{}
-	reply, err := cmsplugin.EncodeLoadVoteResultsReply(r)
-	if err != nil {
-		return "", err
-	}
-	return string(reply), nil
 }

--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -1145,6 +1145,7 @@ func (g *gitBackEnd) pluginDCCVoteSummary(payload string) (string, error) {
 			}
 		}
 	}
+	vsr.Results = vors
 nodata:
 	reply, err := cmsplugin.EncodeVoteSummaryReply(vsr)
 	if err != nil {

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2836,12 +2836,9 @@ func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
 	case cmsplugin.CmdCastVote:
 		payload, err := g.pluginCastVote(payload)
 		return cmsplugin.CmdCastVote, payload, err
-	case cmsplugin.CmdLoadVoteResults:
-		payload, err := g.pluginLoadDCCVoteResults()
-		return cmsplugin.CmdLoadVoteResults, payload, err
-	case cmsplugin.CmdDCCVotes:
-		payload, err := g.pluginDCCVotes(payload)
-		return cmsplugin.CmdDCCVotes, payload, err
+	case cmsplugin.CmdDCCVoteResults:
+		payload, err := g.pluginDCCVoteResults(payload)
+		return cmsplugin.CmdDCCVoteResults, payload, err
 	case cmsplugin.CmdVoteDetails:
 		payload, err := g.pluginDCCVoteDetails(payload)
 		return cmsplugin.CmdVoteDetails, payload, err

--- a/politeiad/backend/gitbe/gitbe.go
+++ b/politeiad/backend/gitbe/gitbe.go
@@ -2836,6 +2836,18 @@ func (g *gitBackEnd) Plugin(command, payload string) (string, string, error) {
 	case cmsplugin.CmdCastVote:
 		payload, err := g.pluginCastVote(payload)
 		return cmsplugin.CmdCastVote, payload, err
+	case cmsplugin.CmdLoadVoteResults:
+		payload, err := g.pluginLoadDCCVoteResults()
+		return cmsplugin.CmdLoadVoteResults, payload, err
+	case cmsplugin.CmdDCCVotes:
+		payload, err := g.pluginDCCVotes(payload)
+		return cmsplugin.CmdDCCVotes, payload, err
+	case cmsplugin.CmdVoteDetails:
+		payload, err := g.pluginDCCVoteDetails(payload)
+		return cmsplugin.CmdVoteDetails, payload, err
+	case cmsplugin.CmdVoteSummary:
+		payload, err := g.pluginDCCVoteSummary(payload)
+		return cmsplugin.CmdVoteSummary, payload, err
 	}
 	return "", "", fmt.Errorf("invalid payload command") // XXX this needs to become a type error
 }

--- a/politeiawww/cmd/cmswww/testrun.go
+++ b/politeiawww/cmd/cmswww/testrun.go
@@ -928,6 +928,11 @@ func testDCCVote(admin user) error {
 	if err != nil {
 		return err
 	}
+	expectedVoteOptionResults := 2
+	if len(vs.Results) != expectedVoteOptionResults {
+		return fmt.Errorf("unexpected number of vote option results: got %v,"+
+			" wanted %v", len(vs.Results), expectedVoteOptionResults)
+	}
 	for _, result := range vs.Results {
 		if result.Option.Id == cmsplugin.DCCApprovalString &&
 			result.VotesReceived != expectedApprovalVotes {

--- a/politeiawww/cmd/cmswww/testrun.go
+++ b/politeiawww/cmd/cmswww/testrun.go
@@ -916,11 +916,32 @@ func testDCCVote(admin user) error {
 	if err != nil {
 		return err
 	}
+	expectedApprovalVotes := uint64(1)
 	err = dccVote(*c3, dccToken, cmsplugin.DCCDisapprovalString)
 	if err != nil {
 		return err
 	}
-
+	expectedDisapprovalVotes := uint64(1)
+	// Check to see that the votes are properly cast in gitbe
+	fmt.Printf("  check DCC votes")
+	vs, err := dccVoteSummary(*c2, dccToken)
+	if err != nil {
+		return err
+	}
+	for _, result := range vs.Results {
+		if result.Option.Id == cmsplugin.DCCApprovalString &&
+			result.VotesReceived != expectedApprovalVotes {
+			return fmt.Errorf("unexpected amount of %v votes, got %v wanted %v",
+				cmsplugin.DCCApprovalString, result.VotesReceived,
+				expectedApprovalVotes)
+		}
+		if result.Option.Id == cmsplugin.DCCDisapprovalString &&
+			result.VotesReceived != expectedDisapprovalVotes {
+			return fmt.Errorf("unexpected amount of %v votes, got %v wanted %v",
+				cmsplugin.DCCDisapprovalString, result.VotesReceived,
+				expectedDisapprovalVotes)
+		}
+	}
 	/*
 		// Have the admin approve the DCC
 		// This can't be done in the test run because the vote needs to


### PR DESCRIPTION
This diff removes the remaining DCC references to the cache and now directly requests the
vote information from the gitbe.  This clears the way for easier implementation of tlog
since it will no longer be using the cache as we have it now.