### PR TITLE
[cms] Fix Invoice payment check and records

### DIFF
--- a/politeiawww/cmsaddresswatcher.go
+++ b/politeiawww/cmsaddresswatcher.go
@@ -240,7 +240,7 @@ func (p *politeiawww) checkHistoricalPayments(ctx context.Context, payment *data
 	payment.AmountReceived = int64(amountReceived)
 	payment.TimeLastUpdated = time.Now().Unix()
 
-	err = p.cmsDB.UpdatePayments(payment)
+	err = p.updateInvoicePayment(ctx, payment)
 	if err != nil {
 		log.Errorf("Error updating payments information for: %v %v",
 			payment.Address, err)
@@ -249,7 +249,7 @@ func (p *politeiawww) checkHistoricalPayments(ctx context.Context, payment *data
 	if payment.Status == cms.PaymentStatusPaid {
 		log.Debugf("Updating invoice %v status to paid", payment.InvoiceToken)
 		// Update invoice status here
-		err := p.invoiceStatusPaid(ctx, payment.InvoiceToken)
+		err := p.invoiceStatusPaid(ctx, payment.InvoiceToken, payment.InvoiceKey)
 		if err != nil {
 			log.Errorf("error updating invoice status to paid %v", err)
 		}
@@ -313,7 +313,7 @@ func (p *politeiawww) checkPayments(ctx context.Context, payment *database.Payme
 	if payment.Status == cms.PaymentStatusPaid {
 		log.Debugf("Updating invoice %v status to paid", payment.InvoiceToken)
 		// Update invoice status here
-		err := p.invoiceStatusPaid(ctx, payment.InvoiceToken)
+		err := p.invoiceStatusPaid(ctx, payment.InvoiceToken, payment.InvoiceKey)
 		if err != nil {
 			log.Errorf("error updating invoice status to paid %v", err)
 		}
@@ -377,8 +377,8 @@ func (p *politeiawww) updateInvoicePayment(ctx context.Context, payment *databas
 	}
 	return nil
 }
-func (p *politeiawww) invoiceStatusPaid(ctx context.Context, token string) error {
-	dbInvoice, err := p.cmsDB.InvoiceByToken(token)
+func (p *politeiawww) invoiceStatusPaid(ctx context.Context, token, key string) error {
+	dbInvoice, err := p.cmsDB.InvoiceByKey(key)
 	if err != nil {
 		if errors.Is(err, cache.ErrRecordNotFound) {
 			err = www.UserError{

--- a/politeiawww/cmsdatabase/database.go
+++ b/politeiawww/cmsdatabase/database.go
@@ -49,6 +49,7 @@ type Database interface {
 	InvoiceByToken(string) (*Invoice, error)                              // Return invoice given its token
 	InvoiceByTokenVersion(token string, version string) (*Invoice, error) // Return invoice by its token and version
 	InvoicesByAddress(string) ([]Invoice, error)                          // Return invoice by its address
+	InvoiceByKey(string) (*Invoice, error)                                // Return invoice given its key
 
 	InvoicesByMonthYearStatus(uint16, uint16, int) ([]Invoice, error) // Returns all invoices by month, year and status
 	InvoicesByMonthYear(uint16, uint16) ([]Invoice, error)            // Returns all invoice by month, year

--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1055,7 +1055,6 @@ func convertRecordToDatabaseInvoice(p pd.Record) (*cmsdatabase.Invoice, error) {
 					payment.Status = cms.PaymentStatusPaid
 				}
 			}
-			dbInvoice.Changes = invChanges
 
 		case mdstream.IDInvoicePayment:
 			ip, err := mdstream.DecodeInvoicePayment([]byte(m.Payload))
@@ -1071,7 +1070,6 @@ func convertRecordToDatabaseInvoice(p pd.Record) (*cmsdatabase.Invoice, error) {
 				payment.TimeLastUpdated = s.Timestamp
 				payment.AmountReceived = s.AmountReceived
 			}
-			dbInvoice.Payments = payment
 		default:
 			// Log error but proceed
 			log.Errorf("convertRecordToInvoiceDB: invalid "+
@@ -1079,6 +1077,7 @@ func convertRecordToDatabaseInvoice(p pd.Record) (*cmsdatabase.Invoice, error) {
 				m.ID, p.CensorshipRecord.Token)
 		}
 	}
+	dbInvoice.Payments = payment
 
 	return &dbInvoice, nil
 }

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -960,6 +960,7 @@ func (p *politeiawww) processSetInvoiceStatus(ctx context.Context, sis cms.SetIn
 	// If approved then update Invoice's Payment table in DB
 	if c.NewStatus == cms.InvoiceStatusApproved {
 		dbInvoice.Payments = database.Payments{
+			InvoiceToken: dbInvoice.Token,
 			Address:      strings.TrimSpace(dbInvoice.PaymentAddress),
 			TimeStarted:  time.Now().Unix(),
 			Status:       cms.PaymentStatusWatching,


### PR DESCRIPTION
There were some issues that were revealed about invoice payment record keeping.
First, payments were not being properly given metadata record updates when checked
during historical payments.  So now on start up we do a quick check on invoice payments
that have been set to paid, if they don't have a proper entry then they are given a metadata
update.  

This also fixes some invoice key/token issues when updating invoice payments. 