### PR TITLE
politeiavoter: Use consistent long flag names

### DIFF
--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -75,8 +75,8 @@ type config struct {
 	Trickle          bool   `long:"trickle" description:"Enable vote trickling, requires --proxy."`
 	SkipVerify       bool   `long:"skipverify" description:"Skip verifying the server's certifcate chain and host name."`
 
-	ClientCert string `long:"cert" description:"Path to TLS certificate for client authentication"`
-	ClientKey  string `long:"key" description:"Path to TLS client authentication key"`
+	ClientCert string `long:"clientcert" description:"Path to TLS certificate for client authentication"`
+	ClientKey  string `long:"clientkey" description:"Path to TLS client authentication key"`
 
 	voteDir      string
 	dial         func(string, string) (net.Conn, error)

--- a/politeiawww/cmd/shared/config.go
+++ b/politeiawww/cmd/shared/config.go
@@ -59,8 +59,8 @@ type Config struct {
 	FaucetHost string // Testnet faucet host
 	CSRF       string // CSRF header token
 
-	ClientCert string `long:"cert" description:"Path to TLS certificate for client authentication"`
-	ClientKey  string `long:"key" description:"Path to TLS client authentication key"`
+	ClientCert string `long:"clientcert" description:"Path to TLS certificate for client authentication"`
+	ClientKey  string `long:"clientkey" description:"Path to TLS client authentication key"`
 
 	Identity *identity.FullIdentity // User identity
 	Cookies  []*http.Cookie         // User cookies


### PR DESCRIPTION
This changes the --cert and --key flags to be named --clientcert and
--clientkey, to more consistently match other Decred tooling (e.g.
dcrctl).