### PR TITLE
ticketvote: Remove testnet linkby path.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -752,22 +752,13 @@ func (p *ticketVotePlugin) startRunoffForParent(token []byte, s ticketvote.Start
 				"parent", token),
 		}
 	}
-	isExpired := vm.LinkBy < time.Now().Unix()
-	isMainNet := p.activeNetParams.Name == chaincfg.MainNetParams().Name
-	switch {
-	case !isExpired && isMainNet:
+	if vm.LinkBy > time.Now().Unix() {
 		return nil, backend.PluginError{
 			PluginID:  ticketvote.PluginID,
 			ErrorCode: uint32(ticketvote.ErrorCodeLinkByNotExpired),
 			ErrorContext: fmt.Sprintf("parent record %x linkby "+
-				"deadline not met %v", token, vm.LinkBy),
+				"deadline (%v) has not expired yet", token, vm.LinkBy),
 		}
-	case !isExpired:
-		// Allow the vote to be started before the link by deadline
-		// expires on testnet and simnet only. This makes testing the
-		// runoff vote process easier.
-		log.Warnf("Parent record linkby deadline has not been met; " +
-			"disregarding deadline since this is not mainnet")
 	}
 
 	// Compile a list of the expected submissions that should be in the

--- a/politeiawww/cmd/pictl/cmdvotetestsetup.go
+++ b/politeiawww/cmd/pictl/cmdvotetestsetup.go
@@ -76,7 +76,7 @@ func (c *cmdVoteTestSetup) Execute(args []string) error {
 		return err
 	}
 	if policyWWW.PaywallEnabled {
-		return fmt.Errorf("paywall is not disabled")
+		fmt.Printf("WARN: politeiawww paywall is not disabled\n")
 	}
 
 	// Setup votes


### PR DESCRIPTION
Closes #1382 

This diff removes a testnet code path that allowed a runoff vote to
start prior to the linkby deadline expiring. It was suppose to make
testing easier, but it is causing bugs so its being removed. Having a
testnet code path was a bad idea.