### PR TITLE
politeiavoter: Fix config bugs.

### DIFF
--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -35,6 +35,7 @@ const (
 	defaultWalletMainnetPort = "9111"
 	defaultWalletTestnetPort = "19111"
 
+	walletCertFile = "rpc.cert"
 	clientCertFile = "client.pem"
 	clientKeyFile  = "client-key.pem"
 
@@ -47,12 +48,14 @@ const (
 )
 
 var (
-	defaultHomeDir        = dcrutil.AppDataDir("politeiavoter", false)
-	defaultConfigFile     = filepath.Join(defaultHomeDir, defaultConfigFilename)
-	defaultLogDir         = filepath.Join(defaultHomeDir, defaultLogDirname)
-	defaultVoteDir        = filepath.Join(defaultHomeDir, defaultVoteDirname)
-	dcrwalletHomeDir      = dcrutil.AppDataDir("dcrwallet", false)
-	defaultWalletCertFile = filepath.Join(dcrwalletHomeDir, "rpc.cert")
+	defaultHomeDir    = dcrutil.AppDataDir("politeiavoter", false)
+	defaultConfigFile = filepath.Join(defaultHomeDir, defaultConfigFilename)
+	defaultLogDir     = filepath.Join(defaultHomeDir, defaultLogDirname)
+	defaultVoteDir    = filepath.Join(defaultHomeDir, defaultVoteDirname)
+	dcrwalletHomeDir  = dcrutil.AppDataDir("dcrwallet", false)
+	defaultWalletCert = filepath.Join(dcrwalletHomeDir, walletCertFile)
+	defaultClientCert = filepath.Join(defaultHomeDir, clientCertFile)
+	defaultClientKey  = filepath.Join(defaultHomeDir, clientKeyFile)
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -90,8 +93,8 @@ type config struct {
 	// correct failures.
 	HoursPrior uint64 `long:"hoursprior" description:"Number of hours to subtract from available voting window."`
 
-	ClientCert string `long:"clientcert" description:"Path to TLS certificate for client authentication (default: client.pem)"`
-	ClientKey  string `long:"clientkey" description:"Path to TLS client authentication key (default: client-key.pem)"`
+	ClientCert string `long:"clientcert" description:"Path to TLS certificate for client authentication"`
+	ClientKey  string `long:"clientkey" description:"Path to TLS client authentication key"`
 
 	voteDir       string
 	dial          func(string, string) (net.Conn, error)
@@ -224,6 +227,9 @@ func loadConfig() (*config, []string, error) {
 		LogDir:     defaultLogDir,
 		voteDir:    defaultVoteDir,
 		Version:    version.String(),
+		WalletCert: defaultWalletCert,
+		ClientCert: defaultClientCert,
+		ClientKey:  defaultClientKey,
 		Bunches:    defaultBunches,
 		HoursPrior: defaultHoursPrior,
 	}
@@ -294,6 +300,18 @@ func loadConfig() (*config, []string, error) {
 			cfg.voteDir = filepath.Join(cfg.HomeDir, defaultVoteDirname)
 		} else {
 			cfg.voteDir = preCfg.voteDir
+		}
+
+		// dcrwallet client key-pair
+		if preCfg.ClientCert == defaultClientCert {
+			cfg.ClientCert = filepath.Join(cfg.HomeDir, clientCertFile)
+		} else {
+			cfg.ClientCert = preCfg.ClientCert
+		}
+		if preCfg.ClientKey == defaultClientKey {
+			cfg.ClientKey = filepath.Join(cfg.HomeDir, clientKeyFile)
+		} else {
+			cfg.ClientKey = preCfg.ClientKey
 		}
 	}
 
@@ -435,11 +453,10 @@ func loadConfig() (*config, []string, error) {
 		}
 	}
 
-	// Wallet cert
-	if cfg.WalletCert == "" {
-		cfg.WalletCert = defaultWalletCertFile
-	}
+	// Clean cert file paths
 	cfg.WalletCert = util.CleanAndExpandPath(cfg.WalletCert)
+	cfg.ClientCert = util.CleanAndExpandPath(cfg.ClientCert)
+	cfg.ClientKey = util.CleanAndExpandPath(cfg.ClientKey)
 
 	// Warn about missing config file only after all other configuration is
 	// done.  This prevents the warning on help messages and invalid
@@ -493,16 +510,6 @@ func loadConfig() (*config, []string, error) {
 			return nil, nil, fmt.Errorf("cannot use --trickle " +
 				"without --proxy")
 		}
-	}
-
-	// Set path for the client key/cert depending on if they are set in options
-	cfg.ClientCert = util.CleanAndExpandPath(cfg.ClientCert)
-	cfg.ClientKey = util.CleanAndExpandPath(cfg.ClientKey)
-	if cfg.ClientCert == "" {
-		cfg.ClientCert = filepath.Join(cfg.HomeDir, clientCertFile)
-	}
-	if cfg.ClientKey == "" {
-		cfg.ClientKey = filepath.Join(cfg.HomeDir, clientKeyFile)
 	}
 
 	return &cfg, remainingArgs, nil

--- a/politeiawww/cmd/politeiavoter/sampleconfig/sampleconfig.go
+++ b/politeiawww/cmd/politeiavoter/sampleconfig/sampleconfig.go
@@ -59,8 +59,8 @@ const FileContents = `[Application Options]
 ; $ cat ~/.politeiavoter/client.pem >> ~/.dcrwallet/clients.pem
 ;
 ; NOTE: dcrwallet looks for the file called clients.pem (plural).
-clientcert=~/.politeiavoter/client.pem
-clientkey=~/.politeiavoter/client-key.pem
+; clientcert=~/.politeiavoter/client.pem
+; clientkey=~/.politeiavoter/client-key.pem
 
 
 ; ------------------------------------------------------------------------------

--- a/politeiawww/cmd/politeiavoter/sampleconfig/sampleconfig.go
+++ b/politeiawww/cmd/politeiavoter/sampleconfig/sampleconfig.go
@@ -47,12 +47,16 @@ const FileContents = `[Application Options]
 ; walletpassphrase=
 
 ; Client certificates are required to communicate with dcrwallet. Generate a
-; client certificate key using the gencerts utility that is provided by dcrd. For
-; example on a machine with a local wallet inside the politeiavoter directory:
-; 'gencerts -L client.pem client-key.pem'
-; Then append 'client.pem' to '~.dcrwallet/clients.pem'. NOTE: the wallet looks
-; for the file called clients (plural).
-
+; client certificate key using the gencerts utility that is provided by dcrd.
+; For example, on a machine with a local wallet, client certificates can be
+; generated using the following command:
+;
+; $ gencerts ~/.politeiavoter/client{,-key}.pem
+;
+; The 'client.pem' must then be appened onto '~/.dcrwallet/clients.pem'.
+; NOTE: dcrwallet looks for the file called clients.pem (plural).
+;
+: $ cat ~/.politeiavoter/client.pem >> ~/.dcrwallet/clients.pem
 clientcert=~/.politeiavoter/client.pem
 clientkey=~/.politeiavoter/client-key.pem
 

--- a/politeiawww/cmd/politeiavoter/sampleconfig/sampleconfig.go
+++ b/politeiawww/cmd/politeiavoter/sampleconfig/sampleconfig.go
@@ -53,10 +53,12 @@ const FileContents = `[Application Options]
 ;
 ; $ gencerts ~/.politeiavoter/client{,-key}.pem
 ;
-; The 'client.pem' must then be appened onto '~/.dcrwallet/clients.pem'.
-; NOTE: dcrwallet looks for the file called clients.pem (plural).
+; The 'client.pem' must then be appened onto '~/.dcrwallet/clients.pem'. This
+; can be done using the following command:
 ;
-: $ cat ~/.politeiavoter/client.pem >> ~/.dcrwallet/clients.pem
+; $ cat ~/.politeiavoter/client.pem >> ~/.dcrwallet/clients.pem
+;
+; NOTE: dcrwallet looks for the file called clients.pem (plural).
 clientcert=~/.politeiavoter/client.pem
 clientkey=~/.politeiavoter/client-key.pem
 

--- a/politeiawww/cmd/politeiavoter/sampleconfig/sampleconfig.go
+++ b/politeiawww/cmd/politeiavoter/sampleconfig/sampleconfig.go
@@ -43,10 +43,8 @@ const FileContents = `[Application Options]
 ; call are run over GRPC and require the wallet GRPC certificate and wallet
 ; password.
 ; wallethost=localhost
-; walletgrpccert=
+; walletgrpccert=~/.dcrwallet/rpc.cert
 ; walletpassphrase=
-; clientcert=client.pem
-; clientkey=client-key.pem
 
 ; Client certificates are required to communicate with dcrwallet. Generate a
 ; client certificate key using the gencerts utility that is provided by dcrd. For
@@ -55,8 +53,8 @@ const FileContents = `[Application Options]
 ; Then append 'client.pem' to '~.dcrwallet/clients.pem'. NOTE: the wallet looks
 ; for the file called clients (plural).
 
-clientcert=client.pem
-clientkey=client-key.pem
+clientcert=~/.politeiavoter/client.pem
+clientkey=~/.politeiavoter/client-key.pem
 
 
 ; ------------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes a few bugs with the politeiavoter config.

- The correct defaults are added for the `walletgrpccert`, `clientcert`,
`clientkey` settings. The defaults are now printed as part of the help
message.

Before
```
--walletgrpccert=   Wallet GRPC certificate
--clientcert=       Path to TLS certificate for client authentication (default: client.pem)
--clientkey=        Path to TLS client authentication key (default: client-key.pem)
```

After
```
--walletgrpccert=   Wallet GRPC certificate (default: /home/luke/.dcrwallet/rpc.cert)
--clientcert=       Path to TLS certificate for client authentication (default: /home/luke/.politeiavoter/client.pem)
--clientkey=        Path to TLS client authentication key (default: /home/luke/.politeiavoter/client-key.pem)
```

- The default `clientcert` and `clientkey` settings are updated if the
  `appdata` directory is manually set so that they use the provided
  `appdata` path.

- The sample config is updated with the correct default values for the
  `walletgrpc`, `clientcert`, and `clientkey` settings.

----

Closes #1566.