### PR TITLE
politeiavoter: Fix retry loop bug.

### DIFF
--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -1674,7 +1674,7 @@ func _main() error {
 	switch action {
 	case cmdInventory, cmdTally, cmdVote:
 		// These commands require a connection to a dcrwallet instance. Get
-		// block height to validate GPRC cerds.
+		// block height to validate GPRC creds.
 		ar, err := c.wallet.Accounts(c.ctx, &pb.AccountsRequest{})
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit fixes a bug that was preventing the failed vote retry loop
from exiting when a SIGINT (ctrl+c) is received. The user was being
forced to use a SIGKILL to kill the politeiavoter process.

The root cause was that the retry loop was using a time.Sleep() call
instead of using the WaitFor() call, which accepts a context and exits
when the context is canceled.