### PR TITLE
multi: Fix set status json typo.

### DIFF
--- a/politeiad/plugins/usermd/usermd.go
+++ b/politeiad/plugins/usermd/usermd.go
@@ -107,7 +107,7 @@ type StatusChangeMetadata struct {
 	Token     string `json:"token"`
 	Version   uint32 `json:"version"`
 	Status    uint32 `json:"status"`
-	Reason    string `json:"message,omitempty"`
+	Reason    string `json:"reason,omitempty"`
 	PublicKey string `json:"publickey"`
 	Signature string `json:"signature"`
 	Timestamp int64  `json:"timestamp"`

--- a/politeiawww/api/records/v1/v1.go
+++ b/politeiawww/api/records/v1/v1.go
@@ -248,7 +248,7 @@ type StatusChange struct {
 	Token     string        `json:"token"`
 	Version   uint32        `json:"version"`
 	Status    RecordStatusT `json:"status"`
-	Reason    string        `json:"message,omitempty"`
+	Reason    string        `json:"reason,omitempty"`
 	PublicKey string        `json:"publickey"`
 	Signature string        `json:"signature"`
 	Timestamp int64         `json:"timestamp"`


### PR DESCRIPTION
This diff fixes a typo in in the JSON of the `Reason` field of a record
status change. This changes the structure that is saved to disk, but the
status change reason is only required when censoring or abandoning
proposals and no proposals have been censored or abandoned yet since the
launch of the new politeia site. We can still fix this before it becomes
a permanent bug.