### PR TITLE
ticketvote: Fix status change validation bug.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/hooks.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/hooks.go
@@ -366,6 +366,13 @@ func (p *ticketVotePlugin) voteMetadataVerifyOnEdits(r backend.Record, newFiles 
 // voteMetadataVerifyOnStatusChange runs vote metadata validation that is
 // specific to record status changes.
 func (p *ticketVotePlugin) voteMetadataVerifyOnStatusChange(status backend.StatusT, files []backend.File) error {
+	// If the record is being censored or archived then this
+	// vote metadata validation doesn't matter.
+	switch status {
+	case backend.StatusCensored, backend.StatusArchived:
+		return nil
+	}
+
 	// Decode vote metadata. Vote metadata is optional so one may not
 	// exist.
 	vm, err := voteMetadataDecode(files)


### PR DESCRIPTION
Closes #1576

This commit skips the vote metadata validation if the record is being
censored or abandoned. It does not matter if fields have become outdated
if the record is not being made public.