### PR TITLE
mysql: Consistent table and columns naming convention.

### DIFF
--- a/politeiawww/user/mysql/mysql.go
+++ b/politeiawww/user/mysql/mysql.go
@@ -66,16 +66,16 @@ const tableUsers = `
 // tableIdentities defines the identities table.
 const tableIdentities = `
   public_key CHAR(64) NOT NULL PRIMARY KEY,
-  user_ID    VARCHAR(36) NOT NULL,
+  user_id    VARCHAR(36) NOT NULL,
   activated INT(11) NOT NULL,
   deactivated INT(11) NOT NULL,
-  FOREIGN KEY (user_ID) REFERENCES users(ID)
+  FOREIGN KEY (user_id) REFERENCES users(ID)
 `
 
 // tableSessions defines the sessions table.
 const tableSessions = `
   k CHAR(64) NOT NULL PRIMARY KEY,
-  user_ID VARCHAR(36) NOT NULL,
+  user_id VARCHAR(36) NOT NULL,
   created_at INT(11) NOT NULL,
   s_blob BLOB NOT NULL
 `
@@ -496,7 +496,7 @@ func (m *mysql) UserUpdate(u user.User) error {
 func upsertIdentities(ctx context.Context, tx *sql.Tx, ids []mysqlIdentity) error {
 	var sb strings.Builder
 	sb.WriteString("INSERT INTO " +
-		"identities(public_key, user_ID, activated, deactivated) VALUES ")
+		"identities(public_key, user_id, activated, deactivated) VALUES ")
 
 	vals := make([]interface{}, 0, len(ids))
 	for i, id := range ids {
@@ -608,7 +608,7 @@ func (m *mysql) UserGetByPubKey(pubKey string) (*user.User, error) {
 	q := `SELECT u_blob
         FROM users
         INNER JOIN identities
-          ON users.ID = identities.user_ID
+          ON users.ID = identities.user_id
           WHERE identities.public_key = ?`
 	err := m.userDB.QueryRowContext(ctx, q, pubKey).Scan(&uBlob)
 	switch {
@@ -651,7 +651,7 @@ func (m *mysql) UsersGetByPubKey(pubKeys []string) (map[string]user.User, error)
 	q := `SELECT u_blob
           FROM users
             INNER JOIN identities
-            ON users.ID = identities.user_ID
+            ON users.ID = identities.user_id
             WHERE identities.public_key IN (?` +
 		strings.Repeat(",?", len(pubKeys)-1) + `)`
 
@@ -815,7 +815,7 @@ func (m *mysql) SessionSave(us user.Session) error {
 	if update {
 		_, err := m.userDB.ExecContext(ctx,
 			`UPDATE sessions
-		  SET user_ID = ?, created_at = ?, s_blob = ?
+		  SET user_id = ?, created_at = ?, s_blob = ?
 			WHERE k = ?`,
 			session.UserID, session.CreatedAt, session.Blob, session.Key)
 		if err != nil {
@@ -824,7 +824,7 @@ func (m *mysql) SessionSave(us user.Session) error {
 	} else {
 		_, err := m.userDB.ExecContext(ctx,
 			`INSERT INTO sessions
-		(k, user_ID, created_at, s_blob)
+		(k, user_id, created_at, s_blob)
 		VALUES (?, ?, ?, ?)`,
 			session.Key, session.UserID, session.CreatedAt, session.Blob)
 		if err != nil {
@@ -909,7 +909,7 @@ func (m *mysql) SessionsDeleteByUserID(uid uuid.UUID, exemptSessionIDs []string)
 	// deleted.
 	if len(exempt) == 0 {
 		_, err := m.userDB.
-			ExecContext(ctx, "DELETE FROM sessions WHERE user_ID = ?", uid.String())
+			ExecContext(ctx, "DELETE FROM sessions WHERE user_id = ?", uid.String())
 		return err
 	}
 

--- a/politeiawww/user/mysql/mysql.go
+++ b/politeiawww/user/mysql/mysql.go
@@ -57,27 +57,27 @@ const tableKeyValue = `
 const tableUsers = `
   ID VARCHAR(36) NOT NULL PRIMARY KEY,
   username VARCHAR(64) NOT NULL,
-  uBlob BLOB NOT NULL,
-  createdAt INT(11) NOT NULL,
-  updatedAt INT(11),
+  u_blob BLOB NOT NULL,
+  created_at INT(11) NOT NULL,
+  updated_at INT(11),
   UNIQUE (username)
 `
 
 // tableIdentities defines the identities table.
 const tableIdentities = `
-  publicKey CHAR(64) NOT NULL PRIMARY KEY,
-  userID    VARCHAR(36) NOT NULL,
+  public_key CHAR(64) NOT NULL PRIMARY KEY,
+  user_ID    VARCHAR(36) NOT NULL,
   activated INT(11) NOT NULL,
   deactivated INT(11) NOT NULL,
-  FOREIGN KEY (userID) REFERENCES users(ID)
+  FOREIGN KEY (user_ID) REFERENCES users(ID)
 `
 
 // tableSessions defines the sessions table.
 const tableSessions = `
   k CHAR(64) NOT NULL PRIMARY KEY,
-  userID VARCHAR(36) NOT NULL,
-  createdAt INT(11) NOT NULL,
-  sBlob BLOB NOT NULL
+  user_ID VARCHAR(36) NOT NULL,
+  created_at INT(11) NOT NULL,
+  s_blob BLOB NOT NULL
 `
 
 var (
@@ -210,7 +210,7 @@ func (m *mysql) userNew(ctx context.Context, tx *sql.Tx, u user.User) (*uuid.UUI
 		CreatedAt: time.Now().Unix(),
 	}
 	_, err = tx.ExecContext(ctx,
-		"INSERT INTO users (ID, username, uBlob, createdAt) VALUES (?, ?, ?, ?)",
+		"INSERT INTO users (ID, username, u_blob, created_at) VALUES (?, ?, ?, ?)",
 		ur.ID, ur.Username, ur.Blob, ur.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("create user: %v", err)
@@ -237,7 +237,7 @@ func rotateKeys(ctx context.Context, tx *sql.Tx, oldKey *[32]byte, newKey *[32]b
 	}
 	var users []User
 
-	rows, err := tx.QueryContext(ctx, "SELECT ID, uBlob FROM users")
+	rows, err := tx.QueryContext(ctx, "SELECT ID, u_blob FROM users")
 	if err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func rotateKeys(ctx context.Context, tx *sql.Tx, oldKey *[32]byte, newKey *[32]b
 		v.Blob = eb
 		// Store new user blob.
 		_, err = tx.ExecContext(ctx,
-			"UPDATE users SET uBlob = ? WHERE ID = ?", v.Blob, v.ID)
+			"UPDATE users SET u_blob = ? WHERE ID = ?", v.Blob, v.ID)
 		if err != nil {
 			return fmt.Errorf("save user '%v': %v", v.ID, err)
 		}
@@ -283,7 +283,7 @@ func rotateKeys(ctx context.Context, tx *sql.Tx, oldKey *[32]byte, newKey *[32]b
 		Blob []byte // Encrypted blob of session data.
 	}
 	var sessions []Session
-	rows, err = tx.QueryContext(ctx, "SELECT k, sBlob FROM sessions")
+	rows, err = tx.QueryContext(ctx, "SELECT k, s_blob FROM sessions")
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func rotateKeys(ctx context.Context, tx *sql.Tx, oldKey *[32]byte, newKey *[32]b
 		v.Blob = eb
 		// Store new user blob.
 		_, err = tx.ExecContext(ctx,
-			"UPDATE sessions SET sBlob = ? WHERE k = ?", v.Blob, v.Key)
+			"UPDATE sessions SET s_blob = ? WHERE k = ?", v.Blob, v.Key)
 		if err != nil {
 			return fmt.Errorf("save session '%v': %v", v.Key, err)
 		}
@@ -364,7 +364,7 @@ func (m *mysql) InsertUser(u user.User) error {
 		CreatedAt: time.Now().Unix(),
 	}
 	_, err = m.userDB.ExecContext(ctx,
-		"INSERT INTO users (ID, username, uBlob, createdAt) VALUES (?, ?, ?, ?)",
+		"INSERT INTO users (ID, username, u_blob, created_at) VALUES (?, ?, ?, ?)",
 		ur.ID, ur.Username, ur.Blob, ur.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("insert user: %v", err)
@@ -455,7 +455,7 @@ func (m *mysql) UserUpdate(u user.User) error {
 		UpdatedAt: time.Now().Unix(),
 	}
 	_, err = tx.ExecContext(ctx,
-		"UPDATE users SET username = ?, uBlob = ?, updatedAt = ? WHERE ID = ? ",
+		"UPDATE users SET username = ?, u_blob = ?, updated_at = ? WHERE ID = ? ",
 		ur.Username, ur.Blob, ur.UpdatedAt, ur.ID)
 	if err != nil {
 		return fmt.Errorf("create user: %v", err)
@@ -496,7 +496,7 @@ func (m *mysql) UserUpdate(u user.User) error {
 func upsertIdentities(ctx context.Context, tx *sql.Tx, ids []mysqlIdentity) error {
 	var sb strings.Builder
 	sb.WriteString("INSERT INTO " +
-		"identities(publicKey, userID, activated, deactivated) VALUES ")
+		"identities(public_key, user_ID, activated, deactivated) VALUES ")
 
 	vals := make([]interface{}, 0, len(ids))
 	for i, id := range ids {
@@ -536,7 +536,7 @@ func (m *mysql) UserGetByUsername(username string) (*user.User, error) {
 
 	var uBlob []byte
 	err := m.userDB.QueryRowContext(ctx,
-		"SELECT uBlob FROM users WHERE username = ?", username).Scan(&uBlob)
+		"SELECT u_blob FROM users WHERE username = ?", username).Scan(&uBlob)
 	switch {
 	case err == sql.ErrNoRows:
 		return nil, user.ErrUserNotFound
@@ -571,7 +571,7 @@ func (m *mysql) UserGetById(id uuid.UUID) (*user.User, error) {
 
 	var uBlob []byte
 	err := m.userDB.QueryRowContext(ctx,
-		"SELECT uBlob FROM users WHERE ID = ?", id).Scan(&uBlob)
+		"SELECT u_blob FROM users WHERE ID = ?", id).Scan(&uBlob)
 	switch {
 	case err == sql.ErrNoRows:
 		return nil, user.ErrUserNotFound
@@ -605,11 +605,11 @@ func (m *mysql) UserGetByPubKey(pubKey string) (*user.User, error) {
 	defer cancel()
 
 	var uBlob []byte
-	q := `SELECT uBlob
+	q := `SELECT u_blob
         FROM users
         INNER JOIN identities
-          ON users.ID = identities.userID
-          WHERE identities.publicKey = ?`
+          ON users.ID = identities.user_ID
+          WHERE identities.public_key = ?`
 	err := m.userDB.QueryRowContext(ctx, q, pubKey).Scan(&uBlob)
 	switch {
 	case err == sql.ErrNoRows:
@@ -648,11 +648,11 @@ func (m *mysql) UsersGetByPubKey(pubKeys []string) (map[string]user.User, error)
 	defer cancel()
 
 	// Lookup users by pubkey.
-	q := `SELECT uBlob
+	q := `SELECT u_blob
           FROM users
             INNER JOIN identities
-            ON users.ID = identities.userID
-            WHERE identities.publicKey IN (?` +
+            ON users.ID = identities.user_ID
+            WHERE identities.public_key IN (?` +
 		strings.Repeat(",?", len(pubKeys)-1) + `)`
 
 	args := make([]interface{}, len(pubKeys))
@@ -721,7 +721,7 @@ func (m *mysql) AllUsers(callback func(u *user.User)) error {
 		Blob []byte
 	}
 	var users []User
-	rows, err := m.userDB.QueryContext(ctx, "SELECT uBlob FROM users")
+	rows, err := m.userDB.QueryContext(ctx, "SELECT u_blob FROM users")
 	if err != nil {
 		return err
 	}
@@ -815,7 +815,7 @@ func (m *mysql) SessionSave(us user.Session) error {
 	if update {
 		_, err := m.userDB.ExecContext(ctx,
 			`UPDATE sessions
-		  SET userID = ?, createdAt = ?, sBlob = ?
+		  SET user_ID = ?, created_at = ?, s_blob = ?
 			WHERE k = ?`,
 			session.UserID, session.CreatedAt, session.Blob, session.Key)
 		if err != nil {
@@ -824,7 +824,7 @@ func (m *mysql) SessionSave(us user.Session) error {
 	} else {
 		_, err := m.userDB.ExecContext(ctx,
 			`INSERT INTO sessions
-		(k, userID, createdAt, sBlob)
+		(k, user_ID, created_at, s_blob)
 		VALUES (?, ?, ?, ?)`,
 			session.Key, session.UserID, session.CreatedAt, session.Blob)
 		if err != nil {
@@ -850,7 +850,7 @@ func (m *mysql) SessionGetByID(sid string) (*user.Session, error) {
 	defer cancel()
 
 	var blob []byte
-	err := m.userDB.QueryRowContext(ctx, "SELECT sBlob FROM sessions WHERE k = ?",
+	err := m.userDB.QueryRowContext(ctx, "SELECT s_blob FROM sessions WHERE k = ?",
 		hex.EncodeToString(util.Digest([]byte(sid)))).
 		Scan(&blob)
 	switch {
@@ -909,7 +909,7 @@ func (m *mysql) SessionsDeleteByUserID(uid uuid.UUID, exemptSessionIDs []string)
 	// deleted.
 	if len(exempt) == 0 {
 		_, err := m.userDB.
-			ExecContext(ctx, "DELETE FROM sessions WHERE userID = ?", uid.String())
+			ExecContext(ctx, "DELETE FROM sessions WHERE user_ID = ?", uid.String())
 		return err
 	}
 

--- a/politeiawww/user/mysql/mysql_test.go
+++ b/politeiawww/user/mysql/mysql_test.go
@@ -120,7 +120,7 @@ func TestUserNew(t *testing.T) {
 	// Queries
 	sqlSelectIndex := `SELECT v FROM key_value WHERE k = ?`
 	sqlInsertUser := `INSERT INTO users ` +
-		`(ID, username, uBlob, createdAt) ` +
+		`(ID, username, u_blob, created_at) ` +
 		`VALUES (?, ?, ?, ?)`
 	sqlUpsertIndex := `INSERT INTO key_value (k,v)
     VALUES (?, ?)
@@ -198,7 +198,7 @@ func TestUserUpdate(t *testing.T) {
 
 	// Update user query
 	uq := `UPDATE users ` +
-		`SET username = ?, uBlob = ?, updatedAt = ? ` +
+		`SET username = ?, u_blob = ?, updated_at = ? ` +
 		`WHERE ID = ?`
 
 	// Success Expectations
@@ -208,7 +208,7 @@ func TestUserUpdate(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// Upsert user identities query
-	iq := "INSERT INTO identities(publicKey, userID, activated, deactivated) " +
+	iq := "INSERT INTO identities(public_key, user_ID, activated, deactivated) " +
 		"VALUES ON DUPLICATE KEY UPDATE " +
 		"activated=VALUES(activated), deactivated=VALUES(deactivated)"
 
@@ -239,11 +239,11 @@ func TestUserGetByUsername(t *testing.T) {
 
 	// Mock rows data
 	rows := sqlmock.NewRows([]string{
-		"uBlob",
+		"u_blob",
 	}).AddRow(blob)
 
 	// Query
-	sql := `SELECT uBlob FROM users WHERE username = ?`
+	sql := `SELECT u_blob FROM users WHERE username = ?`
 
 	// Success Expectations
 	mock.ExpectQuery(regexp.QuoteMeta(sql)).
@@ -301,11 +301,11 @@ func TestUserGetById(t *testing.T) {
 
 	// Mock rows data
 	rows := sqlmock.NewRows([]string{
-		"uBlob",
+		"u_blob",
 	}).AddRow(blob)
 
 	// Query
-	sql := `SELECT uBlob FROM users WHERE ID = ?`
+	sql := `SELECT u_blob FROM users WHERE ID = ?`
 
 	// Success Expectations
 	mock.ExpectQuery(regexp.QuoteMeta(sql)).
@@ -364,13 +364,13 @@ func TestUserGetByPubKey(t *testing.T) {
 
 	// Mock rows data
 	rows := sqlmock.NewRows([]string{
-		"uBlob",
+		"u_blob",
 	}).AddRow(blob)
 
 	// Query
-	sql := `SELECT uBlob FROM users ` +
-		`INNER JOIN identities ON users.ID = identities.userID ` +
-		`WHERE identities.publicKey = ?`
+	sql := `SELECT u_blob FROM users ` +
+		`INNER JOIN identities ON users.ID = identities.user_ID ` +
+		`WHERE identities.public_key = ?`
 
 	// Success Expectations
 	mock.ExpectQuery(regexp.QuoteMeta(sql)).
@@ -430,13 +430,13 @@ func TestUsersGetByPubKey(t *testing.T) {
 
 	// Mock data
 	rows := sqlmock.NewRows([]string{
-		"uBlob",
+		"u_blob",
 	}).AddRow(blob)
 
 	// Query
-	sql := `SELECT uBlob FROM users ` +
-		`INNER JOIN identities ON users.ID = identities.userID ` +
-		`WHERE identities.publicKey IN (?)`
+	sql := `SELECT u_blob FROM users ` +
+		`INNER JOIN identities ON users.ID = identities.user_ID ` +
+		`WHERE identities.public_key IN (?)`
 
 	// Success Expectations
 	mock.ExpectQuery(regexp.QuoteMeta(sql)).
@@ -498,11 +498,11 @@ func TestAllUsers(t *testing.T) {
 	_, blob2 := newUser(t, mdb)
 
 	// Query
-	sql := `SELECT uBlob FROM users`
+	sql := `SELECT u_blob FROM users`
 
 	// Mock data
 	rows := sqlmock.NewRows([]string{
-		"uBlob",
+		"u_blob",
 	}).
 		AddRow(blob).
 		AddRow(blob2)
@@ -574,7 +574,7 @@ func TestSessionSave(t *testing.T) {
 	sqlSelect := `SELECT k FROM sessions WHERE k = ?`
 
 	sqlInsert := `INSERT INTO sessions ` +
-		`(k, userID, createdAt, sBlob) ` +
+		`(k, user_ID, created_at, s_blob) ` +
 		`VALUES (?, ?, ?, ?)`
 
 	// Success Create Expectations
@@ -592,12 +592,12 @@ func TestSessionSave(t *testing.T) {
 	}
 
 	// Mock data for updating a user session
-	rows := sqlmock.NewRows([]string{"sBlob"}).
+	rows := sqlmock.NewRows([]string{"s_blob"}).
 		AddRow([]byte{})
 
 	// Queries
 	sqlUpdate := `UPDATE sessions ` +
-		`SET userID = ?, createdAt = ?, sBlob = ? ` +
+		`SET user_ID = ?, created_at = ?, s_blob = ? ` +
 		`WHERE k = ?`
 
 	// Success Update Expectations
@@ -654,11 +654,11 @@ func TestSessionGetByID(t *testing.T) {
 	}
 
 	// Mock data
-	rows := sqlmock.NewRows([]string{"sBlob"}).
+	rows := sqlmock.NewRows([]string{"s_blob"}).
 		AddRow(eb)
 
 	// Queries
-	sql := `SELECT sBlob FROM sessions WHERE k = ?`
+	sql := `SELECT s_blob FROM sessions WHERE k = ?`
 
 	// Success Expectations
 	mock.ExpectQuery(regexp.QuoteMeta(sql)).
@@ -730,7 +730,7 @@ func TestSessionDeleteByID(t *testing.T) {
 	}
 
 	// Mock data
-	sqlmock.NewRows([]string{"sBlob"}).
+	sqlmock.NewRows([]string{"s_blob"}).
 		AddRow(eb)
 
 	// Queries
@@ -794,11 +794,11 @@ func TestSessionsDeleteByUserID(t *testing.T) {
 	}
 
 	// Mock data
-	sqlmock.NewRows([]string{"sBlob"}).
+	sqlmock.NewRows([]string{"s_blob"}).
 		AddRow(eb)
 
 	// Queries
-	sql := `DELETE FROM sessions WHERE userID = ?`
+	sql := `DELETE FROM sessions WHERE user_ID = ?`
 
 	// Success Expectations
 	mock.ExpectExec(regexp.QuoteMeta(sql)).

--- a/politeiawww/user/mysql/mysql_test.go
+++ b/politeiawww/user/mysql/mysql_test.go
@@ -208,7 +208,7 @@ func TestUserUpdate(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// Upsert user identities query
-	iq := "INSERT INTO identities(public_key, user_ID, activated, deactivated) " +
+	iq := "INSERT INTO identities(public_key, user_id, activated, deactivated) " +
 		"VALUES ON DUPLICATE KEY UPDATE " +
 		"activated=VALUES(activated), deactivated=VALUES(deactivated)"
 
@@ -369,7 +369,7 @@ func TestUserGetByPubKey(t *testing.T) {
 
 	// Query
 	sql := `SELECT u_blob FROM users ` +
-		`INNER JOIN identities ON users.ID = identities.user_ID ` +
+		`INNER JOIN identities ON users.ID = identities.user_id ` +
 		`WHERE identities.public_key = ?`
 
 	// Success Expectations
@@ -435,7 +435,7 @@ func TestUsersGetByPubKey(t *testing.T) {
 
 	// Query
 	sql := `SELECT u_blob FROM users ` +
-		`INNER JOIN identities ON users.ID = identities.user_ID ` +
+		`INNER JOIN identities ON users.ID = identities.user_id ` +
 		`WHERE identities.public_key IN (?)`
 
 	// Success Expectations
@@ -574,7 +574,7 @@ func TestSessionSave(t *testing.T) {
 	sqlSelect := `SELECT k FROM sessions WHERE k = ?`
 
 	sqlInsert := `INSERT INTO sessions ` +
-		`(k, user_ID, created_at, s_blob) ` +
+		`(k, user_id, created_at, s_blob) ` +
 		`VALUES (?, ?, ?, ?)`
 
 	// Success Create Expectations
@@ -597,7 +597,7 @@ func TestSessionSave(t *testing.T) {
 
 	// Queries
 	sqlUpdate := `UPDATE sessions ` +
-		`SET user_ID = ?, created_at = ?, s_blob = ? ` +
+		`SET user_id = ?, created_at = ?, s_blob = ? ` +
 		`WHERE k = ?`
 
 	// Success Update Expectations
@@ -798,7 +798,7 @@ func TestSessionsDeleteByUserID(t *testing.T) {
 		AddRow(eb)
 
 	// Queries
-	sql := `DELETE FROM sessions WHERE user_ID = ?`
+	sql := `DELETE FROM sessions WHERE user_id = ?`
 
 	// Success Expectations
 	mock.ExpectExec(regexp.QuoteMeta(sql)).

--- a/politeiawww/user/mysql/mysql_test.go
+++ b/politeiawww/user/mysql/mysql_test.go
@@ -120,7 +120,7 @@ func TestUserNew(t *testing.T) {
 	// Queries
 	sqlSelectIndex := `SELECT v FROM key_value WHERE k = ?`
 	sqlInsertUser := `INSERT INTO users ` +
-		`(ID, username, u_blob, created_at) ` +
+		`(id, username, u_blob, created_at) ` +
 		`VALUES (?, ?, ?, ?)`
 	sqlUpsertIndex := `INSERT INTO key_value (k,v)
     VALUES (?, ?)
@@ -199,7 +199,7 @@ func TestUserUpdate(t *testing.T) {
 	// Update user query
 	uq := `UPDATE users ` +
 		`SET username = ?, u_blob = ?, updated_at = ? ` +
-		`WHERE ID = ?`
+		`WHERE id = ?`
 
 	// Success Expectations
 	mock.ExpectBegin()
@@ -305,7 +305,7 @@ func TestUserGetById(t *testing.T) {
 	}).AddRow(blob)
 
 	// Query
-	sql := `SELECT u_blob FROM users WHERE ID = ?`
+	sql := `SELECT u_blob FROM users WHERE id = ?`
 
 	// Success Expectations
 	mock.ExpectQuery(regexp.QuoteMeta(sql)).
@@ -369,7 +369,7 @@ func TestUserGetByPubKey(t *testing.T) {
 
 	// Query
 	sql := `SELECT u_blob FROM users ` +
-		`INNER JOIN identities ON users.ID = identities.user_id ` +
+		`INNER JOIN identities ON users.id = identities.user_id ` +
 		`WHERE identities.public_key = ?`
 
 	// Success Expectations
@@ -435,7 +435,7 @@ func TestUsersGetByPubKey(t *testing.T) {
 
 	// Query
 	sql := `SELECT u_blob FROM users ` +
-		`INNER JOIN identities ON users.ID = identities.user_id ` +
+		`INNER JOIN identities ON users.id = identities.user_id ` +
 		`WHERE identities.public_key IN (?)`
 
 	// Success Expectations


### PR DESCRIPTION
This diff migrates the user mysql database columns to follow the 
snake case naming convention - `this_is_a_example`.

Closes #1457.