### PR TITLE
www: Add PaywallConfirmations to policy.

### DIFF
--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -1010,6 +1010,7 @@ type PolicyReply struct {
 	MaxLinkByPeriod            int64    `json:"maxlinkbyperiod"`
 	MinVoteDuration            uint32   `json:"minvoteduration"`
 	MaxVoteDuration            uint32   `json:"maxvoteduration"`
+	PaywallConfirmations       uint64   `json:"paywallconfirmations"`
 }
 
 // VoteOption describes a single vote option.

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -187,6 +187,7 @@ func (p *politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		MaxLinkByPeriod:            0,
 		MinVoteDuration:            0,
 		MaxVoteDuration:            0,
+		PaywallConfirmations:       p.cfg.MinConfirmationsRequired,
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)


### PR DESCRIPTION
This pull request is made for [politeiagui issue: Explain how long it takes to update proposal credit balance](https://github.com/decred/politeiagui/issues/2070)

I see the description of field `MinConfirmationsRequired` in `politeiawww/config.Config`: 
```
MinConfirmationsRequired uint64   `long:"minconfirmations" description:"Minimum blocks confirmation for accepting paywall as paid. Only works in TestNet."`
```
But when I check the code of paywall. It seem be working on both Mainnet and Testnet