### PR TITLE
[cms] Add proposal token validation for line items

### DIFF
--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -660,7 +660,7 @@ func (p *politeiawww) validateInvoice(ni cms.NewInvoice, u *user.CMSUser) error 
 				}
 
 				piToken := formatInvoiceField(lineInput.ProposalToken)
-				if piToken != "" && !validateInvoiceField(piToken) {
+				if piToken != "" && !pd.RegexpSHA256.MatchString(piToken) {
 					return www.UserError{
 						ErrorCode: cms.ErrorStatusMalformedProposalToken,
 					}


### PR DESCRIPTION
There have been some recent instances of users entering bad info into proposal token which has caused problems for pi-gui.

Those issues will be addressed, but this will ensure only proper SHA256 proposal tokens may be entered.