### PR TITLE
politeiavoter: Add hoursprior config setting.

### DIFF
--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -1003,15 +1003,15 @@ func (c *ctx) _vote(token, voteID string) error {
 
 		// Calculate vote duration if not set
 		if c.cfg.voteDuration.Seconds() == 0 {
-			blocksLeft := vs.EndBlockHeight - bestBlock
-			if blocksLeft < uint32(c.cfg.blocksPerHour) {
-				return fmt.Errorf("less than one hour left to" +
-					" vote, please set --voteduration " +
-					"manually")
+			blocksLeft := int64(vs.EndBlockHeight) - int64(bestBlock)
+			if blocksLeft < int64(c.cfg.HoursPrior*c.cfg.blocksPerHour) {
+				return fmt.Errorf("less than twelve hours " +
+					"left to vote, please set " +
+					"--voteduration manually")
 			}
 			c.cfg.voteDuration = activeNetParams.TargetTimePerBlock *
 				(time.Duration(blocksLeft) -
-					time.Duration(c.cfg.blocksPerHour))
+					time.Duration(c.cfg.HoursPrior*c.cfg.blocksPerHour))
 		}
 
 		// Generate work

--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -16,14 +16,16 @@ import (
 
 func (c *ctx) calculateTrickle(token, voteBit string, ctres *pb.CommittedTicketsResponse, smr *pb.SignMessagesResponse) error {
 	votes := len(ctres.TicketAddresses)
+	workers := c.cfg.Workers
 	duration := c.cfg.voteDuration
-	voteDuration := duration - time.Hour
+	voteDuration := duration - time.Duration(c.cfg.HoursPrior)*time.Hour
 	if voteDuration < time.Hour {
 		return fmt.Errorf("not enough time left to trickle votes")
 	}
-	fmt.Printf("Total number of votes: %v\n", votes)
-	fmt.Printf("Total vote duration  : %v\n", duration)
-	fmt.Printf("Duration calculated  : %v\n", voteDuration)
+	fmt.Printf("Total number of votes  : %v\n", votes)
+	fmt.Printf("Total number of workers: %v\n", workers)
+	fmt.Printf("Total vote duration    : %v\n", duration)
+	fmt.Printf("Duration calculated    : %v\n", voteDuration)
 
 	prng, err := uniformprng.RandSource(rand.Reader)
 	if err != nil {


### PR DESCRIPTION
Don't be too aggressive with left over time.

During poor network connections (e.g. when using tor) failed votes stack
up over time. That combined with an aggressive end time (originally 1
hour prior to vote being complete) can lead to clustering or failed
votes towards the end.

This adds a new configuration option called --hoursprior. That value
designates the hours to subtract from the end of the voting period and
is set to a default of 12 hours. These extra hours prior to expiration
gives the user some additional margin to correct failures.

This change also fixes a uint underflow.