### PR TITLE
politeiavoter: improve help output

### DIFF
--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -72,6 +72,7 @@ type config struct {
 	Profile          string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
 	DebugLevel       string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	Version          string
+	ListCommands     bool   `short:"l" long:"listcommands" description:"List available commands"`
 	WalletHost       string `long:"wallethost" description:"Wallet host"`
 	WalletCert       string `long:"walletgrpccert" description:"Wallet GRPC certificate"`
 	WalletPassphrase string `long:"walletpassphrase" description:"Wallet decryption passphrase"`
@@ -262,6 +263,12 @@ func loadConfig() (*config, []string, error) {
 		os.Exit(0)
 	}
 
+	// Print available commands if listcommands flag is specified
+	if preCfg.ListCommands {
+		fmt.Fprintln(os.Stderr, listCmdMessage)
+		os.Exit(0)
+	}
+
 	// Perform service command and exit if specified.  Invalid service
 	// commands show an appropriate error.  Only runs on Windows since
 	// the runServiceCommand function will be nil when not on Windows.
@@ -311,6 +318,12 @@ func loadConfig() (*config, []string, error) {
 			return nil, nil, err
 		}
 		configFileError = err
+	}
+
+	// Print available commands if listcommands flag is specified
+	if cfg.ListCommands {
+		fmt.Fprintln(os.Stderr, listCmdMessage)
+		os.Exit(0)
 	}
 
 	// See if appdata was overridden

--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -63,16 +63,16 @@ var runServiceCommand func(string) error
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
+	ListCommands     bool `short:"l" long:"listcommands" description:"List available commands"`
+	ShowVersion      bool `short:"V" long:"version" description:"Display version information and exit"`
+	Version          string
 	HomeDir          string `short:"A" long:"appdata" description:"Path to application home directory"`
-	ShowVersion      bool   `short:"V" long:"version" description:"Display version information and exit"`
 	ConfigFile       string `short:"C" long:"configfile" description:"Path to configuration file"`
 	LogDir           string `long:"logdir" description:"Directory to log output."`
 	TestNet          bool   `long:"testnet" description:"Use the test network"`
 	PoliteiaWWW      string `long:"politeiawww" description:"Politeia WWW host"`
 	Profile          string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
 	DebugLevel       string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	Version          string
-	ListCommands     bool   `short:"l" long:"listcommands" description:"List available commands"`
 	WalletHost       string `long:"wallethost" description:"Wallet host"`
 	WalletCert       string `long:"walletgrpccert" description:"Wallet GRPC certificate"`
 	WalletPassphrase string `long:"walletpassphrase" description:"Wallet decryption passphrase"`

--- a/politeiawww/cmd/politeiavoter/help.go
+++ b/politeiawww/cmd/politeiavoter/help.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+const listCmdMessage = `Available commands:
+  inventory Retrieve all proposals that are being voted on
+  vote      Vote on a proposal
+  tally     Tally votes on a proposal
+  verify    Verify votes on a proposal
+  help      Print detailed help message for a command
+`
+
+const inventoryHelpMsg = `inventory 
+
+Retrieve all proposals that are being voted on.
+`
+
+const voteHelpMsg = `vote "token" "voteid"
+
+Vote on a proposal.
+
+Arguments:
+1. token   (string, required)  Proposal censorship token
+2. voteid  (string, required)  Vote option ID (e.g. yes)
+`
+
+const tallyHelpMsg = `tally "token"
+
+Tally votes on a proposal.
+
+Arguments:
+1. token   (string, required)  Proposal censorship token
+`
+
+const verifyHelpMsg = `verify "tokens..."
+
+Verify votes on proposals. If no tokens are provided or 'ALL' string is 
+provided then it verifies all votes present in the vote dir.
+
+Arguments:
+1. tokens  ([]string, optional)  Proposal tokens.
+`

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -57,13 +57,6 @@ const (
 	cmdHelp      = "help"
 )
 
-const listCmdMessage = `Available commands:
-  inventory Retrieve all proposals that are being voted on
-  vote      Vote on a proposal
-  tally     Tally votes on a proposal
-  verify    Verify votes on a proposal
-`
-
 const (
 	failedJournal  = "failed.json"
 	successJournal = "success.json"
@@ -1638,37 +1631,6 @@ func (p *piv) verify(args []string) error {
 
 	return nil
 }
-
-const inventoryHelpMsg = `inventory 
-
-Retrieve all proposals that are being voted on.
-`
-
-const voteHelpMsg = `vote "token" "voteid"
-
-Vote on a proposal.
-
-Arguments:
-1. token   (string, required)  Proposal censorship token
-2. voteid  (string, required)  Vote option ID (e.g. yes)
-`
-
-const tallyHelpMsg = `tally "token"
-
-Tally votes on a proposal.
-
-Arguments:
-1. token   (string, required)  Proposal censorship token
-`
-
-const verifyHelpMsg = `verify "tokens..."
-
-Verify votes on proposals. If no tokens are provided or 'ALL' string is 
-provided then it verifies all votes present in the vote dir.
-
-Arguments:
-1. tokens  ([]string, optional)  Proposal tokens.
-`
 
 func (p *piv) help(command string) {
 	switch command {

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -50,6 +50,20 @@ import (
 )
 
 const (
+	cmdInventory = "inventory"
+	cmdVote      = "vote"
+	cmdTally     = "tally"
+	cmdVerify    = "verify"
+)
+
+const listCmdMessage = `Available commands:
+  inventory Retrieve all proposals that are being voted on
+  vote      Vote on a proposal
+  tally     Tally votes on a proposal
+  verify    Verify votes on a proposal
+`
+
+const (
 	failedJournal  = "failed.json"
 	successJournal = "success.json"
 	workJournal    = "work.json"
@@ -63,13 +77,6 @@ func generateSeed() (int64, error) {
 	}
 	return new(big.Int).SetBytes(seedBytes[:]).Int64(), nil
 }
-
-const listCmdMessage = `Available commands:
-  inventory Retrieve all proposals that are being voted on
-  vote      Vote on a proposal
-  tally     Tally votes on a proposal
-  verify    Verify votes on a proposal
-`
 
 // walletPassphrase returns the wallet passphrase from the config if one was
 // provided or prompts the user for their wallet passphrase if one was not
@@ -1658,7 +1665,7 @@ func _main() error {
 
 	// Validate command
 	switch action {
-	case "inventory", "tally", "vote", "verify":
+	case cmdInventory, cmdTally, cmdVote, cmdVerify:
 		// valid command, continue
 	default:
 		fmt.Fprintf(os.Stderr, "Unrecognized command %q\n", action)
@@ -1675,13 +1682,13 @@ func _main() error {
 
 	// Run command
 	switch action {
-	case "inventory":
+	case cmdInventory:
 		err = c.inventory()
-	case "tally":
+	case cmdTally:
 		err = c.tally(args[1:])
-	case "vote":
+	case cmdVote:
 		err = c.vote(args[1:])
-	case "verify":
+	case cmdVerify:
 		err = c.verify(args[1:])
 	}
 


### PR DESCRIPTION
This diff introduces the following improvements for the `politeiavoter`
help output to match the `dcrctl` behavior:

- `politeiavoter -h` prints application options.
- `politeiavoter -l` prints application commands - `long: listcommands`.
 - `politeiavoter help <command>` prints a detailed help message for the
   command.
 - List available commands if no command was specified.
 - List available commands if unknown command was specified.
 - Verify the provided command before trying to connect to wallet.
 - Try to connect to the wallet only if the command requires a connected
   wallet.
 
 ---
 
 Closes #1567.