### PR TITLE
multi: Return comment del signature.

### DIFF
--- a/politeiad/README.md
+++ b/politeiad/README.md
@@ -187,8 +187,7 @@ politeiad
     ```
 
     Use the following config settings to spin up a development politeiad
-    instance. You'll need to replace the `politeiadpass` with the password
-    you created for your politeiad MySQL user.
+    instance.
 
    **politeiad.conf**
 

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1272,10 +1272,12 @@ func convertCommentFromCommentDel(cd comments.CommentDel) comments.Comment {
 	// Score needs to be filled in separately
 	return comments.Comment{
 		UserID:    cd.UserID,
+		State:     cd.State,
 		Token:     cd.Token,
 		ParentID:  cd.ParentID,
 		Comment:   "",
-		Signature: "",
+		PublicKey: cd.PublicKey,
+		Signature: cd.Signature,
 		CommentID: cd.CommentID,
 		Version:   0,
 		Timestamp: cd.Timestamp,

--- a/politeiad/cmd/politeia/README.md
+++ b/politeiad/cmd/politeia/README.md
@@ -22,8 +22,8 @@ Available commands:
 
 ## Obtain politeiad identity
 
-The politeiad identity is the contains the public key that is sued to verify
-replies from politeiad. 
+The politeiad identity contains the public key that is used to verify replies
+from politeiad.
 
 ```
 $ politeia  -v -testnet -rpchost 127.0.0.1 -rpcuser=user -rpcpass=pass identity

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -141,6 +141,13 @@ const (
 // treated as two distinct groups of comments. When a record becomes vetted the
 // comment ID starts back at 1.
 //
+// If a comment is deleted the PublicKey, Signature, Receipt, and Timestamp
+// fields will be the from the deletion action, not from the original comment.
+// The only field that is retained from the original comment is the UserID
+// field so that the client can still display the correct user information for
+// the deleted comment. Everything else from the original comment is
+// permanently deleted.
+//
 // Signature is the client signature of State+Token+ParentID+Comment.
 type Comment struct {
 	UserID    string       `json:"userid"`    // Unique user ID

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -124,6 +124,13 @@ const (
 // treated as two distinct groups of comments. When a record becomes vetted the
 // comment ID starts back at 1.
 //
+// If a comment is deleted the PublicKey, Signature, Receipt, and Timestamp
+// fields will be the from the deletion action, not from the original comment.
+// The only fields that are retained from the original comment are the UserID
+// and Username so that the client can still display the correct user
+// information for the deleted comment. Everything else from the original
+// comment is permanently deleted.
+//
 // Signature is the client signature of State+Token+ParentID+Comment.
 type Comment struct {
 	UserID    string       `json:"userid"`    // Unique user ID


### PR DESCRIPTION
This diff updates how deleted comments are returned from the politeiad
comments plugin and politeiawww API. The public key, signature, receipt,
and timestamp from the deletion event is now returned so that the
deletion event signature and receipt can be verified by the client.