### PR TITLE
politeiawww: Change `password changed` email title.

### DIFF
--- a/politeiawww/email.go
+++ b/politeiawww/email.go
@@ -164,7 +164,7 @@ func (p *politeiawww) emailUserPasswordChanged(username string, recipient map[uu
 		Username: username,
 	}
 
-	subject := "Password Changed - Security Verification"
+	subject := "Password Changed - Security Notification"
 	body, err := createBody(userPasswordChangedTmpl, tplData)
 	if err != nil {
 		return err


### PR DESCRIPTION
This diff changes the password changed email title 
from `Password Changed - Security Verification` 
to `Password Changed - Security Notification`.

Closes #1465.