### PR TITLE
cmd: Add client certs for gRPC dcrwallet changes

### DIFF
--- a/politeiawww/cmd/politeiavoter/README.md
+++ b/politeiawww/cmd/politeiavoter/README.md
@@ -21,8 +21,15 @@ testnet=1
 
 ## Requirements
 
-Voting requires access to wallet GRPC. Therefore this tool needs the wallet
-certificate. By default the tool will look in `~/.dcrwallet/rpc.cert`.
+Voting requires access to wallet GRPC. Therefore this tool needs the wallet's
+server certificate to authenticate the server, as well as a local client keypair
+to authenticate the client to `dcrwallet`.  The server certifiate by default
+will be found in `~/.dcrwallet/rpc.cert`, and this can be modified to another
+path using the `--walletgrpccert` flag.  Client certs can be generated using
+[`gencerts`](https://github.com/decred/dcrd/blob/master/cmd/gencerts/) and
+`politeiavoter` will read `client.pem` and `client-key.pem` from its application
+directory by default.  The certificate must be appended to
+`~/.dcrwallet/clients.pem` in order for `dcrwallet` to trust the client.
 
 In order to sign votes ```politeiavoter``` requires the wallet passphrase.
 

--- a/politeiawww/cmd/politeiavoter/README.md
+++ b/politeiawww/cmd/politeiavoter/README.md
@@ -23,12 +23,12 @@ testnet=1
 
 Voting requires access to wallet GRPC. Therefore this tool needs the wallet's
 server certificate to authenticate the server, as well as a local client keypair
-to authenticate the client to `dcrwallet`.  The server certifiate by default
+to authenticate the client to `dcrwallet`.  The server certificate by default
 will be found in `~/.dcrwallet/rpc.cert`, and this can be modified to another
 path using the `--walletgrpccert` flag.  Client certs can be generated using
 [`gencerts`](https://github.com/decred/dcrd/blob/master/cmd/gencerts/) and
 `politeiavoter` will read `client.pem` and `client-key.pem` from its application
-directory by default.  The certificate must be appended to
+directory by default.  The certificate (`client.pem`) must be appended to
 `~/.dcrwallet/clients.pem` in order for `dcrwallet` to trust the client.
 
 In order to sign votes ```politeiavoter``` requires the wallet passphrase.

--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -476,13 +476,9 @@ func loadConfig() (*config, []string, error) {
 	// Set path for the client key/cert depending on if they are set in options
 	if cfg.ClientCert == "" {
 		cfg.ClientCert = filepath.Join(cfg.HomeDir, clientCertFile)
-	} else {
-		cfg.ClientCert = filepath.Join(cfg.HomeDir, cfg.ClientCert)
 	}
 	if cfg.ClientKey == "" {
 		cfg.ClientKey = filepath.Join(cfg.HomeDir, clientKeyFile)
-	} else {
-		cfg.ClientKey = filepath.Join(cfg.HomeDir, cfg.ClientKey)
 	}
 
 	return &cfg, remainingArgs, nil

--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -33,6 +33,9 @@ const (
 
 	defaultWalletMainnetPort = "9111"
 	defaultWalletTestnetPort = "19111"
+
+	clientCertFile = "client.pem"
+	clientKeyFile  = "client-key.pem"
 )
 
 var (
@@ -71,6 +74,9 @@ type config struct {
 	VoteDuration     string `long:"voteduration" description:"Duration to cast all votes in hours and minutes e.g. 5h10m (default 0s means autodetect duration)"`
 	Trickle          bool   `long:"trickle" description:"Enable vote trickling, requires --proxy."`
 	SkipVerify       bool   `long:"skipverify" description:"Skip verifying the server's certifcate chain and host name."`
+
+	ClientCert string `long:"cert" description:"Path to TLS certificate for client authentication"`
+	ClientKey  string `long:"key" description:"Path to TLS client authentication key"`
 
 	voteDir      string
 	dial         func(string, string) (net.Conn, error)
@@ -465,6 +471,18 @@ func loadConfig() (*config, []string, error) {
 			return nil, nil, fmt.Errorf("cannot use --trickle " +
 				"without --proxy")
 		}
+	}
+
+	// Set path for the client key/cert depending on if they are set in options
+	if cfg.ClientCert == "" {
+		cfg.ClientCert = filepath.Join(cfg.HomeDir, clientCertFile)
+	} else {
+		cfg.ClientCert = filepath.Join(cfg.HomeDir, cfg.ClientCert)
+	}
+	if cfg.ClientKey == "" {
+		cfg.ClientKey = filepath.Join(cfg.HomeDir, clientKeyFile)
+	} else {
+		cfg.ClientKey = filepath.Join(cfg.HomeDir, cfg.ClientKey)
 	}
 
 	return &cfg, remainingArgs, nil

--- a/politeiawww/cmd/shared/config.go
+++ b/politeiawww/cmd/shared/config.go
@@ -29,10 +29,12 @@ const (
 	defaultWalletHost        = "127.0.0.1"
 	defaultWalletTestnetPort = "19111"
 
-	userFile     = "user.txt"
-	csrfFile     = "csrf.txt"
-	cookieFile   = "cookies.json"
-	identityFile = "identity.json"
+	userFile       = "user.txt"
+	csrfFile       = "csrf.txt"
+	cookieFile     = "cookies.json"
+	identityFile   = "identity.json"
+	clientCertFile = "client.pem"
+	clientKeyFile  = "client-key.pem"
 )
 
 var (
@@ -56,6 +58,9 @@ type Config struct {
 	WalletCert string // Wallet GRPC certificate
 	FaucetHost string // Testnet faucet host
 	CSRF       string // CSRF header token
+
+	ClientCert string `long:"cert" description:"Path to TLS certificate for client authentication"`
+	ClientKey  string `long:"key" description:"Path to TLS client authentication key"`
 
 	Identity *identity.FullIdentity // User identity
 	Cookies  []*http.Cookie         // User cookies
@@ -181,6 +186,18 @@ func LoadConfig(homeDir, dataDirname, configFilename string) (*Config, error) {
 		return nil, fmt.Errorf("load identity: %v", err)
 	}
 	cfg.Identity = id
+
+	// Set path for the client key/cert depending on if they are set in options
+	if cfg.ClientCert == "" {
+		cfg.ClientCert = filepath.Join(cfg.HomeDir, clientCertFile)
+	} else {
+		cfg.ClientCert = filepath.Join(cfg.HomeDir, cfg.ClientCert)
+	}
+	if cfg.ClientKey == "" {
+		cfg.ClientKey = filepath.Join(cfg.HomeDir, clientKeyFile)
+	} else {
+		cfg.ClientKey = filepath.Join(cfg.HomeDir, cfg.ClientKey)
+	}
 
 	return &cfg, nil
 }

--- a/politeiawww/cmd/shared/config.go
+++ b/politeiawww/cmd/shared/config.go
@@ -190,13 +190,9 @@ func LoadConfig(homeDir, dataDirname, configFilename string) (*Config, error) {
 	// Set path for the client key/cert depending on if they are set in options
 	if cfg.ClientCert == "" {
 		cfg.ClientCert = filepath.Join(cfg.HomeDir, clientCertFile)
-	} else {
-		cfg.ClientCert = filepath.Join(cfg.HomeDir, cfg.ClientCert)
 	}
 	if cfg.ClientKey == "" {
 		cfg.ClientKey = filepath.Join(cfg.HomeDir, clientKeyFile)
-	} else {
-		cfg.ClientKey = filepath.Join(cfg.HomeDir, cfg.ClientKey)
 	}
 
 	return &cfg, nil


### PR DESCRIPTION
Requires: https://github.com/decred/dcrwallet/pull/1867

This allows both piwww and politeiavoter to communicate with dcrwallet via grpc.  

One must use https://github.com/decred/dcrd/tree/master/cmd/gencerts to create a fresh keypair (default: client.pem and client-key.pem) at the appdata directory of either piwww or politeiavoter (default: ~/.piwww or ~/.politeiavoter respectively).  Then they must also concat the contents of client.pem to their clients.pem file under choosen dcrwallet appdata directory.