### PR TITLE
mysql: Upsert user's identities on user update.

### DIFF
--- a/politeiawww/cmd/shared/users.go
+++ b/politeiawww/cmd/shared/users.go
@@ -11,7 +11,7 @@ import v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 type UsersCmd struct {
 	Email     string `long:"email"`    // Email filter
 	Username  string `long:"username"` // Username filter
-	PublicKey string `long:"pubkey"`   // Username filter
+	PublicKey string `long:"pubkey"`   // Public key filter
 }
 
 // Execute executes the users command.

--- a/politeiawww/user/mysql/mysql.go
+++ b/politeiawww/user/mysql/mysql.go
@@ -509,6 +509,7 @@ func upsertIdentities(ctx context.Context, tx *sql.Tx, ids []mysqlIdentity) erro
 	if err != nil {
 		return err
 	}
+	defer stmt.Close()
 
 	_, err = stmt.ExecContext(ctx, vals...)
 	if err != nil {

--- a/politeiawww/user/mysql/mysql_test.go
+++ b/politeiawww/user/mysql/mysql_test.go
@@ -212,8 +212,7 @@ func TestUserUpdate(t *testing.T) {
 		"VALUES ON DUPLICATE KEY UPDATE " +
 		"activated=VALUES(activated), deactivated=VALUES(deactivated)"
 
-	mock.
-		ExpectExec(regexp.QuoteMeta(iq)).
+	mock.ExpectExec(regexp.QuoteMeta(iq)).
 		WithArgs().
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()

--- a/politeiawww/user/mysql/mysql_test.go
+++ b/politeiawww/user/mysql/mysql_test.go
@@ -208,10 +208,12 @@ func TestUserUpdate(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// Upsert user identities query
-	iq := `INSERT INTO`
+	iq := "INSERT INTO identities(publicKey, userID, activated, deactivated) " +
+		"VALUES ON DUPLICATE KEY UPDATE " +
+		"activated=VALUES(activated), deactivated=VALUES(deactivated)"
 
-	mock.ExpectPrepare(iq).
-		ExpectExec().
+	mock.
+		ExpectExec(regexp.QuoteMeta(iq)).
 		WithArgs().
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()

--- a/politeiawww/user/mysql/mysql_test.go
+++ b/politeiawww/user/mysql/mysql_test.go
@@ -196,15 +196,25 @@ func TestUserUpdate(t *testing.T) {
 		Username:   "test",
 	}
 
-	// Query
-	sql := `UPDATE users ` +
+	// Update user query
+	uq := `UPDATE users ` +
 		`SET username = ?, uBlob = ?, updatedAt = ? ` +
 		`WHERE ID = ?`
 
 	// Success Expectations
-	mock.ExpectExec(regexp.QuoteMeta(sql)).
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(uq)).
 		WithArgs(usr.Username, AnyBlob{}, AnyTime{}, usr.ID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// Upsert user identities query
+	iq := `INSERT INTO`
+
+	mock.ExpectPrepare(iq).
+		ExpectExec().
+		WithArgs().
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
 
 	// Execute method
 	err := mdb.UserUpdate(usr)


### PR DESCRIPTION
This commit fixes a bug in the mysql implementation of the `user.Database` interface 
where user identities weren't synced to the db which caused the bug in the search user by
public key feature reported on #1456.

This part is done automatically by `gorm` in the `cockroachdb` implementation as the
`User` model has a list of `Identity` items and `gorm` syncs the identities to db each time
we save the `User` model on db.

This diff upserts the user identities to the `identties` table manually using a sql transaction 
after each user update - see `UserUpdate` func. 

Closes #1456.