### PR TITLE
Make trickler truly random instead of using random bucketized durations

### DIFF
--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -194,10 +194,8 @@ type ctx struct {
 // timing intervals and vote details. This is a JSON structure for logging
 // purposes.
 type voteInterval struct {
-	Vote  v1.CastVote   `json:"vote"`  // RPC vote
-	Votes int           `json:"votes"` // Always 1 for now
-	Total time.Duration `json:"total"` // Cumulative time
-	At    time.Duration `json:"at"`    // Delay to fire off vote
+	Vote v1.CastVote   `json:"vote"` // RPC vote
+	At   time.Duration `json:"at"`   // Delay to fire off vote
 }
 
 func newClient(shutdownCtx context.Context, cfg *config) (*ctx, error) {
@@ -780,103 +778,6 @@ func (c *ctx) voteIntervalLen() uint64 {
 	c.RLock()
 	defer c.RUnlock()
 	return uint64(c.voteIntervalQ.Len())
-}
-
-// calculateTrickle calculates the trickle schedule.
-func (c *ctx) calculateTrickle(token, voteBit string, ctres *pb.CommittedTicketsResponse, smr *pb.SignMessagesResponse) error {
-	votes := uint64(len(ctres.TicketAddresses))
-	duration := c.cfg.voteDuration
-	maxDelay := uint64(duration.Seconds() / float64(votes) * 2)
-	minAvgInterval := uint64(35)
-	fmt.Printf("Votes       : %v\n", votes)
-	fmt.Printf("Duration    : %v\n", duration)
-	fmt.Printf("Avg Interval: %v\n", time.Duration(maxDelay/2)*time.Second)
-
-	// Ensure that the duration allows for sufficiently randomized delays
-	// in between votes
-	if duration.Seconds() < float64(minAvgInterval)*float64(votes) {
-		return fmt.Errorf("Vote duration must be at least %v",
-			time.Duration(float64(minAvgInterval)*float64(votes))*time.Second)
-	}
-
-	// Create array of work to be done. Vote delays are random durations
-	// between [0, maxDelay] (exclusive) which means that the vote delay
-	// average will converge to slightly less than duration/votes as the
-	// number of votes increases. Vote duration is treated as a hard cap
-	// and can not be exceeded.
-	buckets := make([]*voteInterval, votes)
-	var (
-		done    bool
-		retries int
-	)
-	maxRetries := 100
-	for retries = 0; !done && retries < maxRetries; retries++ {
-		done = true
-		var total time.Duration
-		for i := 0; i < len(buckets); i++ {
-			seconds, err := util.RandomUint64()
-			if err != nil {
-				return err
-			}
-			seconds %= maxDelay
-			if i == 0 {
-				// We always immediately vote the first time
-				// around. This should help catch setup errors.
-				seconds = 0
-			}
-
-			// Assemble missing vote bits
-			h, err := chainhash.NewHash(ctres.TicketAddresses[i].Ticket)
-			if err != nil {
-				return err
-			}
-			signature := hex.EncodeToString(smr.Replies[i].Signature)
-
-			t := time.Duration(seconds) * time.Second
-			total += t
-			buckets[i] = &voteInterval{
-				Vote: v1.CastVote{
-					Token:     token,
-					Ticket:    h.String(),
-					VoteBit:   voteBit,
-					Signature: signature,
-				},
-				Votes: 1,
-				Total: total,
-				At:    t,
-			}
-
-			// Make sure we are not going over our allotted time.
-			if total > duration {
-				done = false
-				break
-			}
-		}
-	}
-	if retries >= maxRetries {
-		// This should not happen
-		return fmt.Errorf("Could not randomize vote delays")
-	}
-
-	// Sanity
-	if len(buckets) != len(ctres.TicketAddresses) {
-		return fmt.Errorf("unexpected time bucket count got "+
-			"%v, wanted %v", len(ctres.TicketAddresses),
-			len(buckets))
-	}
-
-	// Convert buckets to a list
-	for _, v := range buckets {
-		c.voteIntervalPush(v)
-	}
-
-	// Log work
-	err := c.jsonLog(workJournal, token, buckets)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // _voteTrickler trickles votes to the server. The idea here is to not issue

--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"time"
+
+	"crypto/rand"
+
+	pb "decred.org/dcrwallet/rpc/walletrpc"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/politeiawww/cmd/politeiavoter/uniformprng"
+)
+
+func (c *ctx) calculateTrickle(token, voteBit string, ctres *pb.CommittedTicketsResponse, smr *pb.SignMessagesResponse) error {
+	votes := len(ctres.TicketAddresses)
+	duration := c.cfg.voteDuration
+	//maxDelay := uint64(duration.Seconds() / float64(votes) * 2)
+	//minAvgInterval := uint64(35)
+	//votes := 10
+	//duration := time.Hour * 24 * 3
+	voteDuration := duration - time.Hour
+	if voteDuration < time.Hour {
+		return fmt.Errorf("not enough time left to trickle votes")
+	}
+	fmt.Printf("Total number of votes: %v\n", votes)
+	fmt.Printf("Total vote duration  : %v\n", duration)
+	fmt.Printf("Duration calculated  : %v\n", voteDuration)
+
+	prng, err := uniformprng.RandSource(rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	ts := make([]time.Duration, 0, votes)
+	for i := 0; i < votes; i++ {
+		ts = append(ts, time.Duration(prng.Int63n(int64(voteDuration))))
+	}
+	sort.Slice(ts, func(i, j int) bool { return ts[i] < ts[j] })
+	var previous, t time.Duration
+	//for k := range ts {
+	//	fmt.Printf("  %v: %v - %v = %v\n", k, time.Duration(ts[k]), previous,
+	//		ts[k]-previous)
+	//	t += ts[k] - previous
+	//	previous = ts[k]
+	//}
+	//fmt.Printf("t %v\n", t)
+	//if t > voteDuration {
+	//	panic("x")
+	//}
+	//return nil
+
+	buckets := make([]*voteInterval, votes)
+	//previous = 0
+	for k := range ts {
+		// Assemble missing vote bits
+		h, err := chainhash.NewHash(ctres.TicketAddresses[k].Ticket)
+		if err != nil {
+			return err
+		}
+		signature := hex.EncodeToString(smr.Replies[k].Signature)
+
+		buckets[k] = &voteInterval{
+			Vote: v1.CastVote{
+				Token:     token,
+				Ticket:    h.String(),
+				VoteBit:   voteBit,
+				Signature: signature,
+			},
+			At: ts[k] - previous, // Delta to previous timestamp
+		}
+		t += ts[k] - previous
+		previous = ts[k]
+	}
+	// Should not happen
+	if t > voteDuration {
+		return fmt.Errorf("assert t > voteDuration - %v > %v",
+			t, voteDuration)
+	}
+
+	// Sanity
+	if len(buckets) != len(ctres.TicketAddresses) {
+		return fmt.Errorf("unexpected time bucket count got "+
+			"%v, wanted %v", len(ctres.TicketAddresses),
+			len(buckets))
+	}
+
+	// Convert buckets to a list
+	for _, v := range buckets {
+		c.voteIntervalPush(v)
+	}
+
+	// Log work
+	err = c.jsonLog(workJournal, token, buckets)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/politeiawww/cmd/politeiavoter/trickle_test.go
+++ b/politeiawww/cmd/politeiavoter/trickle_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"container/list"
+	"testing"
+	"time"
+
+	pb "decred.org/dcrwallet/rpc/walletrpc"
+)
+
+func fakeTickets(x int) (*pb.CommittedTicketsResponse, *pb.SignMessagesResponse) {
+	ctres := pb.CommittedTicketsResponse{
+		TicketAddresses: make([]*pb.CommittedTicketsResponse_TicketAddress, x),
+	}
+	for k := range ctres.TicketAddresses {
+		ctres.TicketAddresses[k] = &pb.CommittedTicketsResponse_TicketAddress{
+			Ticket: make([]byte, 32),
+		}
+	}
+	smr := pb.SignMessagesResponse{
+		Replies: make([]*pb.SignMessagesResponse_SignReply, x),
+	}
+	for k := range smr.Replies {
+		smr.Replies[k] = &pb.SignMessagesResponse_SignReply{
+			Signature: make([]byte, 64),
+		}
+	}
+
+	return &ctres, &smr
+}
+
+func fakeCtx(d time.Duration, x int) *ctx {
+	return &ctx{
+		cfg: &config{
+			voteDuration: d,
+		},
+		voteIntervalQ: new(list.List),
+	}
+}
+
+func TestTrickleNotEnoughTime(t *testing.T) {
+	x := 10
+	c := fakeCtx(time.Hour, x)
+	ctres, smr := fakeTickets(x)
+	err := c.calculateTrickle("", "", ctres, smr)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestTrickle2(t *testing.T) {
+	x := 10
+	c := fakeCtx(24*time.Hour, x)
+	ctres, smr := fakeTickets(x)
+	err := c.calculateTrickle("", "", ctres, smr)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Currently voting intervals are bucketized in predicatbale time slices. This change makes it truly random by using a true random input. Votes will now not be spaced out as they were and will in fact cluster and be very far apart.