### PR TITLE
politeiad: Setup fscks.

### DIFF
--- a/politeiad/backendv2/backendv2.go
+++ b/politeiad/backendv2/backendv2.go
@@ -356,6 +356,10 @@ type Backend interface {
 	// PluginInventory returns all registered plugins.
 	PluginInventory() []Plugin
 
+	// Fsck performs a synchronous filesystem check that verifies
+	// the coherency of record and plugin data and caches.
+	Fsck() error
+
 	// Close performs cleanup of the backend.
 	Close()
 }

--- a/politeiad/backendv2/tstorebe/plugins/comments/comments.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/comments.go
@@ -95,14 +95,19 @@ func (p *commentsPlugin) Hook(h plugins.HookT, payload string) error {
 	return nil
 }
 
-// Fsck performs a plugin filesystem check.
+// Fsck performs a plugin file system check. The plugin is provided with the
+// tokens for all records in the backend.
 //
 // This function satisfies the plugins PluginClient interface.
-func (p *commentsPlugin) Fsck() error {
+func (p *commentsPlugin) Fsck(tokens [][]byte) error {
 	log.Tracef("comments Fsck")
 
-	// Verify record index coherency
-	// Verify CommentDel blobs were actually deleted
+	// Verify the cohereny of the record index for each token. This
+	// includes verifying that:
+	// - All comment adds are present in the record index.
+	// - All comment dels are present in the record index and the
+	//   corresponding comment adds have been deleted from the db.
+	// - All comment votes are present in the record index.
 
 	return nil
 }

--- a/politeiad/backendv2/tstorebe/plugins/dcrdata/dcrdata.go
+++ b/politeiad/backendv2/tstorebe/plugins/dcrdata/dcrdata.go
@@ -220,10 +220,11 @@ func (p *dcrdataPlugin) Hook(h plugins.HookT, payload string) error {
 	return nil
 }
 
-// Fsck performs a plugin filesystem check.
+// Fsck performs a plugin file system check. The plugin is provided with the
+// tokens for all records in the backend.
 //
 // This function satisfies the plugins PluginClient interface.
-func (p *dcrdataPlugin) Fsck() error {
+func (p *dcrdataPlugin) Fsck(tokens [][]byte) error {
 	log.Tracef("dcrdata Fsck")
 
 	return nil

--- a/politeiad/backendv2/tstorebe/plugins/pi/pi.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/pi.go
@@ -100,10 +100,11 @@ func (p *piPlugin) Hook(h plugins.HookT, payload string) error {
 	return nil
 }
 
-// Fsck performs a plugin filesystem check.
+// Fsck performs a plugin file system check. The plugin is provided with the
+// tokens for all records in the backend.
 //
 // This function satisfies the plugins PluginClient interface.
-func (p *piPlugin) Fsck() error {
+func (p *piPlugin) Fsck(tokens [][]byte) error {
 	log.Tracef("pi Fsck")
 
 	return nil

--- a/politeiad/backendv2/tstorebe/plugins/plugins.go
+++ b/politeiad/backendv2/tstorebe/plugins/plugins.go
@@ -145,8 +145,9 @@ type PluginClient interface {
 	// Hook executes a plugin hook.
 	Hook(h HookT, payload string) error
 
-	// Fsck performs a plugin file system check.
-	Fsck() error
+	// Fsck performs a plugin file system check. The plugin is
+	// provided with the tokens for all records in the backend.
+	Fsck(tokens [][]byte) error
 
 	// Settings returns the plugin settings.
 	Settings() []backend.PluginSetting

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/ticketvote.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/ticketvote.go
@@ -205,17 +205,38 @@ func (p *ticketVotePlugin) Hook(h plugins.HookT, payload string) error {
 	return nil
 }
 
-// Fsck performs a plugin filesystem check.
+// Fsck performs a plugin filesystem check. The plugin is provided with the
+// tokens for all records in the backend.
 //
 // This function satisfies the plugins PluginClient interface.
-func (p *ticketVotePlugin) Fsck() error {
+func (p *ticketVotePlugin) Fsck(tokens [][]byte) error {
 	log.Tracef("ticketvote Fsck")
 
-	// Verify all caches
+	// Verify the coherency of the summaries cache. This can be
+	// accomplished by simply calling the summary() method on each
+	// record.
 
-	// Audit all finished votes
-	//  - All votes that were cast were eligible
-	//  - No duplicate votes
+	// Verify the coherency of the submissions cache. All records
+	// that have the vote metadata LinkTo field set must be included
+	// in the parent record submissions list.
+
+	// Verify the coherency of the cached inventory. This is done in
+	// multi steps.
+	//
+	// 1. For each record, store the token, vote status, and timestamp
+	//    of the most recent vote status change.
+	//
+	// 2. Sort the stored records into vote status groups where each
+	//    vote status group is ordered from oldest to newest using the
+	//    timestamp of their most recent vote status change.
+	//
+	// 3. Add all tokens to the inventory. The tokens MUST be added
+	//    by vote status from oldest to newest. Ongoing votes MUST
+	//    be added to the inventory then updated using the inventory
+	//    method that updates an entry to the started vote status.
+
+	// Audit all finished votes. This verifies that all cast votes
+	// use eligible tickets and that there are no duplicate votes.
 
 	return nil
 }

--- a/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
+++ b/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
@@ -81,11 +81,24 @@ func (p *usermdPlugin) Hook(h plugins.HookT, payload string) error {
 	return nil
 }
 
-// Fsck performs a plugin filesystem check.
+// Fsck performs a plugin file system check. The plugin is provided with the
+// tokens for all records in the backend.
 //
 // This function satisfies the plugins PluginClient interface.
-func (p *usermdPlugin) Fsck() error {
+func (p *usermdPlugin) Fsck(tokens [][]byte) error {
 	log.Tracef("usermd Fsck")
+
+	// Verify the user cache using the following process:
+	//
+	// 1. For each record, get the user metadata file from the db.
+	//
+	// 2. Get the user cache for the record's author.
+	//
+	// 3. Verify that the record is listed in the user cache under the
+	//    correct category. The tokens listed in the user cache MUST be
+	//    ordered by the timestamp of their most recent status change
+	//    from newest to oldest. If the record is not found in the user
+	//    cache, add it.
 
 	return nil
 }

--- a/politeiad/backendv2/tstorebe/tstorebe.go
+++ b/politeiad/backendv2/tstorebe/tstorebe.go
@@ -1004,6 +1004,39 @@ func (t *tstoreBackend) PluginInventory() []backend.Plugin {
 	return t.tstore.Plugins()
 }
 
+// Fsck performs a synchronous filesystem check that verifies the coherency
+// of record and plugin data and caches.
+//
+// This function satisfies the backendv2 Backend interface.
+func (t *tstoreBackend) Fsck() error {
+	log.Infof("Performing record fsck")
+
+	// Get the tokens for all records in the backend
+	allTokens, err := t.tstore.Inventory()
+	if err != nil {
+		return err
+	}
+
+	// Rebuild the inventory cache. This is a multi-step process:
+	//
+	// 1. Sort the tokens into two groups; unvetted and vetted. Each
+	//    group is additionally sorted by the timestamp of their most
+	//    recent status change.
+	//
+	// 2. Add the vetted tokens to the inventory cache. They MUST be
+	//    added starting with the oldest timestamp. The vetted token
+	//    is first added to the unvetted cache then moved to the vetted
+	//    cache. This is a limitation of the inventory API and mimicks
+	//    how records are added and updated when using the politeiad
+	//    API.
+	//
+	// 3. Add the unvetted tokens to the inventory cache. They MUST be
+	//    added starting with the oldest timestamp.
+
+	// Update all plugin caches
+	return t.tstore.Fsck(allTokens)
+}
+
 // Close performs cleanup of the backend.
 //
 // This function satisfies the backendv2 Backend interface.

--- a/politeiad/config.go
+++ b/politeiad/config.go
@@ -94,6 +94,7 @@ type config struct {
 	DcrtimeCert string // Provided in env variable "DCRTIMECERT"
 	Identity    string `long:"identity" description:"File containing the politeiad identity file"`
 	Backend     string `long:"backend" description:"Backend type"`
+	Fsck        bool   `long:"fsck" description:"Perform filesystem checks on all record and plugin data"`
 
 	// Git backend options
 	GitTrace    bool   `long:"gittrace" description:"Enable git tracing in logs"`

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -395,6 +395,14 @@ func (p *politeia) setupBackendTstore(anp *chaincfg.Params) error {
 		}
 	}
 
+	// Perform filesytem check
+	if p.cfg.Fsck {
+		err = p.backendv2.Fsck()
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This diff adds a `--fsck` flag to politeiad that, when provided,
performs synchronous filesystem checks on startup for all record and
plugin data. This includes verifying the coherency of cached data.

The fscks have not been implemented in this diff, but notes have been
added to the various fsck functions to help with the implementation.