### PR TITLE
pi: Add approved proposal status.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/pi/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/cmds.go
@@ -221,8 +221,12 @@ func (p *piPlugin) cmdBillingStatusChanges(token []byte) (string, error) {
 
 // cmdSummary returns the pi summary of a proposal.
 func (p *piPlugin) cmdSummary(token []byte) (string, error) {
-	// Get record metadata
-	r, err := p.recordAbridged(token)
+	// Get an abridged version of the record. We only
+	// need the record metadata and the vote metadata.
+	r, err := p.record(backend.RecordRequest{
+		Token:     token,
+		Filenames: []string{ticketvote.FileNameVoteMetadata},
+	})
 	if err != nil {
 		return "", err
 	}
@@ -231,8 +235,15 @@ func (p *piPlugin) cmdSummary(token []byte) (string, error) {
 		mdStatus   = r.RecordMetadata.Status
 		voteStatus = ticketvote.VoteStatusInvalid
 
-		bscs []pi.BillingStatusChange
+		voteMD *ticketvote.VoteMetadata
+		bscs   []pi.BillingStatusChange
 	)
+
+	// Pull the vote metadata out of the record files.
+	voteMD, err = voteMetadataDecode(r.Files)
+	if err != nil {
+		return "", err
+	}
 
 	// Fetch vote status & billing status change if they are needed in order
 	// to determine the proposal status.
@@ -254,7 +265,9 @@ func (p *piPlugin) cmdSummary(token []byte) (string, error) {
 		}
 	}
 
-	proposalStatus, err := proposalStatus(mdState, mdStatus, voteStatus, bscs)
+	// Determine the proposal status
+	proposalStatus, err := proposalStatus(mdState, mdStatus,
+		voteStatus, voteMD, bscs)
 	if err != nil {
 		return "", err
 	}
@@ -313,7 +326,16 @@ func statusChangesDecode(metadata []backend.MetadataStream) ([]usermd.StatusChan
 }
 
 // proposalStatusApproved returns the proposal status of an approved proposal.
-func proposalStatusApproved(bscs []pi.BillingStatusChange) (pi.PropStatusT, error) {
+func proposalStatusApproved(voteMD *ticketvote.VoteMetadata, bscs []pi.BillingStatusChange) (pi.PropStatusT, error) {
+	// If the proposal in an RFP then we don't need to
+	// check the billing status changes. RFP proposals
+	// do not bill against the treasury. This does not
+	// apply to RFP submission proposals.
+	if isRFP(voteMD) {
+		return pi.PropStatusApproved, nil
+	}
+
+	// Use the billing status to determine the proposal status.
 	bs := proposalBillingStatus(ticketvote.VoteStatusApproved, bscs)
 	switch bs {
 	case pi.BillingStatusClosed:
@@ -358,7 +380,7 @@ func proposalBillingStatus(vs ticketvote.VoteStatusT, bscs []pi.BillingStatusCha
 // proposalStatus combines record metadata and plugin metadata in order to
 // create a unified map of the various paths a proposal can take throughout
 // the proposal process.
-func proposalStatus(state backend.StateT, status backend.StatusT, voteStatus ticketvote.VoteStatusT, bscs []pi.BillingStatusChange) (pi.PropStatusT, error) {
+func proposalStatus(state backend.StateT, status backend.StatusT, voteStatus ticketvote.VoteStatusT, voteMD *ticketvote.VoteMetadata, bscs []pi.BillingStatusChange) (pi.PropStatusT, error) {
 	switch state {
 	case backend.StateUnvetted:
 		switch status {
@@ -386,7 +408,7 @@ func proposalStatus(state backend.StateT, status backend.StatusT, voteStatus tic
 			case ticketvote.VoteStatusRejected:
 				return pi.PropStatusRejected, nil
 			case ticketvote.VoteStatusApproved:
-				return proposalStatusApproved(bscs)
+				return proposalStatusApproved(voteMD, bscs)
 			}
 		}
 	}

--- a/politeiad/plugins/pi/pi.go
+++ b/politeiad/plugins/pi/pi.go
@@ -455,10 +455,10 @@ const (
 	// still be added.
 	PropStatusVoteStarted PropStatusT = "vote-started"
 
-	// PropStatusApproved represents a proposal that was vote on by the Decred
-	// stakeholders, met the approval criteria, but is not being billed against.
-	// An example is an RFP proposal. RFP proposals do not request funding and
-	// are not billed against once approved.
+	// PropStatusApproved represents a proposal that was voted on by the Decred
+	// stakeholders, met the approval criteria, but is not being actively billed
+	// against. An example is an RFP proposal. RFP proposals do not request
+	// funding and are not billed against once approved.
 	PropStatusApproved PropStatusT = "approved"
 
 	// PropStatusRejected represents a proposal that was voted on by the Decred

--- a/politeiad/plugins/pi/pi.go
+++ b/politeiad/plugins/pi/pi.go
@@ -455,6 +455,12 @@ const (
 	// still be added.
 	PropStatusVoteStarted PropStatusT = "vote-started"
 
+	// PropStatusApproved represents a proposal that was vote on by the Decred
+	// stakeholders, met the approval criteria, but is not being billed against.
+	// An example is an RFP proposal. RFP proposals do not request funding and
+	// are not billed against once approved.
+	PropStatusApproved PropStatusT = "approved"
+
 	// PropStatusRejected represents a proposal that was voted on by the Decred
 	// stakeholders and did not meet the approval criteria. A rejected proposal
 	// is locked against any additional proposal or plugin changes.


### PR DESCRIPTION
Closes #1577

This commit adds an 'approved' proposal status to the pi plugin.

Previously, the proposal status was considered to be 'active', meaning
the proposal is active and allowed to be billed against, once the
proposal vote was approved. This is fine for standard proposals. RFP
proposals, however, do not request funds and do not bill against the
treasury. The 'active' status does not apply to them. Once an RFP vote
is approved, the RFP proposal status is 'approved'. This does not apply
to RFP submissions.