### PR TITLE
multi: Break comment timestamps up.

### DIFF
--- a/politeiad/backendv2/tstorebe/tstore/tlogclient.go
+++ b/politeiad/backendv2/tstorebe/tstore/tlogclient.go
@@ -522,7 +522,7 @@ func newTrillianKey() (crypto.Signer, error) {
 }
 
 // tlogKeyParams is saved to the kv store on initial derivation of the tlog
-// private key. It contains the params that were used to derive the key and a
+// signing key. It contains the params that were used to derive the key and a
 // SHA256 digest of the key. Subsequent derivations, i.e. anytime politeiad is
 // restarted, will use the existing params to derive the key and will use the
 // digest to verify that the tlog key has not changed.
@@ -563,13 +563,13 @@ func deriveTlogKey(kvstore store.BlobKV, passphrase string) (*keyspb.PrivateKey,
 	)
 	b, ok := blobs[tlogKeyParamsKey]
 	if ok {
-		log.Debugf("Tlog private key params found in kv store")
+		log.Debugf("Tlog signing key params found in kv store")
 		err = json.Unmarshal(b, &tkp)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		log.Infof("Tlog private key params not found; creating new ones")
+		log.Infof("Tlog signing key params not found; creating new ones")
 		tkp = tlogKeyParams{
 			Params: util.NewArgon2Params(),
 		}
@@ -605,7 +605,7 @@ func deriveTlogKey(kvstore store.BlobKV, passphrase string) (*keyspb.PrivateKey,
 			return nil, fmt.Errorf("put: %v", err)
 		}
 
-		log.Infof("Tlog private key params saved to kv store")
+		log.Infof("Tlog signing key params saved to kv store")
 	} else {
 		// This was not the first time the key was derived. Verify that
 		// the key has not changed.

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -422,18 +422,39 @@ type Timestamp struct {
 	Proofs     []Proof `json:"proofs"`
 }
 
-// Timestamps retrieves the timestamps for a record's comments. If no comment
-// IDs are provided then timestamps for all comments made on the record will
-// be returned. If IncludeVotes is set to true then the timestamps for the
-// comment votes will also be returned. If a provided comment ID does not
-// exist then it will not be included in the reply.
+// CommentTimestamp contains the timestamps for the full history of a single
+// comment.
+//
+// A CommentAdd is the structure that is saved to disk anytime a comment is
+// created or edited. This structure is what will be timestamped.  The data
+// payload of a timestamp in the Adds field will contain a JSON encoded
+// CommentAdd.
+//
+// A CommentDel is the structure that is saved to disk anytime a comment is
+// deleted. This structure is what will be timestamped. The data payload of a
+// timestamp in the Del field will contain a JSON encoded CommentDel.
+//
+// A CommentVote is the structure that is saved to disk anytime a comment is
+// voted on. This structure is what will be timestamped. The data payload of
+// a timestamp in the Votes filed will contain a JSON encoded CommentVote.
+type CommentTimestamp struct {
+	Adds  []Timestamp `json:"adds"`
+	Del   *Timestamp  `json:"del,omitempty"`
+	Votes []Timestamp `json:"votes,omitempty"`
+}
+
+// Timestamps retrieves the timestamps for a record's comments. If a requested
+// comment ID does not exist, it will not be included in the reply. An error is
+// not returned.
+//
+// If IncludeVotes is set to true then the timestamps for the comment votes
+// will also be returned.
 type Timestamps struct {
-	CommentIDs   []uint32 `json:"commentids,omitempty"`
+	CommentIDs   []uint32 `json:"commentids"`
 	IncludeVotes bool     `json:"includevotes,omitempty"`
 }
 
 // TimestampsReply is the reply to the timestamps command.
 type TimestampsReply struct {
-	Comments map[uint32][]Timestamp `json:"comments"`
-	Votes    map[uint32][]Timestamp `json:"votes"`
+	Comments map[uint32]CommentTimestamp `json:"comments"`
 }

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -321,15 +321,33 @@ const (
 	TimestampsPageSize uint32 = 100
 )
 
-// Timestamps requests the timestamps for the comments of a record. If no
-// comment IDs are provided then the timestamps for all comments will be
-// returned.
+// CommentTimestamp contains the timestamps for the full history of a single
+// comment.
+//
+// A CommentAdd is the comments plugin structure that is saved to disk anytime
+// a comment is created or edited. This structure is what will be timestamped.
+// The data payload of a timestamp in the Adds field will contain a JSON
+// encoded CommentAdd. See the politeiad comments plugin API for more details
+// on a CommentAdd.
+//
+// A CommentDel is the comments plugin structure that is saved to disk anytime
+// a comment is deleted. This structure is what will be timestamped. The data
+// payload of a timestamp in the Del field will contain a JSON encoded
+// CommentDel. See the politeiad comments plugin API for more details on a
+// CommentDel.
+type CommentTimestamp struct {
+	Adds []Timestamp `json:"adds"`
+	Del  *Timestamp  `json:"del,omitempty"`
+}
+
+// Timestamps requests the timestamps for the comments of a record.
 type Timestamps struct {
 	Token      string   `json:"token"`
-	CommentIDs []uint32 `json:"commentids,omitempty"`
+	CommentIDs []uint32 `json:"commentids"`
 }
 
 // TimestampsReply is the reply to the Timestamps command.
 type TimestampsReply struct {
-	Comments map[uint32][]Timestamp `json:"comments"` // [commentID]Timestamp
+	// map[commentID]CommentTimestamp
+	Comments map[uint32]CommentTimestamp `json:"comments"`
 }

--- a/politeiawww/cmd/pictl/cmdcommenttimestamps.go
+++ b/politeiawww/cmd/pictl/cmdcommenttimestamps.go
@@ -5,10 +5,6 @@
 package main
 
 import (
-	"fmt"
-
-	backend "github.com/decred/politeia/politeiad/backendv2"
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/tstore"
 	cmv1 "github.com/decred/politeia/politeiawww/api/comments/v1"
 	pclient "github.com/decred/politeia/politeiawww/client"
 )
@@ -49,46 +45,7 @@ func (c *cmdCommentTimestamps) Execute(args []string) error {
 	}
 
 	// Verify timestamps
-	for commentID, timestamps := range tr.Comments {
-		for _, v := range timestamps {
-			err = verifyCommentTimestamp(v)
-			if err != nil {
-				return fmt.Errorf("verify comment timestamp %v: %v",
-					commentID, err)
-			}
-		}
-	}
-
-	return nil
-}
-
-func verifyCommentTimestamp(t cmv1.Timestamp) error {
-	ts := convertCommentTimestamp(t)
-	return tstore.VerifyTimestamp(ts)
-}
-
-func convertCommentProof(p cmv1.Proof) backend.Proof {
-	return backend.Proof{
-		Type:       p.Type,
-		Digest:     p.Digest,
-		MerkleRoot: p.MerkleRoot,
-		MerklePath: p.MerklePath,
-		ExtraData:  p.ExtraData,
-	}
-}
-
-func convertCommentTimestamp(t cmv1.Timestamp) backend.Timestamp {
-	proofs := make([]backend.Proof, 0, len(t.Proofs))
-	for _, v := range t.Proofs {
-		proofs = append(proofs, convertCommentProof(v))
-	}
-	return backend.Timestamp{
-		Data:       t.Data,
-		Digest:     t.Digest,
-		TxID:       t.TxID,
-		MerkleRoot: t.MerkleRoot,
-		Proofs:     proofs,
-	}
+	return pclient.VerifyCommentTimestamps(*tr)
 }
 
 // commentTimestampsHelpMsg is printed to stdout by the help command.


### PR DESCRIPTION
This diff updates the comment timestamp commands in politeiawww and
politeiad to differentiate between comment add timestamps and comment
del timestamps. This is required so that the client is able to decode
the timestamp data payload into the correct structure.