### PR TITLE
politeiaverify: Allow short token filenames.

### DIFF
--- a/politeiawww/cmd/politeiaverify/politeiaverify.go
+++ b/politeiawww/cmd/politeiaverify/politeiaverify.go
@@ -111,12 +111,12 @@ func verifyCensorshipRecord(serverPubKey, token, signature string, filepaths []s
 var (
 	// Regexps for matching file bundles downloaded from politeiagui
 	expJSONFile          = `.json$`
-	expRecord            = `^[0-9a-f]{16}-v[\d]{1,2}.json$`
-	expRecordTimestamps  = `^[0-9a-f]{16}-v[\d]{1,2}-timestamps.json$`
-	expComments          = `^[0-9a-f]{16}-comments.json$`
-	expCommentTimestamps = `^[0-9a-f]{16}-comments-timestamps.json$`
-	expVotes             = `^[0-9a-f]{16}-votes.json$`
-	expVoteTimestamps    = `^[0-9a-f]{16}-votes-timestamps.json$`
+	expRecord            = `^[0-9a-f]{7,16}-v[\d]{1,2}.json$`
+	expRecordTimestamps  = `^[0-9a-f]{7,16}-v[\d]{1,2}-timestamps.json$`
+	expComments          = `^[0-9a-f]{7,16}-comments.json$`
+	expCommentTimestamps = `^[0-9a-f]{7,16}-comments-timestamps.json$`
+	expVotes             = `^[0-9a-f]{7,16}-votes.json$`
+	expVoteTimestamps    = `^[0-9a-f]{7,16}-votes-timestamps.json$`
 
 	regexpJSONFile          = regexp.MustCompile(expJSONFile)
 	regexpRecord            = regexp.MustCompile(expRecord)

--- a/politeiawww/cmd/politeiaverify/ticketvote.go
+++ b/politeiawww/cmd/politeiaverify/ticketvote.go
@@ -96,6 +96,9 @@ func verifyVotesBundle(fp string) error {
 
 	fmt.Printf("Cast votes: %v/%v\n", len(vb.Votes), len(eligible))
 
+	fmt.Printf("Checking votes for eligibility, duplicates, and " +
+		"valid signatures...\n")
+
 	for _, v := range vb.Votes {
 		err := client.CastVoteDetailsVerify(v, vb.ServerPublicKey)
 		if err != nil {
@@ -119,8 +122,6 @@ func verifyVotesBundle(fp string) error {
 			"duplicates %v", notEligible, duplicates)
 	}
 
-	fmt.Printf("All cast votes have been checked for eligibility, " +
-		"duplicates, and valid signatures.\n")
 	fmt.Printf("Cast votes verified!\n")
 
 	return nil


### PR DESCRIPTION
This updates the politeiaverify filename regular expressions to be able
to match against short tokens. politeiagui switched to short token
filenames at some point, causing politeiaverify to not recognize the
filenames anymore.