### PR TITLE
ticketvote: Fix ineligible status bug.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -2405,6 +2405,19 @@ func (p *ticketVotePlugin) summary(token []byte, bestBlock uint32) (*ticketvote.
 
 	// Summary has not been cached. Get it manually.
 
+	// Verify that the record is eligble for a vote.
+	r, err := p.recordAbridged(token)
+	if err != nil {
+		return nil, err
+	}
+	if r.RecordMetadata.Status != backend.StatusPublic {
+		return &ticketvote.SummaryReply{
+			Status:    ticketvote.VoteStatusIneligible,
+			Results:   []ticketvote.VoteOptionResult{},
+			BestBlock: bestBlock,
+		}, nil
+	}
+
 	// Assume vote is unauthorized. Only update the status when the
 	// appropriate record has been found that proves otherwise.
 	status := ticketvote.VoteStatusUnauthorized

--- a/politeiawww/cmd/pictl/ticketvote.go
+++ b/politeiawww/cmd/pictl/ticketvote.go
@@ -67,7 +67,8 @@ func printVoteSummary(token string, s tkv1.Summary) {
 	printf("Token             : %v\n", token)
 	printf("Status            : %v\n", tkv1.VoteStatuses[s.Status])
 	switch s.Status {
-	case tkv1.VoteStatusUnauthorized, tkv1.VoteStatusAuthorized:
+	case tkv1.VoteStatusUnauthorized, tkv1.VoteStatusAuthorized,
+		tkv1.VoteStatusIneligible:
 		// Nothing else to print
 		return
 	}

--- a/politeiawww/legacy/ticketvote/process.go
+++ b/politeiawww/legacy/ticketvote/process.go
@@ -486,6 +486,8 @@ func convertVoteStatusToV1(s ticketvote.VoteStatusT) v1.VoteStatusT {
 		return v1.VoteStatusApproved
 	case ticketvote.VoteStatusRejected:
 		return v1.VoteStatusRejected
+	case ticketvote.VoteStatusIneligible:
+		return v1.VoteStatusIneligible
 	default:
 		return v1.VoteStatusInvalid
 	}


### PR DESCRIPTION
This fixes a bug that was causing the vote status of non-public
proposals to be returned incorrectly from the summary plugin command.
The vote status was being returned as `unauthorized` when it should be
`ineligible`.