### PR TITLE
multi: Handle duplicate payload error gracefully upon saving blobs

### DIFF
--- a/politeiad/api/v2/v2.go
+++ b/politeiad/api/v2/v2.go
@@ -54,6 +54,7 @@ const (
 	ErrorCodeRecordStateInvalid      ErrorCodeT = 20
 	ErrorCodeRecordStatusInvalid     ErrorCodeT = 21
 	ErrorCodeLast                    ErrorCodeT = 22
+	ErrorCodeDuplicateBlob           ErrorCodeT = 23
 )
 
 var (
@@ -81,6 +82,7 @@ var (
 		ErrorCodePageSizeExceeded:        "page size exceeded",
 		ErrorCodeRecordStateInvalid:      "record state invalid",
 		ErrorCodeRecordStatusInvalid:     "record status invalid",
+		ErrorCodeDuplicateBlob:           "duplicate blob payload",
 	}
 )
 

--- a/politeiad/api/v2/v2.go
+++ b/politeiad/api/v2/v2.go
@@ -53,7 +53,7 @@ const (
 	ErrorCodePageSizeExceeded        ErrorCodeT = 19
 	ErrorCodeRecordStateInvalid      ErrorCodeT = 20
 	ErrorCodeRecordStatusInvalid     ErrorCodeT = 21
-	ErrorCodeDuplicateBlob           ErrorCodeT = 22
+	ErrorCodeDuplicatePayload        ErrorCodeT = 22
 	ErrorCodeLast                    ErrorCodeT = 23
 )
 
@@ -82,7 +82,7 @@ var (
 		ErrorCodePageSizeExceeded:        "page size exceeded",
 		ErrorCodeRecordStateInvalid:      "record state invalid",
 		ErrorCodeRecordStatusInvalid:     "record status invalid",
-		ErrorCodeDuplicateBlob:           "duplicate blob payload",
+		ErrorCodeDuplicatePayload:        "duplicate payload",
 	}
 )
 

--- a/politeiad/api/v2/v2.go
+++ b/politeiad/api/v2/v2.go
@@ -53,8 +53,14 @@ const (
 	ErrorCodePageSizeExceeded        ErrorCodeT = 19
 	ErrorCodeRecordStateInvalid      ErrorCodeT = 20
 	ErrorCodeRecordStatusInvalid     ErrorCodeT = 21
-	ErrorCodeDuplicatePayload        ErrorCodeT = 22
-	ErrorCodeLast                    ErrorCodeT = 23
+
+	// ErrorCodeDuplicatePayload is returned when a duplicate payload is sent
+	// to a plugin, where it tries to write data that already exists. Timestamp
+	// data relies on the hash of the payload, therefore duplicate payloads
+	// are not allowed since they will cause collisions.
+	ErrorCodeDuplicatePayload ErrorCodeT = 22
+
+	ErrorCodeLast ErrorCodeT = 23
 )
 
 var (

--- a/politeiad/api/v2/v2.go
+++ b/politeiad/api/v2/v2.go
@@ -56,8 +56,8 @@ const (
 
 	// ErrorCodeDuplicatePayload is returned when a duplicate payload is sent
 	// to a plugin, where it tries to write data that already exists. Timestamp
-	// data relies on the hash of the payload, therefore duplicate payloads
-	// are not allowed since they will cause collisions.
+	// data relies on the hash of the payload, therefore duplicate payloads are
+	// not allowed since they will cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 22
 
 	ErrorCodeLast ErrorCodeT = 23

--- a/politeiad/api/v2/v2.go
+++ b/politeiad/api/v2/v2.go
@@ -53,8 +53,8 @@ const (
 	ErrorCodePageSizeExceeded        ErrorCodeT = 19
 	ErrorCodeRecordStateInvalid      ErrorCodeT = 20
 	ErrorCodeRecordStatusInvalid     ErrorCodeT = 21
-	ErrorCodeLast                    ErrorCodeT = 22
-	ErrorCodeDuplicateBlob           ErrorCodeT = 23
+	ErrorCodeDuplicateBlob           ErrorCodeT = 22
+	ErrorCodeLast                    ErrorCodeT = 23
 )
 
 var (

--- a/politeiad/backendv2/backendv2.go
+++ b/politeiad/backendv2/backendv2.go
@@ -37,7 +37,9 @@ var (
 	ErrPluginCmdInvalid = errors.New("plugin command invalid")
 
 	// ErrDuplicatePayload is returned when a duplicate payload is sent to
-	// a plugin, where it tries to write data that already exists.
+	// a plugin, where it tries to write data that already exists. Timestamp
+	// data relies on the hash of the payload, therefore duplicate payloads
+	// are not allowed since they will cause collisions.
 	ErrDuplicatePayload = errors.New("duplicate payload")
 )
 

--- a/politeiad/backendv2/backendv2.go
+++ b/politeiad/backendv2/backendv2.go
@@ -35,6 +35,10 @@ var (
 	// ErrPluginCmdInvalid is returned when a invalid plugin command is
 	// used.
 	ErrPluginCmdInvalid = errors.New("plugin command invalid")
+
+	// ErrDuplicatePayload is returned when a duplicate payload is sent to
+	// a plugin, where it tries to write data that already exists.
+	ErrDuplicatePayload = errors.New("duplicate payload")
 )
 
 // StateT represents the state of a record.

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -509,7 +509,7 @@ func (p *commentsPlugin) cmdNew(token []byte, payload string) (string, error) {
 	// Save comment
 	digest, err := p.commentAddSave(token, ca)
 	if err != nil {
-		return "", fmt.Errorf("commentAddSave: %v", err)
+		return "", err
 	}
 
 	// Update the index
@@ -657,7 +657,7 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	// Save comment
 	digest, err := p.commentAddSave(token, ca)
 	if err != nil {
-		return "", fmt.Errorf("commentAddSave: %v", err)
+		return "", err
 	}
 
 	// Update the index
@@ -760,7 +760,7 @@ func (p *commentsPlugin) cmdDel(token []byte, payload string) (string, error) {
 	// Save comment del
 	digest, err := p.commentDelSave(token, cd)
 	if err != nil {
-		return "", fmt.Errorf("commentDelSave: %v", err)
+		return "", err
 	}
 
 	// Update the index
@@ -913,7 +913,7 @@ func (p *commentsPlugin) cmdVote(token []byte, payload string) (string, error) {
 	// Save comment vote
 	digest, err := p.commentVoteSave(token, cv)
 	if err != nil {
-		return "", fmt.Errorf("commentVoteSave: %v", err)
+		return "", err
 	}
 
 	// Add vote to the comment index

--- a/politeiad/backendv2/tstorebe/plugins/plugins.go
+++ b/politeiad/backendv2/tstorebe/plugins/plugins.go
@@ -5,16 +5,8 @@
 package plugins
 
 import (
-	"errors"
-
 	backend "github.com/decred/politeia/politeiad/backendv2"
 	"github.com/decred/politeia/politeiad/backendv2/tstorebe/store"
-)
-
-var (
-	// ErrDuplicateBlob is returned when a plugin attempts to save a
-	// blob whose contents are an exact duplicate of an existing blob.
-	ErrDuplicateBlob = errors.New("duplicate blob")
 )
 
 // HookT represents a plugin hook.

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/v3"
 	backend "github.com/decred/politeia/politeiad/backendv2"
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/plugins"
 	"github.com/decred/politeia/politeiad/backendv2/tstorebe/store"
 	"github.com/decred/politeia/politeiad/plugins/dcrdata"
 	"github.com/decred/politeia/politeiad/plugins/ticketvote"
@@ -1335,7 +1334,7 @@ func (p *ticketVotePlugin) ballot(token []byte, votes []ticketvote.CastVote, br 
 
 			// Save cast vote details
 			err = p.castVoteDetailsSave(token, cvd)
-			if err == plugins.ErrDuplicateBlob {
+			if errors.Is(err, backend.ErrDuplicatePayload) {
 				// This cast vote has already been saved. Its
 				// possible that a previous attempt to vote
 				// with this ticket failed before the vote

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -543,7 +543,7 @@ func (p *ticketVotePlugin) startStandard(token []byte, s ticketvote.Start) (*tic
 	// Save vote details
 	err = p.voteDetailsSave(token, vd)
 	if err != nil {
-		return nil, fmt.Errorf("voteDetailsSave: %v", err)
+		return nil, err
 	}
 
 	// Update inventory
@@ -854,8 +854,7 @@ func (p *ticketVotePlugin) startRunoffForParent(token []byte, s ticketvote.Start
 	// Save start runoff record
 	err = p.startRunoffRecordSave(token, *srr)
 	if err != nil {
-		return nil, fmt.Errorf("startRunoffRecordSave %x: %v",
-			token, err)
+		return nil, err
 	}
 
 	return srr, nil

--- a/politeiad/backendv2/tstorebe/tstore/blobclient.go
+++ b/politeiad/backendv2/tstorebe/tstore/blobclient.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	backend "github.com/decred/politeia/politeiad/backendv2"
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/plugins"
 	"github.com/decred/politeia/politeiad/backendv2/tstorebe/store"
 	"github.com/google/trillian"
 	"google.golang.org/grpc/codes"
@@ -109,7 +108,7 @@ func (t *Tstore) BlobSave(token []byte, be store.BlobEntry) error {
 	case codes.OK:
 		// This is ok; continue
 	case codes.AlreadyExists:
-		return plugins.ErrDuplicateBlob
+		return backend.ErrDuplicatePayload
 	default:
 		return fmt.Errorf("queued leaf error: %v", c)
 	}

--- a/politeiad/v2.go
+++ b/politeiad/v2.go
@@ -14,7 +14,6 @@ import (
 
 	v2 "github.com/decred/politeia/politeiad/api/v2"
 	"github.com/decred/politeia/politeiad/backendv2"
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/plugins"
 	"github.com/decred/politeia/util"
 )
 
@@ -508,10 +507,10 @@ func (p *politeia) handlePluginWrite(w http.ResponseWriter, r *http.Request) {
 		pw.Cmd.Command, pw.Cmd.Payload)
 	if err != nil {
 		switch {
-		case errors.Is(err, plugins.ErrDuplicateBlob):
+		case errors.Is(err, backendv2.ErrDuplicatePayload):
 			respondWithErrorV2(w, r, "handlePluginWrite: PluginWrite: %v",
 				v2.UserErrorReply{
-					ErrorCode: v2.ErrorCodeDuplicateBlob,
+					ErrorCode: v2.ErrorCodeDuplicatePayload,
 				})
 			return
 		default:

--- a/politeiad/v2.go
+++ b/politeiad/v2.go
@@ -509,7 +509,6 @@ func (p *politeia) handlePluginWrite(w http.ResponseWriter, r *http.Request) {
 		respondWithErrorV2(w, r,
 			"handlePluginWrite: PluginWrite: %v", err)
 		return
-
 	}
 
 	// Prepare reply

--- a/politeiad/v2.go
+++ b/politeiad/v2.go
@@ -506,18 +506,10 @@ func (p *politeia) handlePluginWrite(w http.ResponseWriter, r *http.Request) {
 	payload, err := p.backendv2.PluginWrite(token, pw.Cmd.ID,
 		pw.Cmd.Command, pw.Cmd.Payload)
 	if err != nil {
-		switch {
-		case errors.Is(err, backendv2.ErrDuplicatePayload):
-			respondWithErrorV2(w, r, "handlePluginWrite: PluginWrite: %v",
-				v2.UserErrorReply{
-					ErrorCode: v2.ErrorCodeDuplicatePayload,
-				})
-			return
-		default:
-			respondWithErrorV2(w, r,
-				"handlePluginWrite: PluginWrite: %v", err)
-			return
-		}
+		respondWithErrorV2(w, r,
+			"handlePluginWrite: PluginWrite: %v", err)
+		return
+
 	}
 
 	// Prepare reply
@@ -971,6 +963,8 @@ func convertErrorToV2(e error) v2.ErrorCodeT {
 		return v2.ErrorCodePluginIDInvalid
 	case backendv2.ErrPluginCmdInvalid:
 		return v2.ErrorCodePluginCmdInvalid
+	case backendv2.ErrDuplicatePayload:
+		return v2.ErrorCodeDuplicatePayload
 	}
 	return v2.ErrorCodeInvalid
 }

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -36,6 +36,7 @@ const (
 	ErrorCodeRecordLocked       ErrorCodeT = 8
 	ErrorCodePageSizeExceeded   ErrorCodeT = 9
 	ErrorCodeLast               ErrorCodeT = 10
+	ErrorCodeDuplicateBlob      ErrorCodeT = 11
 )
 
 var (
@@ -51,6 +52,7 @@ var (
 		ErrorCodeRecordNotFound:     "record not found",
 		ErrorCodeRecordLocked:       "record is locked",
 		ErrorCodePageSizeExceeded:   "page size exceeded",
+		ErrorCodeDuplicateBlob:      "duplicate blob payload",
 	}
 )
 

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -35,8 +35,8 @@ const (
 	ErrorCodeRecordNotFound     ErrorCodeT = 7
 	ErrorCodeRecordLocked       ErrorCodeT = 8
 	ErrorCodePageSizeExceeded   ErrorCodeT = 9
-	ErrorCodeLast               ErrorCodeT = 10
-	ErrorCodeDuplicateBlob      ErrorCodeT = 11
+	ErrorCodeDuplicateBlob      ErrorCodeT = 10
+	ErrorCodeLast               ErrorCodeT = 11
 )
 
 var (

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -38,7 +38,9 @@ const (
 
 	// ErrorCodeDuplicatePayload is returned when a user tries to submit a
 	// duplicate payload for the comments plugin, where it tries to write
-	// data that already exists.
+	// data that already exists. Timestamp data relies on the hash of the
+	// payload, therefore duplicate payloads are not allowed since they will
+	// cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 10
 
 	ErrorCodeLast ErrorCodeT = 11

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -35,8 +35,13 @@ const (
 	ErrorCodeRecordNotFound     ErrorCodeT = 7
 	ErrorCodeRecordLocked       ErrorCodeT = 8
 	ErrorCodePageSizeExceeded   ErrorCodeT = 9
-	ErrorCodeDuplicatePayload   ErrorCodeT = 10
-	ErrorCodeLast               ErrorCodeT = 11
+
+	// ErrorCodeDuplicatePayload is returned when a user tries to submit a
+	// duplicate payload for the comments plugin, where it tries to write
+	// data that already exists.
+	ErrorCodeDuplicatePayload ErrorCodeT = 10
+
+	ErrorCodeLast ErrorCodeT = 11
 )
 
 var (

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -35,7 +35,7 @@ const (
 	ErrorCodeRecordNotFound     ErrorCodeT = 7
 	ErrorCodeRecordLocked       ErrorCodeT = 8
 	ErrorCodePageSizeExceeded   ErrorCodeT = 9
-	ErrorCodeDuplicateBlob      ErrorCodeT = 10
+	ErrorCodeDuplicatePayload   ErrorCodeT = 10
 	ErrorCodeLast               ErrorCodeT = 11
 )
 
@@ -52,7 +52,7 @@ var (
 		ErrorCodeRecordNotFound:     "record not found",
 		ErrorCodeRecordLocked:       "record is locked",
 		ErrorCodePageSizeExceeded:   "page size exceeded",
-		ErrorCodeDuplicateBlob:      "duplicate blob payload",
+		ErrorCodeDuplicatePayload:   "duplicate payload",
 	}
 )
 

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -35,8 +35,8 @@ const (
 	ErrorCodeRecordLocked     ErrorCodeT = 5
 	ErrorCodeTokenInvalid     ErrorCodeT = 6
 	ErrorCodePageSizeExceeded ErrorCodeT = 7
-	ErrorCodeLast             ErrorCodeT = 8
-	ErrorCodeDuplicateBlob    ErrorCodeT = 9
+	ErrorCodeDuplicateBlob    ErrorCodeT = 8
+	ErrorCodeLast             ErrorCodeT = 9
 )
 
 var (

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -36,6 +36,7 @@ const (
 	ErrorCodeTokenInvalid     ErrorCodeT = 6
 	ErrorCodePageSizeExceeded ErrorCodeT = 7
 	ErrorCodeLast             ErrorCodeT = 8
+	ErrorCodeDuplicateBlob    ErrorCodeT = 9
 )
 
 var (
@@ -49,6 +50,7 @@ var (
 		ErrorCodeRecordLocked:     "record locked",
 		ErrorCodeTokenInvalid:     "token is invalid",
 		ErrorCodePageSizeExceeded: "page size exceeded",
+		ErrorCodeDuplicateBlob:    "duplicate blob payload",
 	}
 )
 

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -35,8 +35,13 @@ const (
 	ErrorCodeRecordLocked     ErrorCodeT = 5
 	ErrorCodeTokenInvalid     ErrorCodeT = 6
 	ErrorCodePageSizeExceeded ErrorCodeT = 7
+
+	// ErrorCodeDuplicatePayload is returned when a user tries to submit a
+	// duplicate payload for the ticketvote plugin, where it tries to write
+	// data that already exists.
 	ErrorCodeDuplicatePayload ErrorCodeT = 8
-	ErrorCodeLast             ErrorCodeT = 9
+
+	ErrorCodeLast ErrorCodeT = 9
 )
 
 var (

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -35,7 +35,7 @@ const (
 	ErrorCodeRecordLocked     ErrorCodeT = 5
 	ErrorCodeTokenInvalid     ErrorCodeT = 6
 	ErrorCodePageSizeExceeded ErrorCodeT = 7
-	ErrorCodeDuplicateBlob    ErrorCodeT = 8
+	ErrorCodeDuplicatePayload ErrorCodeT = 8
 	ErrorCodeLast             ErrorCodeT = 9
 )
 
@@ -50,7 +50,7 @@ var (
 		ErrorCodeRecordLocked:     "record locked",
 		ErrorCodeTokenInvalid:     "token is invalid",
 		ErrorCodePageSizeExceeded: "page size exceeded",
-		ErrorCodeDuplicateBlob:    "duplicate blob payload",
+		ErrorCodeDuplicatePayload: "duplicate payload",
 	}
 )
 

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -38,7 +38,9 @@ const (
 
 	// ErrorCodeDuplicatePayload is returned when a user tries to submit a
 	// duplicate payload for the ticketvote plugin, where it tries to write
-	// data that already exists.
+	// data that already exists. Timestamp data relies on the hash of the
+	// payload, therefore duplicate payloads are not allowed since they will
+	// cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 8
 
 	ErrorCodeLast ErrorCodeT = 9

--- a/politeiawww/comments/error.go
+++ b/politeiawww/comments/error.go
@@ -68,60 +68,8 @@ func respondWithError(w http.ResponseWriter, r *http.Request, format string, err
 		return
 
 	case errors.As(err, &pde):
-		// Politeiad error
-		var (
-			pluginID   = pde.ErrorReply.PluginID
-			errCode    = pde.ErrorReply.ErrorCode
-			errContext = pde.ErrorReply.ErrorContext
-		)
-		e := convertPDErrorCode(errCode)
-		switch {
-		case pluginID != "":
-			// politeiad plugin error. Log it and return a 400.
-			m := fmt.Sprintf("%v Plugin error: %v %v",
-				util.RemoteAddr(r), pluginID, errCode)
-			if errContext != "" {
-				m += fmt.Sprintf(": %v", errContext)
-			}
-			log.Infof(m)
-			util.RespondWithJSON(w, http.StatusBadRequest,
-				v1.PluginErrorReply{
-					PluginID:     pluginID,
-					ErrorCode:    errCode,
-					ErrorContext: errContext,
-				})
-			return
-
-		case e == v1.ErrorCodeInvalid:
-			// politeiad error does not correspond to a user error. Log it
-			// and return a 500.
-			ts := time.Now().Unix()
-			log.Errorf("%v %v %v %v Internal error %v: error code "+
-				"from politeiad: %v", util.RemoteAddr(r), r.Method, r.URL,
-				r.Proto, ts, errCode)
-
-			util.RespondWithJSON(w, http.StatusInternalServerError,
-				v1.ServerErrorReply{
-					ErrorCode: ts,
-				})
-			return
-
-		default:
-			// User error from politeiad that corresponds to a comments
-			// user error. Log it and return a 400.
-			m := fmt.Sprintf("%v Records user error: %v %v",
-				util.RemoteAddr(r), e, v1.ErrorCodes[e])
-			if errContext != "" {
-				m += fmt.Sprintf(": %v", errContext)
-			}
-			log.Infof(m)
-			util.RespondWithJSON(w, http.StatusBadRequest,
-				v1.UserErrorReply{
-					ErrorCode:    e,
-					ErrorContext: errContext,
-				})
-			return
-		}
+		// Politeiad user error
+		handlePDError(w, r, format, pde)
 
 	default:
 		// Internal server error. Log it and return a 500.
@@ -148,6 +96,61 @@ func respondWithError(w http.ResponseWriter, r *http.Request, format string, err
 	}
 }
 
+func handlePDError(w http.ResponseWriter, r *http.Request, format string, pde pdclient.RespError) {
+	var (
+		pluginID   = pde.ErrorReply.PluginID
+		errCode    = pde.ErrorReply.ErrorCode
+		errContext = pde.ErrorReply.ErrorContext
+	)
+	e := convertPDErrorCode(errCode)
+	switch {
+	case pluginID != "":
+		// politeiad plugin error. Log it and return a 400.
+		m := fmt.Sprintf("%v Plugin error: %v %v",
+			util.RemoteAddr(r), pluginID, errCode)
+		if errContext != "" {
+			m += fmt.Sprintf(": %v", errContext)
+		}
+		log.Infof(m)
+		util.RespondWithJSON(w, http.StatusBadRequest,
+			v1.PluginErrorReply{
+				PluginID:     pluginID,
+				ErrorCode:    errCode,
+				ErrorContext: errContext,
+			})
+		return
+
+	case e != v1.ErrorCodeInvalid:
+		// User error from politeiad that corresponds to a comments
+		// user error. Log it and return a 400.
+		m := fmt.Sprintf("%v Comments user error: %v %v",
+			util.RemoteAddr(r), e, v1.ErrorCodes[e])
+		if errContext != "" {
+			m += fmt.Sprintf(": %v", errContext)
+		}
+		log.Infof(m)
+		util.RespondWithJSON(w, http.StatusBadRequest,
+			v1.UserErrorReply{
+				ErrorCode:    e,
+				ErrorContext: errContext,
+			})
+		return
+	default:
+		// politeiad error does not correspond to a user error. Log it
+		// and return a 500.
+		ts := time.Now().Unix()
+		log.Errorf("%v %v %v %v Internal error %v: error code "+
+			"from politeiad: %v", util.RemoteAddr(r), r.Method, r.URL,
+			r.Proto, ts, errCode)
+
+		util.RespondWithJSON(w, http.StatusInternalServerError,
+			v1.ServerErrorReply{
+				ErrorCode: ts,
+			})
+		return
+	}
+}
+
 func convertPDErrorCode(errCode uint32) v1.ErrorCodeT {
 	// These are the only politeiad user errors that the comments
 	// API expects to encounter.
@@ -158,6 +161,8 @@ func convertPDErrorCode(errCode uint32) v1.ErrorCodeT {
 		return v1.ErrorCodeRecordNotFound
 	case pdv2.ErrorCodeRecordLocked:
 		return v1.ErrorCodeRecordLocked
+	case pdv2.ErrorCodeDuplicateBlob:
+		return v1.ErrorCodeDuplicateBlob
 	}
 	return v1.ErrorCodeInvalid
 }

--- a/politeiawww/comments/error.go
+++ b/politeiawww/comments/error.go
@@ -161,8 +161,8 @@ func convertPDErrorCode(errCode uint32) v1.ErrorCodeT {
 		return v1.ErrorCodeRecordNotFound
 	case pdv2.ErrorCodeRecordLocked:
 		return v1.ErrorCodeRecordLocked
-	case pdv2.ErrorCodeDuplicateBlob:
-		return v1.ErrorCodeDuplicateBlob
+	case pdv2.ErrorCodeDuplicatePayload:
+		return v1.ErrorCodeDuplicatePayload
 	}
 	return v1.ErrorCodeInvalid
 }

--- a/politeiawww/ticketvote/error.go
+++ b/politeiawww/ticketvote/error.go
@@ -146,8 +146,8 @@ func convertPDErrorCode(errCode uint32) v1.ErrorCodeT {
 		return v1.ErrorCodeTokenInvalid
 	case pdv2.ErrorCodeRecordLocked:
 		return v1.ErrorCodeRecordLocked
-	case pdv2.ErrorCodeDuplicateBlob:
-		return v1.ErrorCodeDuplicateBlob
+	case pdv2.ErrorCodeDuplicatePayload:
+		return v1.ErrorCodeDuplicatePayload
 	}
 	return v1.ErrorCodeInvalid
 }

--- a/politeiawww/ticketvote/error.go
+++ b/politeiawww/ticketvote/error.go
@@ -146,6 +146,8 @@ func convertPDErrorCode(errCode uint32) v1.ErrorCodeT {
 		return v1.ErrorCodeTokenInvalid
 	case pdv2.ErrorCodeRecordLocked:
 		return v1.ErrorCodeRecordLocked
+	case pdv2.ErrorCodeDuplicateBlob:
+		return v1.ErrorCodeDuplicateBlob
 	}
 	return v1.ErrorCodeInvalid
 }


### PR DESCRIPTION
This diff redefines the `plugins.ErrDuplicateBlob` error on the backend as `backend.ErrDuplicatePayload`, since we now key-off this error on the API layer. Now it handles gracefully this error that may arise when calling the `BlobSave` function with a duplicate payload. It also refactors `politeiawww/comments/error.go` to match the standard of other plugins when dealing with politeiad user errors.

Closes #1455 