### PR TITLE
[cms] Update config for CMS code stats

### DIFF
--- a/politeiawww/codestats.go
+++ b/politeiawww/codestats.go
@@ -133,15 +133,16 @@ func (p *politeiawww) processUserCodeStats(ucs cms.UserCodeStats, u *user.User) 
 	}, nil
 }
 
-func (p *politeiawww) updateCodeStats(org string, repos []string, start, end int64) error {
+func (p *politeiawww) updateCodeStats(skipStartupSync bool, repos []string, start, end int64) error {
 
 	// make sure tracker was created, if not alert for them to check github api
 	// token config
 	if p.tracker == nil {
 		return fmt.Errorf("code tracker not running")
 	}
-
-	p.tracker.Update(org, repos, start, end)
+	if !skipStartupSync {
+		p.tracker.Update(repos, start, end)
+	}
 
 	// Go fetch all Development contractors to update their stats
 	cu := user.CMSUsersByDomain{
@@ -213,8 +214,8 @@ func (p *politeiawww) updateCodeStats(org string, repos []string, start, end int
 			return err
 		}
 
-		githubUserInfo, err := p.tracker.UserInfo(org,
-			u.GitHubName, currentYear, currentMonth)
+		githubUserInfo, err := p.tracker.UserInfo(u.GitHubName, currentYear,
+			currentMonth)
 		if err != nil {
 			log.Errorf("github user information failed: %v %v %v %v",
 				u.GitHubName, currentYear, currentMonth, err)
@@ -330,8 +331,8 @@ func (p *politeiawww) startCodeStatsCron() {
 		// Start time is 1 month and 1 day prior to the current time.
 		start := time.Date(end.Year(), end.Month()-1, end.Day()-1, end.Hour(),
 			end.Minute(), end.Second(), 0, end.Location())
-		err := p.updateCodeStats(p.cfg.CodeStatOrganization,
-			p.cfg.CodeStatRepos, start.Unix(), end.Unix())
+		err := p.updateCodeStats(false, p.cfg.CodeStatRepos, start.Unix(),
+			end.Unix())
 		if err != nil {
 			log.Errorf("erroring updating code stats %v", err)
 		}

--- a/politeiawww/codestats.go
+++ b/politeiawww/codestats.go
@@ -232,6 +232,7 @@ func (p *politeiawww) updateCodeStats(skipStartupSync bool, repos []string, star
 			if err != nil {
 				return err
 			}
+			return nil
 		}
 
 		log.Tracef("New UserCodeStats: %v %v %v", u.GitHubName, currentYear,
@@ -276,9 +277,14 @@ func (p *politeiawww) checkUpdateCodeStats(existing, new []user.CodeStats) error
 				if ucs.MergedAdditions != cs.MergedAdditions ||
 					ucs.MergedDeletions != cs.MergedDeletions ||
 					ucs.ReviewDeletions != cs.ReviewDeletions ||
-					ucs.ReviewAdditions != ucs.ReviewAdditions ||
+					ucs.ReviewAdditions != cs.ReviewAdditions ||
+					ucs.UpdatedAdditions != cs.UpdatedAdditions ||
+					ucs.UpdatedDeletions != cs.UpdatedDeletions ||
+					ucs.CommitAdditions != cs.CommitAdditions ||
+					ucs.CommitDeletions != cs.CommitDeletions ||
 					len(ucs.PRs) != len(cs.PRs) ||
-					len(ucs.Reviews) != len(cs.Reviews) {
+					len(ucs.Reviews) != len(cs.Reviews) ||
+					len(ucs.Commits) != len(cs.Commits) {
 					updated = true
 					break
 				}

--- a/politeiawww/codetracker/codetracker.go
+++ b/politeiawww/codetracker/codetracker.go
@@ -8,23 +8,22 @@ package codetracker
 // site (Github/Gitlab etc).
 type CodeTracker interface {
 	// Update updates the code stats for a (organization, repos, start end date)
-	Update(org string, repos []string, start, end int64)
+	Update(repos []string, start, end int64)
 
 	// UserInfo returns pull request, review and commit information about
 	// a given user over a given start and stop time.
-	UserInfo(org, username string, start, end int) (*UserInformationResult, error)
+	UserInfo(username string, start, end int) (*UserInformationResult, error)
 }
 
 // UserInformationResult models the data from the userinformation command.
 type UserInformationResult struct {
-	User         string                   `json:"user"`
-	Organization string                   `json:"organization"`
-	MergedPRs    []PullRequestInformation `json:"mergedprs"`
-	UpdatedPRs   []PullRequestInformation `json:"updatedprs"`
-	Commits      []CommitInformation      `json:"commits"`
-	Reviews      []ReviewInformation      `json:"reviews"`
-	Year         int                      `json:"year"`
-	Month        int                      `json:"month"`
+	User       string                   `json:"user"`
+	MergedPRs  []PullRequestInformation `json:"mergedprs"`
+	UpdatedPRs []PullRequestInformation `json:"updatedprs"`
+	Commits    []CommitInformation      `json:"commits"`
+	Reviews    []ReviewInformation      `json:"reviews"`
+	Year       int                      `json:"year"`
+	Month      int                      `json:"month"`
 }
 
 // PullRequestInformation contains all the specific details of pull request.

--- a/politeiawww/codetracker/github/update.go
+++ b/politeiawww/codetracker/github/update.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"strings"
 	"time"
 
 	"github.com/decred/politeia/politeiawww/codetracker"
@@ -47,9 +48,12 @@ func New(apiToken, host, rootCert, cert, key string) (*github, error) {
 // users' information once the info is fully received.  If repoRequest is
 // included then only that repo will be fetched and updated, typically
 // used for speeding up testing.
-func (g *github) Update(org string, repos []string, start, end int64) {
+func (g *github) Update(repos []string, start, end int64) {
 	for _, repo := range repos {
 		log.Infof("%s", repo)
+		orgRepo := strings.Split(repo, "-")
+		org := orgRepo[0]
+		repo = orgRepo[1]
 		log.Infof("Syncing %s/%s", org, repo)
 
 		// Grab latest sync time
@@ -184,7 +188,7 @@ func (g *github) fetchPullRequestCommits(org, repoName string, prNum int) ([]*da
 
 // UserInfo provides the converted information from pull requests and
 // reviews for a given user of a given period of time.
-func (g *github) UserInfo(org string, user string, year, month int) (*codetracker.UserInformationResult, error) {
+func (g *github) UserInfo(user string, year, month int) (*codetracker.UserInformationResult, error) {
 	startDate := time.Date(year, time.Month(month), 0, 0, 0, 0, 0,
 		time.UTC).Unix()
 	endDate := time.Date(year, time.Month(month+1), 0, 0, 0, 0, 0,
@@ -252,7 +256,6 @@ func (g *github) UserInfo(org string, user string, year, month int) (*codetracke
 	userInfo.Reviews = convertDBPullRequestReviewsToReviews(dbReviews)
 	userInfo.Commits = convertDBCommitsToCommits(dbCommits)
 	userInfo.User = user
-	userInfo.Organization = org
 	return userInfo, nil
 }
 

--- a/politeiawww/config.go
+++ b/politeiawww/config.go
@@ -154,10 +154,10 @@ type config struct {
 	SMTPCert                 string `long:"smtpcert" description:"File containing the smtp certificate file"`
 	SystemCerts              *x509.CertPool
 	GithubAPIToken           string   `long:"githubapitoken" description:"API Token used to communicate with github API.  When populated in cmswww mode, github-tracker is enabled."`
-	CodeStatRepos            []string `long:"codestatrepos" description:"Repositories under the organization to crawl for code statistics"`
-	CodeStatOrganization     string   `long:"codestatorg" description:"Organization to crawl for code statistics"`
+	CodeStatRepos            []string `long:"codestatrepos" description:"Org/Repositories to crawl for code statistics"`
 	CodeStatStart            int64    `long:"codestatstart" description:"Date in which to look back to for code stat crawl (default 6 months back)"`
 	CodeStatEnd              int64    `long:"codestatend" description:"Date in which to end look back to for code stat crawl (default today)"`
+	CodeStatSkipSync         bool     `long:"codestatskipsync" description:"Skip pull request crawl on startup"`
 }
 
 // serviceOptions defines the configuration options for the rpc as a service
@@ -691,11 +691,6 @@ func loadConfig() (*config, []string, error) {
 			return nil, nil, fmt.Errorf("file not found %v",
 				cfg.OldEncryptionKey)
 		}
-	}
-
-	if cfg.CodeStatOrganization != "" && len(cfg.CodeStatRepos) < 1 {
-		return nil, nil, fmt.Errorf("you must specify repos if code stat " +
-			"organization is given")
 	}
 
 	if cfg.CodeStatStart > 0 &&

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -660,14 +660,14 @@ func _main() error {
 				return fmt.Errorf("build cache: %v", err)
 			}
 		}
-		if p.cfg.GithubAPIToken != "" && p.cfg.CodeStatOrganization != "" {
+		if p.cfg.GithubAPIToken != "" {
 			p.tracker, err = ghtracker.New(p.cfg.GithubAPIToken,
 				p.cfg.DBHost, p.cfg.DBRootCert, p.cfg.DBCert, p.cfg.DBKey)
 			if err != nil {
 				return fmt.Errorf("code tracker failed to load: %v", err)
 			}
 			go func() {
-				err = p.updateCodeStats(p.cfg.CodeStatOrganization,
+				err = p.updateCodeStats(p.cfg.CodeStatSkipSync,
 					p.cfg.CodeStatRepos, p.cfg.CodeStatStart, p.cfg.CodeStatEnd)
 				if err != nil {
 					log.Errorf("erroring updating code stats %v", err)


### PR DESCRIPTION
To allow for retrieving pull requests from other organizations we are going to change the config to only pull repos but expecting them to have the organization on the front like "decred-politeia"  or "alexlyp-politeia"

Also includes an additional config option boolean to avoid the pull request sync on start up.  That means it will only be run as scheduled on the first of the month.