### PR TITLE
politeiad: Execute batch reads concurrently.

### DIFF
--- a/politeiad/batch.go
+++ b/politeiad/batch.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package main
+
+import (
+	"sync"
+
+	v2 "github.com/decred/politeia/politeiad/api/v2"
+	"github.com/decred/politeia/util"
+)
+
+type pluginRead func(token []byte, pluginID,
+	cmd, payload string) (string, error)
+
+type batch struct {
+	sync.Mutex
+	cmds []batchCmd
+}
+
+type batchCmd struct {
+	index int
+	cmd   v2.PluginCmd
+	reply string // JSON encoded reply payload
+	err   error  // Only set if an error is encountered
+}
+
+func newBatch(pluginCmds []v2.PluginCmd) *batch {
+	batchCmds := make([]batchCmd, 0, len(pluginCmds))
+	for i, cmd := range pluginCmds {
+		batchCmds = append(batchCmds, batchCmd{
+			index: i,
+			cmd:   cmd,
+		})
+	}
+	return &batch{
+		cmds: batchCmds,
+	}
+}
+
+func (b *batch) exec(fn pluginRead) {
+	// Execute commands concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < len(b.cmds); i++ {
+		wg.Add(1)
+		go b.execReadCmd(fn, b.getCmd(i), i, &wg)
+	}
+
+	// Wait for all commands to finish executing
+	wg.Wait()
+}
+
+func (b *batch) execReadCmd(fn pluginRead, cmd v2.PluginCmd, index int, wg *sync.WaitGroup) {
+	// Decrement the wait group on exit
+	defer wg.Done()
+
+	// Decode the token. The token is optional
+	// for plugin reads.
+	var (
+		token []byte
+		err   error
+	)
+	if cmd.Token != "" {
+		token, err = decodeTokenAnyLength(cmd.Token)
+		if err != nil {
+			// Invalid token
+			err = v2.UserErrorReply{
+				ErrorCode:    v2.ErrorCodeTokenInvalid,
+				ErrorContext: util.TokenRegexp(),
+			}
+			b.setReply(index, "", err)
+			return
+		}
+	}
+
+	// Execute the read command
+	reply, err := fn(token, cmd.ID, cmd.Command, cmd.Payload)
+	if err != nil {
+		b.setReply(index, "", err)
+		return
+	}
+
+	b.setReply(index, reply, nil)
+}
+
+func (b *batch) getCmd(index int) v2.PluginCmd {
+	b.Lock()
+	defer b.Unlock()
+
+	return b.cmds[index].cmd
+}
+
+func (b *batch) setReply(index int, reply string, err error) {
+	b.Lock()
+	defer b.Unlock()
+
+	c := b.cmds[index]
+	c.reply = reply
+	c.err = err
+	b.cmds[index] = c
+}

--- a/politeiad/batch.go
+++ b/politeiad/batch.go
@@ -10,27 +10,33 @@ import (
 	"github.com/decred/politeia/util"
 )
 
+// pluginRead contains the same function signature as the backendv2 PluginRead
+// function. This allows test coverage to be added to the batch implemenation
+// without needing to deal with a backendv2 stub.
 type pluginRead func(token []byte, pluginID,
 	cmd, payload string) (string, error)
 
+// batch contains a batch of plugin commands and implements the methods that
+// allow for the concurrent execution of these plugin commands.
 type batch struct {
 	sync.Mutex
 	cmds []batchCmd
 }
 
+// batchCmd contains a single plugin command and the reply/error that resulted
+// from the execution of the plugin command.
 type batchCmd struct {
-	index int
 	cmd   v2.PluginCmd
 	reply string // JSON encoded reply payload
 	err   error  // Only set if an error is encountered
 }
 
+// newBatch returns a new batch.
 func newBatch(pluginCmds []v2.PluginCmd) *batch {
 	batchCmds := make([]batchCmd, 0, len(pluginCmds))
-	for i, cmd := range pluginCmds {
+	for _, cmd := range pluginCmds {
 		batchCmds = append(batchCmds, batchCmd{
-			index: i,
-			cmd:   cmd,
+			cmd: cmd,
 		})
 	}
 	return &batch{
@@ -38,7 +44,8 @@ func newBatch(pluginCmds []v2.PluginCmd) *batch {
 	}
 }
 
-func (b *batch) exec(fn pluginRead) {
+// execConcurrently executes the batch of plugin commands concurrently.
+func (b *batch) execConcurrently(fn pluginRead) {
 	// Execute commands concurrently
 	var wg sync.WaitGroup
 	for i := 0; i < len(b.cmds); i++ {
@@ -50,6 +57,7 @@ func (b *batch) exec(fn pluginRead) {
 	wg.Wait()
 }
 
+// execReadCmd executes a single plugin read-only command.
 func (b *batch) execReadCmd(fn pluginRead, cmd v2.PluginCmd, index int, wg *sync.WaitGroup) {
 	// Decrement the wait group on exit
 	defer wg.Done()
@@ -83,6 +91,7 @@ func (b *batch) execReadCmd(fn pluginRead, cmd v2.PluginCmd, index int, wg *sync
 	b.setReply(index, reply, nil)
 }
 
+// getCmd returns the PluginCmd at the provided index.
 func (b *batch) getCmd(index int) v2.PluginCmd {
 	b.Lock()
 	defer b.Unlock()
@@ -90,6 +99,7 @@ func (b *batch) getCmd(index int) v2.PluginCmd {
 	return b.cmds[index].cmd
 }
 
+// setReply sets the reply for the plugin command at that provided index.
 func (b *batch) setReply(index int, reply string, err error) {
 	b.Lock()
 	defer b.Unlock()

--- a/politeiad/batch.go
+++ b/politeiad/batch.go
@@ -10,9 +10,9 @@ import (
 	"github.com/decred/politeia/util"
 )
 
-// pluginRead contains the same function signature as the backendv2 PluginRead
-// function. This allows test coverage to be added to the batch implemenation
-// without needing to deal with a backendv2 stub.
+// pluginRead is the same function signature as the backendv2 PluginRead
+// function. This allows test coverage to be added to the batch implementation
+// using a custom pluginRead function setup for testing.
 type pluginRead func(token []byte, pluginID,
 	cmd, payload string) (string, error)
 
@@ -20,12 +20,12 @@ type pluginRead func(token []byte, pluginID,
 // allow for the concurrent execution of these plugin commands.
 type batch struct {
 	sync.Mutex
-	cmds []batchCmd
+	entries []batchEntry
 }
 
-// batchCmd contains a single plugin command and the reply/error that resulted
-// from the execution of the plugin command.
-type batchCmd struct {
+// batchEntry contains a single plugin command and the reply/error that
+// resulted from the execution of the plugin command.
+type batchEntry struct {
 	cmd   v2.PluginCmd
 	reply string // JSON encoded reply payload
 	err   error  // Only set if an error is encountered
@@ -33,14 +33,14 @@ type batchCmd struct {
 
 // newBatch returns a new batch.
 func newBatch(pluginCmds []v2.PluginCmd) *batch {
-	batchCmds := make([]batchCmd, 0, len(pluginCmds))
+	entries := make([]batchEntry, 0, len(pluginCmds))
 	for _, cmd := range pluginCmds {
-		batchCmds = append(batchCmds, batchCmd{
+		entries = append(entries, batchEntry{
 			cmd: cmd,
 		})
 	}
 	return &batch{
-		cmds: batchCmds,
+		entries: entries,
 	}
 }
 
@@ -48,7 +48,7 @@ func newBatch(pluginCmds []v2.PluginCmd) *batch {
 func (b *batch) execConcurrently(fn pluginRead) {
 	// Execute commands concurrently
 	var wg sync.WaitGroup
-	for i := 0; i < len(b.cmds); i++ {
+	for i := 0; i < len(b.entries); i++ {
 		wg.Add(1)
 		go b.execReadCmd(fn, b.getCmd(i), i, &wg)
 	}
@@ -96,7 +96,7 @@ func (b *batch) getCmd(index int) v2.PluginCmd {
 	b.Lock()
 	defer b.Unlock()
 
-	return b.cmds[index].cmd
+	return b.entries[index].cmd
 }
 
 // setReply sets the reply for the plugin command at that provided index.
@@ -104,8 +104,8 @@ func (b *batch) setReply(index int, reply string, err error) {
 	b.Lock()
 	defer b.Unlock()
 
-	c := b.cmds[index]
+	c := b.entries[index]
 	c.reply = reply
 	c.err = err
-	b.cmds[index] = c
+	b.entries[index] = c
 }

--- a/politeiad/batch_test.go
+++ b/politeiad/batch_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package main
+
+import (
+	"testing"
+
+	v2 "github.com/decred/politeia/politeiad/api/v2"
+	"github.com/pkg/errors"
+)
+
+func TestExecConcurrently(t *testing.T) {
+	// NOTE: these tests should be executed using the -race flag since
+	// they are testing the concurrent execution of plugin commands.
+
+	// Setup random tokens
+	var (
+		token        = "114cb8a95cb86355"
+		invalidToken = "zzz"
+	)
+
+	// Setup a basic test case of plugin commands. The
+	// command payload is used to mark the ordering of
+	// the plugin commands so that the test can verify
+	// that the batch does not change the ordering.
+	pluginCmds := []v2.PluginCmd{
+		// Success with a token
+		{
+			Token:   token,
+			ID:      testPluginID,
+			Command: testCmdSuccess,
+			Payload: "0",
+		},
+		// Sucess without a token
+		{
+			Token:   token,
+			ID:      testPluginID,
+			Command: testCmdSuccess,
+			Payload: "1",
+		},
+		// Invalid token
+		{
+			Token:   invalidToken,
+			ID:      testPluginID,
+			Command: testCmdSuccess,
+			Payload: "2",
+		},
+		// Error case
+		{
+			Token:   token,
+			ID:      testPluginID,
+			Command: testCmdError,
+			Payload: "3",
+		},
+	}
+
+	// Setup the batch and execute the commands
+	b := newBatch(pluginCmds)
+	b.execConcurrently(testPluginRead)
+
+	// Verify the replies
+	for i, entry := range b.entries {
+		// Verify that the batch entries are in the same order
+		// that the plugin commands were provided in. The
+		// command payloads were set to unique strings in order
+		// to verify this.
+		pluginCmd := pluginCmds[i]
+		if entry.cmd.Payload != pluginCmd.Payload {
+			t.Errorf("batch commands ordered incorrectly: got %v, want %v",
+				entry.cmd.Payload, pluginCmd.Payload)
+		}
+
+		// Verify that either a reply payload was returned or
+		// the error field has been populated.
+		switch {
+		case entry.reply != "" && entry.err != nil:
+			// Both fields were populated
+			t.Errorf("both the reply payload and the error were populated")
+
+		case entry.reply == "" && entry.err == nil:
+			// Neither field were populated
+			t.Errorf("neither the reply payload or the error were populated")
+		}
+
+		// Verify that the reply is correct
+		switch {
+		case entry.cmd.Token == invalidToken:
+			// An invalid token was provided. The error
+			// should be an invalid token user error.
+			var ue v2.UserErrorReply
+			if !errors.As(entry.err, &ue) ||
+				ue.ErrorCode != v2.ErrorCodeTokenInvalid {
+				t.Errorf("wrong error; got %v, want %v user error",
+					entry.err, v2.ErrorCodes[v2.ErrorCodeTokenInvalid])
+			}
+
+		case entry.cmd.Command == testCmdSuccess:
+			// Success case
+			if entry.reply != successReply {
+				t.Errorf("wrong reply payload; got %v, want %v",
+					entry.reply, successReply)
+			}
+
+		case entry.cmd.Command == testCmdError:
+			// Error case
+			if !errors.Is(entry.err, errorReply) {
+				t.Errorf("wrong error reply; got %v, want %v",
+					entry.err, errorReply)
+			}
+
+		default:
+			t.Fatalf("unhandled test case: %v %v", entry, pluginCmd)
+		}
+	}
+
+	// Test concurrency race conditions by executing a large
+	// number of plugin command. If a race condition occurs,
+	// the golang race detector should pick it up.
+	cmdCount := 1000
+	pluginCmds = make([]v2.PluginCmd, 0, cmdCount)
+	for i := 0; i < cmdCount; i++ {
+		pluginCmds = append(pluginCmds, v2.PluginCmd{
+			Token:   "",
+			ID:      testPluginID,
+			Command: testCmdSuccess,
+			Payload: "",
+		})
+	}
+
+	// Setup the batch and execute the commands. If a race
+	// condition does not occur then this test passes.
+	b = newBatch(pluginCmds)
+	b.execConcurrently(testPluginRead)
+}
+
+const (
+	// testPluginID is the plugin ID for the test plugin.
+	testPluginID = "test-plugin"
+
+	// Plugin test commands
+	testCmdSuccess = "test-cmd-success"
+	testCmdError   = "test-cmd-error"
+)
+
+var (
+	// Expected replies
+	successReply = "success-reply-payload"
+	errorReply   = errors.New("test command error reply")
+)
+
+// testPluginRead is the plugin read function that is used for testing.
+func testPluginRead(token []byte, pluginID, cmd, payload string) (string, error) {
+	switch cmd {
+	case testCmdSuccess:
+		return successReply, nil
+	case testCmdError:
+		return "", errorReply
+	}
+	return "", errors.Errorf("invalid command '%v'", cmd)
+}

--- a/politeiad/batch_test.go
+++ b/politeiad/batch_test.go
@@ -32,7 +32,7 @@ func TestExecConcurrently(t *testing.T) {
 			Command: testCmdSuccess,
 			Payload: "0",
 		},
-		// Sucess without a token
+		// Success without a token
 		{
 			Token:   token,
 			ID:      testPluginID,

--- a/politeiad/v2.go
+++ b/politeiad/v2.go
@@ -546,76 +546,72 @@ func (p *politeia) handlePluginReads(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Execute the batch of read cmds
+	batch := newBatch(pr.Cmds)
+	batch.exec(p.backendv2.PluginRead)
+
+	// Prepare the replies
 	replies := make([]v2.PluginCmdReply, len(pr.Cmds))
-	for k, v := range pr.Cmds {
-		// Decode token. The token is optional on plugin reads.
-		var token []byte
-		if v.Token != "" {
-			token, err = decodeTokenAnyLength(v.Token)
-			if err != nil {
-				// Invalid token. Save the reply and continue to next cmd.
-				replies[k] = v2.PluginCmdReply{
-					UserError: &v2.UserErrorReply{
-						ErrorCode:    v2.ErrorCodeTokenInvalid,
-						ErrorContext: util.TokenRegexp(),
-					},
-				}
-				continue
+	for k, v := range batch.cmds {
+		if v.err == nil {
+			// Command executed successfully
+			replies[k] = v2.PluginCmdReply{
+				Token:   v.cmd.Token,
+				ID:      v.cmd.ID,
+				Command: v.cmd.Command,
+				Payload: v.reply,
 			}
+			continue
 		}
 
-		// Execute plugin cmd
-		replyPayload, err := p.backendv2.PluginRead(token, v.ID,
-			v.Command, v.Payload)
-		if err != nil {
-			var (
-				errCode = convertErrorToV2(err)
-				pe      backendv2.PluginError
-			)
-			switch {
-			case errCode != v2.ErrorCodeInvalid:
-				// User error. Save the reply and continue to next cmd.
-				replies[k] = v2.PluginCmdReply{
-					UserError: &v2.UserErrorReply{
-						ErrorCode: errCode,
-					},
-				}
-				continue
-
-			case errors.As(err, &pe):
-				// Plugin error. Save the reply and continue to next cmd.
-				replies[k] = v2.PluginCmdReply{
-					PluginError: &v2.PluginErrorReply{
-						PluginID:     pe.PluginID,
-						ErrorCode:    pe.ErrorCode,
-						ErrorContext: pe.ErrorContext,
-					},
-				}
-
-			default:
-				// Internal server error. Log it and return a 500.
-				t := time.Now().Unix()
-				e := fmt.Sprintf("PluginRead %v %v %v: %v",
-					v.ID, v.Command, v.Payload, err)
-				log.Errorf("%v %v %v %v Internal error %v: %v",
-					util.RemoteAddr(r), r.Method, r.URL, r.Proto, t, e)
-				log.Errorf("Stacktrace (NOT A REAL CRASH): %s", debug.Stack())
-
-				util.RespondWithJSON(w, http.StatusInternalServerError,
-					v2.ServerErrorReply{
-						ErrorCode: t,
-					})
-				return
+		// An error was encountered. Plugin and user errors
+		// are returned in valid replies. Unexpected errors
+		// cause a 500 and the whole batch to be aborted.
+		var (
+			pluginErr   backendv2.PluginError
+			userErr     v2.UserErrorReply
+			userErrCode = convertErrorToV2(v.err)
+		)
+		switch {
+		case errors.As(v.err, &pluginErr):
+			// A plugin error was returned
+			replies[k] = v2.PluginCmdReply{
+				PluginError: &v2.PluginErrorReply{
+					PluginID:     pluginErr.PluginID,
+					ErrorCode:    pluginErr.ErrorCode,
+					ErrorContext: pluginErr.ErrorContext,
+				},
 			}
-		}
 
-		// Successful cmd execution. Save the reply and continue to
-		// the next cmd.
-		replies[k] = v2.PluginCmdReply{
-			Token:   v.Token,
-			ID:      v.ID,
-			Command: v.Command,
-			Payload: replyPayload,
+		case errors.As(v.err, &userErr):
+			// A user error was returned
+			replies[k] = v2.PluginCmdReply{
+				UserError: &userErr,
+			}
+
+		case userErrCode != v2.ErrorCodeInvalid:
+			// Backend error was returned that was
+			// converted into a valid user error.
+			replies[k] = v2.PluginCmdReply{
+				UserError: &v2.UserErrorReply{
+					ErrorCode: userErrCode,
+				},
+			}
+
+		default:
+			// Internal server error. Log it and return a 500.
+			t := time.Now().Unix()
+			e := fmt.Sprintf("PluginRead %v %v %v: %v",
+				v.cmd.ID, v.cmd.Command, v.cmd.Payload, err)
+			log.Errorf("%v %v %v %v Internal error %v: %v",
+				util.RemoteAddr(r), r.Method, r.URL, r.Proto, t, e)
+			log.Errorf("Stacktrace (NOT A REAL CRASH): %s", debug.Stack())
+
+			util.RespondWithJSON(w, http.StatusInternalServerError,
+				v2.ServerErrorReply{
+					ErrorCode: t,
+				})
+			return
 		}
 	}
 

--- a/politeiad/v2.go
+++ b/politeiad/v2.go
@@ -552,7 +552,7 @@ func (p *politeia) handlePluginReads(w http.ResponseWriter, r *http.Request) {
 
 	// Prepare the replies
 	replies := make([]v2.PluginCmdReply, len(pr.Cmds))
-	for k, v := range batch.cmds {
+	for k, v := range batch.entries {
 		if v.err == nil {
 			// Command executed successfully
 			replies[k] = v2.PluginCmdReply{

--- a/politeiad/v2.go
+++ b/politeiad/v2.go
@@ -548,7 +548,7 @@ func (p *politeia) handlePluginReads(w http.ResponseWriter, r *http.Request) {
 
 	// Execute the batch of read cmds
 	batch := newBatch(pr.Cmds)
-	batch.exec(p.backendv2.PluginRead)
+	batch.execConcurrently(p.backendv2.PluginRead)
 
 	// Prepare the replies
 	replies := make([]v2.PluginCmdReply, len(pr.Cmds))


### PR DESCRIPTION
Part of #1582.

This commit updates the politeiad batch read route to execute the read
commands concurrently instead of serially in order to improve
performance.

A batch of read commands is executed using a sync WaitGroup counter to
track the completion status of the commands and a shared memory cache to
aggregate the replies. Each batch uses its own unique memory cache.

This performance optimization cut the execution time of a 5 command batch
by ~50%.