### PR TITLE
store: Close deblob reader.

### DIFF
--- a/politeiad/backendv2/tstorebe/store/store.go
+++ b/politeiad/backendv2/tstorebe/store/store.go
@@ -74,23 +74,14 @@ func Deblob(blob []byte) (bep *BlobEntry, err error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		err2 := zr.Close()
-		if err2 != nil && err != nil {
-			// There was both a pre existing error and a gzip
-			// close error. Wrap the pre existing error in the
-			// gzip close error.
-			err = errors.Errorf("%v: close gzip reader failed: %v",
-				err, err2)
-		} else if err2 != nil {
-			// There was no pre existing error,
-			// but there was a gzip close error.
-			err = err2
-		}
-	}()
 	r := gob.NewDecoder(zr)
 	var be BlobEntry
 	err = r.Decode(&be)
+	if err != nil {
+		zr.Close()
+		return nil, err
+	}
+	err = zr.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/politeiad/backendv2/tstorebe/store/store.go
+++ b/politeiad/backendv2/tstorebe/store/store.go
@@ -66,7 +66,6 @@ func Blobify(be BlobEntry) ([]byte, error) {
 		return nil, err
 	}
 	return b.Bytes(), nil
-
 }
 
 // Deblob decodes the provided gzipped byte slice into a BlobEntry.

--- a/politeiad/backendv2/tstorebe/store/store.go
+++ b/politeiad/backendv2/tstorebe/store/store.go
@@ -58,6 +58,7 @@ func Blobify(be BlobEntry) ([]byte, error) {
 	enc := gob.NewEncoder(zw)
 	err := enc.Encode(be)
 	if err != nil {
+		zw.Close()
 		return nil, err
 	}
 	err = zw.Close() // we must flush gzip buffers
@@ -76,6 +77,11 @@ func Deblob(blob []byte) (*BlobEntry, error) {
 	r := gob.NewDecoder(zr)
 	var be BlobEntry
 	err = r.Decode(&be)
+	if err != nil {
+		zr.Close()
+		return nil, err
+	}
+	err = zr.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/politeiad/backendv2/tstorebe/store/store.go
+++ b/politeiad/backendv2/tstorebe/store/store.go
@@ -69,7 +69,7 @@ func Blobify(be BlobEntry) ([]byte, error) {
 }
 
 // Deblob decodes the provided gzipped byte slice into a BlobEntry.
-func Deblob(blob []byte) (bep *BlobEntry, err error) {
+func Deblob(blob []byte) (*BlobEntry, error) {
 	zr, err := gzip.NewReader(bytes.NewReader(blob))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This diff fixes a memory leak that was caused by the key-value store
gzip reader not being closed out when decoding a blob.

This bug was originally intoduced in #951 and was carried over to 
politeiad in #1180.