### PR TITLE
cms: Fix invoices requests for different versions

### DIFF
--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -205,7 +205,6 @@ func (c *cockroachdb) InvoicesByMonthYearStatus(month, year uint16, status int) 
                 FROM invoices b 
                 WHERE invoices.token = b.token
               )`
-	fmt.Println("here", query)
 	rows, err := c.recordsdb.Raw(query, month, year, status).Rows()
 	if err != nil {
 		return nil, err
@@ -377,7 +376,6 @@ func (c *cockroachdb) InvoicesAll() ([]database.Invoice, error) {
               FROM invoices b 
               WHERE invoices.token = b.token
             )`
-	fmt.Println("all", query)
 	rows, err := c.recordsdb.Raw(query).Rows()
 	if err != nil {
 		return nil, err

--- a/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
+++ b/politeiawww/cmsdatabase/cockroachdb/cockroachdb.go
@@ -201,10 +201,10 @@ func (c *cockroachdb) InvoicesByMonthYearStatus(month, year uint16, status int) 
 	query := `SELECT *
               FROM invoices
               WHERE month = ? AND year = ? AND status = ? AND version = (
-				SELECT max(version) 
-				FROM invoices b 
-				WHERE invoices.token = b.token
-			  )`
+                SELECT max(version) 
+                FROM invoices b 
+                WHERE invoices.token = b.token
+              )`
 	fmt.Println("here", query)
 	rows, err := c.recordsdb.Raw(query, month, year, status).Rows()
 	if err != nil {
@@ -258,10 +258,10 @@ func (c *cockroachdb) InvoicesByMonthYear(month, year uint16) ([]database.Invoic
 	query := `SELECT *
             FROM invoices
             WHERE month = ? AND year = ? AND version = (
-			  SELECT max(version) 
-			  FROM invoices b 
-			  WHERE invoices.token = b.token
-			)`
+              SELECT max(version) 
+              FROM invoices b 
+              WHERE invoices.token = b.token
+            )`
 	rows, err := c.recordsdb.Raw(query, month, year).Rows()
 	if err != nil {
 		return nil, err
@@ -315,10 +315,10 @@ func (c *cockroachdb) InvoicesByStatus(status int) ([]database.Invoice, error) {
 	query := `SELECT *
             FROM invoices
             WHERE status = ? AND version = (
-			  SELECT max(version) 
-			  FROM invoices b 
-			  WHERE invoices.token = b.token
-			)`
+              SELECT max(version) 
+              FROM invoices b 
+              WHERE invoices.token = b.token
+            )`
 	rows, err := c.recordsdb.Raw(query, status).Rows()
 	if err != nil {
 		return nil, err
@@ -372,11 +372,11 @@ func (c *cockroachdb) InvoicesAll() ([]database.Invoice, error) {
 	// Lookup the latest version of each invoice
 	query := `SELECT *
             FROM invoices 
-			WHERE version = (
-			  SELECT max(version) 
-			  FROM invoices b 
-			  WHERE invoices.token = b.token
-			)`
+            WHERE version = (
+              SELECT max(version) 
+              FROM invoices b 
+              WHERE invoices.token = b.token
+            )`
 	fmt.Println("all", query)
 	rows, err := c.recordsdb.Raw(query).Rows()
 	if err != nil {

--- a/politeiawww/invoices.go
+++ b/politeiawww/invoices.go
@@ -867,7 +867,10 @@ func (p *politeiawww) processInvoiceDetails(invDetails cms.InvoiceDetails, u *us
 		reply.Invoice = *invRec
 		reply.Payout = payout
 	} else {
-		reply.Invoice = filterDomainInvoice(invRec, requestingUser.Domain)
+		filteredInvoice := filterDomainInvoice(invRec, requestingUser.Domain)
+		if len(filteredInvoice.Input.LineItems) > 0 {
+			reply.Invoice = filteredInvoice
+		}
 	}
 	return &reply, nil
 }


### PR DESCRIPTION
Closes GUI issue 2423

Previously all versions of any invoice was being returned by these requests.  Now only the most recent (max version) one will be.