### PR TITLE
cms: Fix DCC support/oppose id update

### DIFF
--- a/politeiawww/convert.go
+++ b/politeiawww/convert.go
@@ -1338,13 +1338,17 @@ func convertDCCDatabaseToRecord(dbDCC *cmsdatabase.DCC) cms.DCCRecord {
 	supportUserIDs := strings.Split(dbDCC.SupportUserIDs, ",")
 	cleanedSupport := make([]string, 0, len(supportUserIDs))
 	for _, support := range supportUserIDs {
-		cleanedSupport = append(cleanedSupport, strings.TrimSpace(support))
+		if len(support) > 0 {
+			cleanedSupport = append(cleanedSupport, strings.TrimSpace(support))
+		}
 	}
 	dccRecord.SupportUserIDs = cleanedSupport
 	oppositionUserIDs := strings.Split(dbDCC.OppositionUserIDs, ",")
 	cleanedOpposed := make([]string, 0, len(oppositionUserIDs))
 	for _, oppose := range oppositionUserIDs {
-		cleanedOpposed = append(cleanedOpposed, strings.TrimSpace(oppose))
+		if len(oppose) > 0 {
+			cleanedOpposed = append(cleanedOpposed, strings.TrimSpace(oppose))
+		}
 	}
 	dccRecord.OppositionUserIDs = cleanedOpposed
 

--- a/politeiawww/dcc.go
+++ b/politeiawww/dcc.go
@@ -29,6 +29,7 @@ import (
 	"github.com/decred/politeia/politeiawww/user"
 	wwwutil "github.com/decred/politeia/politeiawww/util"
 	"github.com/decred/politeia/util"
+	"github.com/google/uuid"
 )
 
 const (
@@ -445,10 +446,14 @@ func (p *politeiawww) getDCC(token string) (*cms.DCCRecord, error) {
 	opposeUsernames := make([]string, 0, len(i.OppositionUserIDs))
 	for _, v := range i.SupportUserIDs {
 		// Fill in userID and username fields
-		u, err := p.db.UserGetByPubKey(v)
+		vid, err := uuid.Parse(v)
 		if err != nil {
-			log.Errorf("getDCC: getUserByPubKey: token:%v "+
-				"pubKey:%v err:%v", token, v, err)
+			continue
+		}
+		u, err := p.db.UserGetById(vid)
+		if err != nil {
+			log.Errorf("getDCC support: UserGetById: token: %v "+
+				"id: %v err: %v", token, v, err)
 		} else {
 			supportUserIDs = append(supportUserIDs, u.ID.String())
 			supportUsernames = append(supportUsernames, u.Username)
@@ -456,10 +461,14 @@ func (p *politeiawww) getDCC(token string) (*cms.DCCRecord, error) {
 	}
 	for _, v := range i.OppositionUserIDs {
 		// Fill in userID and username fields
-		u, err := p.db.UserGetByPubKey(v)
+		vid, err := uuid.Parse(v)
 		if err != nil {
-			log.Errorf("getDCC: getUserByPubKey: token:%v "+
-				"pubKey:%v err:%v", token, v, err)
+			continue
+		}
+		u, err := p.db.UserGetById(vid)
+		if err != nil {
+			log.Errorf("getDCC oppose: UserGetById: token: %v "+
+				"id: %v err: %v", token, v, err)
 		} else {
 			opposeUserIDs = append(opposeUserIDs, u.ID.String())
 			opposeUsernames = append(opposeUsernames, u.Username)
@@ -677,9 +686,9 @@ func (p *politeiawww) processSupportOpposeDCC(ctx context.Context, sd cms.Suppor
 	}
 
 	if sd.Vote == supportString {
-		dcc.SupportUserIDs = append(dcc.SupportUserIDs, sd.PublicKey)
+		dcc.SupportUserIDs = append(dcc.SupportUserIDs, u.ID.String())
 	} else if sd.Vote == opposeString {
-		dcc.OppositionUserIDs = append(dcc.OppositionUserIDs, sd.PublicKey)
+		dcc.OppositionUserIDs = append(dcc.OppositionUserIDs, u.ID.String())
 	}
 	dbDcc := convertDCCDatabaseFromDCCRecord(*dcc)
 	if err != nil {


### PR DESCRIPTION
Previously there was intermingling of pubkeys and userIDs which was causing errors.  This now properly updates the cmsdatabase entries with the user ids of any support or opposition.