### PR TITLE
pi: Fix typo in `Summary.Status` field json key.

### DIFF
--- a/politeiawww/api/pi/v1/v1.go
+++ b/politeiawww/api/pi/v1/v1.go
@@ -307,6 +307,6 @@ type SummariesReply struct {
 // reason to be given. Examples include when a proposal is censored/abandoned
 // or when the billing status of the proposal is set to closed.
 type Summary struct {
-	Status       string `json:"string"`
+	Status       string `json:"status"`
 	StatusReason string `json:"statusreason"`
 }


### PR DESCRIPTION
This diff fixes a typo in the politeiawww pi API Summary struct where
the json key of the Status was defined as "string" instead of "status".