### PR TITLE
piwww: Fix context usage for PayWithTestNetFaucet

### DIFF
--- a/politeiawww/cmd/piwww/newuser.go
+++ b/politeiawww/cmd/piwww/newuser.go
@@ -5,11 +5,10 @@
 package main
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 
-	"github.com/decred/politeia/politeiawww/api/www/v1"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 	"github.com/decred/politeia/util"
 )
@@ -28,7 +27,7 @@ type NewUserCmd struct {
 }
 
 // Execute executes the new user command.
-func (cmd *NewUserCmd) Execute(ctx context.Context, args []string) error {
+func (cmd *NewUserCmd) Execute(args []string) error {
 	email := cmd.Args.Email
 	username := cmd.Args.Username
 	password := cmd.Args.Password
@@ -142,7 +141,7 @@ func (cmd *NewUserCmd) Execute(ctx context.Context, args []string) error {
 		faucet := SendFaucetTxCmd{}
 		faucet.Args.Address = lr.PaywallAddress
 		faucet.Args.Amount = lr.PaywallAmount
-		err = faucet.Execute(ctx, nil)
+		err = faucet.Execute(nil)
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmd/piwww/sendfaucettx.go
+++ b/politeiawww/cmd/piwww/sendfaucettx.go
@@ -22,7 +22,7 @@ type SendFaucetTxCmd struct {
 }
 
 // Execute executes the send faucet tx command.
-func (cmd *SendFaucetTxCmd) Execute(ctx context.Context, args []string) error {
+func (cmd *SendFaucetTxCmd) Execute(args []string) error {
 	address := cmd.Args.Address
 	atoms := cmd.Args.Amount
 	dcr := float64(atoms) / 1e8
@@ -32,6 +32,7 @@ func (cmd *SendFaucetTxCmd) Execute(ctx context.Context, args []string) error {
 			dcr, address)
 	}
 
+	ctx := context.Background()
 	txID, err := util.PayWithTestnetFaucet(ctx, cfg.FaucetHost, address, atoms,
 		cmd.Args.OverrideToken)
 	if err != nil {

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -238,7 +238,7 @@ func (cmd *TestRunCmd) Execute(args []string) error {
 	nuc.Args.Email = email
 	nuc.Args.Username = username
 	nuc.Args.Password = password
-	err = nuc.Execute(ctx, nil)
+	err = nuc.Execute(nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The additional argument in NewUserCmd and SendFauctTxCmd Execute was not allowing the commands to be properly called on cli.  