### PR TITLE
politeiawww: Add logger package.

### DIFF
--- a/politeiawww/events/log.go
+++ b/politeiawww/events/log.go
@@ -4,7 +4,10 @@
 
 package events
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("EVNT"))
 }

--- a/politeiawww/legacy/cmsdatabase/cockroachdb/log.go
+++ b/politeiawww/legacy/cmsdatabase/cockroachdb/log.go
@@ -4,7 +4,10 @@
 
 package cockroachdb
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("CMDB"))
 }

--- a/politeiawww/legacy/codetracker/github/database/cockroachdb/log.go
+++ b/politeiawww/legacy/codetracker/github/database/cockroachdb/log.go
@@ -4,7 +4,10 @@
 
 package cockroachdb
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("GHDB"))
 }

--- a/politeiawww/legacy/codetracker/github/log.go
+++ b/politeiawww/legacy/codetracker/github/log.go
@@ -4,7 +4,10 @@
 
 package github
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 var log = slog.Disabled
 
@@ -12,4 +15,9 @@ var log = slog.Disabled
 // made before a server is created and used (it is not concurrent safe).
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("GHTR"))
 }

--- a/politeiawww/legacy/comments/log.go
+++ b/politeiawww/legacy/comments/log.go
@@ -4,7 +4,10 @@
 
 package comments
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("PWWW"))
 }

--- a/politeiawww/legacy/log.go
+++ b/politeiawww/legacy/log.go
@@ -4,7 +4,10 @@
 
 package legacy
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("LWWW"))
 }

--- a/politeiawww/legacy/pi/log.go
+++ b/politeiawww/legacy/pi/log.go
@@ -4,7 +4,10 @@
 
 package pi
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("PWWW"))
 }

--- a/politeiawww/legacy/testing.go
+++ b/politeiawww/legacy/testing.go
@@ -26,6 +26,7 @@ import (
 	"github.com/decred/politeia/politeiawww/config"
 	"github.com/decred/politeia/politeiawww/legacy/user"
 	"github.com/decred/politeia/politeiawww/legacy/user/localdb"
+	"github.com/decred/politeia/politeiawww/logger"
 	"github.com/decred/politeia/politeiawww/mail"
 	"github.com/decred/politeia/politeiawww/sessions"
 	"github.com/decred/politeia/util"
@@ -369,9 +370,9 @@ func newTestCMSwww(t *testing.T) (*Politeiawww, func()) {
 		t.Fatalf("open tmp dir: %v", err)
 	}
 
-	// Setup logging
-	// initLogRotator(filepath.Join(dataDir, "cmswww.test.log"))
-	// setLogLevels("off")
+	// Turn logging off
+	logger.InitLogRotator(filepath.Join(dataDir, "cmswww.test.log"))
+	logger.SetLogLevels("off")
 
 	// Setup config
 	xpub := "tpubVobLtToNtTq6TZNw4raWQok35PRPZou53vegZqNubtBTJMMFm" +
@@ -413,9 +414,6 @@ func newTestCMSwww(t *testing.T) (*Politeiawww, func()) {
 	if err != nil {
 		t.Fatalf("create cookie key: %v", err)
 	}
-
-	// initLogRotator(filepath.Join(dataDir, "cmswww.test.log"))
-	// setLogLevels("off")
 
 	// Create politeiawww context
 	p := Politeiawww{

--- a/politeiawww/legacy/ticketvote/log.go
+++ b/politeiawww/legacy/ticketvote/log.go
@@ -4,7 +4,10 @@
 
 package ticketvote
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("PWWW"))
 }

--- a/politeiawww/legacy/user/cockroachdb/log.go
+++ b/politeiawww/legacy/user/cockroachdb/log.go
@@ -4,7 +4,10 @@
 
 package cockroachdb
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("USER"))
 }

--- a/politeiawww/legacy/user/localdb/log.go
+++ b/politeiawww/legacy/user/localdb/log.go
@@ -4,7 +4,10 @@
 
 package localdb
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("USER"))
 }

--- a/politeiawww/legacy/user/mysql/log.go
+++ b/politeiawww/legacy/user/mysql/log.go
@@ -4,7 +4,10 @@
 
 package mysql
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("USER"))
 }

--- a/politeiawww/log.go
+++ b/politeiawww/log.go
@@ -1,171 +1,33 @@
-// Copyright (c) 2017-2021 The Decred developers
+// Copyright (c) 2013-2015 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package main
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/decred/politeia/politeiawww/events"
-	"github.com/decred/politeia/politeiawww/legacy"
-	cmsdb "github.com/decred/politeia/politeiawww/legacy/cmsdatabase/cockroachdb"
-	"github.com/decred/politeia/politeiawww/legacy/codetracker/github"
-	ghdb "github.com/decred/politeia/politeiawww/legacy/codetracker/github/database/cockroachdb"
-	"github.com/decred/politeia/politeiawww/legacy/comments"
-	"github.com/decred/politeia/politeiawww/legacy/pi"
-	"github.com/decred/politeia/politeiawww/legacy/ticketvote"
-	"github.com/decred/politeia/politeiawww/legacy/user/cockroachdb"
-	"github.com/decred/politeia/politeiawww/legacy/user/localdb"
-	"github.com/decred/politeia/politeiawww/legacy/user/mysql"
-	"github.com/decred/politeia/politeiawww/mail"
-	"github.com/decred/politeia/politeiawww/records"
-	"github.com/decred/politeia/politeiawww/sessions"
-	"github.com/decred/politeia/wsdcrdata"
+	"github.com/decred/politeia/politeiawww/logger"
 	"github.com/decred/slog"
-	"github.com/jrick/logrotate/rotator"
 )
 
-// logWriter implements an io.Writer that outputs to both standard output and
-// the write-end pipe of an initialized log rotator.
-type logWriter struct{}
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = slog.Disabled
 
-func (logWriter) Write(p []byte) (n int, err error) {
-	os.Stdout.Write(p)
-	return logRotator.Write(p)
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until either UseLogger or SetLogWriter are called.
+func DisableLog() {
+	log = slog.Disabled
 }
 
-// Loggers per subsystem.  A single backend logger is created and all subsytem
-// loggers created from it will write to the backend.  When adding new
-// subsystems, add the subsystem logger variable here and to the
-// subsystemLoggers map.
-//
-// Loggers can not be used before the log rotator has been initialized with a
-// log file.  This must be performed early during application startup by calling
-// initLogRotator.
-var (
-	// backendLog is the logging backend used to create all subsystem loggers.
-	// The backend must not be used before the log rotator has been initialized,
-	// or data races and/or nil pointer dereferences will occur.
-	backendLog = slog.NewBackend(logWriter{})
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using slog.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}
 
-	// logRotator is one of the logging outputs.  It should be closed on
-	// application shutdown.
-	logRotator *rotator.Rotator
-
-	log         = backendLog.Logger("PWWW")
-	eventsLog   = backendLog.Logger("EVNT")
-	sessionsLog = backendLog.Logger("SESS")
-	apiLog      = backendLog.Logger("APIS")
-
-	// Legacy loggers
-	userdbLog = backendLog.Logger("USER")
-
-	// Legacy CMS loggers
-	cmsdbLog         = backendLog.Logger("CMDB")
-	wsdcrdataLog     = backendLog.Logger("WSDD")
-	githubTrackerLog = backendLog.Logger("GHTR")
-	githubdbLog      = backendLog.Logger("GHDB")
-)
-
-// Initialize package-global logger variables.
+// Initialize the package logger.
 func init() {
-	mail.UseLogger(log)
-	sessions.UseLogger(sessionsLog)
-	events.UseLogger(eventsLog)
-
-	// Legacy server logger
-	legacy.UseLogger(log)
-
-	// Legacy UserDB loggers
-	localdb.UseLogger(userdbLog)
-	cockroachdb.UseLogger(userdbLog)
-	mysql.UseLogger(userdbLog)
-
-	// API loggers
-	records.UseLogger(apiLog)
-	comments.UseLogger(apiLog)
-	ticketvote.UseLogger(apiLog)
-	pi.UseLogger(apiLog)
-
-	// CMS loggers
-	cmsdb.UseLogger(cmsdbLog)
-	wsdcrdata.UseLogger(wsdcrdataLog)
-	github.UseLogger(githubTrackerLog)
-	ghdb.UseLogger(githubdbLog)
-}
-
-// subsystemLoggers maps each subsystem identifier to its associated logger.
-var subsystemLoggers = map[string]slog.Logger{
-	"PWWW": log,
-	"SESS": sessionsLog,
-	"EVNT": eventsLog,
-	"APIS": apiLog,
-
-	// Legacy loggers
-	"USER": userdbLog,
-	"CMDB": cmsdbLog,
-	"WSDD": wsdcrdataLog,
-	"GHTR": githubTrackerLog,
-	"GHDB": githubdbLog,
-}
-
-// initLogRotator initializes the logging rotater to write logs to logFile and
-// create roll files in the same directory.  It must be called before the
-// package-global log rotater variables are used.
-func initLogRotator(logFile string) {
-	logDir, _ := filepath.Split(logFile)
-	err := os.MkdirAll(logDir, 0700)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
-		os.Exit(1)
-	}
-	r, err := rotator.New(logFile, 10*1024, false, 3)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
-		os.Exit(1)
-	}
-
-	logRotator = r
-}
-
-// setLogLevel sets the logging level for provided subsystem.  Invalid
-// subsystems are ignored.  Uninitialized subsystems are dynamically created as
-// needed.
-func setLogLevel(subsystemID string, logLevel string) {
-	// Ignore invalid subsystems.
-	logger, ok := subsystemLoggers[subsystemID]
-	if !ok {
-		return
-	}
-
-	// Defaults to info if the log level is invalid.
-	level, _ := slog.LevelFromString(logLevel)
-	logger.SetLevel(level)
-}
-
-// setLogLevels sets the log level for all subsystem loggers to the passed
-// level.  It also dynamically creates the subsystem loggers as needed, so it
-// can be used to initialize the logging system.
-func setLogLevels(logLevel string) {
-	// Configure all sub-systems with the new logging level.  Dynamically
-	// create loggers as needed.
-	for subsystemID := range subsystemLoggers {
-		setLogLevel(subsystemID, logLevel)
-	}
-}
-
-// LogClosure is a closure that can be printed with %v to be used to
-// generate expensive-to-create data for a detailed log level and avoid doing
-// the work if the data isn't printed.
-type logClosure func() string
-
-func (c logClosure) String() string {
-	return c()
-}
-
-func newLogClosure(c func() string) logClosure {
-	return logClosure(c)
+	UseLogger(logger.NewSubsystem("PWWW"))
 }

--- a/politeiawww/logger/logger.go
+++ b/politeiawww/logger/logger.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2017-2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package logger
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/decred/slog"
+	"github.com/jrick/logrotate/rotator"
+)
+
+// logWriter implements an io.Writer that outputs to both standard output and
+// the write-end pipe of an initialized log rotator.
+type logWriter struct{}
+
+func (logWriter) Write(p []byte) (n int, err error) {
+	os.Stdout.Write(p)
+	return logRotator.Write(p)
+}
+
+// Loggers per subsystem.  A single backend logger is created and all subsytem
+// loggers created from it will write to the backend.  When adding new
+// subsystems, add the subsystem logger variable here and to the
+// subsystemLoggers map.
+//
+// Loggers can not be used before the log rotator has been initialized with a
+// log file.  This must be performed early during application startup by calling
+// initLogRotator.
+var (
+	// backendLog is the logging backend used to create all subsystem loggers.
+	// The backend must not be used before the log rotator has been initialized,
+	// or data races and/or nil pointer dereferences will occur.
+	backendLog = slog.NewBackend(logWriter{})
+
+	// logRotator is one of the logging outputs.  It should be closed on
+	// application shutdown.
+	logRotator *rotator.Rotator
+
+	// subsystemsLoggers contains all of the subsystem loggers. A new subsystem
+	// logger is registered using Register().
+	subsystemLoggers = map[string]slog.Logger{}
+)
+
+// InitLogRotator initializes the logging rotater to write logs to logFile and
+// create roll files in the same directory.  It must be called before the
+// package-global log rotater variables are used.
+func InitLogRotator(logFile string) {
+	logDir, _ := filepath.Split(logFile)
+	err := os.MkdirAll(logDir, 0700)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
+		os.Exit(1)
+	}
+	r, err := rotator.New(logFile, 10*1024, false, 3)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
+		os.Exit(1)
+	}
+
+	logRotator = r
+}
+
+// CloseLogRotator closes the log rotator.
+func CloseLogRotator() {
+	if logRotator != nil {
+		logRotator.Close()
+	}
+}
+
+// NewSubsystem registers and returns a new subsystem logger.
+func NewSubsystem(subsystemTag string) slog.Logger {
+	l := backendLog.Logger(subsystemTag)
+	subsystemLoggers[subsystemTag] = l
+	return l
+}
+
+// SupportedSubsystems returns a sorted slice of the supported subsystems for
+// logging purposes.
+func SupportedSubsystems() []string {
+	// Convert the subsystemLoggers map keys to a slice.
+	subsystems := make([]string, 0, len(subsystemLoggers))
+	for subsysID := range subsystemLoggers {
+		subsystems = append(subsystems, subsysID)
+	}
+
+	// Sort the subsytems for stable display.
+	sort.Strings(subsystems)
+	return subsystems
+}
+
+// SetLogLevel sets the logging level for provided subsystem.  Invalid
+// subsystems are ignored.  Uninitialized subsystems are dynamically created as
+// needed.
+func SetLogLevel(subsystemID string, logLevel string) {
+	// Ignore invalid subsystems.
+	logger, ok := subsystemLoggers[subsystemID]
+	if !ok {
+		return
+	}
+
+	// Defaults to info if the log level is invalid.
+	level, _ := slog.LevelFromString(logLevel)
+	logger.SetLevel(level)
+}
+
+// SetLogLevels sets the log level for all subsystem loggers to the passed
+// level.  It also dynamically creates the subsystem loggers as needed, so it
+// can be used to initialize the logging system.
+func SetLogLevels(logLevel string) {
+	// Configure all sub-systems with the new logging level.  Dynamically
+	// create loggers as needed.
+	for subsystemID := range subsystemLoggers {
+		SetLogLevel(subsystemID, logLevel)
+	}
+}
+
+// LogClosure is a closure that can be printed with %v to be used to
+// generate expensive-to-create data for a detailed log level and avoid doing
+// the work if the data isn't printed.
+type LogClosure func() string
+
+func (c LogClosure) String() string {
+	return c()
+}
+
+// NewLogClosure returns a new LogClosure.
+func NewLogClosure(c func() string) LogClosure {
+	return LogClosure(c)
+}

--- a/politeiawww/mail/log.go
+++ b/politeiawww/mail/log.go
@@ -4,7 +4,10 @@
 
 package mail
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("MAIL"))
 }

--- a/politeiawww/middleware.go
+++ b/politeiawww/middleware.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
+	"github.com/decred/politeia/politeiawww/logger"
 	"github.com/decred/politeia/util"
 )
 
@@ -30,7 +31,7 @@ func closeBodyMiddleware(next http.Handler) http.Handler {
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Trace incoming request
-		log.Tracef("%v", newLogClosure(func() string {
+		log.Tracef("%v", logger.NewLogClosure(func() string {
 			trace, err := httputil.DumpRequest(r, true)
 			if err != nil {
 				trace = []byte(fmt.Sprintf("logging: "+

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -21,6 +21,7 @@ import (
 	"github.com/decred/politeia/politeiawww/config"
 	"github.com/decred/politeia/politeiawww/events"
 	"github.com/decred/politeia/politeiawww/legacy"
+	"github.com/decred/politeia/politeiawww/logger"
 	"github.com/decred/politeia/politeiawww/sessions"
 	"github.com/decred/politeia/util"
 	"github.com/decred/politeia/util/version"
@@ -58,9 +59,7 @@ func _main() error {
 		return fmt.Errorf("Could not load configuration file: %v", err)
 	}
 	defer func() {
-		if logRotator != nil {
-			logRotator.Close()
-		}
+		logger.CloseLogRotator()
 	}()
 
 	log.Infof("Version : %v", version.String())

--- a/politeiawww/records/log.go
+++ b/politeiawww/records/log.go
@@ -4,7 +4,10 @@
 
 package records
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("PWWW"))
 }

--- a/politeiawww/sessions/log.go
+++ b/politeiawww/sessions/log.go
@@ -4,7 +4,10 @@
 
 package sessions
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/politeia/politeiawww/logger"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -22,4 +25,9 @@ func DisableLog() {
 // using slog.
 func UseLogger(logger slog.Logger) {
 	log = logger
+}
+
+// Initialize the package logger.
+func init() {
+	UseLogger(logger.NewSubsystem("SESS"))
 }

--- a/politeiawww/www.go
+++ b/politeiawww/www.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 
+	"github.com/decred/politeia/politeiawww/logger"
 	"github.com/decred/politeia/util"
 )
 
@@ -19,7 +20,7 @@ func handleNotFound(w http.ResponseWriter, r *http.Request) {
 		util.RemoteAddr(r), r.Method, r.URL, r.Proto)
 
 	// Trace incoming request
-	log.Tracef("%v", newLogClosure(func() string {
+	log.Tracef("%v", logger.NewLogClosure(func() string {
 		trace, err := httputil.DumpRequest(r, true)
 		if err != nil {
 			trace = []byte(fmt.Sprintf("handleNotFound: DumpRequest %v", err))


### PR DESCRIPTION
This diff moves the logging state into into a new `logger` package
instead of storing it in the global main scope. This allows external
packages, such as plugins, to setup their own loggers without having to
add any code to main. This will allow plugins to be completely self
contained.