### PR TITLE
usermd: Add cache fsck.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/usermd/cache.go
+++ b/politeiad/backendv2/tstorebe/plugins/usermd/cache.go
@@ -75,6 +75,16 @@ func (p *usermdPlugin) userCache(userID string) (*userCache, error) {
 	return p.userCacheLocked(userID)
 }
 
+// userCacheSave saves the provided userCache to the plugin data dir.
+//
+// This function must be called WITHOUT the lock held.
+func (p *usermdPlugin) userCacheSave(userID string, uc userCache) error {
+	p.Lock()
+	defer p.Unlock()
+
+	return p.userCacheSaveLocked(userID, uc)
+}
+
 // userCacheSaveLocked saves the provided userCache to the plugin data dir.
 //
 // This function must be called WITH the lock held.

--- a/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
+++ b/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
@@ -96,9 +96,9 @@ func (p *usermdPlugin) Fsck(tokens [][]byte) error {
 	// addMissingRecord adds the given record's token to a list of tokens sorted
 	// by the latest status change timestamp, from newest to oldest.
 	addMissingRecord := func(tokens []string, missingRecord *backend.Record) ([]string, error) {
-		records := make([]*backend.Record, 0, len(tokens)+1)
 		// Make list of records to be able to sort by latest status change
 		// timestamp.
+		records := make([]*backend.Record, 0, len(tokens)+1)
 		for _, t := range tokens {
 			// Search in known records map
 			r := rs[t]

--- a/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
+++ b/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
@@ -84,7 +84,7 @@ func (p *usermdPlugin) Hook(h plugins.HookT, payload string) error {
 }
 
 // addMissingRecord adds the given record's token to a list of tokens sorted
-// by the latest status change timestamp, from newest to oldest.
+// by the latest status change timestamp, from oldest to newest.
 func (p *usermdPlugin) addMissingRecord(tokens []string, missingRecord *backend.Record) ([]string, error) {
 	// Make list of records to be able to sort by latest status change
 	// timestamp.
@@ -103,12 +103,12 @@ func (p *usermdPlugin) addMissingRecord(tokens []string, missingRecord *backend.
 	}
 
 	// Append new record then sort records by latest status change timestamp
-	// from newest to oldest.
+	// from oldest to newest.
 	records = append(records, missingRecord)
 
 	// Sort records
 	sort.Slice(records, func(i, j int) bool {
-		return records[i].RecordMetadata.Timestamp >
+		return records[i].RecordMetadata.Timestamp <
 			records[j].RecordMetadata.Timestamp
 	})
 
@@ -132,7 +132,7 @@ func (p *usermdPlugin) addMissingRecord(tokens []string, missingRecord *backend.
 //    correct category.  If the record is not found in the user
 //    cache, add it.  The tokens listed in the user cache are
 //    ordered by the timestamp of their most recent status change
-//    from newest to oldest.
+//    from oldest to newest.
 //
 // This function satisfies the plugins PluginClient interface.
 func (p *usermdPlugin) Fsck(tokens [][]byte) error {

--- a/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
+++ b/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
@@ -86,6 +86,16 @@ func (p *usermdPlugin) Hook(h plugins.HookT, payload string) error {
 // Fsck performs a plugin file system check. The plugin is provided with the
 // tokens for all records in the backend.
 //
+// It verifies the user cache using the following process:
+//
+// 1. For each record, get the user metadata file from the db.
+// 2. Get the user cache for the record's author.
+// 3. Verify that the record is listed in the user cache under the
+//    correct category.  If the record is not found in the user
+//    cache, add it.  The tokens listed in the user cache are
+//    ordered by the timestamp of their most recent status change
+//    from newest to oldest.
+//
 // This function satisfies the plugins PluginClient interface.
 func (p *usermdPlugin) Fsck(tokens [][]byte) error {
 	log.Tracef("usermd Fsck")

--- a/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
+++ b/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
@@ -142,7 +142,6 @@ func (p *usermdPlugin) Fsck(tokens [][]byte) error {
 	var c int64
 
 	for _, token := range tokens {
-		tokenStr := hex.EncodeToString(token)
 		r, err := p.tstore.RecordPartial(token, 0, nil, false)
 		if err != nil {
 			return err
@@ -163,6 +162,7 @@ func (p *usermdPlugin) Fsck(tokens [][]byte) error {
 		// Verify that the record is listed in the user cache under the
 		// correct category.
 		var found bool
+		tokenStr := hex.EncodeToString(token)
 		switch r.RecordMetadata.State {
 		case backend.StateUnvetted:
 			for _, t := range uc.Unvetted {

--- a/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
+++ b/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
@@ -95,14 +95,14 @@ func (p *usermdPlugin) addMissingRecord(tokens []string, missingRecord *backend.
 		if err != nil {
 			return nil, err
 		}
-		r, err := p.tstore.RecordPartial(b, 0, nil, false)
+		r, err := p.tstore.RecordPartial(b, 0, nil, true)
 		if err != nil {
 			return nil, err
 		}
 		records = append(records, r)
 	}
 
-	// Append new record then sort reocrds by latest status change timestamp
+	// Append new record then sort records by latest status change timestamp
 	// from newest to oldest.
 	records = append(records, missingRecord)
 
@@ -142,7 +142,7 @@ func (p *usermdPlugin) Fsck(tokens [][]byte) error {
 	var c int64
 
 	for _, token := range tokens {
-		r, err := p.tstore.RecordPartial(token, 0, nil, false)
+		r, err := p.tstore.RecordPartial(token, 0, nil, true)
 		if err != nil {
 			return err
 		}
@@ -196,15 +196,12 @@ func (p *usermdPlugin) Fsck(tokens [][]byte) error {
 		// If a missing token was added to the user cache, save new user cache
 		// to disk.
 		if !found {
-			p.Lock()
-			err = p.userCacheSaveLocked(um.UserID, *uc)
+			err = p.userCacheSave(um.UserID, *uc)
 			if err != nil {
-				p.Unlock()
 				return err
 			}
-			p.Unlock()
 			c++
-			log.Debugf("missing %v record %v was added to %v user records cache",
+			log.Debugf("Missing %v record %v was added to %v user records cache",
 				backend.States[r.RecordMetadata.State], tokenStr, um.UserID)
 		}
 	}

--- a/politeiad/plugins/usermd/usermd.go
+++ b/politeiad/plugins/usermd/usermd.go
@@ -10,10 +10,10 @@ const (
 	// PluginID is the unique identifier for this plugin.
 	PluginID = "usermd"
 
-	// CmdAuthor gets record author
+	// CmdAuthor command retrieves the record author.
 	CmdAuthor = "author"
 
-	// CmdUserRecords gets user submitted records
+	// CmdUserRecords command returns all records submitted by the given user.
 	CmdUserRecords = "userrecords"
 )
 

--- a/politeiad/plugins/usermd/usermd.go
+++ b/politeiad/plugins/usermd/usermd.go
@@ -10,9 +10,11 @@ const (
 	// PluginID is the unique identifier for this plugin.
 	PluginID = "usermd"
 
-	// Plugin commands
-	CmdAuthor      = "author"      // Get record author
-	CmdUserRecords = "userrecords" // Get user submitted records
+	// CmdAuthor gets record author
+	CmdAuthor = "author"
+
+	// CmdUserRecords gets user submitted records
+	CmdUserRecords = "userrecords"
 )
 
 // Stream IDs are the metadata stream IDs for metadata defined in this package.


### PR DESCRIPTION
This diff adds a `fsck` command to the `usermd` plugin using the
following process:

  1. For each record, get the user metadata file from the db.

  2. Get the user cache for the record's author.

  3. Verify that the record is listed in the user cache under the
     correct category. The tokens listed in the user cache are
     ordered by the timestamp of their most recent status change
     from newest to oldest. If the record is not found in the user
     cache, add it.
     
 ---

Closes #1511.