### PR TITLE
pictl: Fix print bug and standardize vote params.

### DIFF
--- a/politeiad/plugins/ticketvote/ticketvote.go
+++ b/politeiad/plugins/ticketvote/ticketvote.go
@@ -309,8 +309,8 @@ type VoteParams struct {
 	// the vote to meet a quorum.
 	QuorumPercentage uint32 `json:"quorumpercentage"`
 
-	// PassPercentage is the percent of total votes that are required
-	// to consider a vote option as passed.
+	// PassPercentage is the percent of cast votes required for a vote
+	// option to be considered as passing.
 	PassPercentage uint32 `json:"passpercentage"`
 
 	Options []VoteOption `json:"options"`

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -336,8 +336,8 @@ type VoteParams struct {
 	// the vote to meet a quorum.
 	QuorumPercentage uint32 `json:"quorumpercentage"`
 
-	// PassPercentage is the percent of total votes that are required
-	// to consider a vote option as passed.
+	// PassPercentage is the percent of cast votes required for a vote
+	// option to be considered as passing.
 	PassPercentage uint32 `json:"passpercentage"`
 
 	Options []VoteOption `json:"options"`
@@ -554,8 +554,8 @@ type Summary struct {
 	// vote in order to have a quorum.
 	QuorumPercentage uint32 `json:"quorumpercentage"`
 
-	// PassPercentage is the percent of total votes required to approve
-	// the vote in order for the vote to pass.
+	// PassPercentage is the percent of cast votes required for a vote
+	// option to be considered as passing.
 	PassPercentage uint32 `json:"passpercentage"`
 
 	Results []VoteResult `json:"results"`

--- a/politeiawww/cmd/pictl/cmdrfptest.go
+++ b/politeiawww/cmd/pictl/cmdrfptest.go
@@ -43,10 +43,6 @@ func (c *cmdRFPTest) Execute(args []string) error {
 		// waiting for the RFP linkby deadline to expire before
 		// starting the runoff vote.
 		sleepInterval = 15 * time.Second
-
-		// Vote options
-		voteOptionYes = "yes"
-		voteOptionNo  = "no"
 	)
 
 	// Setup vote parameters
@@ -171,7 +167,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 		cfg.Silent = true
 	}
 
-	err = castBallot(tokenRFP, voteOptionYes, password)
+	err = castBallot(tokenRFP, tkv1.VoteOptionIDApprove, password)
 	if err != nil {
 		return err
 	}
@@ -323,13 +319,13 @@ func (c *cmdRFPTest) Execute(args []string) error {
 		" don't vote on third\n")
 
 	tokenFirst := tokensPublic[0]
-	err = castBallot(tokenFirst, voteOptionYes, password)
+	err = castBallot(tokenFirst, tkv1.VoteOptionIDApprove, password)
 	if err != nil {
 		return err
 	}
 
 	tokenSecond := tokensPublic[1]
-	err = castBallot(tokenSecond, voteOptionNo, password)
+	err = castBallot(tokenSecond, tkv1.VoteOptionIDReject, password)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/pictl/cmdrfptest.go
+++ b/politeiawww/cmd/pictl/cmdrfptest.go
@@ -16,12 +16,21 @@ import (
 // cmdRFPTest runs tests to ensure the RFP workflow works as expected.
 type cmdRFPTest struct {
 	Args struct {
-		AdminEmail    string `positional-arg-name:"adminemail" required:"true"`
-		AdminPassword string `positional-arg-name:"adminpassword" required:"true"`
+		AdminEmail    string `positional-arg-name:"adminemail"`
+		AdminPassword string `positional-arg-name:"adminpassword"`
 	} `positional-args:"true" required:"true"`
-	Password         string `long:"password" optional:"true"`
-	QuorumPercentage uint32 `long:"quorumpercentage" optional:"true"`
-	PassPercentage   uint32 `long:"passpercentage" optional:"true"`
+
+	// Password is the user's dcrwallet password.
+	Password string `long:"password"`
+
+	// Quorum is the percent of total votes required for a quorum. This is a
+	// pointer so that a value of 0 can be provided. A quorum of zero allows
+	// for the vote to be approved or rejected using a single DCR ticket.
+	Quorum *uint32 `long:"quorum"`
+
+	// Passing is the percent of cast votes required for a vote options to be
+	// considered as passing.
+	Passing uint32 `long:"passing"`
 }
 
 // Execute executes the cmdRFPTest command.
@@ -35,16 +44,25 @@ func (c *cmdRFPTest) Execute(args []string) error {
 		// starting the runoff vote.
 		sleepInterval = 15 * time.Second
 
-		// quorumPerc is the percent of total votes required for a quorum.
-		quorumPerc uint32 = 0
-
-		// passPerc is the percent of cast votes required for approval.
-		passPerc uint32 = 1
-
 		// Vote options
 		voteOptionYes = "yes"
 		voteOptionNo  = "no"
 	)
+
+	// Setup vote parameters
+	var (
+		quorum  = defaultQuorum
+		passing = defaultPassing
+	)
+	if c.Quorum != nil {
+		quorum = *c.Quorum
+	}
+	if c.Passing != 0 {
+		passing = c.Passing
+	}
+
+	fmt.Printf("Quorum : %v%%\n", quorum)
+	fmt.Printf("Passing: %v%%\n", passing)
 
 	// We don't want the output of individual commands printed.
 	cfg.Verbose = false
@@ -131,7 +149,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 	// Start RFP vote
 	fmt.Printf("  Start vote on RFP\n")
 	err = voteStart(admin, tokenRFP, pr.VoteDurationMin,
-		quorumPerc, passPerc)
+		quorum, passing)
 	if err != nil {
 		return err
 	}
@@ -182,7 +200,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 		}
 	}
 	fmt.Printf("  RFP approved successfully\n")
-	fmt.Printf("%v\n", voteSummaryString(tokenRFP, vs, "    "))
+	fmt.Printf("%v\n", voteSummaryString(tokenRFP, vs, 4))
 
 	// Create 1 unvetted censored RFP submission
 	fmt.Printf("  Create 1 unvetted censored RFP submission\n")
@@ -254,7 +272,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 
 	// Start runoff vote for the submissions
 	fmt.Printf("  Start runoff vote for the submissions\n")
-	err = voteRunoff(admin, tokenRFP, pr.VoteDurationMin, quorumPerc, passPerc)
+	err = voteRunoff(admin, tokenRFP, pr.VoteDurationMin, quorum, passing)
 	if err != nil {
 		return err
 	}
@@ -337,7 +355,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 		}
 	}
 	fmt.Printf("  First submission was approved successfully\n")
-	fmt.Printf("%v\n", voteSummaryString(tokenFirst, vs, "    "))
+	fmt.Printf("%v\n", voteSummaryString(tokenFirst, vs, 4))
 
 	// Fetch vote summary of rejected proposal
 	cvs = cmdVoteSummaries{}
@@ -358,7 +376,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 	}
 	fmt.Printf("  The other two submissions were rejected successfully\n")
 	for i, t := range tokens {
-		fmt.Printf("%v\n", voteSummaryString(t, summaries[t], "    "))
+		fmt.Printf("%v\n", voteSummaryString(t, summaries[t], 4))
 		if i != len(tokens)-1 {
 			fmt.Printf("    -----\n")
 		}
@@ -381,7 +399,13 @@ Arguments:
 2. adminpassword  (string, required)  Password for admin account.
 
 Flags:
- --password (string, optional) dcrwallet password. The user will be prompted
-                               for their password if one is not provided using
-                               this flag.
+ --password (string) dcrwallet password. The user will be prompted for their
+                     password if one is not provided using this flag.
+ --quorum   (uint32) Percent of total votes required to reach a quorum. A
+                     quorum of 0 means that the vote can be approved or
+                     rejected using a single DCR ticket.
+                     (default: 0)
+ --passing  (uint32) Percent of cast votes required for a vote option to be
+                     considered as passing.
+                     (default: 60)
 `

--- a/politeiawww/cmd/pictl/cmdrfptest.go
+++ b/politeiawww/cmd/pictl/cmdrfptest.go
@@ -260,7 +260,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 	tokensPublic[2] = r.CensorshipRecord.Token
 
 	// Wait for the rfp deadline to expire
-	for linkByTime.Unix() > time.Now().Unix() {
+	for linkByTime.Unix() >= time.Now().Unix() {
 		fmt.Printf("  Waiting for the RFP deadline to expire, remaining: %v\n",
 			time.Until(linkByTime).Round(time.Second))
 		time.Sleep(sleepInterval)

--- a/politeiawww/cmd/pictl/cmdvotesummaries.go
+++ b/politeiawww/cmd/pictl/cmdvotesummaries.go
@@ -53,7 +53,7 @@ func voteSummaries(c *cmdVoteSummaries) (map[string]tkv1.Summary, error) {
 
 	// Print summaries
 	for k, v := range sr.Summaries {
-		printf("%v\n", voteSummaryString(k, v, ""))
+		printf("%v\n", voteSummaryString(k, v, 0))
 		printf("-----\n")
 	}
 

--- a/politeiawww/cmd/pictl/cmdvotesummaries.go
+++ b/politeiawww/cmd/pictl/cmdvotesummaries.go
@@ -53,7 +53,7 @@ func voteSummaries(c *cmdVoteSummaries) (map[string]tkv1.Summary, error) {
 
 	// Print summaries
 	for k, v := range sr.Summaries {
-		printf(voteSummaryString(k, "", v))
+		printf("%v\n", voteSummaryString(k, v, ""))
 		printf("-----\n")
 	}
 

--- a/politeiawww/cmd/pictl/cmdvotetestsetup.go
+++ b/politeiawww/cmd/pictl/cmdvotetestsetup.go
@@ -8,34 +8,39 @@ import (
 	"fmt"
 )
 
-// cmdVoteTestSetup sets up a batch of proposal votes.
+// cmdVoteTestSetup starts a batch of proposal votes.
 type cmdVoteTestSetup struct {
 	Args struct {
-		AdminEmail    string `positional-arg-name:"adminemail" required:"true"`
-		AdminPassword string `positional-arg-name:"adminpassword" required:"true"`
-	} `positional-args:"true"`
+		AdminEmail    string `positional-arg-name:"adminemail"`
+		AdminPassword string `positional-arg-name:"adminpassword"`
+	} `positional-args:"true" required:"true"`
 
-	// Options to adjust the vote params.
-	Votes            uint32 `long:"votes" optional:"true"`
-	Duration         uint32 `long:"duration" optional:"true"`
-	QuorumPercentage uint32 `long:"quorumpercentage" optional:"true"`
-	PassPercentage   uint32 `long:"passpercentage" optional:"true"`
+	// Votes is the number of DCR ticket votes that will be started.
+	Votes uint32 `long:"votes"`
 
-	// IncludeImages is used to include a random number of images when
-	// submitting proposals.
-	IncludeImages bool `long:"includeimages"`
+	// Duration is the duration, in blocks of the DCR ticket votes.
+	Duration uint32 `long:"duration"`
+
+	// Quorum is the percent of total votes required for a quorum. This is a
+	// pointer so that a value of 0 can be provided. A quorum of zero allows
+	// for the vote to be approved or rejected using a single DCR ticket.
+	Quorum *uint32 `long:"quorum"`
+
+	// Passing is the percent of cast votes required for a vote options to be
+	// considered as passing.
+	Passing uint32 `long:"passing"`
 }
 
 // Execute executes the cmdVoteTestSetup command.
 //
 // This function satisfies the go-flags Commander interface.
 func (c *cmdVoteTestSetup) Execute(args []string) error {
-	// Setup test parameters
+	// Setup vote parameters
 	var (
 		votes    uint32 = 10
-		duration uint32 = 6  // In blocks
-		quorum   uint32 = 1  // Percentage of total tickets
-		pass     uint32 = 50 // Percentage of votes cast
+		duration        = defaultDuration
+		quorum          = defaultQuorum
+		passing         = defaultPassing
 	)
 	if c.Votes > 0 {
 		votes = c.Votes
@@ -43,11 +48,11 @@ func (c *cmdVoteTestSetup) Execute(args []string) error {
 	if c.Duration > 0 {
 		duration = c.Duration
 	}
-	if c.QuorumPercentage > 0 {
-		quorum = c.QuorumPercentage
+	if c.Quorum != nil {
+		quorum = *c.Quorum
 	}
-	if c.PassPercentage > 0 {
-		pass = c.PassPercentage
+	if c.Passing != 0 {
+		passing = c.Passing
 	}
 
 	// We don't want the output of individual commands printed.
@@ -104,7 +109,7 @@ func (c *cmdVoteTestSetup) Execute(args []string) error {
 		}
 
 		// Start vote
-		err = voteStart(admin, token, duration, quorum, pass)
+		err = voteStart(admin, token, duration, quorum, passing)
 		if err != nil {
 			return err
 		}
@@ -117,7 +122,7 @@ func (c *cmdVoteTestSetup) Execute(args []string) error {
 // voteTestSetupHelpMsg is the printed to stdout by the help command.
 const voteTestSetupHelpMsg = `votetestsetup [flags] "adminemail" "adminpassword"
 
-Setup a batch of proposal votes. This command submits the specified number of
+Start batch of proposal votes. This command submits the specified number of
 proposals, makes them public, then starts the voting period on each one.
 
 Arguments:
@@ -125,13 +130,15 @@ Arguments:
 2. adminpassword  (string, required)  Password for admin account.
 
 Flags
- --votes         (uint32) Number of votes to start. (default: 10)
- --duration      (uint32) Duration of each vote in blocks. (default: 6)
- --quorum        (uint32) Percent of total votes required to reach a quorum.
-                          (default: 1)
- --pass          (uint32) Percent of votes cast required for the vote to be
-                          approved. (default: 50)
- --includeimages (bool)   Include images in proposal submissions. This will
-                          substantially increase the size of the proposal
-                          payload.
+ --votes    (uint32) Number of votes to start.
+                     (default: 10)
+ --duration (uint32) Duration, in blocks, of the vote.
+                     (default: 6)
+ --quorum   (uint32) Percent of total votes required to reach a quorum. A
+                     quorum of 0 means that the vote can be approved or
+                     rejected using a single DCR ticket.
+                     (default: 0)
+ --passing  (uint32) Percent of cast votes required for a vote option to be
+                     considered as passing.
+                     (default: 60)
 `

--- a/politeiawww/cmd/pictl/print.go
+++ b/politeiawww/cmd/pictl/print.go
@@ -33,6 +33,37 @@ func printJSON(v interface{}) {
 	printf("%v\n", util.FormatJSON(v))
 }
 
+// printInPlace prints the provided text to stdout in a way that overwrites the
+// existing stdout text. This function can be called multiple times. Each
+// subsequent call will overwrite the existing text that was printed to stdout.
+func printInPlace(s string) {
+	fmt.Printf("\033[2K\r%s", s)
+}
+
+// addIndent adds indentation to the beginning of each line of the provided
+// string. The indentInSpaces argument is the number of spaces that will be
+// inserted into each line.
+//
+// Example: addIndent("hello,\nworld!\n", 2) -> "  hello,\n  world!\n"
+func addIndent(s string, indentInSpaces uint) string {
+	// Setup indent string
+	var b strings.Builder
+	for i := 0; i < int(indentInSpaces); i++ {
+		b.WriteString(" ")
+	}
+	indent := b.String()
+
+	// Add indentation after each new line
+	r := strings.NewReplacer("\n", "\n"+indent)
+	ss := r.Replace(s)
+
+	// Remove trailing spaces
+	ss = strings.TrimSpace(ss)
+
+	// Add indent to the first line
+	return indent + ss
+}
+
 // byteCountSI converts the provided bytes to a string representation of the
 // closest SI unit (kB, MB, GB, etc).
 func byteCountSI(b int64) string {
@@ -47,13 +78,6 @@ func byteCountSI(b int64) string {
 	}
 	return fmt.Sprintf("%.1f %cB",
 		float64(b)/float64(div), "kMGTPE"[exp])
-}
-
-// printInPlace prints the provided text to stdout in a way that overwrites the
-// existing stdout text. This function can be called multiple times. Each
-// subsequent call will overwrite the existing text that was printed to stdout.
-func printInPlace(s string) {
-	fmt.Printf("\033[2K\r%s", s)
 }
 
 // dollars converts an int64 price in cents into a human readable dollar

--- a/politeiawww/cmd/pictl/ticketvote.go
+++ b/politeiawww/cmd/pictl/ticketvote.go
@@ -96,9 +96,9 @@ func printVoteResults(votes []tkv1.CastVoteDetails) {
 //   1 yes 0 votes
 //   2 no  60 votes
 //
-// The indent argument can be used to add indentation to each line of the
-// string. The provided number of spaces will be inserted into the beginning
-// of each line.
+// indentInSpaces can be used to add indentation to each line of the string.
+// The provided number of spaces will be inserted at the beginning of each
+// line.
 func voteSummaryString(token string, s tkv1.Summary, indentInSpaces uint) string {
 	var sb strings.Builder
 

--- a/politeiawww/cmd/pictl/ticketvote.go
+++ b/politeiawww/cmd/pictl/ticketvote.go
@@ -133,7 +133,7 @@ func voteSummaryString(token string, s tkv1.Summary, indent string) string {
 		s.EligibleTickets))
 	sb.WriteString(fmt.Sprintf("Best Block        : %v\n",
 		s.BestBlock))
-	sb.WriteString(fmt.Sprintf("Results\n"))
+	sb.WriteString("Results\n")
 	for _, v := range s.Results {
 		sb.WriteString(fmt.Sprintf("  %v %-3v %v votes\n",
 			v.VoteBit, v.ID, v.Votes))


### PR DESCRIPTION
This commit fixes a bug that was introduced by 63d933ce that caused the
percent signs in the vote summary printing to be printed incorrectly.

`printf(voteSummaryString())`

The above code is same thing as:

`fmt.Printf("%\n") // Prints "%!(MISSING)"`

These should be:

`printf("%v\n", voteSummaryString())`

It also cleans up the `voteSummaryString()` function and standardizes
the vote parameters (duration, quorum, passing) used in various vote
commands.