### PR TITLE
ticketvote: Fix active votes cache bug.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -1411,8 +1411,8 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 	}
 
 	// Get the data that we need to validate the votes
-	voteDetails := p.activeVotes.VoteDetails(token)
 	eligible := p.activeVotes.EligibleTickets(token)
+	voteDetails := p.activeVotes.VoteDetails(token)
 	bestBlock, err := p.bestBlock()
 	if err != nil {
 		return "", err
@@ -1491,7 +1491,15 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		}
 
 		// Verify ticket has not already voted
-		if p.activeVotes.VoteIsDuplicate(v.Token, v.Ticket) {
+		isActive, isDup := p.activeVotes.VoteIsDuplicate(v.Token, v.Ticket)
+		if !isActive {
+			e := ticketvote.VoteErrorVoteStatusInvalid
+			receipts[k].Ticket = v.Ticket
+			receipts[k].ErrorCode = e
+			receipts[k].ErrorContext = fmt.Sprintf("%v: vote is "+
+				"not active", ticketvote.VoteErrors[e])
+		}
+		if isDup {
 			e := ticketvote.VoteErrorTicketAlreadyVoted
 			receipts[k].Ticket = v.Ticket
 			receipts[k].ErrorCode = e


### PR DESCRIPTION
Closes #1381

This diff removes all panics from the active votes cache and replaces
them with graceful failures.

When a ballot is cast the record is locked by the tstore backend, but
this does not apply to the active votes cache which is lazily updated on
read requests. This can lead to a vote being removed from the active
votes cache while another thread is still validating a ballot, causing the
panic code paths to be hit.

This diff is pretty ugly. These concurrency issues will be resolved and
cleaned up for good once a plugin command and all cache updates are
executed using a single kv store transaction.