### PR TITLE
pi: Allow zero `billingstatuschangesmax`.

### DIFF
--- a/politeiawww/legacy/pi/pi.go
+++ b/politeiawww/legacy/pi/pi.go
@@ -263,9 +263,6 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, m mail.Mai
 	case len(domains) == 0:
 		return nil, errors.Errorf("plugin setting not found: %v",
 			pi.SettingKeyProposalDomains)
-	case billingStatusChangesMax == 0:
-		return nil, errors.Errorf("plugin setting not found: %v",
-			pi.SettingKeyBillingStatusChangesMax)
 	}
 
 	// Setup pi context


### PR DESCRIPTION
This diff removes a validation in the pi plugin which prevented
setting the `billingstatuschangesmax` as zero. We would like to allow that
as there may be cases where the sysadmin would want to disallow billing
status changes temporarily.