### PR TITLE
userdb: Create user lookup table by email

### DIFF
--- a/politeiawww/cmsuser.go
+++ b/politeiawww/cmsuser.go
@@ -69,7 +69,7 @@ func (p *politeiawww) processInviteNewUser(u cms.InviteNewUser) (*cms.InviteNewU
 	}
 
 	// Check if the user is already verified.
-	existingUser, err := p.userByEmail(u.Email)
+	existingUser, err := p.db.UserGetByEmail(u.Email)
 	if err == nil {
 		if existingUser.NewUserVerificationToken == nil {
 			return &cms.InviteNewUserReply{}, nil
@@ -151,7 +151,7 @@ func (p *politeiawww) processInviteNewUser(u cms.InviteNewUser) (*cms.InviteNewU
 	if err != nil {
 		return nil, err
 	}
-	p.setUserEmailsCache(usr.Email, usr.ID)
+	p.db.UserSetLookup(usr.Email, usr.ID)
 
 	return &cms.InviteNewUserReply{
 		VerificationToken: hex.EncodeToString(token),
@@ -166,7 +166,7 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 	var reply cms.RegisterUserReply
 
 	// Check that the user already exists.
-	existingUser, err := p.userByEmail(u.Email)
+	existingUser, err := p.db.UserGetByEmail(u.Email)
 	if err != nil {
 		if errors.Is(err, user.ErrUserNotFound) {
 			log.Debugf("RegisterUser failure for %v: user not found",
@@ -293,7 +293,7 @@ func (p *politeiawww) processRegisterUser(u cms.RegisterUser) (*cms.RegisterUser
 
 	// Even if user is non-nil, this will bring it up-to-date
 	// with the new information inserted via newUser.
-	existingUser, err = p.userByEmail(newUser.Email)
+	existingUser, err = p.db.UserGetByEmail(newUser.Email)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve account info for %v: %v",
 			newUser.Email, err)

--- a/politeiawww/cmsuser_test.go
+++ b/politeiawww/cmsuser_test.go
@@ -169,7 +169,7 @@ func TestInviteNewUser(t *testing.T) {
 				t.Errorf("error inviting user %v %v", v.email, err)
 				return
 			}
-			u, err := p.userByEmail(v.email)
+			u, err := p.db.UserGetByEmail(v.email)
 			if err != nil {
 				t.Errorf("error getting user by email %v %v", v.email, err)
 				return
@@ -266,7 +266,8 @@ func TestRegisterUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting user by username %v", err)
 	}
-	p.setUserEmailsCache(usr.Email, usr.ID)
+	p.db.UserSetLookup(usr.Email, usr.ID)
+
 	var tests = []struct {
 		name      string
 		email     string

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -131,7 +131,7 @@ type politeiawww struct {
 
 	// XXX userEmails is a temporary measure until the user by email
 	// lookups are completely removed from politeiawww.
-	userEmails map[string]uuid.UUID // [email]userID
+	// userEmails map[string]uuid.UUID // [email]userID
 
 	// Following entries are use only during cmswww mode
 	cmsDB   cmsdatabase.Database

--- a/politeiawww/user.go
+++ b/politeiawww/user.go
@@ -1066,10 +1066,7 @@ func (p *politeiawww) login(l www.Login) loginResult {
 	// Get user record
 	u, err := p.db.UserGetByEmail(l.Email)
 	if err != nil {
-		fmt.Println("failing here")
-		fmt.Println(u)
 		if errors.Is(err, user.ErrUserNotFound) {
-			fmt.Println("user not found??")
 			log.Debugf("login: user not found for email '%v'",
 				l.Email)
 			err = www.UserError{

--- a/politeiawww/user/cockroachdb/models.go
+++ b/politeiawww/user/cockroachdb/models.go
@@ -48,6 +48,17 @@ func (User) TableName() string {
 	return tableUsers
 }
 
+// UserLookup .
+type UserLookup struct {
+	Email string    `gorm:"primary_key"`
+	ID    uuid.UUID `gorm:"not null"`
+}
+
+// TableName returns the table name of the UserLookup table.
+func (UserLookup) TableName() string {
+	return tableUserLookup
+}
+
 // Session represents a user session.
 //
 // Key is a SHA256 hash of the decoded session ID. The session Store handles

--- a/politeiawww/user/localdb/cms.go
+++ b/politeiawww/user/localdb/cms.go
@@ -57,7 +57,7 @@ func (l *localdb) cmdNewCMSUser(payload string) (string, error) {
 	}
 
 	// Get user that we just created to get the ID and other User stuff set
-	setUser, err := l.UserGet(nu.Email)
+	setUser, err := l.UserGetByEmail(nu.Email)
 	if err != nil {
 		return "", err
 	}

--- a/politeiawww/user/localdb/localdb.go
+++ b/politeiawww/user/localdb/localdb.go
@@ -309,6 +309,15 @@ func (l *localdb) UserGetById(id uuid.UUID) (*user.User, error) {
 	return nil, user.ErrUserNotFound
 }
 
+// UserGetByEmail is a stub to satisfy the interface. The lookup function
+// is not needed on leveldb because it already implements UserGet, which
+// fetches user by email.
+//
+// UserGetByEmail satisfies the Database interface.
+func (l *localdb) UserGetByEmail(email string) (*user.User, error) {
+	return nil, nil
+}
+
 // Update existing user.
 //
 // UserUpdate satisfies the Database interface.
@@ -338,9 +347,18 @@ func (l *localdb) UserUpdate(u user.User) error {
 	return l.userdb.Put([]byte(u.Email), payload, nil)
 }
 
-// Update existing user.
+// UserSetLookup is a stub to satisfy the interface. The lookup function
+// is not needed on leveldb because it already implements UserGet, which
+// fetches user by email.
 //
-// UserUpdate satisfies the Database interface.
+// UserSetLoopUp
+func (l *localdb) UserSetLookup(email string, id uuid.UUID) error {
+	return nil
+}
+
+// Get all users from db.
+//
+// AllUsers satisfies the Database interface.
 func (l *localdb) AllUsers(callbackFn func(u *user.User)) error {
 	l.Lock()
 	defer l.Unlock()
@@ -417,18 +435,6 @@ func (l *localdb) RegisterPlugin(p user.Plugin) error {
 	l.pluginSettings[p.ID] = p.Settings
 
 	return nil
-}
-
-// Close shuts down the database.  All interface functions MUST return with
-// errShutdown if the backend is shutting down.
-//
-// Close satisfies the Database interface.
-func (l *localdb) Close() error {
-	l.Lock()
-	defer l.Unlock()
-
-	l.shutdown = true
-	return l.userdb.Close()
 }
 
 // SessionSave saves the given session to the database. New sessions are
@@ -544,6 +550,18 @@ func (l *localdb) SessionsDeleteByUserID(uid uuid.UUID, exemptSessionIDs []strin
 	iter.Release()
 
 	return l.userdb.Write(batch, nil)
+}
+
+// Close shuts down the database.  All interface functions MUST return with
+// errShutdown if the backend is shutting down.
+//
+// Close satisfies the Database interface.
+func (l *localdb) Close() error {
+	l.Lock()
+	defer l.Unlock()
+
+	l.shutdown = true
+	return l.userdb.Close()
 }
 
 // New creates a new localdb instance.

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -460,11 +460,17 @@ type Database interface {
 	// Return user record given its id
 	UserGetById(uuid.UUID) (*User, error)
 
+	// Return user record given its email
+	UserGetByEmail(string) (*User, error)
+
 	// Return user record given a public key
 	UserGetByPubKey(string) (*User, error)
 
 	// Return a map of public key to user record
 	UsersGetByPubKey(pubKeys []string) (map[string]User, error)
+
+	// Set email/uuid entry for user lookup by email
+	UserSetLookup(string, uuid.UUID) error
 
 	// Iterate over all users
 	AllUsers(callbackFn func(u *User)) error

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -334,7 +334,6 @@ func _main() error {
 		templates: make(map[string]*template.Template),
 
 		// XXX reevaluate where this goes
-		userEmails:      make(map[string]uuid.UUID),
 		userPaywallPool: make(map[uuid.UUID]paywallPoolMember),
 		commentVotes:    make(map[string]counters),
 		voteSummaries:   make(map[string]www.VoteSummary),


### PR DESCRIPTION
This diff adds a user lookup table to replace the in-memory email/uuid lookup that politeiawww has.

Removing this field from politeiawww's memory is needed so that we can run multiple instances of politeiawww.