### PR TITLE
[tstore] optimize map allocation

### DIFF
--- a/politeiad/backendv2/tstorebe/tstore/blobclient.go
+++ b/politeiad/backendv2/tstorebe/tstore/blobclient.go
@@ -134,7 +134,7 @@ func (t *Tstore) BlobsDel(token []byte, digests [][]byte) error {
 	// Put merkle leaf hashes into a map so that we can tell if a leaf
 	// corresponds to one of the target merkle leaf hashes in O(n)
 	// time.
-	merkleHashes := make(map[string]struct{}, len(leaves))
+	merkleHashes := make(map[string]struct{}, len(digests))
 	for _, v := range digests {
 		m := hex.EncodeToString(merkleLeafHash(v))
 		merkleHashes[m] = struct{}{}


### PR DESCRIPTION
Not sure whether this is was a typo, it seems that `map` pre-allocation here is not optimal. This PR fixes that.