### PR TITLE
politeiawww: Add server read limits.

### DIFF
--- a/politeiawww/config.go
+++ b/politeiawww/config.go
@@ -90,6 +90,14 @@ var (
 	defaultCookieKeyFile = filepath.Join(defaultHomeDir, "cookie.key")
 	defaultLogDir        = filepath.Join(defaultHomeDir, defaultLogDirname)
 
+	// defaultReqBodySizeLimit is the maximum number of bytes allowed in a
+	// request body.
+	defaultReqBodySizeLimit int64 = 3 * 1024 * 1024 // 3 MiB
+
+	// defaultWebsocketReadLimit is the maximum number of bytes allowed for a
+	// message read from a websocket client.
+	defaultWebsocketReadLimit int64 = 4 * 1024 * 1024 // 4 KiB
+
 	// Default start date to start pulling code statistics if none specified.
 	defaultCodeStatStart = time.Now().Add(-1 * time.Minute * 60 * 24 * 7 * 26) // 6 months in minutes 60min * 24h * 7days * 26 weeks
 
@@ -333,6 +341,8 @@ func loadConfig() (*config.Config, []string, error) {
 		RPCCert:                  defaultRPCCertFile,
 		CookieKeyFile:            defaultCookieKeyFile,
 		Version:                  version.String(),
+		ReqBodySizeLimit:         defaultReqBodySizeLimit,
+		WebsocketReadLimit:       defaultWebsocketReadLimit,
 		Mode:                     defaultWWWMode,
 		UserDB:                   defaultUserDB,
 		PaywallAmount:            defaultPaywallAmount,

--- a/politeiawww/config/config.go
+++ b/politeiawww/config/config.go
@@ -69,6 +69,10 @@ type Config struct {
 	AdminLogFile    string   `long:"adminlogfile" description:"admin log filename (Default: admin.log)"`
 	Mode            string   `long:"mode" description:"Mode www runs as. Supported values: piwww, cmswww"`
 
+	// Webserver settings
+	ReqBodySizeLimit   int64 `long:"reqbodysizelimit" description:"Maximum number of bytes allowed for a request body from a http client"`
+	WebsocketReadLimit int64 `long:"websocketreadlimit" description:"Maximum number of bytes allowed for a message read from a websocket client"`
+
 	// User database settings
 	UserDB           string `long:"userdb" description:"Database choice for the user database"`
 	DBHost           string `long:"dbhost" description:"Database ip:port"`

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -15,6 +15,11 @@ import (
 	"github.com/decred/politeia/util"
 )
 
+const (
+	// reqBodyLimit is the maximum number of bytes allowed in a request body.
+	reqBodyLimit = 3 * 1024 * 1024 // 3 MiB
+)
+
 // isLoggedIn ensures that a user is logged in before calling the next
 // function.
 func (p *politeiawww) isLoggedIn(f http.HandlerFunc) http.HandlerFunc {
@@ -83,6 +88,14 @@ func closeBodyMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		next.ServeHTTP(w, r)
 		r.Body.Close()
+	})
+}
+
+// bodySizeLimitMiddleware applies a request body size limit to requests.
+func bodySizeLimitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, reqBodyLimit)
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	// reqBodyLimit is the maximum number of bytes allowed in a request body.
-	reqBodyLimit = 3 * 1024 * 1024 // 3 MiB
+	// reqBodySizeLimit is the maximum number of bytes allowed in a request body.
+	reqBodySizeLimit = 3 * 1024 * 1024 // 3 MiB
 )
 
 // isLoggedIn ensures that a user is logged in before calling the next
@@ -91,10 +91,10 @@ func closeBodyMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// bodySizeLimitMiddleware applies a request body size limit to requests.
-func bodySizeLimitMiddleware(next http.Handler) http.Handler {
+// maxBodySizeMiddleware applies a request body size limit to requests.
+func maxBodySizeMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Body = http.MaxBytesReader(w, r.Body, reqBodyLimit)
+		r.Body = http.MaxBytesReader(w, r.Body, reqBodySizeLimit)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/politeiawww/middleware_test.go
+++ b/politeiawww/middleware_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestReqBodySizeMiddleware(t *testing.T) {
+	// Setup the test router
+	router := mux.NewRouter()
+	m := middleware{
+		reqBodySizeLimit: 5,
+	}
+	router.Use(closeBodyMiddleware)
+	router.Use(m.reqBodySizeLimitMiddleware)
+
+	// Setup a route handler that reads the request body. Reading
+	// the request body is required in order to trigger the error.
+	testRoute := "/test"
+	router.HandleFunc(testRoute, func(w http.ResponseWriter, r *http.Request) {
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Setup test request bodies
+	const (
+		fourBytes = "1234"
+		fiveBytes = "12345"
+		sixBytes  = "123456"
+	)
+
+	// Setup tests
+	var tests = []struct {
+		name     string
+		reqBody  string
+		wantCode int
+	}{
+		{
+			"no request body",
+			"",
+			http.StatusOK,
+		},
+		{
+			"under the req body limit",
+			fourBytes,
+			http.StatusOK,
+		},
+		{
+			"at the req body limit",
+			fiveBytes,
+			http.StatusOK,
+		},
+		{
+			"over the req body limit",
+			sixBytes,
+			http.StatusBadRequest,
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup the test request
+			req, err := http.NewRequest(http.MethodPost,
+				testRoute, strings.NewReader(tc.reqBody))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Send the test request
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			// Verify the response
+			if rr.Code != tc.wantCode {
+				t.Errorf("wrong http response code: got %v, want %v",
+					rr.Code, tc.wantCode)
+			}
+		})
+	}
+}

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -352,6 +352,9 @@ func (p *politeiawww) handleWebsocket(w http.ResponseWriter, r *http.Request, id
 	}
 	defer wc.conn.Close() // causes read to exit as well
 
+	// Set connection read limit
+	wc.conn.SetReadLimit(p.cfg.WebsocketReadLimit)
+
 	// Create and assign session to map
 	p.wsMtx.Lock()
 	if _, ok := p.ws[id]; !ok {

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -600,6 +600,7 @@ func _main() error {
 	// Setup router
 	router := mux.NewRouter()
 	router.Use(closeBodyMiddleware)
+	router.Use(bodySizeLimitMiddleware)
 	router.Use(loggingMiddleware)
 	router.Use(recoverMiddleware)
 

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -597,8 +597,8 @@ func _main() error {
 		csrf.MaxAge(sessions.SessionMaxAge),
 	)
 
-	// Setup router. Middleware is executed in the same order
-	// that they are registered in.
+	// Setup the router. Middleware is executed in
+	// the same order that they are registered in.
 	router := mux.NewRouter()
 	m := middleware{
 		reqBodySizeLimit: loadedCfg.ReqBodySizeLimit,

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -597,10 +597,14 @@ func _main() error {
 		csrf.MaxAge(sessions.SessionMaxAge),
 	)
 
-	// Setup router
+	// Setup router. Middleware is executed in the same order
+	// that they are registered in.
 	router := mux.NewRouter()
-	router.Use(closeBodyMiddleware)
-	router.Use(maxBodySizeMiddleware)
+	m := middleware{
+		reqBodySizeLimit: loadedCfg.ReqBodySizeLimit,
+	}
+	router.Use(closeBodyMiddleware) // MUST be registered first
+	router.Use(m.reqBodySizeLimitMiddleware)
 	router.Use(loggingMiddleware)
 	router.Use(recoverMiddleware)
 

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -600,7 +600,7 @@ func _main() error {
 	// Setup router
 	router := mux.NewRouter()
 	router.Use(closeBodyMiddleware)
-	router.Use(bodySizeLimitMiddleware)
+	router.Use(maxBodySizeMiddleware)
 	router.Use(loggingMiddleware)
 	router.Use(recoverMiddleware)
 


### PR DESCRIPTION
This diff makes the following changes to politeiawww:

- Adds req body size limit middleware to the politeiawww router.
- Adds tests to verify the middleware behavior.
- Adds a client read limit to the politeiawww websocket implementation.
- Add politeiawww config options for both the req body size limt and the
  websocket read limit.