### PR TITLE
multi: Document exported names.

### DIFF
--- a/politeiad/api/v2/v2.go
+++ b/politeiad/api/v2/v2.go
@@ -125,8 +125,8 @@ const (
 	// does not match the record state.
 	ErrorCodeRecordStateInvalid ErrorCodeT = 20
 
-	// ErrorCodeRecordStatusInvalid is returned when a ticketvote write
-	// command is executed on a record that is not public.
+	// ErrorCodeRecordStatusInvalid is returned when a record status is
+	// invalid.
 	ErrorCodeRecordStatusInvalid ErrorCodeT = 21
 
 	// ErrorCodeDuplicatePayload is returned when a duplicate payload is sent
@@ -135,7 +135,9 @@ const (
 	// not allowed since they will cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 22
 
-	// ErrorCodeLast unit test only.
+	// ErrorCodeLast is used by unit tests to verify that all error codes have
+	// a human readable entry in the ErrorCodes map. This error will never be
+	// returned.
 	ErrorCodeLast ErrorCodeT = 23
 )
 

--- a/politeiad/api/v2/v2.go
+++ b/politeiad/api/v2/v2.go
@@ -10,18 +10,41 @@ const (
 	// APIRoute is prefixed onto all routes in this package.
 	APIRoute = "/v2"
 
-	// Routes
-	RouteRecordNew          = "/recordnew"
-	RouteRecordEdit         = "/recordedit"
+	// RouteRecordNew creates a new record.
+	RouteRecordNew = "/recordnew"
+
+	// RouteRecordEdit edits a record.
+	RouteRecordEdit = "/recordedit"
+
+	// RouteRecordEditMetadata edits record's metadata.
 	RouteRecordEditMetadata = "/recordeditmetadata"
-	RouteRecordSetStatus    = "/recordsetstatus"
-	RouteRecordTimestamps   = "/recordtimestamps"
-	RouteRecords            = "/records"
-	RouteInventory          = "/inventory"
-	RouteInventoryOrdered   = "/inventoryordered"
-	RoutePluginWrite        = "/pluginwrite"
-	RoutePluginReads        = "/pluginreads"
-	RoutePluginInventory    = "/plugininventory"
+
+	// RouteRecordSetStatus sets the status of a record.
+	RouteRecordSetStatus = "/recordsetstatus"
+
+	// RouteRecordTimestamps returns the record timestamps.
+	RouteRecordTimestamps = "/recordtimestamps"
+
+	// RouteRecords retrieves a page of records.
+	RouteRecords = "/records"
+
+	// RouteInventory returns the tokens of records in the inventory
+	// categorized by record state and record status.
+	RouteInventory = "/inventory"
+
+	// RouteInventoryOrdered returns a page of record tokens ordered by the
+	// timestamp of their most recent status change from newest to
+	// oldest. The returned tokens will include all record statuses.
+	RouteInventoryOrdered = "/inventoryordered"
+
+	// RoutePluginWrite executes a plugin command that writes data.
+	RoutePluginWrite = "/pluginwrite"
+
+	// RoutePluginReads executes a read-only plugin command.
+	RoutePluginReads = "/pluginreads"
+
+	// RoutePluginInventory returns all registered plugins.
+	RoutePluginInventory = "/plugininventory"
 
 	// ChallengeSize is the size of a request challenge token in bytes.
 	ChallengeSize = 32
@@ -31,28 +54,80 @@ const (
 type ErrorCodeT uint32
 
 const (
-	ErrorCodeInvalid                 ErrorCodeT = 0
-	ErrorCodeRequestPayloadInvalid   ErrorCodeT = 1
-	ErrorCodeChallengeInvalid        ErrorCodeT = 2
-	ErrorCodeMetadataStreamInvalid   ErrorCodeT = 3
+	// ErrorCodeInvalid is an invalid error code.
+	ErrorCodeInvalid ErrorCodeT = 0
+
+	// ErrorCodeRequestPayloadInvalid is returned when a request's payload
+	// is invalid.
+	ErrorCodeRequestPayloadInvalid ErrorCodeT = 1
+
+	// ErrorCodeChallengeInvalid is returned when a challenge is invalid.
+	ErrorCodeChallengeInvalid ErrorCodeT = 2
+
+	// ErrorCodeMetadataStreamInvalid is returned when a metadata stream
+	// is invalid.
+	ErrorCodeMetadataStreamInvalid ErrorCodeT = 3
+
+	// ErrorCodeMetadataStreamDuplicate is returned when a metadata stream
+	// is a duplicate.
 	ErrorCodeMetadataStreamDuplicate ErrorCodeT = 4
-	ErrorCodeFilesEmpty              ErrorCodeT = 5
-	ErrorCodeFileNameInvalid         ErrorCodeT = 6
-	ErrorCodeFileNameDuplicate       ErrorCodeT = 7
-	ErrorCodeFileDigestInvalid       ErrorCodeT = 8
-	ErrorCodeFilePayloadInvalid      ErrorCodeT = 9
-	ErrorCodeFileMIMETypeInvalid     ErrorCodeT = 10
+
+	// ErrorCodeFilesEmpty is returned when no files found.
+	ErrorCodeFilesEmpty ErrorCodeT = 5
+
+	// ErrorCodeFileNameInvalid is returned when a file name is invalid.
+	ErrorCodeFileNameInvalid ErrorCodeT = 6
+
+	// ErrorCodeFileNameDuplicate is returned when a file name is a duplicate.
+	ErrorCodeFileNameDuplicate ErrorCodeT = 7
+
+	// ErrorCodeFileDigestInvalid is returned when a file digest is invalid.
+	ErrorCodeFileDigestInvalid ErrorCodeT = 8
+
+	// ErrorCodeFilePayloadInvalid is returned when a file payload is invalid.
+	ErrorCodeFilePayloadInvalid ErrorCodeT = 9
+
+	// ErrorCodeFileMIMETypeInvalid is returned when a file MIME type is
+	// invalid.
+	ErrorCodeFileMIMETypeInvalid ErrorCodeT = 10
+
+	// ErrorCodeFileMIMETypeUnsupported is returned when a file MIME type is
+	// unsupoorted.
 	ErrorCodeFileMIMETypeUnsupported ErrorCodeT = 11
-	ErrorCodeTokenInvalid            ErrorCodeT = 12
-	ErrorCodeRecordNotFound          ErrorCodeT = 13
-	ErrorCodeRecordLocked            ErrorCodeT = 14
-	ErrorCodeNoRecordChanges         ErrorCodeT = 15
-	ErrorCodeStatusChangeInvalid     ErrorCodeT = 16
-	ErrorCodePluginIDInvalid         ErrorCodeT = 17
-	ErrorCodePluginCmdInvalid        ErrorCodeT = 18
-	ErrorCodePageSizeExceeded        ErrorCodeT = 19
-	ErrorCodeRecordStateInvalid      ErrorCodeT = 20
-	ErrorCodeRecordStatusInvalid     ErrorCodeT = 21
+
+	// ErrorCodeTokenInvalid is returned when a token is invalid.
+	ErrorCodeTokenInvalid ErrorCodeT = 12
+
+	// ErrorCodeRecordNotFound is returned when a record is not found.
+	ErrorCodeRecordNotFound ErrorCodeT = 13
+
+	// ErrorCodeRecordLocked is returned when a record is locked.
+	ErrorCodeRecordLocked ErrorCodeT = 14
+
+	// ErrorCodeNoRecordChanges is retuned when no record changes found.
+	ErrorCodeNoRecordChanges ErrorCodeT = 15
+
+	// ErrorCodeStatusChangeInvalid is returned when a record status change
+	// is invalid.
+	ErrorCodeStatusChangeInvalid ErrorCodeT = 16
+
+	// ErrorCodePluginIDInvalid is returned when a plugin ID is invalid.
+	ErrorCodePluginIDInvalid ErrorCodeT = 17
+
+	// ErrorCodePluginCmdInvalid is returned when a plugin cmd is invalid.
+	ErrorCodePluginCmdInvalid ErrorCodeT = 18
+
+	// ErrorCodePageSizeExceeded is returned when the request's page size
+	// exceeds the maximum page size of the request.
+	ErrorCodePageSizeExceeded ErrorCodeT = 19
+
+	// ErrorCodeRecordStateInvalid is returned when the provided state
+	// does not match the record state.
+	ErrorCodeRecordStateInvalid ErrorCodeT = 20
+
+	// ErrorCodeRecordStatusInvalid is returned when a ticketvote write
+	// command is executed on a record that is not public.
+	ErrorCodeRecordStatusInvalid ErrorCodeT = 21
 
 	// ErrorCodeDuplicatePayload is returned when a duplicate payload is sent
 	// to a plugin, where it tries to write data that already exists. Timestamp
@@ -60,6 +135,7 @@ const (
 	// not allowed since they will cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 22
 
+	// ErrorCodeLast unit test only.
 	ErrorCodeLast ErrorCodeT = 23
 )
 

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -64,7 +64,7 @@ const (
 	// ErrorCodeTokenInvalid is returned when a token is invalid.
 	ErrorCodeTokenInvalid ErrorCodeT = 6
 
-	// ErrorCodeRecordNotFound is returned when no record was found.
+	// ErrorCodeRecordNotFound is returned when a record not found.
 	ErrorCodeRecordNotFound ErrorCodeT = 7
 
 	// ErrorCodeRecordLocked is returned when the roced is locked and

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -81,7 +81,9 @@ const (
 	// cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 10
 
-	// ErrorCodeLast unit test only.
+	// ErrorCodeLast is used by unit tests to verify that all error codes have
+	// a human readable entry in the ErrorCodes map. This error will never be
+	// returned.
 	ErrorCodeLast ErrorCodeT = 11
 )
 

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -67,8 +67,7 @@ const (
 	// ErrorCodeRecordNotFound is returned when a record not found.
 	ErrorCodeRecordNotFound ErrorCodeT = 7
 
-	// ErrorCodeRecordLocked is returned when the roced is locked and
-	// no writes can be made.
+	// ErrorCodeRecordLocked is returned when a record is locked.
 	ErrorCodeRecordLocked ErrorCodeT = 8
 
 	// ErrorCodePageSizeExceeded is returned when the request's page size

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -10,14 +10,28 @@ const (
 	// APIRoute is prefixed onto all routes defined in this package.
 	APIRoute = "/comments/v1"
 
-	// Routes
-	RoutePolicy     = "/policy"
-	RouteNew        = "/new"
-	RouteVote       = "/vote"
-	RouteDel        = "/del"
-	RouteCount      = "/count"
-	RouteComments   = "/comments"
-	RouteVotes      = "/votes"
+	// RoutePolicy returns the policy for the comments API.
+	RoutePolicy = "/policy"
+
+	// RouteNew adds a new comment.
+	RouteNew = "/new"
+
+	// RouteVote votes on a comment.
+	RouteVote = "/vote"
+
+	// RouteDel deletes a comment.
+	RouteDel = "/del"
+
+	// RouteCount returns the number of comment on a record.
+	RouteCount = "/count"
+
+	// RouteComments returns all comments on a record.
+	RouteComments = "/comments"
+
+	// RouteVotes returns all comment votes of a record.
+	RouteVotes = "/votes"
+
+	// RouteTimestamps returns the timestamps for the comments of a record.
 	RouteTimestamps = "/timestamps"
 )
 
@@ -25,16 +39,41 @@ const (
 type ErrorCodeT uint32
 
 const (
-	ErrorCodeInvalid            ErrorCodeT = 0
-	ErrorCodeInputInvalid       ErrorCodeT = 1
-	ErrorCodeUnauthorized       ErrorCodeT = 2
-	ErrorCodePublicKeyInvalid   ErrorCodeT = 3
-	ErrorCodeSignatureInvalid   ErrorCodeT = 4
+	// ErrorCodeInvalid is an invalid error code.
+	ErrorCodeInvalid ErrorCodeT = 0
+
+	// ErrorCodeInputInvalid is returned when there is an error
+	// while prasing a command payload.
+	ErrorCodeInputInvalid ErrorCodeT = 1
+
+	// ErrorCodeUnauthorized is returned when the user is not authorized.
+	ErrorCodeUnauthorized ErrorCodeT = 2
+
+	// ErrorCodePublicKeyInvalid is returned when a public key is
+	// invalid.
+	ErrorCodePublicKeyInvalid ErrorCodeT = 3
+
+	// ErrorCodeSignatureInvalid is returned when a signature is
+	// invalid.
+	ErrorCodeSignatureInvalid ErrorCodeT = 4
+
+	// ErrorCodeRecordStateInvalid is returned when the provided state
+	// does not match the record state.
 	ErrorCodeRecordStateInvalid ErrorCodeT = 5
-	ErrorCodeTokenInvalid       ErrorCodeT = 6
-	ErrorCodeRecordNotFound     ErrorCodeT = 7
-	ErrorCodeRecordLocked       ErrorCodeT = 8
-	ErrorCodePageSizeExceeded   ErrorCodeT = 9
+
+	// ErrorCodeTokenInvalid is returned when a token is invalid.
+	ErrorCodeTokenInvalid ErrorCodeT = 6
+
+	// ErrorCodeRecordNotFound is returned when no record was found.
+	ErrorCodeRecordNotFound ErrorCodeT = 7
+
+	// ErrorCodeRecordLocked is returned when the roced is locked and
+	// no writes can be made.
+	ErrorCodeRecordLocked ErrorCodeT = 8
+
+	// ErrorCodePageSizeExceeded is returned when the request's page size
+	// exceeds the maximum page size of the request.
+	ErrorCodePageSizeExceeded ErrorCodeT = 9
 
 	// ErrorCodeDuplicatePayload is returned when a user tries to submit a
 	// duplicate payload for the comments plugin, where it tries to write
@@ -43,6 +82,7 @@ const (
 	// cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 10
 
+	// ErrorCodeLast unit test only.
 	ErrorCodeLast ErrorCodeT = 11
 )
 

--- a/politeiawww/api/pi/v1/v1.go
+++ b/politeiawww/api/pi/v1/v1.go
@@ -39,7 +39,9 @@ const (
 	// ErrorCodeRecordNotFound is returned when no record was found.
 	ErrorCodeRecordNotFound ErrorCodeT = 4
 
-	// ErrorCodeLast unit test only
+	// ErrorCodeLast is used by unit tests to verify that all error codes have
+	// a human readable entry in the ErrorCodes map. This error will never be
+	// returned.
 	ErrorCodeLast ErrorCodeT = 5
 )
 

--- a/politeiawww/api/records/v1/v1.go
+++ b/politeiawww/api/records/v1/v1.go
@@ -10,17 +10,33 @@ const (
 	// APIRoute is prefixed onto all routes defined in this package.
 	APIRoute = "/records/v1"
 
-	// Record routes
-	RouteNew              = "/new"
-	RouteEdit             = "/edit"
-	RouteSetStatus        = "/setstatus"
-	RouteDetails          = "/details"
-	RouteTimestamps       = "/timestamps"
-	RouteRecords          = "/records"
-	RouteInventory        = "/inventory"
+	// RouteNew adds a new record.
+	RouteNew = "/new"
+
+	// RouteEdit edits a record.
+	RouteEdit = "/edit"
+
+	// RouteSetStatus sets the status of a record.
+	RouteSetStatus = "/setstatus"
+
+	// RouteDetails returns the details of a record.
+	RouteDetails = "/details"
+
+	// RouteTimestamps returns the timestamps of a record.
+	RouteTimestamps = "/timestamps"
+
+	// RouteRecords returns a batch of records.
+	RouteRecords = "/records"
+
+	// RouteInventory returns the tokens of the records in the inventory,
+	// categorized by record state and record status.
+	RouteInventory = "/inventory"
+
+	// RouteInventoryOrdered returns a page of record tokens ordered by the
+	// timestamp of their most recent status change from newest to oldest.
 	RouteInventoryOrdered = "/inventoryordered"
 
-	// Metadata routes
+	// RouteUserRecords returnes the tokens of all records submitted by a user.
 	RouteUserRecords = "/userrecords"
 )
 
@@ -28,29 +44,89 @@ const (
 type ErrorCodeT uint32
 
 const (
-	// Error codes
-	ErrorCodeInvalid                 ErrorCodeT = 0
-	ErrorCodeInputInvalid            ErrorCodeT = 1
-	ErrorCodeFilesEmpty              ErrorCodeT = 2
-	ErrorCodeFileNameInvalid         ErrorCodeT = 3
-	ErrorCodeFileNameDuplicate       ErrorCodeT = 4
-	ErrorCodeFileMIMETypeInvalid     ErrorCodeT = 5
+	// ErrorCodeInvalid is an invalid error code.
+	ErrorCodeInvalid ErrorCodeT = 0
+
+	// ErrorCodeInputInvalid is returned when there is an error
+	// while prasing a command payload.
+	ErrorCodeInputInvalid ErrorCodeT = 1
+
+	// ErrorCodeFilesEmpty is returned when record's files are
+	// empty.
+	ErrorCodeFilesEmpty ErrorCodeT = 2
+
+	// ErrorCodeFileNameInvalid is returned when a file name is
+	// invalid.
+	ErrorCodeFileNameInvalid ErrorCodeT = 3
+
+	// ErrorCodeFileNameDuplicate is returned when a file name is
+	// a duplicate.
+	ErrorCodeFileNameDuplicate ErrorCodeT = 4
+
+	// ErrorCodeFileMIMETypeInvalid is returned when a file MIME type
+	// is invalid.
+	ErrorCodeFileMIMETypeInvalid ErrorCodeT = 5
+
+	// ErrorCodeFileMIMETypeUnsupported is returned when a file MIME
+	// type is unsupported.
 	ErrorCodeFileMIMETypeUnsupported ErrorCodeT = 6
-	ErrorCodeFileDigestInvalid       ErrorCodeT = 7
-	ErrorCodeFilePayloadInvalid      ErrorCodeT = 8
+
+	// ErrorCodeFileDigestInvalid is returned when an invalid file
+	// digest found.
+	ErrorCodeFileDigestInvalid ErrorCodeT = 7
+
+	// ErrorCodeFilePayloadInvalid is returned when an invalid file
+	// payload found.
+	ErrorCodeFilePayloadInvalid ErrorCodeT = 8
+
+	// ErrorCodeMetadataStreamIDInvalid is returned a metadata stream
+	// ID is invalid.
 	ErrorCodeMetadataStreamIDInvalid ErrorCodeT = 9
-	ErrorCodePublicKeyInvalid        ErrorCodeT = 10
-	ErrorCodeSignatureInvalid        ErrorCodeT = 11
-	ErrorCodeRecordTokenInvalid      ErrorCodeT = 12
-	ErrorCodeRecordNotFound          ErrorCodeT = 13
-	ErrorCodeRecordLocked            ErrorCodeT = 14
-	ErrorCodeNoRecordChanges         ErrorCodeT = 15
-	ErrorCodeRecordStateInvalid      ErrorCodeT = 16
-	ErrorCodeRecordStatusInvalid     ErrorCodeT = 17
-	ErrorCodeStatusChangeInvalid     ErrorCodeT = 18
-	ErrorCodeStatusReasonNotFound    ErrorCodeT = 19
-	ErrorCodePageSizeExceeded        ErrorCodeT = 20
-	ErrorCodeLast                    ErrorCodeT = 21
+
+	// ErrorCodePublicKeyInvalid is returned when a public key is not
+	// a valid hex encoded, Ed25519 public key.
+	ErrorCodePublicKeyInvalid ErrorCodeT = 10
+
+	// ErrorCodeSignatureInvalid is returned when a signature is not
+	// a valid hex encoded, Ed25519 signature or when the signature is
+	// wrong.
+	ErrorCodeSignatureInvalid ErrorCodeT = 11
+
+	// ErrorCodeRecordTokenInvalid is returned when a record token is
+	// invalid.
+	ErrorCodeRecordTokenInvalid ErrorCodeT = 12
+
+	// ErrorCodeRecordNotFound is returned when a record is not found.
+	ErrorCodeRecordNotFound ErrorCodeT = 13
+
+	// ErrorCodeRecordLocked is returned when a record is locked.
+	ErrorCodeRecordLocked ErrorCodeT = 14
+
+	// ErrorCodeNoRecordChanges is retuned when no record changes found.
+	ErrorCodeNoRecordChanges ErrorCodeT = 15
+
+	// ErrorCodeRecordStateInvalid is returned when a record state is
+	// invalid.
+	ErrorCodeRecordStateInvalid ErrorCodeT = 16
+
+	// ErrorCodeRecordStatusInvalid is returned when a record status is
+	// invalid.
+	ErrorCodeRecordStatusInvalid ErrorCodeT = 17
+
+	// ErrorCodeStatusChangeInvalid is returned when a record status change
+	// is invalid.
+	ErrorCodeStatusChangeInvalid ErrorCodeT = 18
+
+	// ErrorCodeStatusReasonNotFound is returned when a record status change
+	// reason is not found.
+	ErrorCodeStatusReasonNotFound ErrorCodeT = 19
+
+	// ErrorCodePageSizeExceeded is returned when the request's page size
+	// exceeds the maximum page size of the request.
+	ErrorCodePageSizeExceeded ErrorCodeT = 20
+
+	// ErrorCodeLast unit test only.
+	ErrorCodeLast ErrorCodeT = 21
 )
 
 var (
@@ -318,8 +394,8 @@ type DetailsReply struct {
 // Proof contains an inclusion proof for the digest in the merkle root. All
 // digests are hex encoded SHA256 digests.
 //
-// The ExtraData field is used by certain types of proofs to include additional
-// data that is required to validate the proof.
+// The ExtraData field is used by certain types of proofs to include
+// additional data that is required to validate the proof.
 type Proof struct {
 	Type       string   `json:"type"`
 	Digest     string   `json:"digest"`
@@ -328,15 +404,15 @@ type Proof struct {
 	ExtraData  string   `json:"extradata"` // JSON encoded
 }
 
-// Timestamp contains all of the data required to verify that a piece of record
-// data was timestamped onto the decred blockchain.
+// Timestamp contains all of the data required to verify that a piece of
+// record data was timestamped onto the decred blockchain.
 //
-// All digests are hex encoded SHA256 digests. The merkle root can be found in
-// the OP_RETURN of the specified DCR transaction.
+// All digests are hex encoded SHA256 digests. The merkle root can be found
+// in the OP_RETURN of the specified DCR transaction.
 //
-// TxID, MerkleRoot, and Proofs will only be populated once the merkle root has
-// been included in a DCR tx and the tx has 6 confirmations. The Data field
-// will not be populated if the data has been censored.
+// TxID, MerkleRoot, and Proofs will only be populated once the merkle root
+// has been included in a DCR tx and the tx has 6 confirmations. The Data
+// field will not be populated if the data has been censored.
 type Timestamp struct {
 	Data       string  `json:"data"` // JSON encoded
 	Digest     string  `json:"digest"`
@@ -440,8 +516,8 @@ type InventoryOrderedReply struct {
 	Tokens []string `json:"tokens"`
 }
 
-// UserRecords requests the tokens of all records submitted by a user. Unvetted
-// record tokens are only returned to admins and the record author.
+// UserRecords requests the tokens of all records submitted by a user.
+// Unvetted record tokens are only returned to admins and the record author.
 type UserRecords struct {
 	UserID string `json:"userid"`
 }

--- a/politeiawww/api/records/v1/v1.go
+++ b/politeiawww/api/records/v1/v1.go
@@ -125,7 +125,9 @@ const (
 	// exceeds the maximum page size of the request.
 	ErrorCodePageSizeExceeded ErrorCodeT = 20
 
-	// ErrorCodeLast unit test only.
+	// ErrorCodeLast is used by unit tests to verify that all error codes have
+	// a human readable entry in the ErrorCodes map. This error will never be
+	// returned.
 	ErrorCodeLast ErrorCodeT = 21
 )
 

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -10,30 +10,68 @@ const (
 	// APIRoute is prefixed onto all routes defined in this package.
 	APIRoute = "/ticketvote/v1"
 
-	RoutePolicy      = "/policy"
-	RouteAuthorize   = "/authorize"
-	RouteStart       = "/start"
-	RouteCastBallot  = "/castballot"
-	RouteDetails     = "/details"
-	RouteResults     = "/results"
-	RouteSummaries   = "/summaries"
+	// RoutePolicy returns the policy for the ticketvote API.
+	RoutePolicy = "/policy"
+
+	// RouteAuthorize authorizes a record vote.
+	RouteAuthorize = "/authorize"
+
+	// RouteStart starts a record vote.
+	RouteStart = "/start"
+
+	// RouteCastBallot casts ballot of votes.
+	RouteCastBallot = "/castballot"
+
+	// RouteDetails returns the vote details for a record vote.
+	RouteDetails = "/details"
+
+	// RouteResults returns the vote results for a record vote.
+	RouteResults = "/results"
+
+	// RouteSummaries returns the vote summary for a page of record
+	// votes.
+	RouteSummaries = "/summaries"
+
+	// RouteSubmissions returns the submissions of a runoff vote.
 	RouteSubmissions = "/submissions"
-	RouteInventory   = "/inventory"
-	RouteTimestamps  = "/timestamps"
+
+	// RouteInventory returns the tokens of public records in the inventory
+	// categorized by vote status.
+	RouteInventory = "/inventory"
+
+	// RouteTimestamps returns the timestamps for ticket vote data.
+	RouteTimestamps = "/timestamps"
 )
 
 // ErrorCodeT represents a user error code.
 type ErrorCodeT uint32
 
 const (
-	// Error codes
-	ErrorCodeInvalid          ErrorCodeT = 0
-	ErrorCodeInputInvalid     ErrorCodeT = 1
+	// ErrorCodeInvalid is an invalid error code.
+	ErrorCodeInvalid ErrorCodeT = 0
+
+	// ErrorCodeInputInvalid is returned when there is an error
+	// while prasing a command payload.
+	ErrorCodeInputInvalid ErrorCodeT = 1
+
+	// ErrorCodePublicKeyInvalid is returned when a public key used
+	// in a signature is not valid.
 	ErrorCodePublicKeyInvalid ErrorCodeT = 2
-	ErrorCodeUnauthorized     ErrorCodeT = 3
-	ErrorCodeRecordNotFound   ErrorCodeT = 4
-	ErrorCodeRecordLocked     ErrorCodeT = 5
-	ErrorCodeTokenInvalid     ErrorCodeT = 6
+
+	// ErrorCodeUnauthorized is returned when the user is not authorized.
+	ErrorCodeUnauthorized ErrorCodeT = 3
+
+	// ErrorCodeRecordNotFound is returned when a record not found.
+	ErrorCodeRecordNotFound ErrorCodeT = 4
+
+	// ErrorCodeRecordLocked is returned when a record is locked.
+	ErrorCodeRecordLocked ErrorCodeT = 5
+
+	// ErrorCodeTokenInvalid is returned when a token is invalid.
+	ErrorCodeTokenInvalid ErrorCodeT = 6
+
+	// ErrorCodePageSizeExceeded is returned when the request's page size
+	// exceeds the maximum page size of the request.
 	ErrorCodePageSizeExceeded ErrorCodeT = 7
 
 	// ErrorCodeDuplicatePayload is returned when a user tries to submit a
@@ -43,6 +81,7 @@ const (
 	// cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 8
 
+	// ErrorCodeLast unit test only.
 	ErrorCodeLast ErrorCodeT = 9
 )
 
@@ -122,8 +161,8 @@ const (
 	AuthActionRevoke AuthActionT = "revoke"
 )
 
-// Authorize authorizes a record vote or revokes a previous vote authorization.
-// Not all vote types require an authorization.
+// Authorize authorizes a record vote or revokes a previous vote
+// authorization. Not all vote types require an authorization.
 //
 // Signature contains the client signature of the Token+Version+Action.
 type Authorize struct {
@@ -534,17 +573,17 @@ type Summaries struct {
 
 // SummariesReply is the reply to the Summaries command.
 //
-// Summaries field contains a vote summary for each of the provided tokens. The
-// map will not contain an entry for any tokens that did not correspond to an
-// actual record. It is the callers responsibility to ensure that a summary is
-// returned for all provided tokens.
+// Summaries field contains a vote summary for each of the provided tokens.
+// The map will not contain an entry for any tokens that did not correspond
+// to an actual record. It is the callers responsibility to ensure that a
+// summary is returned for all provided tokens.
 type SummariesReply struct {
 	Summaries map[string]Summary `json:"summaries"` // [token]Summary
 }
 
-// Submissions requests the submissions of a runoff vote. The only records that
-// will have a submissions list are the parent records in a runoff vote. The
-// list will contain all public runoff vote submissions, i.e. records that
+// Submissions requests the submissions of a runoff vote. The only records
+// that will have a submissions list are the parent records in a runoff vote.
+// The list will contain all public runoff vote submissions, i.e. records that
 // have linked to the parent record using the VoteMetadata LinkTo field.
 type Submissions struct {
 	Token string `json:"token"`
@@ -561,8 +600,8 @@ const (
 	InventoryPageSize uint32 = 20
 )
 
-// Inventory requests the tokens of public records in the inventory categorized
-// by vote status.
+// Inventory requests the tokens of public records in the inventory
+// categorized by vote status.
 //
 // The status and page arguments can be provided to request a specific page of
 // record tokens.
@@ -625,7 +664,7 @@ type Timestamp struct {
 }
 
 const (
-	// VoteTimetsampsPageSize is the maximum number of vote timestamps
+	// VoteTimestampsPageSize is the maximum number of vote timestamps
 	// that will be returned for any single request.
 	VoteTimestampsPageSize uint32 = 100
 )
@@ -633,8 +672,8 @@ const (
 // Timestamps requests the timestamps for ticket vote data.
 //
 // If no votes page number is provided then the vote authorization and vote
-// details timestamps will be returned. If a votes page number is provided then
-// the specified page of cast vote timestamps will be returned.
+// details timestamps will be returned. If a votes page number is provided
+// then the specified page of cast vote timestamps will be returned.
 type Timestamps struct {
 	Token     string `json:"token"`
 	VotesPage uint32 `json:"votespage,omitempty"`

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -81,7 +81,9 @@ const (
 	// cause collisions.
 	ErrorCodeDuplicatePayload ErrorCodeT = 8
 
-	// ErrorCodeLast unit test only.
+	// ErrorCodeLast is used by unit tests to verify that all error codes have
+	// a human readable entry in the ErrorCodes map. This error will never be
+	// returned.
 	ErrorCodeLast ErrorCodeT = 9
 )
 


### PR DESCRIPTION
This adds documentation for undocumented exported names in multiple
parts of the codebase:

- www: comments API. 
- www: records API.
- www: tikcetvote API.
- d: v2 API.
