### PR TITLE
pictl: use cmdVoteStart in test commands.

### DIFF
--- a/politeiawww/cmd/pictl/cmdlegacytest.go
+++ b/politeiawww/cmd/pictl/cmdlegacytest.go
@@ -77,7 +77,7 @@ func (c *cmdLegacyTest) Execute(args []string) error {
 		if err != nil {
 			return err
 		}
-		err = voteStart(admin, v, 1000, 1, 50)
+		err = voteStart(admin, v, 1000, 1, 50, false)
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmd/pictl/cmdrfptest.go
+++ b/politeiawww/cmd/pictl/cmdrfptest.go
@@ -145,7 +145,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 	// Start RFP vote
 	fmt.Printf("  Start vote on RFP\n")
 	err = voteStart(admin, tokenRFP, pr.VoteDurationMin,
-		quorum, passing)
+		quorum, passing, false)
 	if err != nil {
 		return err
 	}
@@ -268,7 +268,7 @@ func (c *cmdRFPTest) Execute(args []string) error {
 
 	// Start runoff vote for the submissions
 	fmt.Printf("  Start runoff vote for the submissions\n")
-	err = voteRunoff(admin, tokenRFP, pr.VoteDurationMin, quorum, passing)
+	err = voteStart(admin, tokenRFP, pr.VoteDurationMin, quorum, passing, true)
 	if err != nil {
 		return err
 	}

--- a/politeiawww/cmd/pictl/cmdvotetestsetup.go
+++ b/politeiawww/cmd/pictl/cmdvotetestsetup.go
@@ -109,7 +109,7 @@ func (c *cmdVoteTestSetup) Execute(args []string) error {
 		}
 
 		// Start vote
-		err = voteStart(admin, token, duration, quorum, passing)
+		err = voteStart(admin, token, duration, quorum, passing, false)
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmd/pictl/testing.go
+++ b/politeiawww/cmd/pictl/testing.go
@@ -410,7 +410,7 @@ func voteAuthorize(author user, token string) error {
 }
 
 // voteStart starts the voting period on a record. The runoff param can be
-// used to start the a runoff vote on a RFP.
+// used to start a runoff vote on a RFP.
 //
 // This function returns with the admin logged out.
 func voteStart(admin user, token string, duration, quorum, pass uint32, runoff bool) error {

--- a/politeiawww/cmd/pictl/testing.go
+++ b/politeiawww/cmd/pictl/testing.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	rcv1 "github.com/decred/politeia/politeiawww/api/records/v1"
-	pclient "github.com/decred/politeia/politeiawww/client"
 	"github.com/decred/politeia/politeiawww/cmd/shared"
 	"github.com/decred/politeia/util"
 )
@@ -410,71 +409,28 @@ func voteAuthorize(author user, token string) error {
 	return nil
 }
 
-// voteStart starts the voting period on a record.
+// voteStart starts the voting period on a record. The runoff param can be
+// used to start the a runoff vote on a RFP.
 //
 // This function returns with the admin logged out.
-func voteStart(admin user, token string, duration, quorum, pass uint32) error {
+func voteStart(admin user, token string, duration, quorum, pass uint32, runoff bool) error {
 	// Login admin
 	err := userLogin(admin)
-	if err != nil {
-		return err
-	}
-
-	// Setup client
-	opts := pclient.Opts{
-		HTTPSCert:  cfg.HTTPSCert,
-		Cookies:    cfg.Cookies,
-		HeaderCSRF: cfg.CSRF,
-		Verbose:    cfg.Verbose,
-		RawJSON:    cfg.RawJSON,
-	}
-	pc, err := pclient.New(cfg.Host, opts)
 	if err != nil {
 		return err
 	}
 
 	// Start the voting period
-	_, err = voteStartStandard(token, duration, quorum, pass, pc)
-	if err != nil {
-		return err
+	c := cmdVoteStart{
+		Runoff:   runoff,
+		Duration: duration,
+		Quorum:   &quorum,
+		Passing:  pass,
 	}
-
-	// Logout admin
-	err = userLogout()
+	c.Args.Token = token
+	err = c.Execute(nil)
 	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// voteStartRunoff starts the runoff voting period on a RFP.
-//
-// This function returns with the admin logged out.
-func voteRunoff(admin user, token string, duration, quorum, pass uint32) error {
-	// Login admin
-	err := userLogin(admin)
-	if err != nil {
-		return err
-	}
-
-	// Setup client
-	opts := pclient.Opts{
-		HTTPSCert:  cfg.HTTPSCert,
-		Cookies:    cfg.Cookies,
-		HeaderCSRF: cfg.CSRF,
-		Verbose:    cfg.Verbose,
-		RawJSON:    cfg.RawJSON,
-	}
-	pc, err := pclient.New(cfg.Host, opts)
-	if err != nil {
-		return err
-	}
-
-	// Start the runoff voting period
-	_, err = voteStartRunoff(token, duration, quorum, pass, pc)
-	if err != nil {
-		return err
+		return fmt.Errorf("cmdVoteStart: %v", err)
 	}
 
 	// Logout admin


### PR DESCRIPTION
This diff uses the `cmdVoteStart` command directly when starting 
a normal or a runoff vote; It ditches the `voteRunoff` and uses the new
`runoff` bool param in `voteStart` to start a runoff vote.