### PR TITLE
pi: Allow comment writes on unvetted proposals.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/pi/hooks.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/hooks.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2020-2021 The Decred developers
+// Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package pi


### PR DESCRIPTION
This diff fixes a bug in the pi plugin comment writes validations where
the vote criteria was applied on both vetted and unvetted proposals
which disabled comments on unvetted proposals.

This ensures the vote criteria is applied only on vetted proposals.

--- 

Closes #1545.