### PR TITLE
d/backendv2: Fix trillian rfc6962 import.

### DIFF
--- a/politeiad/backendv2/verify.go
+++ b/politeiad/backendv2/verify.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/trillian"
 	tmerkle "github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/hashers/registry"
+	_ "github.com/google/trillian/merkle/rfc6962"
 )
 
 const (


### PR DESCRIPTION
When the timestamp verify functions were moved out of the tstore package
it silently broke the `politeiaverify` tool. `politeiaverify` now
returns the following error when attempting to verify timestamps.

`LogHasher(RFC6962_SHA256) is an unknown hasher`

Importing the `google/trillian/merkle/rfc6962` using a blank identifier
fixes this issue.