### PR TITLE
tstorebe: Add record inventory fsck.

### DIFF
--- a/politeiad/backendv2/tstorebe/inventory.go
+++ b/politeiad/backendv2/tstorebe/inventory.go
@@ -43,6 +43,16 @@ func (t *tstoreBackend) invPathVetted() string {
 	return filepath.Join(t.dataDir, filenameInvVetted)
 }
 
+// invRemoveUnvetted removes the unvetted inventory from its respective path.
+func (t *tstoreBackend) invRemoveUnvetted() error {
+	return os.RemoveAll(t.invPathUnvetted())
+}
+
+// invRemoveVetted removes the vetted inventory from its respective path.
+func (t *tstoreBackend) invRemoveVetted() error {
+	return os.RemoveAll(t.invPathVetted())
+}
+
 // invGetLocked retrieves the inventory from disk. A new inventory is returned
 // if one does not exist yet.
 //

--- a/politeiad/backendv2/tstorebe/tstorebe.go
+++ b/politeiad/backendv2/tstorebe/tstorebe.go
@@ -1030,10 +1030,8 @@ func (t *tstoreBackend) Fsck() error {
 	}
 
 	// Sort records into vetted and unvetted groups.
-	var (
-		vetted   []*backend.Record
-		unvetted []*backend.Record
-	)
+	vetted := make([]*backend.Record, 0, len(allTokens))
+	unvetted := make([]*backend.Record, 0, len(allTokens))
 	for _, token := range allTokens {
 		record := records[hex.EncodeToString(token)]
 		if record.RecordMetadata.State == backend.StateVetted {

--- a/politeiad/backendv2/tstorebe/tstorebe.go
+++ b/politeiad/backendv2/tstorebe/tstorebe.go
@@ -1030,8 +1030,10 @@ func (t *tstoreBackend) Fsck() error {
 	}
 
 	// Sort records into vetted and unvetted groups.
-	vetted := make([]*backend.Record, 0, len(allTokens))
-	unvetted := make([]*backend.Record, 0, len(allTokens))
+	var (
+		vetted   = make([]*backend.Record, 0, len(allTokens))
+		unvetted = make([]*backend.Record, 0, len(allTokens))
+	)
 	for _, token := range allTokens {
 		record := records[hex.EncodeToString(token)]
 		if record.RecordMetadata.State == backend.StateVetted {
@@ -1091,6 +1093,8 @@ func (t *tstoreBackend) Fsck() error {
 		t.inventoryAdd(record.RecordMetadata.State, bToken,
 			record.RecordMetadata.Status)
 	}
+
+	log.Infof("%v records added to the inventory", len(allTokens))
 
 	// Update all plugin caches
 	return t.tstore.Fsck(allTokens)

--- a/politeiad/backendv2/tstorebe/tstorebe.go
+++ b/politeiad/backendv2/tstorebe/tstorebe.go
@@ -1030,8 +1030,10 @@ func (t *tstoreBackend) Fsck() error {
 	}
 
 	// Sort records into vetted and unvetted groups.
-	vetted := make([]*backend.Record, len(allTokens))
-	unvetted := make([]*backend.Record, len(allTokens))
+	var (
+		vetted   []*backend.Record
+		unvetted []*backend.Record
+	)
 	for _, token := range allTokens {
 		record := records[hex.EncodeToString(token)]
 		if record.RecordMetadata.State == backend.StateVetted {


### PR DESCRIPTION
This diff adds a cache rebuild for the record inventory with the
filesystem check command `--fsck`.

Part of #1511 