### PR TITLE
MySQL: fix u_blub user table column bug.

### DIFF
--- a/politeiawww/user/mysql/mysql.go
+++ b/politeiawww/user/mysql/mysql.go
@@ -59,7 +59,7 @@ const tableKeyValue = `
 const tableUsers = `
   id VARCHAR(36) NOT NULL PRIMARY KEY,
   username VARCHAR(64) NOT NULL,
-  u_blob BLOB NOT NULL,
+  u_blob LONGBLOB NOT NULL,
   created_at INT(11) NOT NULL,
   updated_at INT(11),
   UNIQUE (username)


### PR DESCRIPTION
This diff fixes a bug in the MySQL user database implementation where
the `u_blob` column type defined as `BLOB` which wasn't enough in some
cases where the user had 300+ active identities and creating new
identity resulted in: `Error 1406: Data too long for column 'u_blob' at
row 1`.

This commit fixes the bug described above by changing the `u_blob`
column type to `LONGBLOB` which should be able to store up to:
4,294,967,295 bytes.