### PR TITLE
comments: Sort votes by timestamp.

### DIFF
--- a/politeiawww/comments/process.go
+++ b/politeiawww/comments/process.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	pdv2 "github.com/decred/politeia/politeiad/api/v2"
 	"github.com/decred/politeia/politeiad/plugins/comments"
@@ -320,6 +321,10 @@ func (c *Comments) processVotes(ctx context.Context, v v1.Votes) (*v1.VotesReply
 		return nil, err
 	}
 	commentVotePopulateUserData(cv, *u)
+
+	// Sort comment votes by timestamp.
+	sort.Slice(cv,
+		func(i, j int) bool { return cv[i].Timestamp > cv[j].Timestamp })
 
 	return &v1.VotesReply{
 		Votes: cv,

--- a/politeiawww/comments/process.go
+++ b/politeiawww/comments/process.go
@@ -322,9 +322,10 @@ func (c *Comments) processVotes(ctx context.Context, v v1.Votes) (*v1.VotesReply
 	}
 	commentVotePopulateUserData(cv, *u)
 
-	// Sort comment votes by timestamp.
-	sort.Slice(cv,
-		func(i, j int) bool { return cv[i].Timestamp > cv[j].Timestamp })
+	// Sort comment votes by timestamp from newest to oldest.
+	sort.SliceStable(cv, func(i, j int) bool {
+		return cv[i].Timestamp > cv[j].Timestamp
+	})
 
 	return &v1.VotesReply{
 		Votes: cv,


### PR DESCRIPTION
This commit sorts the comment votes list by timestamp prior
to returning them.

Closes #1454.