### PR TITLE
logger: Fix nil pointer bug.

### DIFF
--- a/politeiawww/logger/logger.go
+++ b/politeiawww/logger/logger.go
@@ -20,6 +20,9 @@ type logWriter struct{}
 
 func (logWriter) Write(p []byte) (n int, err error) {
 	os.Stdout.Write(p)
+	if logRotator == nil {
+		return 0, nil
+	}
 	return logRotator.Write(p)
 }
 


### PR DESCRIPTION
This fixes a nil pointer bug that is hit when a package attempts to
use its logger without having the log rotator setup.

Now that individual packages initialize the logger themselves instead of
having it initialized by main, it's possible for package loggers to be
used without ever having the log rotator setup. An example is when CLI
tools use politeiawww packages, like when dbutil uses the userdb
implemenations.