### PR TITLE
politeiad: Move timestamp verify functions.

### DIFF
--- a/politeiad/backendv2/tstorebe/tstore/record.go
+++ b/politeiad/backendv2/tstorebe/tstore/record.go
@@ -937,7 +937,7 @@ func (t *Tstore) timestamp(treeID int64, merkleLeafHash []byte, leaves []*trilli
 	}
 
 	// Setup proof for data digest inclusion in the log merkle root
-	edt := ExtraDataTrillianRFC6962{
+	edt := backend.ExtraDataTrillianRFC6962{
 		LeafIndex: p.LeafIndex,
 		TreeSize:  int64(a.LogRoot.TreeSize),
 	}
@@ -950,7 +950,7 @@ func (t *Tstore) timestamp(treeID int64, merkleLeafHash []byte, leaves []*trilli
 		merklePath = append(merklePath, hex.EncodeToString(v))
 	}
 	trillianProof := backend.Proof{
-		Type:       ProofTypeTrillianRFC6962,
+		Type:       backend.ProofTypeTrillianRFC6962,
 		Digest:     ts.Digest,
 		MerkleRoot: hex.EncodeToString(a.LogRoot.RootHash),
 		MerklePath: merklePath,
@@ -967,7 +967,7 @@ func (t *Tstore) timestamp(treeID int64, merkleLeafHash []byte, leaves []*trilli
 		hashes    = a.VerifyDigest.ChainInformation.MerklePath.Hashes
 		flags     = a.VerifyDigest.ChainInformation.MerklePath.Flags
 	)
-	edd := ExtraDataDcrtime{
+	edd := backend.ExtraDataDcrtime{
 		NumLeaves: numLeaves,
 		Flags:     base64.StdEncoding.EncodeToString(flags),
 	}
@@ -980,7 +980,7 @@ func (t *Tstore) timestamp(treeID int64, merkleLeafHash []byte, leaves []*trilli
 		merklePath = append(merklePath, hex.EncodeToString(v[:]))
 	}
 	dcrtimeProof := backend.Proof{
-		Type:       ProofTypeDcrtime,
+		Type:       backend.ProofTypeDcrtime,
 		Digest:     a.VerifyDigest.Digest,
 		MerkleRoot: a.VerifyDigest.ChainInformation.MerkleRoot,
 		MerklePath: merklePath,
@@ -996,7 +996,7 @@ func (t *Tstore) timestamp(treeID int64, merkleLeafHash []byte, leaves []*trilli
 	}
 
 	// Verify timestamp
-	err = VerifyTimestamp(ts)
+	err = backend.VerifyTimestamp(ts)
 	if err != nil {
 		return nil, fmt.Errorf("VerifyTimestamp: %v", err)
 	}

--- a/politeiad/backendv2/verify.go
+++ b/politeiad/backendv2/verify.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package tstore
+package backendv2
 
 import (
 	"crypto/sha256"
@@ -14,7 +14,6 @@ import (
 
 	"github.com/decred/dcrtime/merkle"
 	dmerkle "github.com/decred/dcrtime/merkle"
-	backend "github.com/decred/politeia/politeiad/backendv2"
 	"github.com/decred/politeia/util"
 	"github.com/google/trillian"
 	tmerkle "github.com/google/trillian/merkle"
@@ -38,7 +37,7 @@ type ExtraDataTrillianRFC6962 struct {
 }
 
 // verifyProofTrillian verifies a proof with the type ProofTypeTrillianRFC6962.
-func verifyProofTrillian(p backend.Proof) error {
+func verifyProofTrillian(p Proof) error {
 	// Verify type
 	if p.Type != ProofTypeTrillianRFC6962 {
 		return fmt.Errorf("invalid proof type")
@@ -90,7 +89,7 @@ type ExtraDataDcrtime struct {
 }
 
 // verifyProofDcrtime verifies a proof with the type ProofTypeDcrtime.
-func verifyProofDcrtime(p backend.Proof) error {
+func verifyProofDcrtime(p Proof) error {
 	if p.Type != ProofTypeDcrtime {
 		return fmt.Errorf("invalid proof type")
 	}
@@ -151,7 +150,7 @@ func verifyProofDcrtime(p backend.Proof) error {
 }
 
 // verifyProof verifies a backend proof.
-func verifyProof(p backend.Proof) error {
+func verifyProof(p Proof) error {
 	switch p.Type {
 	case ProofTypeTrillianRFC6962:
 		return verifyProofTrillian(p)
@@ -170,7 +169,7 @@ var (
 
 // VerifyTimestamp verifies the inclusion of the data in the merkle root that
 // was timestamped onto the dcr blockchain.
-func VerifyTimestamp(t backend.Timestamp) error {
+func VerifyTimestamp(t Timestamp) error {
 	if t.TxID == "" {
 		return ErrNotTimestamped
 	}

--- a/politeiawww/client/comments.go
+++ b/politeiawww/client/comments.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	backend "github.com/decred/politeia/politeiad/backendv2"
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/tstore"
 	cmv1 "github.com/decred/politeia/politeiawww/api/comments/v1"
 	"github.com/decred/politeia/util"
 )
@@ -214,9 +213,9 @@ func CommentVerify(c cmv1.Comment, serverPublicKey string) error {
 func CommentTimestampVerify(ct cmv1.CommentTimestamp) error {
 	// Verify comment adds
 	for i, ts := range ct.Adds {
-		err := tstore.VerifyTimestamp(convertCommentTimestamp(ts))
+		err := backend.VerifyTimestamp(convertCommentTimestamp(ts))
 		if err != nil {
-			if err == tstore.ErrNotTimestamped {
+			if err == backend.ErrNotTimestamped {
 				return err
 			}
 			return fmt.Errorf("verify comment add timestamp %v: %v", i, err)
@@ -227,9 +226,9 @@ func CommentTimestampVerify(ct cmv1.CommentTimestamp) error {
 	if ct.Del == nil {
 		return nil
 	}
-	err := tstore.VerifyTimestamp(convertCommentTimestamp(*ct.Del))
+	err := backend.VerifyTimestamp(convertCommentTimestamp(*ct.Del))
 	if err != nil {
-		if err == tstore.ErrNotTimestamped {
+		if err == backend.ErrNotTimestamped {
 			return err
 		}
 		return fmt.Errorf("verify comment del timestamp: %v", err)
@@ -246,7 +245,7 @@ func CommentTimestampsVerify(tr cmv1.TimestampsReply) ([]uint32, error) {
 	for cid, v := range tr.Comments {
 		err := CommentTimestampVerify(v)
 		if err != nil {
-			if err == tstore.ErrNotTimestamped {
+			if err == backend.ErrNotTimestamped {
 				notTimestamped = append(notTimestamped, cid)
 				continue
 			}

--- a/politeiawww/client/records.go
+++ b/politeiawww/client/records.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	backend "github.com/decred/politeia/politeiad/backendv2"
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/tstore"
 	"github.com/decred/politeia/politeiad/plugins/usermd"
 	rcv1 "github.com/decred/politeia/politeiawww/api/records/v1"
 	v1 "github.com/decred/politeia/politeiawww/api/records/v1"
@@ -286,7 +285,7 @@ func RecordVerify(r rcv1.Record, serverPubKey string) error {
 // inclusion of the data in the merkle root that was timestamped onto the dcr
 // blockchain.
 func RecordTimestampVerify(t rcv1.Timestamp) error {
-	return tstore.VerifyTimestamp(convertRecordTimestamp(t))
+	return backend.VerifyTimestamp(convertRecordTimestamp(t))
 }
 
 // RecordTimestampsVerify verifies all timestamps in a records v1 API

--- a/politeiawww/client/ticketvote.go
+++ b/politeiawww/client/ticketvote.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/v3"
 	backend "github.com/decred/politeia/politeiad/backendv2"
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/tstore"
 	tkv1 "github.com/decred/politeia/politeiawww/api/ticketvote/v1"
 	"github.com/decred/politeia/util"
 )
@@ -195,7 +194,7 @@ func (c *Client) TicketVoteTimestamps(t tkv1.Timestamps) (*tkv1.TimestampsReply,
 // TicketVoteTimestampVerify verifies that the provided ticketvote v1 Timestamp
 // is valid.
 func TicketVoteTimestampVerify(t tkv1.Timestamp) error {
-	return tstore.VerifyTimestamp(convertVoteTimestamp(t))
+	return backend.VerifyTimestamp(convertVoteTimestamp(t))
 }
 
 // TicketVoteTimestampsVerify verifies that all timestamps in the ticketvote

--- a/politeiawww/cmd/politeiaverify/ticketvote.go
+++ b/politeiawww/cmd/politeiaverify/ticketvote.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/tstore"
+	backend "github.com/decred/politeia/politeiad/backendv2"
 	tkplugin "github.com/decred/politeia/politeiad/plugins/ticketvote"
 	tkv1 "github.com/decred/politeia/politeiawww/api/ticketvote/v1"
 	"github.com/decred/politeia/politeiawww/client"
@@ -176,7 +176,7 @@ func verifyVoteTimestamps(fp string) error {
 		case nil:
 			// Timestamp verified. Check the next one.
 			continue
-		case tstore.ErrNotTimestamped:
+		case backend.ErrNotTimestamped:
 			// This ticket has not been timestamped yet. Continue to the
 			// code below so that the ticket hash gets printed.
 		default:


### PR DESCRIPTION
This diff moves the timestamp verification code from the `tstore`
package to the `backendv2` package to reduce the number of
dependencies that clients must import in order to verify timestamps.