### PR TITLE
[cms] Add LineItemKey so versions are properly seen

### DIFF
--- a/politeiawww/cmsdatabase/cockroachdb/encoding.go
+++ b/politeiawww/cmsdatabase/cockroachdb/encoding.go
@@ -49,12 +49,14 @@ func EncodeInvoice(dbInvoice *database.Invoice) *Invoice {
 
 	for i, dbInvoiceLineItem := range dbInvoice.LineItems {
 		invoiceLineItem := EncodeInvoiceLineItem(&dbInvoiceLineItem)
-		invoiceLineItem.LineItemKey = dbInvoice.Token + strconv.Itoa(i)
+		invoiceLineItem.LineItemKey = dbInvoice.Token + dbInvoice.Version + strconv.Itoa(i)
+		invoiceLineItem.InvoiceToken = dbInvoice.Token
 		invoice.LineItems = append(invoice.LineItems, invoiceLineItem)
 	}
 
 	for _, dbInvoiceChange := range dbInvoice.Changes {
 		invoiceChange := encodeInvoiceChange(&dbInvoiceChange)
+		invoiceChange.InvoiceToken = dbInvoice.Token
 		invoice.Changes = append(invoice.Changes, invoiceChange)
 	}
 

--- a/politeiawww/cmsdatabase/cockroachdb/models.go
+++ b/politeiawww/cmsdatabase/cockroachdb/models.go
@@ -45,9 +45,9 @@ type Invoice struct {
 	ContractorContact  string    `gorm:"not null"`
 	PaymentAddress     string    `gorm:"not null"`
 
-	LineItems []LineItem      `gorm:"foreignkey:InvoiceToken"`
-	Changes   []InvoiceChange `gorm:"foreignkey:InvoiceToken"`
-	Payments  Payments        `gorm:"foreignkey:InvoiceToken"`
+	LineItems []LineItem      `gorm:"foreignkey:InvoiceKey"`
+	Changes   []InvoiceChange `gorm:"foreignkey:InvoiceKey"`
+	Payments  Payments        `gorm:"foreignkey:InvoiceKey"`
 }
 
 // TableName returns the table name of the invoices table.
@@ -57,7 +57,8 @@ func (Invoice) TableName() string {
 
 // LineItem is the database model for the database.LineItem type
 type LineItem struct {
-	LineItemKey    string `gorm:"primary_key"` // Token of the Invoice + array index
+	LineItemKey    string `gorm:"primary_key"` // Token of the Invoice + version + array index
+	InvoiceKey     string `gorm:"not null"`    // The key of the invoice that it is attached
 	InvoiceToken   string `gorm:"not null"`    // Censorship token of the invoice
 	Type           uint   `gorm:"not null"`    // Type of line item
 	Domain         string `gorm:"not null"`    // Domain of the work performed (dev, marketing etc)
@@ -78,6 +79,7 @@ func (LineItem) TableName() string {
 // InvoiceChange contains entries for any status update that occurs to a given
 // invoice.  This will give a full history of an invoices history.
 type InvoiceChange struct {
+	InvoiceKey     string    `gorm:"not null"` // The key of the invoice that it is attached
 	InvoiceToken   string    `gorm:"not null"` // Censorship token of the invoice
 	AdminPublicKey string    `gorm:"not null"` // The public of the admin that processed the status change.
 	NewStatus      uint      `gorm:"not null"` // Updated status of the invoice.
@@ -104,7 +106,8 @@ func (ExchangeRate) TableName() string {
 
 // Payments contains all the information about a given invoice's payment
 type Payments struct {
-	InvoiceToken    string `gorm:"primary_key"`
+	InvoiceKey      string `gorm:"primary_key"` // The key of the invoice that it is attached
+	InvoiceToken    string `gorm:"not null"`
 	Address         string `gorm:"not null"`
 	TxIDs           string `gorm:"not null"`
 	TimeStarted     int64  `gorm:"not null"`


### PR DESCRIPTION
Previously on cms build from records, line items were not properly being keyed so the differing versions weren't being seen.

Also includes a fix for retaining invoice versions after editing.  Previously db entries were being updated, but with the removal of the cache we actually want to start storing all version of the invoices in the db and only add new entries instead of updating rows.