### PR TITLE
cms: Fix domain check for invoices route

### DIFF
--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1569,6 +1569,7 @@ func filterDomainInvoice(inv *cms.InvoiceRecord) cms.InvoiceRecord {
 	inv.Input.ContractorLocation = ""
 	inv.Input.ContractorName = ""
 	inv.Input.ContractorRate = 0
+	inv.Input.PaymentAddress = ""
 
 	for i, li := range inv.Input.LineItems {
 		li.Expenses = 0

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -1509,7 +1509,7 @@ func (p *politeiawww) processInvoices(ai cms.Invoices, u *user.User) (*cms.UserI
 			break
 		}
 
-		invoiceUser, err := p.getCMSUserByIDRaw(u.ID.String())
+		invoiceUser, err := p.getCMSUserByIDRaw(v.UserID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
An incorrect userID was being used to pull user information, therefore leading to invoices not being skipped as expected.

Also filter out PaymentAddress from returned invoice input