### PR TITLE
pi: Add API to retreive billing status changes.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/pi/hooks.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/hooks.go
@@ -587,12 +587,13 @@ func (p *piPlugin) writesAllowedOnApprovedProposal(token []byte, cmd, payload st
 	// Get billing status to determine whether to allow author updates
 	// or not.
 	var bsc *pi.BillingStatusChange
-	bsc, err := p.billingStatusChange(token)
+	bscs, err := p.billingStatusChanges(token)
 	if err != nil {
 		return err
 	}
-	// We assume here that admins can set a billing status only once
-	if bsc != nil {
+	if len(bscs) > 0 {
+		// Get latest billing status change
+		bsc = &bscs[len(bscs)-1]
 		if bsc.Status == pi.BillingStatusClosed ||
 			bsc.Status == pi.BillingStatusCompleted {
 			// If billing status is set to closed or completed, comment writes

--- a/politeiad/backendv2/tstorebe/plugins/pi/pi.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/pi.go
@@ -79,6 +79,8 @@ func (p *piPlugin) Cmd(token []byte, cmd, payload string) (string, error) {
 		return p.cmdSetBillingStatus(token, payload)
 	case pi.CmdSummary:
 		return p.cmdSummary(token)
+	case pi.CmdBillingStatusChanges:
+		return p.cmdBillingStatusChanges(token)
 	}
 
 	return "", backend.ErrPluginCmdInvalid

--- a/politeiad/client/pi.go
+++ b/politeiad/client/pi.go
@@ -89,7 +89,7 @@ func (c *Client) PiSummaries(ctx context.Context, tokens []string) (map[string]p
 func (c *Client) PiBillingStatusChanges(ctx context.Context, token string) (*pi.BillingStatusChangesReply, error) {
 	// Setup request
 	cmds := []pdv2.PluginCmd{
-		pdv2.PluginCmd{
+		{
 			Token:   token,
 			ID:      pi.PluginID,
 			Command: pi.CmdBillingStatusChanges,

--- a/politeiad/client/pi.go
+++ b/politeiad/client/pi.go
@@ -13,7 +13,7 @@ import (
 	"github.com/decred/politeia/politeiad/plugins/pi"
 )
 
-// PiSetBillingStatus sends the pi plugin BillingStatus command to the
+// PiSetBillingStatus sends the pi plugin SetBillingStatus command to the
 // politeiad v2 API.
 func (c *Client) PiSetBillingStatus(ctx context.Context, sbs pi.SetBillingStatus) (*pi.SetBillingStatusReply, error) {
 	// Setup request

--- a/politeiad/client/pi.go
+++ b/politeiad/client/pi.go
@@ -7,10 +7,42 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	pdv2 "github.com/decred/politeia/politeiad/api/v2"
 	"github.com/decred/politeia/politeiad/plugins/pi"
 )
+
+// PiSetBillingStatus sends the pi plugin BillingStatus command to the
+// politeiad v2 API.
+func (c *Client) PiSetBillingStatus(ctx context.Context, sbs pi.SetBillingStatus) (*pi.SetBillingStatusReply, error) {
+	// Setup request
+	b, err := json.Marshal(sbs)
+	if err != nil {
+		return nil, err
+	}
+	cmd := pdv2.PluginCmd{
+		Token:   sbs.Token,
+		ID:      pi.PluginID,
+		Command: pi.CmdSetBillingStatus,
+		Payload: string(b),
+	}
+
+	// Send request
+	reply, err := c.PluginWrite(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode reply
+	var sbsr pi.SetBillingStatusReply
+	err = json.Unmarshal([]byte(reply), &sbsr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sbsr, nil
+}
 
 // PiSummaries sends a page of pi plugin Summary commands to the politeiad
 // v2 API.
@@ -52,33 +84,40 @@ func (c *Client) PiSummaries(ctx context.Context, tokens []string) (map[string]p
 	return ssr, nil
 }
 
-// PiSetBillingStatus sends the pi plugin BillingStatus command to the
-// politeiad v2 API.
-func (c *Client) PiSetBillingStatus(ctx context.Context, sbs pi.SetBillingStatus) (*pi.SetBillingStatusReply, error) {
+// PiBillingStatusChanges sends the pi plugin BillingStatusChanges command
+// to the politeiad v2 API.
+func (c *Client) PiBillingStatusChanges(ctx context.Context, token string) (*pi.BillingStatusChangesReply, error) {
 	// Setup request
-	b, err := json.Marshal(sbs)
-	if err != nil {
-		return nil, err
-	}
-	cmd := pdv2.PluginCmd{
-		Token:   sbs.Token,
-		ID:      pi.PluginID,
-		Command: pi.CmdSetBillingStatus,
-		Payload: string(b),
+	cmds := []pdv2.PluginCmd{
+		pdv2.PluginCmd{
+			Token:   token,
+			ID:      pi.PluginID,
+			Command: pi.CmdBillingStatusChanges,
+			Payload: "",
+		},
 	}
 
 	// Send request
-	reply, err := c.PluginWrite(ctx, cmd)
+	replies, err := c.PluginReads(ctx, cmds)
+	if err != nil {
+		return nil, err
+	}
+	if len(replies) == 0 {
+		return nil, fmt.Errorf("no replies found")
+	}
+	pcr := replies[0]
+	err = extractPluginCmdError(pcr)
 	if err != nil {
 		return nil, err
 	}
 
 	// Decode reply
-	var sbsr pi.SetBillingStatusReply
-	err = json.Unmarshal([]byte(reply), &sbsr)
+	var bscsr pi.BillingStatusChangesReply
+	err = json.Unmarshal([]byte(pcr.Payload), &bscsr)
 	if err != nil {
 		return nil, err
 	}
 
-	return &sbsr, nil
+	return &bscsr, nil
+
 }

--- a/politeiad/plugins/pi/pi.go
+++ b/politeiad/plugins/pi/pi.go
@@ -15,6 +15,10 @@ const (
 
 	// CmdSummary command returns a summary for a proposal.
 	CmdSummary = "summary"
+
+	// CmdBillingStatusChanges command returns the billing status changes
+	// of a proposal.
+	CmdBillingStatusChanges = "billingstatuschanges"
 )
 
 // Plugin setting keys can be used to specify custom plugin settings. Default
@@ -359,13 +363,8 @@ type SummaryReply struct {
 }
 
 // ProposalSummary summarizes proposal information.
-//
-// StatusReason field will be populated if the status change required a
-// reason to be given. Examples include when a proposal is censored/abandoned
-// or when the billing status of the proposal is set to closed.
 type ProposalSummary struct {
-	Status       PropStatusT `json:"status"`
-	StatusReason string      `json:"statusreason"`
+	Status PropStatusT `json:"status"`
 }
 
 // PropStatusT represents the status of a proposal. It combines record and
@@ -472,4 +471,15 @@ const (
 // from the proposal author.
 type ProposalUpdateMetadata struct {
 	Title string `json:"title"`
+}
+
+// BillingStatusChanges requests the billing status changes for the provided
+// proposal token.
+type BillingStatusChanges struct {
+	Token string `json:"token"`
+}
+
+// BillingStatusChangesReply is the reply to the BillingStatusChanges command.
+type BillingStatusChangesReply struct {
+	BillingStatusChanges []BillingStatusChange `json:"billingstatuschanges"`
 }

--- a/politeiawww/api/pi/v1/v1.go
+++ b/politeiawww/api/pi/v1/v1.go
@@ -13,12 +13,15 @@ const (
 	// RoutePolicy returns the policy for the pi API.
 	RoutePolicy = "/policy"
 
-	// RouteSetBillingStatus sets the record's billing status.
+	// RouteSetBillingStatus sets the proposal's billing status.
 	RouteSetBillingStatus = "/setbillingstatus"
 
 	// RouteSummaries returns the proposal summary for a page of
 	// records.
 	RouteSummaries = "/summaries"
+
+	// RouteBillingStatusChanges returns the proposal's billing status changes.
+	RouteBillingStatusChanges = "/billingstatuschanges"
 )
 
 // ErrorCodeT represents a user error code.
@@ -283,16 +286,16 @@ const (
 	SummariesPageSize uint32 = 5
 )
 
-// Summaries requests the proposal summaries for the provided record tokens.
+// Summaries requests the proposal summaries for the provided proposal tokens.
 type Summaries struct {
 	Tokens []string `json:"tokens"`
 }
 
 // SummariesReply is the reply to the Summaries command.
 //
-// Summaries field contains a vote summary for each of the provided tokens.
+// Summaries field contains a proposal summary for each of the provided tokens.
 // The map will not contain an entry for any tokens that did not correspond
-// to an actual record. It is the callers responsibility to ensure that a
+// to an actual proposal. It is the callers responsibility to ensure that a
 // summary is returned for all provided tokens.
 type SummariesReply struct {
 	Summaries map[string]Summary `json:"summaries"` // [token]Summary
@@ -302,11 +305,17 @@ type SummariesReply struct {
 //
 // Status field is the string value of the PropStatusT type which is defined
 // along with all of it's possible values in the pi plugin API.
-//
-// StatusReason field will be populated if the status change required a
-// reason to be given. Examples include when a proposal is censored/abandoned
-// or when the billing status of the proposal is set to closed.
 type Summary struct {
-	Status       string `json:"status"`
-	StatusReason string `json:"statusreason"`
+	Status string `json:"status"`
+}
+
+// BillingStatusChanges requests the billing status changes for the provided
+// proposal token.
+type BillingStatusChanges struct {
+	Token string `json:"token"`
+}
+
+// BillingStatusChangesReply is the reply to the BillingStatusChanges command.
+type BillingStatusChangesReply struct {
+	BillingStatusChanges []BillingStatusChange `json:"billingstatuschanges"`
 }

--- a/politeiawww/client/pi.go
+++ b/politeiawww/client/pi.go
@@ -66,6 +66,24 @@ func (c *Client) PiSummaries(s piv1.Summaries) (*piv1.SummariesReply, error) {
 	return &sr, nil
 }
 
+// PiBillingStatusChanges sends a pi v1 BillingStatusChanges request to
+// politeiawww.
+func (c *Client) PiBillingStatusChanges(bscs piv1.BillingStatusChanges) (*piv1.BillingStatusChangesReply, error) {
+	resBody, err := c.makeReq(http.MethodPost,
+		piv1.APIRoute, piv1.RouteBillingStatusChanges, bscs)
+	if err != nil {
+		return nil, err
+	}
+
+	var bscsr piv1.BillingStatusChangesReply
+	err = json.Unmarshal(resBody, &bscsr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bscsr, nil
+}
+
 // ProposalMetadataDecode decodes and returns the ProposalMetadata from the
 // Provided record files. An error returned if a ProposalMetadata is not found.
 func ProposalMetadataDecode(files []rcv1.File) (*piv1.ProposalMetadata, error) {

--- a/politeiawww/cmd/pictl/cmdhelp.go
+++ b/politeiawww/cmd/pictl/cmdhelp.go
@@ -79,6 +79,8 @@ func (c *cmdHelp) Execute(args []string) error {
 		fmt.Printf("%s\n", proposalSetStatusHelpMsg)
 	case "proposalsetbillingstatus":
 		fmt.Printf("%s\n", proposalSetBillingStatusHelpMsg)
+	case "proposalbillingstatuschanges":
+		fmt.Printf("%s\n", proposalBillingStatusChangesHelpMsg)
 	case "proposaldetails":
 		fmt.Printf("%s\n", proposalDetailsHelpMsg)
 	case "proposaltimestamps":

--- a/politeiawww/cmd/pictl/cmdproposalbillingstatuschanges.go
+++ b/politeiawww/cmd/pictl/cmdproposalbillingstatuschanges.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	piv1 "github.com/decred/politeia/politeiawww/api/pi/v1"
+	pclient "github.com/decred/politeia/politeiawww/client"
+)
+
+// cmdProposalBillingStatusChanges returns the billing status changes of a
+// proposal.
+type cmdProposalBillingStatusChanges struct {
+	Args struct {
+		Token string `positional-arg-name:"token" required:"true"`
+	} `positional-args:"true"`
+}
+
+// Execute executes the cmdProposalBillingStatusChanges command.
+//
+// This function satisfies the go-flags Commander interface.
+func (c *cmdProposalBillingStatusChanges) Execute(args []string) error {
+	// Setup client
+	opts := pclient.Opts{
+		HTTPSCert:  cfg.HTTPSCert,
+		Cookies:    cfg.Cookies,
+		HeaderCSRF: cfg.CSRF,
+		Verbose:    cfg.Verbose,
+		RawJSON:    cfg.RawJSON,
+	}
+	pc, err := pclient.New(cfg.Host, opts)
+	if err != nil {
+		return err
+	}
+
+	// Setup request
+	bscs := piv1.BillingStatusChanges{
+		Token: c.Args.Token,
+	}
+
+	// Send request
+	bscsr, err := pc.PiBillingStatusChanges(bscs)
+	if err != nil {
+		return err
+	}
+
+	// Print billing status changes
+	for _, bsc := range bscsr.BillingStatusChanges {
+		printBillingStatusChange(bsc)
+		printf("-----\n")
+	}
+
+	return nil
+}
+
+// proposalBillingStatusChangesHelpMsg is printed to stdout by the help command.
+const proposalBillingStatusChangesHelpMsg = `proposalbillingstatuschanges
+"token"
+
+Return the billing status changes of a proposal.
+
+Arguments:
+1. token   (string, required)   Proposal censorship token
+`

--- a/politeiawww/cmd/pictl/cmdproposalbillingstatuschanges.go
+++ b/politeiawww/cmd/pictl/cmdproposalbillingstatuschanges.go
@@ -55,8 +55,7 @@ func (c *cmdProposalBillingStatusChanges) Execute(args []string) error {
 }
 
 // proposalBillingStatusChangesHelpMsg is printed to stdout by the help command.
-const proposalBillingStatusChangesHelpMsg = `proposalbillingstatuschanges
-"token"
+const proposalBillingStatusChangesHelpMsg = `proposalbillingstatuschanges "token"
 
 Return the billing status changes of a proposal.
 

--- a/politeiawww/cmd/pictl/pictl.go
+++ b/politeiawww/cmd/pictl/pictl.go
@@ -64,18 +64,19 @@ type pictl struct {
 	Users                   shared.UsersCmd              `command:"users"`
 
 	// Proposal commands
-	ProposalPolicy           cmdProposalPolicy           `command:"proposalpolicy"`
-	ProposalNew              cmdProposalNew              `command:"proposalnew"`
-	ProposalEdit             cmdProposalEdit             `command:"proposaledit"`
-	ProposalSetStatus        cmdProposalSetStatus        `command:"proposalsetstatus"`
-	ProposalSetBillingStatus cmdProposalSetBillingStatus `command:"proposalsetbillingstatus"`
-	ProposalDetails          cmdProposalDetails          `command:"proposaldetails"`
-	ProposalTimestamps       cmdProposalTimestamps       `command:"proposaltimestamps"`
-	Proposals                cmdProposals                `command:"proposals"`
-	ProposalSummaries        cmdProposalSummaries        `command:"proposalsummaries"`
-	ProposalInv              cmdProposalInv              `command:"proposalinv"`
-	ProposalInvOrdered       cmdProposalInvOrdered       `command:"proposalinvordered"`
-	UserProposals            cmdUserProposals            `command:"userproposals"`
+	ProposalPolicy               cmdProposalPolicy               `command:"proposalpolicy"`
+	ProposalNew                  cmdProposalNew                  `command:"proposalnew"`
+	ProposalEdit                 cmdProposalEdit                 `command:"proposaledit"`
+	ProposalSetStatus            cmdProposalSetStatus            `command:"proposalsetstatus"`
+	ProposalSetBillingStatus     cmdProposalSetBillingStatus     `command:"proposalsetbillingstatus"`
+	ProposalBillingStatusChanges cmdProposalBillingStatusChanges `command:"proposalbillingstatuschanges"`
+	ProposalDetails              cmdProposalDetails              `command:"proposaldetails"`
+	ProposalTimestamps           cmdProposalTimestamps           `command:"proposaltimestamps"`
+	Proposals                    cmdProposals                    `command:"proposals"`
+	ProposalSummaries            cmdProposalSummaries            `command:"proposalsummaries"`
+	ProposalInv                  cmdProposalInv                  `command:"proposalinv"`
+	ProposalInvOrdered           cmdProposalInvOrdered           `command:"proposalinvordered"`
+	UserProposals                cmdUserProposals                `command:"userproposals"`
 
 	// Records commands
 	RecordPolicy cmdRecordPolicy `command:"recordpolicy"`

--- a/politeiawww/cmd/pictl/proposal.go
+++ b/politeiawww/cmd/pictl/proposal.go
@@ -120,11 +120,8 @@ func printProposal(r rcv1.Record) error {
 
 // printProposalSummary prints a proposal summary.
 func printProposalSummary(token string, s piv1.Summary) {
-	printf("Token       : %v\n", token)
-	printf("Status      : %v\n", s.Status)
-	if s.StatusReason != "" {
-		printf("StatusReason: %v\n", s.StatusReason)
-	}
+	printf("Token : %v\n", token)
+	printf("Status: %v\n", s.Status)
 }
 
 // indexFileRandom returns a proposal index file filled with random data.

--- a/politeiawww/cmd/pictl/proposal.go
+++ b/politeiawww/cmd/pictl/proposal.go
@@ -124,6 +124,17 @@ func printProposalSummary(token string, s piv1.Summary) {
 	printf("Status: %v\n", s.Status)
 }
 
+// printBillingStatusChanges prints a proposal billing status change.
+func printBillingStatusChange(bsc piv1.BillingStatusChange) {
+	printf("Token    : %v\n", bsc.Token)
+	printf("Status   : %v\n", piv1.BillingStatuses[bsc.Status])
+	printf("Reason   : %v\n", bsc.Reason)
+	printf("PublicKey: %v\n", bsc.PublicKey)
+	printf("Signature: %v\n", bsc.Signature)
+	printf("Receipt  : %v\n", bsc.Receipt)
+	printf("Timestamp: %v\n", timestampFromUnix(bsc.Timestamp))
+}
+
 // indexFileRandom returns a proposal index file filled with random data.
 func indexFileRandom(sizeInBytes int) (*rcv1.File, error) {
 	// Create lines of text that are 80 characters long

--- a/politeiawww/pi.go
+++ b/politeiawww/pi.go
@@ -172,6 +172,9 @@ func (p *politeiawww) setupPiRoutes(r *records.Records, c *comments.Comments, t 
 	p.addRoute(http.MethodPost, piv1.APIRoute,
 		piv1.RouteSummaries, pic.HandleSummaries,
 		permissionPublic)
+	p.addRoute(http.MethodPost, piv1.APIRoute,
+		piv1.RouteBillingStatusChanges, pic.HandleBillingStatusChanges,
+		permissionPublic)
 }
 
 func (p *politeiawww) setupPi() error {

--- a/politeiawww/pi/pi.go
+++ b/politeiawww/pi/pi.go
@@ -96,6 +96,32 @@ func (p *Pi) HandleSummaries(w http.ResponseWriter, r *http.Request) {
 	util.RespondWithJSON(w, http.StatusOK, bsr)
 }
 
+// HandleBillingStatusChanges is the request handler for the pi v1
+// BillingStatusChanges route.
+func (p *Pi) HandleBillingStatusChanges(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("HandleBillingStatusChanges")
+
+	var bscs v1.BillingStatusChanges
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&bscs); err != nil {
+		respondWithError(w, r, "HandleBillingStatusChanges: unmarshal",
+			v1.UserErrorReply{
+				ErrorCode: v1.ErrorCodeInputInvalid,
+			})
+		return
+	}
+
+	bsr, err := p.processBillingStatusChanges(r.Context(), bscs)
+	if err != nil {
+		respondWithError(w, r,
+			"HandleBillingStatusChanges: processBillingStatusChanges: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, bsr)
+
+}
+
 // New returns a new Pi context.
 func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, m mail.Mailer, s *sessions.Sessions, e *events.Manager, plugins []pdv2.Plugin) (*Pi, error) {
 	// Parse plugin settings


### PR DESCRIPTION
Clients need to be able to retrieve the full billing status metadata so
that the admin username can be displayed and so that the admin signature
is available if the client wants it. In order to do this, API needs to
be added to the pi plugin for retrieving the full billing status change
metadata objects.  With that said, the current `StatusReason` in not
needed in the pi `Summary` and can be removed as this feature wasn't
deployed to production yet.

**Implementation:**

   - Remove `StatusReason` from pi API `Summary`.
   - Add new `/billingstatuschanges` route to the pi API.
   - Add new pictl command `pictl proposalbillingstatuschanges "token"`
   command which consumes the new pi API.
 
---

Closes #1524.