### PR TITLE
[cms] Add cms plugin support to user leveldb implementation

### DIFF
--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -171,7 +171,7 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 			log.Debugf("RegisterUser failure for %v: user not found",
 				u.Email)
 			return nil, www.UserError{
-				ErrorCode: www.ErrorStatusVerificationTokenInvalid,
+				ErrorCode: www.ErrorStatusCannotCensorComment,
 			}
 		}
 		return nil, err

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -259,10 +259,12 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 
 	// Create a new database user with the provided information.
 	newUser := user.User{
-		ID:             existingUser.ID,
-		Email:          strings.ToLower(u.Email),
-		Username:       username,
-		HashedPassword: hashedPassword,
+		ID:                        existingUser.ID,
+		Email:                     strings.ToLower(u.Email),
+		Username:                  username,
+		HashedPassword:            hashedPassword,
+		NewUserVerificationToken:  nil,
+		NewUserVerificationExpiry: 0,
 	}
 
 	// Setup newUser's identity with the provided public key. An

--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -171,7 +171,7 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 			log.Debugf("RegisterUser failure for %v: user not found",
 				u.Email)
 			return nil, www.UserError{
-				ErrorCode: www.ErrorStatusCannotCensorComment,
+				ErrorCode: www.ErrorStatusVerificationTokenInvalid,
 			}
 		}
 		return nil, err

--- a/politeiawww/cmsuser_test.go
+++ b/politeiawww/cmsuser_test.go
@@ -463,7 +463,8 @@ func TestPostRegisterUser(t *testing.T) {
 
 			cmsUser, err := p.getCMSUserByID(u.ID.String())
 			if err != nil {
-				t.Errorf("error getting cms user by id %v %v", u.ID.String(), err)
+				t.Errorf("error getting cms user by id %v %v", u.ID.String(),
+					err)
 				return
 			}
 

--- a/politeiawww/cmsuser_test.go
+++ b/politeiawww/cmsuser_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/hex"
+	"testing"
+
+	cms "github.com/decred/politeia/politeiawww/api/cms/v1"
+	www "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+func TestInviteNewUser(t *testing.T) {
+	p, cleanup := newTestCMSwww(t)
+	defer cleanup()
+
+	var tests = []struct {
+		name      string
+		email     string
+		wantError error
+	}{
+		{
+			"success",
+			"test@example.com",
+			nil,
+		},
+		{
+			"error malformed",
+			"testemailmalformed",
+			www.UserError{
+				ErrorCode: www.ErrorStatusMalformedEmail,
+			},
+		},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			inviteUserReq := cms.InviteNewUser{
+				Email:     v.email,
+				Temporary: false,
+			}
+			_, err := p.processInviteNewUser(inviteUserReq)
+
+			got := errToStr(err)
+			want := errToStr(v.wantError)
+			if got != want {
+				t.Errorf("got error %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestRegisterUser(t *testing.T) {
+	p, cleanup := newTestCMSwww(t)
+	defer cleanup()
+
+	// Create user identity and save it to disk
+	id, err := shared.NewIdentity()
+	if err != nil {
+		t.Fatalf("error generating identity")
+	}
+
+	// Create another user identity and save it to disk
+	idFresh, err := shared.NewIdentity()
+	if err != nil {
+		t.Fatalf("error another generating identity")
+	}
+	email := "test1@example.org"
+	username := "test1"
+	pwd := "password1"
+
+	inviteUserReq := cms.InviteNewUser{
+		Email:     email,
+		Temporary: false,
+	}
+	reply, err := p.processInviteNewUser(inviteUserReq)
+	if err != nil {
+		t.Fatalf("error inviting user %v", err)
+	}
+	var tests = []struct {
+		name      string
+		username  string
+		token     string
+		wantError error
+		pubkey    string
+	}{
+		{
+			"error bad verification",
+			username,
+			"12345",
+			www.UserError{
+				ErrorCode: www.ErrorStatusVerificationTokenInvalid,
+			},
+			hex.EncodeToString(id.Public.Key[:]),
+		},
+		{
+			"success",
+			username,
+			reply.VerificationToken,
+			nil,
+			hex.EncodeToString(id.Public.Key[:]),
+		},
+		{
+			"error duplicate pubkey",
+			username,
+			"12345",
+			www.UserError{
+				ErrorCode: www.ErrorStatusDuplicatePublicKey,
+			},
+			hex.EncodeToString(id.Public.Key[:]),
+		},
+		{
+			"error duplicate username",
+			username,
+			"12345",
+			www.UserError{
+				ErrorCode: www.ErrorStatusDuplicateUsername,
+			},
+			hex.EncodeToString(idFresh.Public.Key[:]),
+		},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			registerReq := cms.RegisterUser{
+				Email:             email,
+				Username:          v.username,
+				Password:          pwd,
+				VerificationToken: v.token,
+				PublicKey:         v.pubkey,
+			}
+			_, err = p.processRegisterUser(registerReq)
+			got := errToStr(err)
+			want := errToStr(v.wantError)
+			if got != want {
+				t.Errorf("got error %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/politeiawww/cmsuser_test.go
+++ b/politeiawww/cmsuser_test.go
@@ -131,8 +131,6 @@ func TestInviteNewUser(t *testing.T) {
 				// If token is expected to be fresh from one previously received
 				t.Errorf("expecting fresh token but got the same")
 			}
-
-			return
 		})
 	}
 }

--- a/politeiawww/cmsuser_test.go
+++ b/politeiawww/cmsuser_test.go
@@ -301,7 +301,7 @@ func TestRegisterUser(t *testing.T) {
 			emailFresh,
 			usernameTooShort,
 			pwd,
-			"12345",
+			"123456",
 			www.UserError{
 				ErrorCode: www.ErrorStatusMalformedUsername,
 			},
@@ -312,7 +312,7 @@ func TestRegisterUser(t *testing.T) {
 			emailFresh,
 			usernameTooLong,
 			pwd,
-			"12345",
+			"123456",
 			www.UserError{
 				ErrorCode: www.ErrorStatusMalformedUsername,
 			},
@@ -323,7 +323,7 @@ func TestRegisterUser(t *testing.T) {
 			emailFresh,
 			usernameRegExp,
 			pwd,
-			"12345",
+			"123456",
 			www.UserError{
 				ErrorCode: www.ErrorStatusMalformedUsername,
 			},
@@ -334,7 +334,7 @@ func TestRegisterUser(t *testing.T) {
 			emailFresh,
 			usernameFresh,
 			passwordTooShort,
-			"12345",
+			"123456",
 			www.UserError{
 				ErrorCode: www.ErrorStatusMalformedPassword,
 			},
@@ -347,6 +347,17 @@ func TestRegisterUser(t *testing.T) {
 			pwd,
 			replyFresh.VerificationToken,
 			nil,
+			hex.EncodeToString(idFresh.Public.Key[:]),
+		},
+		{
+			"error user not found",
+			"notfound@example.org",
+			"notfound",
+			pwd,
+			"123456",
+			www.UserError{
+				ErrorCode: www.ErrorStatusVerificationTokenInvalid,
+			},
 			hex.EncodeToString(idFresh.Public.Key[:]),
 		},
 	}

--- a/politeiawww/cmsuser_test.go
+++ b/politeiawww/cmsuser_test.go
@@ -370,92 +370,48 @@ func TestRegisterUser(t *testing.T) {
 	}
 }
 
-func TestPostRegisterUser(t *testing.T) {
+func TestTempInviteUser(t *testing.T) {
 	p, cleanup := newTestCMSwww(t)
 	defer cleanup()
 
-	// Create user identity and save it to disk
-	idFirst, err := shared.NewIdentity()
-	if err != nil {
-		t.Fatalf("error generating identity")
-	}
-
 	emailFirst := "test1@example.org"
-	usernameFirst := "test1"
-	pwdFirst := "password1"
-
-	// Create user identity and save it to disk
-	idSecond, err := shared.NewIdentity()
-	if err != nil {
-		t.Fatalf("error generating identity")
-	}
 
 	emailSecond := "test2@example.org"
-	usernameSecond := "test2"
-	pwdSecond := "password1"
 
 	var tests = []struct {
 		name                   string
 		email                  string
-		username               string
-		pwd                    string
-		pubkey                 string
 		temp                   bool
 		expectedContractorType cms.ContractorTypeT
-		wantError              error
 	}{
 		{
 			"success",
 			emailFirst,
-			usernameFirst,
-			pwdFirst,
-			hex.EncodeToString(idFirst.Public.Key[:]),
 			false,
 			cms.ContractorTypeNominee,
-			nil,
 		},
 		{
 			"success temp",
 			emailSecond,
-			usernameSecond,
-			pwdSecond,
-			hex.EncodeToString(idSecond.Public.Key[:]),
 			true,
 			cms.ContractorTypeTemp,
-			nil,
 		},
 	}
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-
 			inviteUserReq := cms.InviteNewUser{
 				Email:     v.email,
 				Temporary: v.temp,
 			}
-			reply, err := p.processInviteNewUser(inviteUserReq)
+			_, err := p.processInviteNewUser(inviteUserReq)
 			if err != nil {
-				t.Errorf("error inviting user %v %v", v.username, err)
+				t.Errorf("error inviting user %v %v", v.email, err)
 				return
 			}
-			verificationToken := reply.VerificationToken
-
-			registerReq := cms.RegisterUser{
-				Email:             v.email,
-				Username:          v.username,
-				Password:          v.pwd,
-				VerificationToken: verificationToken,
-				PublicKey:         v.pubkey,
-			}
-			_, err = p.processRegisterUser(registerReq)
+			u, err := p.userByEmail(v.email)
 			if err != nil {
-				t.Errorf("error registering user %v %v", v.username, err)
-				return
-			}
-
-			u, err := p.db.UserGetByPubKey(v.pubkey)
-			if err != nil {
-				t.Errorf("error getting user by pubkey %v %v", v.username, err)
+				t.Errorf("error getting user by email %v %v", v.email, err)
 				return
 			}
 
@@ -469,11 +425,6 @@ func TestPostRegisterUser(t *testing.T) {
 			if cmsUser.ContractorType != v.expectedContractorType {
 				t.Errorf("unexpected contractor type got %v, want %v",
 					cmsUser.ContractorType, v.expectedContractorType)
-			}
-			got := errToStr(err)
-			want := errToStr(v.wantError)
-			if got != want {
-				t.Errorf("got error %v, want %v", got, want)
 			}
 		})
 	}

--- a/politeiawww/user/localdb/cms.go
+++ b/politeiawww/user/localdb/cms.go
@@ -19,7 +19,7 @@ const (
 // and false otherwise. This is helpful when iterating the user records
 // because the DB contains some non-user records.
 func isCMSUserRecord(key string) bool {
-	return !strings.HasPrefix(key, cmsUserPrefix)
+	return strings.HasPrefix(key, cmsUserPrefix)
 }
 
 // cmdNewCMSUser inserts a new CMSUser record into the database.

--- a/politeiawww/user/localdb/cms.go
+++ b/politeiawww/user/localdb/cms.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package localdb
+
+import (
+	"strings"
+
+	"github.com/decred/politeia/politeiawww/user"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+const (
+	cmsUserPrefix = "cmswww"
+)
+
+// isCMSUserRecord returns true if the given key is a cms user record,
+// and false otherwise. This is helpful when iterating the user records
+// because the DB contains some non-user records.
+func isCMSUserRecord(key string) bool {
+	return !strings.HasPrefix(key, cmsUserPrefix)
+}
+
+// cmdNewCMSUser inserts a new CMSUser record into the database.
+func (l *localdb) cmdNewCMSUser(payload string) (string, error) {
+	// Decode payload
+	nu, err := user.DecodeNewCMSUser([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	if l.shutdown {
+		return "", user.ErrShutdown
+	}
+
+	log.Debugf("cmdNewCMSUser: %v", nu.Email)
+
+	// Create a new User record
+	u := user.User{
+		Email:                     nu.Email,
+		Username:                  nu.Username,
+		NewUserVerificationToken:  nu.NewUserVerificationToken,
+		NewUserVerificationExpiry: nu.NewUserVerificationExpiry,
+	}
+	err = l.UserNew(u)
+	if err != nil {
+		return "", err
+	}
+
+	// Get user that we just created to get the ID and other User stuff set
+	setUser, err := l.UserGet(nu.Email)
+	if err != nil {
+		return "", err
+	}
+
+	l.Lock()
+	defer l.Unlock()
+
+	cmsUser := user.CMSUser{
+		User:           *setUser,
+		ContractorType: nu.ContractorType,
+	}
+	key := []byte(cmsUserPrefix + cmsUser.Email)
+
+	// Make sure cms user does not exist
+	ok, err := l.userdb.Has(key, nil)
+	if err != nil {
+		return "", err
+	} else if ok {
+		return "", user.ErrUserExists
+	}
+
+	cmsPayload, err := user.EncodeCMSUser(cmsUser)
+	if err != nil {
+		return "", err
+	}
+
+	err = l.userdb.Put(key, cmsPayload, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare reply
+	var nur user.NewCMSUserReply
+	reply, err := user.EncodeNewCMSUserReply(nur)
+	if err != nil {
+		return "", nil
+	}
+
+	return string(reply), nil
+}
+
+// updateCMSUser updates an existing CMSUser record with the provided user
+// info.
+func (l *localdb) updateCMSUser(nu user.UpdateCMSUser) error {
+	if l.shutdown {
+		return user.ErrShutdown
+	}
+
+	log.Debugf("updateCMSUser: %v", nu.ID)
+
+	// Get user that we just created to get the ID and other User stuff set
+	setUser, err := l.UserGetById(nu.ID)
+	if err != nil {
+		return err
+	}
+
+	l.Lock()
+	defer l.Unlock()
+
+	u := user.CMSUser{
+		User:               *setUser,
+		Domain:             nu.Domain,
+		ContractorName:     nu.ContractorName,
+		ContractorType:     nu.ContractorType,
+		ContractorContact:  nu.ContractorContact,
+		ContractorLocation: nu.ContractorLocation,
+		GitHubName:         nu.GitHubName,
+		MatrixName:         nu.MatrixName,
+		ProposalsOwned:     nu.ProposalsOwned,
+		SupervisorUserIDs:  nu.SupervisorUserIDs,
+	}
+	key := []byte(cmsUserPrefix + setUser.Email)
+
+	// Make sure user already exists
+	exists, err := l.userdb.Has(key, nil)
+	if err != nil {
+		return err
+	} else if !exists {
+		return user.ErrUserNotFound
+	}
+
+	payload, err := user.EncodeCMSUser(u)
+	if err != nil {
+		return err
+	}
+
+	return l.userdb.Put(key, payload, nil)
+}
+
+// cmdUpdateCMSUser updates an existing CMSUser record in the database.
+func (l *localdb) cmdUpdateCMSUser(payload string) (string, error) {
+	// Decode payload
+	uu, err := user.DecodeUpdateCMSUser([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	err = l.updateCMSUser(*uu)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare reply
+	var uur user.UpdateCMSUserReply
+	reply, err := user.EncodeUpdateCMSUserReply(uur)
+	if err != nil {
+		return "", nil
+	}
+
+	return string(reply), nil
+}
+
+// cmdCMSUserByID returns the user information for a given user ID.
+func (l *localdb) cmdCMSUserByID(payload string) (string, error) {
+	// Decode payload
+	p, err := user.DecodeCMSUserByID([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+
+	l.RLock()
+	defer l.RUnlock()
+
+	if l.shutdown {
+		return "", user.ErrShutdown
+	}
+
+	log.Debugf("cmsCMSUserById")
+
+	iter := l.userdb.NewIterator(util.BytesPrefix([]byte(cmsUserPrefix)), nil)
+	for iter.Next() {
+		key := iter.Key()
+		value := iter.Value()
+
+		if !isCMSUserRecord(string(key)) {
+			continue
+		}
+
+		u, err := user.DecodeCMSUser(value)
+		if err != nil {
+			return "", err
+		}
+
+		if u.ID.String() == p.ID {
+			r := user.CMSUserByIDReply{
+				User: u,
+			}
+			reply, err := user.EncodeCMSUserByIDReply(r)
+			if err != nil {
+				return "", err
+			}
+
+			return string(reply), nil
+		}
+	}
+	iter.Release()
+
+	if iter.Error() != nil {
+		return "", iter.Error()
+	}
+
+	return "", user.ErrUserNotFound
+}
+
+// Exec executes a cms plugin command.
+func (l *localdb) cmsPluginExec(cmd, payload string) (string, error) {
+	switch cmd {
+	case user.CmdNewCMSUser:
+		return l.cmdNewCMSUser(payload)
+	case user.CmdUpdateCMSUser:
+		return l.cmdUpdateCMSUser(payload)
+	case user.CmdCMSUserByID:
+		return l.cmdCMSUserByID(payload)
+	default:
+		return "", user.ErrInvalidPluginCmd
+	}
+}
+
+// cmsPluginSetup creates all cms plugin tables and ensures the database
+// is using the correct cms plugin version.
+func (l *localdb) cmsPluginSetup() error {
+
+	// do some kind of leveldb set up here?
+	return nil
+}

--- a/politeiawww/user/localdb/cms.go
+++ b/politeiawww/user/localdb/cms.go
@@ -227,11 +227,3 @@ func (l *localdb) cmsPluginExec(cmd, payload string) (string, error) {
 		return "", user.ErrInvalidPluginCmd
 	}
 }
-
-// cmsPluginSetup creates all cms plugin tables and ensures the database
-// is using the correct cms plugin version.
-func (l *localdb) cmsPluginSetup() error {
-
-	// do some kind of leveldb set up here?
-	return nil
-}

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -49,7 +49,8 @@ type Version struct {
 func isUserRecord(key string) bool {
 	return key != UserVersionKey &&
 		key != LastPaywallAddressIndex &&
-		!strings.HasPrefix(key, sessionPrefix)
+		!strings.HasPrefix(key, sessionPrefix) &&
+		!strings.HasPrefix(key, cmsUserPrefix)
 }
 
 // Store new user.

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -399,7 +399,7 @@ func (l *localdb) RegisterPlugin(p user.Plugin) error {
 	var err error
 	switch p.ID {
 	case user.CMSPluginID:
-		err = l.cmsPluginSetup()
+		// This is an acceptable plugin ID
 	default:
 		return user.ErrInvalidPlugin
 	}

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -31,9 +31,10 @@ var (
 type localdb struct {
 	sync.RWMutex
 
-	shutdown bool        // Backend is shutdown
-	root     string      // Database root
-	userdb   *leveldb.DB // Database context
+	shutdown       bool                            // Backend is shutdown
+	root           string                          // Database root
+	userdb         *leveldb.DB                     // Database context
+	pluginSettings map[string][]user.PluginSetting // [pluginID][]PluginSettings
 }
 
 // Version contains the database version.
@@ -370,12 +371,49 @@ func (l *localdb) AllUsers(callbackFn func(u *user.User)) error {
 
 // PluginExec executes the provided plugin command.
 func (l *localdb) PluginExec(pc user.PluginCommand) (*user.PluginCommandReply, error) {
-	return nil, user.ErrInvalidPlugin
+	log.Tracef("PluginExec: %v %v", pc.ID, pc.Command)
+
+	var payload string
+	var err error
+	switch pc.ID {
+	case user.CMSPluginID:
+		payload, err = l.cmsPluginExec(pc.Command, pc.Payload)
+	default:
+		return nil, user.ErrInvalidPlugin
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &user.PluginCommandReply{
+		ID:      pc.ID,
+		Command: pc.Command,
+		Payload: payload,
+	}, nil
 }
 
 // RegisterPlugin registers a plugin with the user database.
-func (l *localdb) RegisterPlugin(user.Plugin) error {
-	return user.ErrInvalidPlugin
+func (l *localdb) RegisterPlugin(p user.Plugin) error {
+	log.Tracef("RegisterPlugin: %v %v", p.ID, p.Version)
+
+	var err error
+	switch p.ID {
+	case user.CMSPluginID:
+		err = l.cmsPluginSetup()
+	default:
+		return user.ErrInvalidPlugin
+	}
+	if err != nil {
+		return err
+	}
+
+	// Save plugin settings
+	l.Lock()
+	defer l.Unlock()
+
+	l.pluginSettings[p.ID] = p.Settings
+
+	return nil
 }
 
 // Close shuts down the database.  All interface functions MUST return with
@@ -510,7 +548,8 @@ func New(root string) (*localdb, error) {
 	log.Tracef("localdb New: %v", root)
 
 	l := &localdb{
-		root: root,
+		root:           root,
+		pluginSettings: make(map[string][]user.PluginSetting),
 	}
 	err := l.openUserDB(filepath.Join(l.root, UserdbPath))
 	if err != nil {


### PR DESCRIPTION
This diff adds the leveldb implementation for userdb plugins for
cms.  Now this can be used for testing infrastructure without
needing to bring up a full cockroachdb in CI.

Along with plugin support for New/UpdateCMSUser and CMSUserByID,
there is also added tests for InviteNewUser and RegisterUser for
cms.