### PR TITLE
[cmd] fix: force lowercased emails on newuser command

### DIFF
--- a/politeiawww/cmd/piwww/newuser.go
+++ b/politeiawww/cmd/piwww/newuser.go
@@ -7,6 +7,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
@@ -28,7 +29,7 @@ type NewUserCmd struct {
 
 // Execute executes the new user command.
 func (cmd *NewUserCmd) Execute(args []string) error {
-	email := cmd.Args.Email
+	email := strings.ToLower(cmd.Args.Email)
 	username := cmd.Args.Username
 	password := cmd.Args.Password
 


### PR DESCRIPTION
This fixes a minor issue I noticed while working with https://github.com/decred/politeiagui/issues/2216 regarding the `newuser` cmd. If you enter an uppercased email like:

`piwww newuser EmAil@example.com password --verify --paywall`

the email verification will return a ` 400, invalid verification token` error.

This diff fixes it.