### PR TITLE
ticketvote: Cast vote error format.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -1315,7 +1315,7 @@ func (p *ticketVotePlugin) ballot(token []byte, votes []ticketvote.CastVote, br 
 					"found %v", t)
 				e := ticketvote.VoteErrorInternalError
 				cvr.Ticket = v.Ticket
-				cvr.ErrorCode = e
+				cvr.ErrorCode = &e
 				cvr.ErrorContext = fmt.Sprintf("%v: %v",
 					ticketvote.VoteErrors[e], t)
 				goto saveReply
@@ -1347,7 +1347,7 @@ func (p *ticketVotePlugin) ballot(token []byte, votes []ticketvote.CastVote, br 
 					"%v", t, err)
 				e := ticketvote.VoteErrorInternalError
 				cvr.Ticket = v.Ticket
-				cvr.ErrorCode = e
+				cvr.ErrorCode = &e
 				cvr.ErrorContext = fmt.Sprintf("%v: %v",
 					ticketvote.VoteErrors[e], t)
 				goto saveReply
@@ -1364,7 +1364,7 @@ func (p *ticketVotePlugin) ballot(token []byte, votes []ticketvote.CastVote, br 
 				log.Errorf("cmdCastBallot: voteColliderSave %v: %v", t, err)
 				e := ticketvote.VoteErrorInternalError
 				cvr.Ticket = v.Ticket
-				cvr.ErrorCode = e
+				cvr.ErrorCode = &e
 				cvr.ErrorContext = fmt.Sprintf("%v: %v",
 					ticketvote.VoteErrors[e], t)
 				goto saveReply
@@ -1429,7 +1429,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if err != nil {
 			e := ticketvote.VoteErrorTokenInvalid
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: not hex",
 				ticketvote.VoteErrors[e])
 			continue
@@ -1439,7 +1439,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if !bytes.Equal(t, token) {
 			e := ticketvote.VoteErrorMultipleRecordVotes
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = ticketvote.VoteErrors[e]
 			continue
 		}
@@ -1448,7 +1448,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if voteDetails == nil {
 			e := ticketvote.VoteErrorVoteStatusInvalid
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: vote is "+
 				"not active", ticketvote.VoteErrors[e])
 			continue
@@ -1456,7 +1456,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if voteHasEnded(bestBlock, voteDetails.EndBlockHeight) {
 			e := ticketvote.VoteErrorVoteStatusInvalid
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: vote has "+
 				"ended", ticketvote.VoteErrors[e])
 			continue
@@ -1467,7 +1467,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if err != nil {
 			e := ticketvote.VoteErrorVoteBitInvalid
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = ticketvote.VoteErrors[e]
 			continue
 		}
@@ -1476,7 +1476,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if err != nil {
 			e := ticketvote.VoteErrorVoteBitInvalid
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: %v",
 				ticketvote.VoteErrors[e], err)
 			continue
@@ -1487,7 +1487,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if !ok {
 			e := ticketvote.VoteErrorTicketNotEligible
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = ticketvote.VoteErrors[e]
 			continue
 		}
@@ -1497,14 +1497,14 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if !isActive {
 			e := ticketvote.VoteErrorVoteStatusInvalid
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: vote is "+
 				"not active", ticketvote.VoteErrors[e])
 		}
 		if isDup {
 			e := ticketvote.VoteErrorTicketAlreadyVoted
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = ticketvote.VoteErrors[e]
 			continue
 		}
@@ -1521,7 +1521,8 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 	// that are not found in the cache are fetched manually.
 	tickets := make([]string, 0, len(cb.Ballot))
 	for k, v := range votes {
-		if receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
+		if receipts[k].ErrorCode != nil &&
+			*receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
 			// Vote has an error. Skip it.
 			continue
 		}
@@ -1554,7 +1555,8 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 
 	// Verify the signatures
 	for k, v := range votes {
-		if receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
+		if receipts[k].ErrorCode != nil &&
+			*receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
 			// Vote has an error. Skip it.
 			continue
 		}
@@ -1567,7 +1569,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 				"%v: %v", t, v.Ticket)
 			e := ticketvote.VoteErrorInternalError
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: %v",
 				ticketvote.VoteErrors[e], t)
 			continue
@@ -1578,7 +1580,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 				"%v %v", t, v.Ticket, commitmentAddr.err)
 			e := ticketvote.VoteErrorInternalError
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: %v",
 				ticketvote.VoteErrors[e], t)
 			continue
@@ -1587,7 +1589,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		if err != nil {
 			e := ticketvote.VoteErrorSignatureInvalid
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: %v",
 				ticketvote.VoteErrors[e], err)
 			continue
@@ -1641,7 +1643,8 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		ballotCount int
 	)
 	for k, v := range votes {
-		if receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
+		if receipts[k].ErrorCode != nil &&
+			*receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
 			// Vote has an error. Skip it.
 			continue
 		}
@@ -1679,7 +1682,8 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 
 	// Fill in the receipts
 	for k, v := range votes {
-		if receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
+		if receipts[k].ErrorCode != nil &&
+			*receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
 			// Vote has an error. Skip it.
 			continue
 		}
@@ -1690,7 +1694,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 				"%v", t, v.Ticket)
 			e := ticketvote.VoteErrorInternalError
 			receipts[k].Ticket = v.Ticket
-			receipts[k].ErrorCode = e
+			receipts[k].ErrorCode = &e
 			receipts[k].ErrorContext = fmt.Sprintf("%v: %v",
 				ticketvote.VoteErrors[e], t)
 			continue

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -1521,8 +1521,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 	// that are not found in the cache are fetched manually.
 	tickets := make([]string, 0, len(cb.Ballot))
 	for k, v := range votes {
-		if receipts[k].ErrorCode != nil &&
-			*receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
+		if receipts[k].ErrorCode != nil {
 			// Vote has an error. Skip it.
 			continue
 		}
@@ -1555,8 +1554,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 
 	// Verify the signatures
 	for k, v := range votes {
-		if receipts[k].ErrorCode != nil &&
-			*receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
+		if receipts[k].ErrorCode != nil {
 			// Vote has an error. Skip it.
 			continue
 		}
@@ -1643,8 +1641,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 		ballotCount int
 	)
 	for k, v := range votes {
-		if receipts[k].ErrorCode != nil &&
-			*receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
+		if receipts[k].ErrorCode != nil {
 			// Vote has an error. Skip it.
 			continue
 		}
@@ -1682,8 +1679,7 @@ func (p *ticketVotePlugin) cmdCastBallot(token []byte, payload string) (string, 
 
 	// Fill in the receipts
 	for k, v := range votes {
-		if receipts[k].ErrorCode != nil &&
-			*receipts[k].ErrorCode != ticketvote.VoteErrorInvalid {
+		if receipts[k].ErrorCode != nil {
 			// Vote has an error. Skip it.
 			continue
 		}

--- a/politeiad/plugins/ticketvote/ticketvote.go
+++ b/politeiad/plugins/ticketvote/ticketvote.go
@@ -497,8 +497,8 @@ type CastVoteReply struct {
 
 	// The follwing fields will only be present if an error occurred
 	// while attempting to cast the vote.
-	ErrorCode    VoteErrorT `json:"errorcode,omitempty"`
-	ErrorContext string     `json:"errorcontext,omitempty"`
+	ErrorCode    *VoteErrorT `json:"errorcode,omitempty"`
+	ErrorContext string      `json:"errorcontext,omitempty"`
 }
 
 // CastBallot casts a ballot of votes. A ballot can only contain votes for a

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -446,8 +446,8 @@ type CastVoteReply struct {
 
 	// The follwing fields will only be present if an error occurred
 	// while attempting to cast the vote.
-	ErrorCode    VoteErrorT `json:"errorcode,omitempty"`
-	ErrorContext string     `json:"errorcontext,omitempty"`
+	ErrorCode    *VoteErrorT `json:"errorcode,omitempty"`
+	ErrorContext string      `json:"errorcontext,omitempty"`
 }
 
 // CastBallot casts a ballot of votes. A ballot can only contain the votes for

--- a/politeiawww/cmd/pictl/cmdcastballot.go
+++ b/politeiawww/cmd/pictl/cmdcastballot.go
@@ -194,7 +194,7 @@ func (c *cmdCastBallot) Execute(args []string) error {
 		h := eligibleTickets[i]
 
 		// Check for vote error
-		if v.ErrorContext != "" {
+		if v.ErrorCode != nil {
 			failedReceipts = append(failedReceipts, v)
 			failedTickets = append(failedTickets, h)
 			continue

--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -150,7 +150,7 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 	// Wait
 	err := WaitUntil(ectx, va.At)
 	if err != nil {
-		return fmt.Errorf("%v bunch %v vote %v failed: %v\n",
+		return fmt.Errorf("%v bunch %v vote %v failed: %v",
 			time.Now(), bunchID, voteID, err)
 	}
 
@@ -187,15 +187,7 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 			return fmt.Errorf("unrecoverable error: %v",
 				err)
 		} else {
-			// XXX TODO(lukebp) please make this a pointer and only
-			// evaluate these errors when it is set. For now we
-			// have to treat VoteErrorInvalid as valid because of
-			// this.
-			switch vr.ErrorCode {
-			// Success
-			case tkv1.VoteErrorInvalid:
-				// XXX treat as success for now
-
+			switch *vr.ErrorCode {
 			// Silently ignore.
 			case tkv1.VoteErrorTicketAlreadyVoted:
 				// This happens during network errors. Since

--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -186,7 +186,8 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 			// Unrecoverable error
 			return fmt.Errorf("unrecoverable error: %v",
 				err)
-		} else {
+		} else if vr.ErrorCode != nil {
+			// Evaluate errors when ErrorCode is set
 			switch *vr.ErrorCode {
 			// Silently ignore.
 			case tkv1.VoteErrorTicketAlreadyVoted:

--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -145,7 +145,6 @@ func waitRandom(min, max byte) time.Duration {
 
 func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteAlarm) error {
 	voteID++ // make human readable
-	//fmt.Printf("bunchID: %v voterID: %v at: %v\n", bunchID, voteID, va.At)
 
 	// Wait
 	err := WaitUntil(ectx, va.At)
@@ -250,7 +249,7 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 
 				return nil
 			}
-
+		} else {
 			// Success, log it and exit
 			err = p.jsonLog(successJournal, va.Vote.Token, vr)
 			if err != nil {

--- a/politeiawww/legacy/proposals.go
+++ b/politeiawww/legacy/proposals.go
@@ -556,15 +556,12 @@ func (p *Politeiawww) processCastVotes(ctx context.Context, ballot *www.Ballot) 
 	// Prepare reply
 	receipts := make([]www.CastVoteReply, 0, len(cbr.Receipts))
 	for k, v := range cbr.Receipts {
-		r := www.CastVoteReply{
+		receipts = append(receipts, www.CastVoteReply{
 			ClientSignature: ballot.Votes[k].Signature,
 			Signature:       v.Receipt,
 			Error:           v.ErrorContext,
-		}
-		if v.ErrorCode != nil {
-			r.ErrorStatus = convertVoteErrorCodeToWWW(*v.ErrorCode)
-		}
-		receipts = append(receipts, r)
+			ErrorStatus:     convertVoteErrorCodeToWWW(v.ErrorCode),
+		})
 	}
 
 	return &www.BallotReply{
@@ -835,8 +832,11 @@ func convertVoteTypeToWWW(t tkplugin.VoteT) www.VoteT {
 	}
 }
 
-func convertVoteErrorCodeToWWW(e tkplugin.VoteErrorT) decredplugin.ErrorStatusT {
-	switch e {
+func convertVoteErrorCodeToWWW(e *tkplugin.VoteErrorT) decredplugin.ErrorStatusT {
+	if e == nil {
+		return decredplugin.ErrorStatusInvalid
+	}
+	switch *e {
 	case tkplugin.VoteErrorInvalid:
 		return decredplugin.ErrorStatusInvalid
 	case tkplugin.VoteErrorInternalError:

--- a/politeiawww/legacy/proposals.go
+++ b/politeiawww/legacy/proposals.go
@@ -556,12 +556,15 @@ func (p *Politeiawww) processCastVotes(ctx context.Context, ballot *www.Ballot) 
 	// Prepare reply
 	receipts := make([]www.CastVoteReply, 0, len(cbr.Receipts))
 	for k, v := range cbr.Receipts {
-		receipts = append(receipts, www.CastVoteReply{
+		r := www.CastVoteReply{
 			ClientSignature: ballot.Votes[k].Signature,
 			Signature:       v.Receipt,
 			Error:           v.ErrorContext,
-			ErrorStatus:     convertVoteErrorCodeToWWW(v.ErrorCode),
-		})
+		}
+		if v.ErrorCode != nil {
+			r.ErrorStatus = convertVoteErrorCodeToWWW(*v.ErrorCode)
+		}
+		receipts = append(receipts, r)
 	}
 
 	return &www.BallotReply{

--- a/politeiawww/legacy/ticketvote/process.go
+++ b/politeiawww/legacy/ticketvote/process.go
@@ -391,40 +391,43 @@ func convertVoteParamsToV1(v ticketvote.VoteParams) v1.VoteParams {
 	return vp
 }
 
-func convertVoteErrorToV1(e ticketvote.VoteErrorT) v1.VoteErrorT {
-	switch e {
-	case ticketvote.VoteErrorInvalid:
-		return v1.VoteErrorInvalid
-	case ticketvote.VoteErrorInternalError:
-		return v1.VoteErrorInternalError
-	case ticketvote.VoteErrorRecordNotFound:
-		return v1.VoteErrorRecordNotFound
-	case ticketvote.VoteErrorVoteBitInvalid:
-		return v1.VoteErrorVoteBitInvalid
-	case ticketvote.VoteErrorVoteStatusInvalid:
-		return v1.VoteErrorVoteStatusInvalid
-	case ticketvote.VoteErrorTicketAlreadyVoted:
-		return v1.VoteErrorTicketAlreadyVoted
-	case ticketvote.VoteErrorTicketNotEligible:
-		return v1.VoteErrorTicketNotEligible
-	default:
-		return v1.VoteErrorInternalError
+func convertVoteErrorToV1(e *ticketvote.VoteErrorT) *v1.VoteErrorT {
+	if e == nil {
+		return nil
 	}
+
+	var ve v1.VoteErrorT
+	switch *e {
+	case ticketvote.VoteErrorInvalid:
+		ve = v1.VoteErrorInvalid
+	case ticketvote.VoteErrorInternalError:
+		ve = v1.VoteErrorInternalError
+	case ticketvote.VoteErrorRecordNotFound:
+		ve = v1.VoteErrorRecordNotFound
+	case ticketvote.VoteErrorVoteBitInvalid:
+		ve = v1.VoteErrorVoteBitInvalid
+	case ticketvote.VoteErrorVoteStatusInvalid:
+		ve = v1.VoteErrorVoteStatusInvalid
+	case ticketvote.VoteErrorTicketAlreadyVoted:
+		ve = v1.VoteErrorTicketAlreadyVoted
+	case ticketvote.VoteErrorTicketNotEligible:
+		ve = v1.VoteErrorTicketNotEligible
+	default:
+		ve = v1.VoteErrorInternalError
+	}
+
+	return &ve
 }
 
 func convertCastVoteRepliesToV1(replies []ticketvote.CastVoteReply) []v1.CastVoteReply {
 	r := make([]v1.CastVoteReply, 0, len(replies))
 	for _, v := range replies {
-		cvr := v1.CastVoteReply{
+		r = append(r, v1.CastVoteReply{
 			Ticket:       v.Ticket,
 			Receipt:      v.Receipt,
 			ErrorContext: v.ErrorContext,
-		}
-		if v.ErrorCode != nil {
-			ec := convertVoteErrorToV1(*v.ErrorCode)
-			cvr.ErrorCode = &ec
-		}
-		r = append(r, cvr)
+			ErrorCode:    convertVoteErrorToV1(v.ErrorCode),
+		})
 	}
 	return r
 }

--- a/politeiawww/legacy/ticketvote/process.go
+++ b/politeiawww/legacy/ticketvote/process.go
@@ -425,8 +425,8 @@ func convertCastVoteRepliesToV1(replies []ticketvote.CastVoteReply) []v1.CastVot
 		r = append(r, v1.CastVoteReply{
 			Ticket:       v.Ticket,
 			Receipt:      v.Receipt,
-			ErrorContext: v.ErrorContext,
 			ErrorCode:    convertVoteErrorToV1(v.ErrorCode),
+			ErrorContext: v.ErrorContext,
 		})
 	}
 	return r

--- a/politeiawww/legacy/ticketvote/process.go
+++ b/politeiawww/legacy/ticketvote/process.go
@@ -415,12 +415,16 @@ func convertVoteErrorToV1(e ticketvote.VoteErrorT) v1.VoteErrorT {
 func convertCastVoteRepliesToV1(replies []ticketvote.CastVoteReply) []v1.CastVoteReply {
 	r := make([]v1.CastVoteReply, 0, len(replies))
 	for _, v := range replies {
-		r = append(r, v1.CastVoteReply{
+		cvr := v1.CastVoteReply{
 			Ticket:       v.Ticket,
 			Receipt:      v.Receipt,
-			ErrorCode:    convertVoteErrorToV1(v.ErrorCode),
 			ErrorContext: v.ErrorContext,
-		})
+		}
+		if v.ErrorCode != nil {
+			ec := convertVoteErrorToV1(*v.ErrorCode)
+			cvr.ErrorCode = &ec
+		}
+		r = append(r, cvr)
 	}
 	return r
 }


### PR DESCRIPTION
This commit changes the `ErrorCode` field in the `CastVoteReply` structs
to a pointer, in order to  fix a bug where default error code value
`ErrorCodeInvalid` was returned on success.

After this, in case of success the error code pointer will be nil.

--- 

Closes #1557.