### PR TITLE
ticketvote: Fix summary best block bug.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -2400,7 +2400,8 @@ func (p *ticketVotePlugin) summary(token []byte, bestBlock uint32) (*ticketvote.
 		// Some other error
 		return nil, fmt.Errorf("summaryCache: %v", err)
 	default:
-		// Caches summary was found. Return it.
+		// Cached summary was found. Update the best block and return it.
+		s.BestBlock = bestBlock
 		return s, nil
 	}
 


### PR DESCRIPTION
This diff fixes a bug that was causing the best block in a vote summary
to not be accurate when the summary was being pulled from the cache.