### PR TITLE
multi: Add pkg/errors stack traces.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/marcopeereboom/sbox v1.1.0
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/pquerna/otp v1.2.0
 	github.com/robfig/cron v1.2.0

--- a/politeiad/v1.go
+++ b/politeiad/v1.go
@@ -73,7 +73,7 @@ func (p *politeia) newRecord(w http.ResponseWriter, r *http.Request) {
 		errorCode := time.Now().Unix()
 		log.Errorf("%v New record error code %v: %v", remoteAddr(r),
 			errorCode, err)
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 
@@ -176,7 +176,7 @@ func (p *politeia) updateRecord(w http.ResponseWriter, r *http.Request, vetted b
 		errorCode := time.Now().Unix()
 		log.Errorf("%v Update %v record error code %v: %v",
 			remoteAddr(r), cmd, errorCode, err)
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 
@@ -224,7 +224,7 @@ func (p *politeia) updateReadme(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errorCode := time.Now().Unix()
 		log.Errorf("Error updating readme: %v", err)
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 
@@ -269,7 +269,7 @@ func (p *politeia) getUnvetted(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("%v Get unvetted record error code %v: %v",
 			remoteAddr(r), errorCode, err)
 
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	} else {
 		reply.Record = p.convertBackendRecord(*bpr)
@@ -284,7 +284,7 @@ func (p *politeia) getUnvetted(w http.ResponseWriter, r *http.Request) {
 				"error code %v: %v", remoteAddr(r), errorCode,
 				err)
 
-			p.respondWithServerError(w, errorCode)
+			p.respondWithServerError(w, errorCode, err)
 			return
 		}
 
@@ -333,7 +333,7 @@ func (p *politeia) getVetted(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("%v Get vetted record error code %v: %v",
 			remoteAddr(r), errorCode, err)
 
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	} else {
 		reply.Record = p.convertBackendRecord(*bpr)
@@ -348,7 +348,7 @@ func (p *politeia) getVetted(w http.ResponseWriter, r *http.Request) {
 				"error code %v: %v", remoteAddr(r), errorCode,
 				err)
 
-			p.respondWithServerError(w, errorCode)
+			p.respondWithServerError(w, errorCode, err)
 			return
 		}
 		log.Infof("Get vetted record %v: token %v", remoteAddr(r),
@@ -386,7 +386,7 @@ func (p *politeia) inventory(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("%v Inventory error code %v: %v", remoteAddr(r),
 			errorCode, err)
 
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 
@@ -454,7 +454,7 @@ func (p *politeia) setVettedStatus(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("%v Set status error code %v: %v",
 			remoteAddr(r), errorCode, err)
 
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 
@@ -517,7 +517,7 @@ func (p *politeia) setUnvettedStatus(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("%v Set unvetted status error code %v: %v",
 			remoteAddr(r), errorCode, err)
 
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 
@@ -582,7 +582,7 @@ func (p *politeia) updateVettedMetadata(w http.ResponseWriter, r *http.Request) 
 		errorCode := time.Now().Unix()
 		log.Errorf("%v Update vetted metadata error code %v: %v",
 			remoteAddr(r), errorCode, err)
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 
@@ -622,7 +622,7 @@ func (p *politeia) pluginInventory(w http.ResponseWriter, r *http.Request) {
 		errorCode := time.Now().Unix()
 		log.Errorf("%v Get plugins error code %v: %v",
 			remoteAddr(r), errorCode, err)
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 	for _, v := range plugins {
@@ -654,7 +654,7 @@ func (p *politeia) pluginCommand(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("%v %v: backend plugin failed with "+
 			"command:%v payload:%v err:%v", remoteAddr(r),
 			errorCode, pc.Command, pc.Payload, err)
-		p.respondWithServerError(w, errorCode)
+		p.respondWithServerError(w, errorCode, err)
 		return
 	}
 

--- a/politeiawww/comments/error.go
+++ b/politeiawww/comments/error.go
@@ -16,7 +16,14 @@ import (
 	pdclient "github.com/decred/politeia/politeiad/client"
 	v1 "github.com/decred/politeia/politeiawww/api/comments/v1"
 	"github.com/decred/politeia/util"
+	errs "github.com/pkg/errors"
 )
+
+// stackTracer represents the stack trace functionality for an error from
+// pkg/errors.
+type stackTracer interface {
+	StackTrace() errs.StackTrace
+}
 
 func respondWithError(w http.ResponseWriter, r *http.Request, format string, err error) {
 	// Check if the client dropped the connection
@@ -129,7 +136,17 @@ func respondWithError(w http.ResponseWriter, r *http.Request, format string, err
 		e := fmt.Sprintf(format, err)
 		log.Errorf("%v %v %v %v Internal error %v: %v",
 			util.RemoteAddr(r), r.Method, r.URL, r.Proto, t, e)
-		log.Errorf("Stacktrace (NOT A REAL CRASH): %s", debug.Stack())
+
+		// If this is a pkg/errors error then we can pull the
+		// stack trace out of the error, otherwise, we use the
+		// stack trace for this function.
+		stacktrace := string(debug.Stack())
+		err, ok := errs.Cause(err).(stackTracer)
+		if ok {
+			stacktrace = fmt.Sprintf("%+v\n", err.StackTrace())
+		}
+
+		log.Errorf("Stacktrace (NOT A REAL CRASH): %v", stacktrace)
 
 		util.RespondWithJSON(w, http.StatusInternalServerError,
 			v1.ServerErrorReply{

--- a/politeiawww/comments/error.go
+++ b/politeiawww/comments/error.go
@@ -16,14 +16,7 @@ import (
 	pdclient "github.com/decred/politeia/politeiad/client"
 	v1 "github.com/decred/politeia/politeiawww/api/comments/v1"
 	"github.com/decred/politeia/util"
-	errs "github.com/pkg/errors"
 )
-
-// stackTracer represents the stack trace functionality for an error from
-// pkg/errors.
-type stackTracer interface {
-	StackTrace() errs.StackTrace
-}
 
 func respondWithError(w http.ResponseWriter, r *http.Request, format string, err error) {
 	// Check if the client dropped the connection
@@ -140,13 +133,12 @@ func respondWithError(w http.ResponseWriter, r *http.Request, format string, err
 		// If this is a pkg/errors error then we can pull the
 		// stack trace out of the error, otherwise, we use the
 		// stack trace for this function.
-		stacktrace := string(debug.Stack())
-		err, ok := errs.Cause(err).(stackTracer)
-		if ok {
-			stacktrace = fmt.Sprintf("%+v\n", err.StackTrace())
+		stack, ok := util.StackTrace(err)
+		if !ok {
+			stack = string(debug.Stack())
 		}
 
-		log.Errorf("Stacktrace (NOT A REAL CRASH): %v", stacktrace)
+		log.Errorf("Stacktrace (NOT A REAL CRASH): %v", stack)
 
 		util.RespondWithJSON(w, http.StatusInternalServerError,
 			v1.ServerErrorReply{

--- a/politeiawww/ticketvote/error.go
+++ b/politeiawww/ticketvote/error.go
@@ -16,7 +16,14 @@ import (
 	pdclient "github.com/decred/politeia/politeiad/client"
 	v1 "github.com/decred/politeia/politeiawww/api/ticketvote/v1"
 	"github.com/decred/politeia/util"
+	errs "github.com/pkg/errors"
 )
+
+// stackTracer represents the stack trace functionality for an error from
+// pkg/errors.
+type stackTracer interface {
+	StackTrace() errs.StackTrace
+}
 
 func respondWithError(w http.ResponseWriter, r *http.Request, format string, err error) {
 	// Check if the client dropped the connection
@@ -60,7 +67,17 @@ func respondWithError(w http.ResponseWriter, r *http.Request, format string, err
 		e := fmt.Sprintf(format, err)
 		log.Errorf("%v %v %v %v Internal error %v: %v",
 			util.RemoteAddr(r), r.Method, r.URL, r.Proto, t, e)
-		log.Errorf("Stacktrace (NOT A REAL CRASH): %s", debug.Stack())
+
+		// If this is a pkg/errors error then we can pull the
+		// stack trace out of the error, otherwise, we use the
+		// stack trace for this function.
+		stacktrace := string(debug.Stack())
+		err, ok := errs.Cause(err).(stackTracer)
+		if ok {
+			stacktrace = fmt.Sprintf("%+v\n", err.StackTrace())
+		}
+
+		log.Errorf("Stacktrace (NOT A REAL CRASH): %v", stacktrace)
 
 		util.RespondWithJSON(w, http.StatusInternalServerError,
 			v1.ServerErrorReply{

--- a/politeiawww/ticketvote/error.go
+++ b/politeiawww/ticketvote/error.go
@@ -16,14 +16,7 @@ import (
 	pdclient "github.com/decred/politeia/politeiad/client"
 	v1 "github.com/decred/politeia/politeiawww/api/ticketvote/v1"
 	"github.com/decred/politeia/util"
-	errs "github.com/pkg/errors"
 )
-
-// stackTracer represents the stack trace functionality for an error from
-// pkg/errors.
-type stackTracer interface {
-	StackTrace() errs.StackTrace
-}
 
 func respondWithError(w http.ResponseWriter, r *http.Request, format string, err error) {
 	// Check if the client dropped the connection
@@ -71,13 +64,12 @@ func respondWithError(w http.ResponseWriter, r *http.Request, format string, err
 		// If this is a pkg/errors error then we can pull the
 		// stack trace out of the error, otherwise, we use the
 		// stack trace for this function.
-		stacktrace := string(debug.Stack())
-		err, ok := errs.Cause(err).(stackTracer)
-		if ok {
-			stacktrace = fmt.Sprintf("%+v\n", err.StackTrace())
+		stack, ok := util.StackTrace(err)
+		if !ok {
+			stack = string(debug.Stack())
 		}
 
-		log.Errorf("Stacktrace (NOT A REAL CRASH): %v", stacktrace)
+		log.Errorf("Stacktrace (NOT A REAL CRASH): %v", stack)
 
 		util.RespondWithJSON(w, http.StatusInternalServerError,
 			v1.ServerErrorReply{

--- a/util/errors.go
+++ b/util/errors.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"fmt"
+
+	errs "github.com/pkg/errors"
+)
+
+// stackTracer represents the stack trace functionality for an error from
+// pkg/errors.
+type stackTracer interface {
+	StackTrace() errs.StackTrace
+}
+
+// StackTrace returns the stack trace for a pkg/errors error. The returned bool
+// indicates whether the provided error is a pkg/errors error. Stack traces are
+// not available for stdlib errors.
+func StackTrace(err error) (string, bool) {
+	e, ok := errs.Cause(err).(stackTracer)
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%+v\n", e.StackTrace()), true
+}


### PR DESCRIPTION
This diff adds the `pkg/errors` module as a dependency and adds error
handling for `pkg/errors` errors. This change is needed because of the
stack trace limitations of the golang stdlib errors.

When politeiad or politeiawww encounters an unexpected error, the error
message and a stack trace are printed to stdout. Listed below is an
example stack trace for an error that occured while attempting to submit
a new record.

```
2021-06-09 16:44:10.281 [ERR] APIS: Stacktrace (NOT A REAL CRASH): goroutine 83 [running]:
runtime/debug.Stack
        /usr/local/go/src/runtime/debug/stack.go:24
github.com/decred/politeia/politeiawww/records.respondWithError
        /home/luke/go/src/github.com/decred/politeia/politeiawww/records/error.go:86
github.com/decred/politeia/politeiawww/records.(*Records).HandleNew
```

You'll notice that the stack trace is for the error handler function
`respondWithError`, not for the actual error itself. The golang stdlib
has no easy way to print the stack trace from the error itself.
`pkg/errors` solves this issue. Errors created using either the
`pkg/errors` `New()` or `Errorf()` methods include the stack trace for
the error. Using a `pkg/errors` error combined with the changes in this
diff results the following stack trace for the same new record error.

```
2021-06-09 16:45:37.888 [ERR] APIS: Stacktrace (NOT A REAL CRASH):
github.com/decred/politeia/politeiawww/records.(*Records).processNew
        /home/luke/go/src/github.com/decred/politeia/politeiawww/records/process.go:27
github.com/decred/politeia/politeiawww/records.(*Records).HandleNew
        /home/luke/go/src/github.com/decred/politeia/politeiawww/records/records.go:50
```

As you can see, it's the stack trace for the error itself. This provides
far more useful information and also allows for cleaner code.  You no
longer have to wrap errors in function descriptions when returning them
since you already have the full stack trace.

Before
```
err := someFunc()
if err != nil {
  return fmt.Errorf("someFunc: %v", err)
}
```

After
```
err := someFunc()
if err != nil {
  return err
}
```