### PR TITLE
politeiawww: Setup userdb env variables.

### DIFF
--- a/politeiawww/config/config.go
+++ b/politeiawww/config/config.go
@@ -175,7 +175,7 @@ type Config struct {
 // The above results in politeia functioning properly without any config
 // settings while still allowing the user to override settings with config
 // files and command line options. Command line options always take precedence
-// over the config file. Env variables always take precendence over the command
+// over the config file. Env variables always take precedence over the command
 // line options.
 func Load() (*Config, []string, error) {
 	// Setup the default config. Most of settings that contain file

--- a/politeiawww/config/config.go
+++ b/politeiawww/config/config.go
@@ -162,18 +162,21 @@ type Config struct {
 	SystemCerts *x509.CertPool
 }
 
-// Load initializes and parses the config using a config file and command line
-// options.
+// Load initializes and parses the config using a config file, command line
+// options, and env variables.
 //
 // The configuration proceeds as follows:
 // 	1) Start with a default config with sane settings
 // 	2) Pre-parse the command line to check for an alternative config file
 // 	3) Load configuration file overwriting defaults with any specified options
 // 	4) Parse CLI options and overwrite/add any specified options
+//  5) Parse env variables and overwrite/add any specified options
 //
-// The above results in rpc functioning properly without any config settings
-// while still allowing the user to override settings with config files and
-// command line options.  Command line options always take precedence.
+// The above results in politeia functioning properly without any config
+// settings while still allowing the user to override settings with config
+// files and command line options. Command line options always take precedence
+// over the config file. Env variables always take precendence over the command
+// line options.
 func Load() (*Config, []string, error) {
 	// Setup the default config. Most of settings that contain file
 	// paths are not set to default values and handled later on, once


### PR DESCRIPTION
Previously, some user database config options were provided using the
config file or CLI flags, while others were provided using env
variables. This updates the user database config options to accept
values provided in any of the three methods. The hierarchy that dictates
what values take precedence is as follows:

1. env variables (supersedes all others)
2. CLI flags
3. config file

Accepting env variable values will make it easier to containerize the
politeia application in the future.

Only the user database options have been setup this way for now. The
rest will be added at a later date. The user database options serve as
an example for how the others should be setup.