### PR TITLE
pictl: Add proposal status flag to seedproposals.

### DIFF
--- a/politeiawww/cmd/pictl/proposal.go
+++ b/politeiawww/cmd/pictl/proposal.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	"github.com/decred/politeia/politeiad/api/v1/mime"
+	pi "github.com/decred/politeia/politeiad/plugins/pi"
 	piplugin "github.com/decred/politeia/politeiad/plugins/pi"
 	piv1 "github.com/decred/politeia/politeiawww/api/pi/v1"
 	rcv1 "github.com/decred/politeia/politeiawww/api/records/v1"
@@ -274,4 +275,29 @@ func signedMerkleRoot(files []rcv1.File, fid *identity.FullIdentity) (string, er
 	mr := hex.EncodeToString(m[:])
 	sig := fid.SignMessage([]byte(mr))
 	return hex.EncodeToString(sig[:]), nil
+}
+
+// parseProposalStatus parses a pi PropStatusT from the provided string. A
+// PropStatusInvalid is returned if the provided string does not correspond to
+// a valid proposal status.
+func parseProposalStatus(status string) pi.PropStatusT {
+	switch pi.PropStatusT(status) {
+	// The following are valid proposal statuses
+	case pi.PropStatusUnvetted,
+		pi.PropStatusUnvettedAbandoned,
+		pi.PropStatusUnvettedCensored,
+		pi.PropStatusUnderReview,
+		pi.PropStatusAbandoned,
+		pi.PropStatusCensored,
+		pi.PropStatusVoteAuthorized,
+		pi.PropStatusVoteStarted,
+		pi.PropStatusApproved,
+		pi.PropStatusRejected,
+		pi.PropStatusActive,
+		pi.PropStatusCompleted,
+		pi.PropStatusClosed:
+	default:
+		return pi.PropStatusInvalid
+	}
+	return pi.PropStatusT(status)
 }


### PR DESCRIPTION
This commit adds a --proposalstatus option to the `pictl seedproposals`
command. If provided, all proposals submitted by the command will be set
to the specified proposal status. This makes it easier to fine tune your
testing environment, which is desirable when needing to test specific
features or bug fixes.

It also makes two additional changes to the `seedproposals` command:

- Updates the comment and comment like defaults to be more reasonable.

- Switches the hard coded proposal statuses out for the newly added pi
  plugin proposal statuses.