### PR TITLE
politeiad: Cleanup middleware.

### DIFF
--- a/politeiad/config.go
+++ b/politeiad/config.go
@@ -63,6 +63,10 @@ var (
 	defaultHTTPSCertFile = filepath.Join(defaultHomeDir, "https.cert")
 	defaultLogDir        = filepath.Join(defaultHomeDir, defaultLogDirname)
 	defaultIdentityFile  = filepath.Join(defaultHomeDir, defaultIdentityFilename)
+
+	// defaultReqBodySizeLimit is the maximum number of bytes allowed in a
+	// request body.
+	defaultReqBodySizeLimit int64 = 3 * 1024 * 1024 // 3 MiB
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -73,27 +77,28 @@ var runServiceCommand func(string) error
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	HomeDir     string   `short:"A" long:"appdata" description:"Path to application home directory"`
-	ShowVersion bool     `short:"V" long:"version" description:"Display version information and exit"`
-	ConfigFile  string   `short:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir     string   `short:"b" long:"datadir" description:"Directory to store data"`
-	LogDir      string   `long:"logdir" description:"Directory to log output."`
-	TestNet     bool     `long:"testnet" description:"Use the test network"`
-	SimNet      bool     `long:"simnet" description:"Use the simulation test network"`
-	Profile     string   `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	CPUProfile  string   `long:"cpuprofile" description:"Write CPU profile to the specified file"`
-	MemProfile  string   `long:"memprofile" description:"Write mem profile to the specified file"`
-	DebugLevel  string   `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	Listeners   []string `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 49152, testnet: 59152)"`
-	Version     string
-	HTTPSCert   string `long:"httpscert" description:"File containing the https certificate file"`
-	HTTPSKey    string `long:"httpskey" description:"File containing the https certificate key"`
-	RPCUser     string `long:"rpcuser" description:"RPC user name for privileged commands"`
-	RPCPass     string `long:"rpcpass" description:"RPC password for privileged commands"`
-	DcrtimeHost string `long:"dcrtimehost" description:"Dcrtime ip:port"`
-	DcrtimeCert string // Provided in env variable "DCRTIMECERT"
-	Identity    string `long:"identity" description:"File containing the politeiad identity file"`
-	Backend     string `long:"backend" description:"Backend type"`
+	HomeDir          string   `short:"A" long:"appdata" description:"Path to application home directory"`
+	ShowVersion      bool     `short:"V" long:"version" description:"Display version information and exit"`
+	ConfigFile       string   `short:"C" long:"configfile" description:"Path to configuration file"`
+	DataDir          string   `short:"b" long:"datadir" description:"Directory to store data"`
+	LogDir           string   `long:"logdir" description:"Directory to log output."`
+	TestNet          bool     `long:"testnet" description:"Use the test network"`
+	SimNet           bool     `long:"simnet" description:"Use the simulation test network"`
+	Profile          string   `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
+	CPUProfile       string   `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	MemProfile       string   `long:"memprofile" description:"Write mem profile to the specified file"`
+	DebugLevel       string   `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	Listeners        []string `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 49152, testnet: 59152)"`
+	Version          string
+	HTTPSCert        string `long:"httpscert" description:"File containing the https certificate file"`
+	HTTPSKey         string `long:"httpskey" description:"File containing the https certificate key"`
+	RPCUser          string `long:"rpcuser" description:"RPC user name for privileged commands"`
+	RPCPass          string `long:"rpcpass" description:"RPC password for privileged commands"`
+	DcrtimeHost      string `long:"dcrtimehost" description:"Dcrtime ip:port"`
+	DcrtimeCert      string // Provided in env variable "DCRTIMECERT"
+	Identity         string `long:"identity" description:"File containing the politeiad identity file"`
+	Backend          string `long:"backend" description:"Backend type"`
+	ReqBodySizeLimit int64  `long:"reqbodysizelimit" description:"Maximum number of bytes allowed for a request body from a http client"`
 
 	// Git backend options
 	GitTrace    bool   `long:"gittrace" description:"Enable git tracing in logs"`
@@ -249,18 +254,19 @@ func newConfigParser(cfg *config, so *serviceOptions, options flags.Options) *fl
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		HomeDir:    defaultHomeDir,
-		ConfigFile: defaultConfigFile,
-		DebugLevel: defaultLogLevel,
-		DataDir:    defaultDataDir,
-		LogDir:     defaultLogDir,
-		HTTPSKey:   defaultHTTPSKeyFile,
-		HTTPSCert:  defaultHTTPSCertFile,
-		Version:    version.String(),
-		Backend:    defaultBackend,
-		DBType:     defaultDBType,
-		DBHost:     defaultDBHost,
-		TlogHost:   defaultTlogHost,
+		HomeDir:          defaultHomeDir,
+		ConfigFile:       defaultConfigFile,
+		DebugLevel:       defaultLogLevel,
+		DataDir:          defaultDataDir,
+		LogDir:           defaultLogDir,
+		HTTPSKey:         defaultHTTPSKeyFile,
+		HTTPSCert:        defaultHTTPSCertFile,
+		Version:          version.String(),
+		Backend:          defaultBackend,
+		ReqBodySizeLimit: defaultReqBodySizeLimit,
+		DBType:           defaultDBType,
+		DBHost:           defaultDBHost,
+		TlogHost:         defaultTlogHost,
 	}
 
 	// Service options which are only added on Windows.

--- a/politeiad/middleware.go
+++ b/politeiad/middleware.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"runtime/debug"
+	"time"
+
+	v2 "github.com/decred/politeia/politeiad/api/v2"
+	"github.com/decred/politeia/util"
+)
+
+const (
+	// reqBodySizeLimit is the maximum number of bytes allowed in a request body.
+	reqBodySizeLimit = 5 * 1024 * 1024 // 5 MiB
+)
+
+// closeBodyMiddleware closes the request body.
+func closeBodyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+		r.Body.Close()
+	})
+}
+
+// maxBodySizeMiddleware applies a maximum size limit to the request body.
+func maxBodySizeMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, reqBodySizeLimit)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// loggingMiddleware logs all incoming commands before calling the next
+// function.
+//
+// NOTE: LOGGING WILL LOG PASSWORDS IF TRACING IS ENABLED.
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Trace incoming request
+		log.Tracef("%v", newLogClosure(func() string {
+			trace, err := httputil.DumpRequest(r, true)
+			if err != nil {
+				trace = []byte(fmt.Sprintf("logging: "+
+					"DumpRequest %v", err))
+			}
+			return string(trace)
+		}))
+
+		// Log incoming connection
+		log.Infof("%v %v %v %v", util.RemoteAddr(r), r.Method, r.URL, r.Proto)
+
+		// Call next handler
+		next.ServeHTTP(w, r)
+	})
+}
+
+// recoverMiddleware recovers from any panics by logging the panic and
+// returning a 500 response.
+func recoverMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Defer the function so that it gets executed when the request
+		// is being closed out, not when its being opened.
+		defer func() {
+			if err := recover(); err != nil {
+				errorCode := time.Now().Unix()
+				log.Criticalf("%v %v %v %v Internal error %v: %v",
+					util.RemoteAddr(r), r.Method, r.URL, r.Proto, errorCode, err)
+
+				log.Criticalf("Stacktrace (THIS IS AN ACTUAL PANIC): %s",
+					debug.Stack())
+
+				util.RespondWithJSON(w, http.StatusInternalServerError,
+					v2.ServerErrorReply{
+						ErrorCode: errorCode,
+					})
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/politeiad/middleware.go
+++ b/politeiad/middleware.go
@@ -38,8 +38,6 @@ func maxBodySizeMiddleware(next http.Handler) http.Handler {
 
 // loggingMiddleware logs all incoming commands before calling the next
 // function.
-//
-// NOTE: LOGGING WILL LOG PASSWORDS IF TRACING IS ENABLED.
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Trace incoming request

--- a/politeiad/middleware_test.go
+++ b/politeiad/middleware_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestReqBodySizeMiddleware(t *testing.T) {
+	// Setup the test router
+	router := mux.NewRouter()
+	m := middleware{
+		reqBodySizeLimit: 5,
+	}
+	router.Use(closeBodyMiddleware)
+	router.Use(m.reqBodySizeLimitMiddleware)
+
+	// Setup a route handler that reads the request body. Reading
+	// the request body is required in order to trigger the error.
+	testRoute := "/test"
+	router.HandleFunc(testRoute, func(w http.ResponseWriter, r *http.Request) {
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Setup test request bodies
+	const (
+		fourBytes = "1234"
+		fiveBytes = "12345"
+		sixBytes  = "123456"
+	)
+
+	// Setup tests
+	var tests = []struct {
+		name     string
+		reqBody  string
+		wantCode int
+	}{
+		{
+			"no request body",
+			"",
+			http.StatusOK,
+		},
+		{
+			"under the req body limit",
+			fourBytes,
+			http.StatusOK,
+		},
+		{
+			"at the req body limit",
+			fiveBytes,
+			http.StatusOK,
+		},
+		{
+			"over the req body limit",
+			sixBytes,
+			http.StatusBadRequest,
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup the test request
+			req, err := http.NewRequest(http.MethodPost,
+				testRoute, strings.NewReader(tc.reqBody))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Send the test request
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			// Verify the response
+			if rr.Code != tc.wantCode {
+				t.Errorf("wrong http response code: got %v, want %v",
+					rr.Code, tc.wantCode)
+			}
+		})
+	}
+}

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -142,8 +142,8 @@ func (p *politeia) setupBackendGit(anp *chaincfg.Params) error {
 		return errors.Errorf("router must be initialized")
 	}
 
-	b, err := gitbe.New(activeNetParams.Params, p.cfg.DataDir,
-		p.cfg.DcrtimeHost, "", p.identity, p.cfg.GitTrace, p.cfg.DcrdataHost)
+	b, err := gitbe.New(anp, p.cfg.DataDir, p.cfg.DcrtimeHost,
+		"", p.identity, p.cfg.GitTrace, p.cfg.DcrdataHost)
 	if err != nil {
 		return fmt.Errorf("new gitbe: %v", err)
 	}

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -426,10 +426,14 @@ func _main() error {
 		log.Infof("Signing identity created...")
 	}
 
-	// Setup the router
+	// Setup the router. Middleware is executed in
+	// the same order that they are registered in.
 	router := mux.NewRouter()
-	router.Use(closeBodyMiddleware)
-	router.Use(maxBodySizeMiddleware)
+	m := middleware{
+		reqBodySizeLimit: cfg.ReqBodySizeLimit,
+	}
+	router.Use(closeBodyMiddleware) // MUST be registered first
+	router.Use(m.reqBodySizeLimitMiddleware)
 	router.Use(loggingMiddleware)
 	router.Use(recoverMiddleware)
 


### PR DESCRIPTION
This diff makes the following changes to politeiad:

- Cleans up the existing middleware. Instead of registering middleware
  on individual routes, the middleware is now registered on the router
  itself.
- Adds new middleware for a maximum request body size.
- Adds tests to verify the request body size middleware.
- Adds a config options to make the maximum request body size
  configurable.