### PR TITLE
multi: Move identity methods.

### DIFF
--- a/politeiad/api/v1/identity/identity.go
+++ b/politeiad/api/v1/identity/identity.go
@@ -122,6 +122,16 @@ func PublicIdentityFromBytes(data []byte) (*PublicIdentity, error) {
 	return &pi, nil
 }
 
+// PublicIdentityFromString converts a hex encoded public key into a
+// PublicIdentity.
+func PublicIdentityFromString(id string) (*PublicIdentity, error) {
+	pk, err := hex.DecodeString(id)
+	if err != nil {
+		return nil, err
+	}
+	return PublicIdentityFromBytes(pk)
+}
+
 func LoadPublicIdentity(filename string) (*PublicIdentity, error) {
 	idx, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/politeiad/client/pdv1.go
+++ b/politeiad/client/pdv1.go
@@ -40,7 +40,7 @@ func (c *Client) Identity(ctx context.Context) (*identity.PublicIdentity, error)
 	if err != nil {
 		return nil, err
 	}
-	pid, err := util.IdentityFromString(ir.PublicKey)
+	pid, err := identity.PublicIdentityFromString(ir.PublicKey)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiad/client/pdv2.go
+++ b/politeiad/client/pdv2.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	pdv2 "github.com/decred/politeia/politeiad/api/v2"
 	v2 "github.com/decred/politeia/politeiad/api/v2"
 	"github.com/decred/politeia/util"
@@ -420,7 +421,7 @@ func RecordVerify(r pdv2.Record, serverPubKey string) error {
 	}
 
 	// Verify censorship record signature
-	id, err := util.IdentityFromString(serverPubKey)
+	id, err := identity.PublicIdentityFromString(serverPubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -523,7 +523,7 @@ func recordVerify() error {
 	merkle := hex.EncodeToString(mr[:])
 
 	// Load identity
-	pid, err := util.IdentityFromString(serverKey)
+	pid, err := identity.PublicIdentityFromString(serverKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/client/records.go
+++ b/politeiawww/client/records.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	backend "github.com/decred/politeia/politeiad/backendv2"
 	"github.com/decred/politeia/politeiad/plugins/usermd"
 	rcv1 "github.com/decred/politeia/politeiawww/api/records/v1"
@@ -249,7 +250,7 @@ func CensorshipRecordVerify(r rcv1.Record, serverPubKey string) error {
 	}
 
 	// Verify censorship record signature
-	id, err := util.IdentityFromString(serverPubKey)
+	id, err := identity.PublicIdentityFromString(serverPubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/cmswww/batchproposals.go
+++ b/politeiawww/cmd/cmswww/batchproposals.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/decred/dcrtime/merkle"
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 	"github.com/decred/politeia/util"
@@ -176,7 +177,7 @@ func verifyProposal(p v1.ProposalRecord, serverPubKey string) error {
 	}
 
 	// Verify proposal signature
-	pid, err := util.IdentityFromString(p.PublicKey)
+	pid, err := identity.PublicIdentityFromString(p.PublicKey)
 	if err != nil {
 		return err
 	}
@@ -189,7 +190,7 @@ func verifyProposal(p v1.ProposalRecord, serverPubKey string) error {
 	}
 
 	// Verify censorship record signature
-	id, err := util.IdentityFromString(serverPubKey)
+	id, err := identity.PublicIdentityFromString(serverPubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/cmswww/censorcomment.go
+++ b/politeiawww/cmd/cmswww/censorcomment.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 	"github.com/decred/politeia/util"
@@ -63,7 +64,7 @@ func (cmd *CensorCommentCmd) Execute(args []string) error {
 	}
 
 	// Validate censor comment receipt
-	serverID, err := util.IdentityFromString(vr.PubKey)
+	serverID, err := identity.PublicIdentityFromString(vr.PubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/cmswww/cmswww.go
+++ b/politeiawww/cmd/cmswww/cmswww.go
@@ -147,7 +147,7 @@ func verifyInvoice(p cms.InvoiceRecord, serverPubKey string) error {
 	}
 
 	// Verify invoice signature
-	pid, err := util.IdentityFromString(p.PublicKey)
+	pid, err := identity.PublicIdentityFromString(p.PublicKey)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func verifyInvoice(p cms.InvoiceRecord, serverPubKey string) error {
 	}
 
 	// Verify censorship record signature
-	id, err := util.IdentityFromString(serverPubKey)
+	id, err := identity.PublicIdentityFromString(serverPubKey)
 	if err != nil {
 		return err
 	}
@@ -310,7 +310,7 @@ func verifyDCC(p cms.DCCRecord, serverPubKey string) error {
 	}
 
 	// Verify dcc signature
-	pid, err := util.IdentityFromString(p.PublicKey)
+	pid, err := identity.PublicIdentityFromString(p.PublicKey)
 	if err != nil {
 		return err
 	}
@@ -323,7 +323,7 @@ func verifyDCC(p cms.DCCRecord, serverPubKey string) error {
 	}
 
 	// Verify censorship record signature
-	id, err := util.IdentityFromString(serverPubKey)
+	id, err := identity.PublicIdentityFromString(serverPubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/pictl/cmdcastballot.go
+++ b/politeiawww/cmd/pictl/cmdcastballot.go
@@ -15,7 +15,6 @@ import (
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	tkv1 "github.com/decred/politeia/politeiawww/api/ticketvote/v1"
 	pclient "github.com/decred/politeia/politeiawww/client"
-	"github.com/decred/politeia/util"
 )
 
 // cmdCastBallot casts a ballot of votes.
@@ -178,7 +177,7 @@ func (c *cmdCastBallot) Execute(args []string) error {
 	if err != nil {
 		return fmt.Errorf("Version: %v", err)
 	}
-	serverID, err := util.IdentityFromString(version.PubKey)
+	serverID, err := identity.PublicIdentityFromString(version.PubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/pictl/cmdcommentvote.go
+++ b/politeiawww/cmd/pictl/cmdcommentvote.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	cmv1 "github.com/decred/politeia/politeiawww/api/comments/v1"
 	pclient "github.com/decred/politeia/politeiawww/client"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
@@ -87,7 +88,7 @@ func (c *cmdCommentVote) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	serverID, err := util.IdentityFromString(vr.PubKey)
+	serverID, err := identity.PublicIdentityFromString(vr.PubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/pictl/cmdvoteauthorize.go
+++ b/politeiawww/cmd/pictl/cmdvoteauthorize.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	rcv1 "github.com/decred/politeia/politeiawww/api/records/v1"
 	tkv1 "github.com/decred/politeia/politeiawww/api/ticketvote/v1"
 	pclient "github.com/decred/politeia/politeiawww/client"
@@ -99,7 +100,7 @@ func (c *cmdVoteAuthorize) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	serverID, err := util.IdentityFromString(vr.PubKey)
+	serverID, err := identity.PublicIdentityFromString(vr.PubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/politeiaverify/politeiaverify.go
+++ b/politeiawww/cmd/politeiaverify/politeiaverify.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	rcv1 "github.com/decred/politeia/politeiawww/api/records/v1"
 	"github.com/decred/politeia/politeiawww/client"
 	"github.com/decred/politeia/util"
@@ -79,7 +80,7 @@ func verifyCensorshipRecord(serverPubKey, token, signature string, filepaths []s
 	merkle := hex.EncodeToString(mr[:])
 
 	// Load identity
-	pid, err := util.IdentityFromString(serverPubKey)
+	pid, err := identity.PublicIdentityFromString(serverPubKey)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -415,7 +415,7 @@ func firstContact(shutdownCtx context.Context, cfg *config) (*ctx, error) {
 	log.Debugf("Route  : %v", version.Route)
 	log.Debugf("Pubkey : %v", version.PubKey)
 
-	c.id, err = util.IdentityFromString(version.PubKey)
+	c.id, err = identity.PublicIdentityFromString(version.PubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -27,6 +27,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/politeia/decredplugin"
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiad/backend/gitbe"
 	"github.com/decred/politeia/politeiawww/config"
 	"github.com/decred/politeia/politeiawww/legacy/user"
@@ -401,7 +402,7 @@ func cmdStubUsers() error {
 	for k := range pubkeys {
 		username := fmt.Sprintf("dbutil_user%v", i)
 		email := username + "@example.com"
-		id, err := util.IdentityFromString(k)
+		id, err := identity.PublicIdentityFromString(k)
 		if err != nil {
 			return err
 		}

--- a/politeiawww/identity.go
+++ b/politeiawww/identity.go
@@ -6,15 +6,23 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 
+	v1 "github.com/decred/politeia/politeiad/api/v1"
+	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/util"
 )
 
 // getIdentity fetches the remote identity from politeiad.
 func getIdentity(rpcHost, rpcCert, rpcIdentityFile, interactive string) error {
-	id, err := util.RemoteIdentity(false, rpcHost, rpcCert)
+	id, err := remoteIdentity(false, rpcHost, rpcCert)
 	if err != nil {
 		return err
 	}
@@ -49,4 +57,62 @@ func getIdentity(rpcHost, rpcCert, rpcIdentityFile, interactive string) error {
 	log.Infof("Identity saved to: %v", rpcIdentityFile)
 
 	return nil
+}
+
+// remoteIdentity fetches the identity from politeiad.
+func remoteIdentity(skipTLSVerify bool, host, cert string) (*identity.PublicIdentity, error) {
+	challenge, err := util.Random(v1.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+	id, err := json.Marshal(v1.Identity{
+		Challenge: hex.EncodeToString(challenge),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := util.NewHTTPClient(skipTLSVerify, cert)
+	if err != nil {
+		return nil, err
+	}
+	r, err := c.Post(host+v1.IdentityRoute, "application/json",
+		bytes.NewReader(id))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		e, err := util.GetErrorFromJSON(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("%v", r.Status)
+		}
+		return nil, fmt.Errorf("%v: %v", r.Status, e)
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var ir v1.IdentityReply
+	err = json.Unmarshal(body, &ir)
+	if err != nil {
+		return nil, fmt.Errorf("Could node unmarshal IdentityReply: %v",
+			err)
+	}
+
+	// Convert and verify server identity
+	identity, err := identity.PublicIdentityFromString(ir.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	err = util.VerifyChallenge(identity, challenge, ir.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	return identity, nil
 }

--- a/util/identity.go
+++ b/util/identity.go
@@ -5,84 +5,11 @@
 package util
 
 import (
-	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
-	v1 "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 )
-
-// IdentityFromString converts a string public key into a public identity
-// structure.
-func IdentityFromString(id string) (*identity.PublicIdentity, error) {
-	pk, err := hex.DecodeString(id)
-	if err != nil {
-		return nil, err
-	}
-	return identity.PublicIdentityFromBytes(pk)
-}
-
-// RemoteIdentity fetches the identity from politeiad.
-func RemoteIdentity(skipTLSVerify bool, host, cert string) (*identity.PublicIdentity, error) {
-	challenge, err := Random(v1.ChallengeSize)
-	if err != nil {
-		return nil, err
-	}
-	id, err := json.Marshal(v1.Identity{
-		Challenge: hex.EncodeToString(challenge),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := NewHTTPClient(skipTLSVerify, cert)
-	if err != nil {
-		return nil, err
-	}
-	r, err := c.Post(host+v1.IdentityRoute, "application/json",
-		bytes.NewReader(id))
-	if err != nil {
-		return nil, err
-	}
-	defer r.Body.Close()
-
-	if r.StatusCode != http.StatusOK {
-		e, err := GetErrorFromJSON(r.Body)
-		if err != nil {
-			return nil, fmt.Errorf("%v", r.Status)
-		}
-		return nil, fmt.Errorf("%v: %v", r.Status, e)
-	}
-
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var ir v1.IdentityReply
-	err = json.Unmarshal(body, &ir)
-	if err != nil {
-		return nil, fmt.Errorf("Could node unmarshal IdentityReply: %v",
-			err)
-	}
-
-	// Convert and verify server identity
-	identity, err := IdentityFromString(ir.PublicKey)
-	if err != nil {
-		return nil, err
-	}
-
-	err = VerifyChallenge(identity, challenge, ir.Response)
-	if err != nil {
-		return nil, err
-	}
-
-	return identity, nil
-}
 
 // VerifyChallenge checks that the signature returned from politeiad is the
 // challenge signed with the given identity.


### PR DESCRIPTION
This diff moves two identity methods out of the `util` package and in
into more appropriate places.

`IdentityFromString` was moved into the `identity` package with the
other identity methods and was renamed to `PublicIdentityFromString` in
order to be consistent with the existing naming convetion.

`RemoteIdentity` was moved into `politeiawww/identity.go` since this is
the only place in the codebase that it was being invoked. It was renamed
to `remoteIdentity`.