### PR TITLE
politeiavoter: Fix duplicate vote bug.

### DIFF
--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -262,6 +262,9 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 		// Vote completed
 		p.Lock()
 		p.ballotResults = append(p.ballotResults, *vr)
+
+		// This is required to be in the lock to prevent a
+		// ballotResults race
 		fmt.Printf("%v finished bunch %v vote %v -- "+
 			"total progress %v/%v\n", time.Now(), bunchID,
 			voteID, len(p.ballotResults), cap(p.ballotResults))

--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -262,11 +262,10 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 		// Vote completed
 		p.Lock()
 		p.ballotResults = append(p.ballotResults, *vr)
-		p.Unlock()
-
 		fmt.Printf("%v finished bunch %v vote %v -- "+
 			"total progress %v/%v\n", time.Now(), bunchID,
 			voteID, len(p.ballotResults), cap(p.ballotResults))
+		p.Unlock()
 
 		return nil
 	}

--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -175,7 +175,6 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 			err := p.jsonLog(failedJournal, va.Vote.Token, b, e)
 			if err != nil {
 				return fmt.Errorf("0 jsonLog: %v", err)
-
 			}
 
 			// Retry
@@ -185,8 +184,10 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 			// Unrecoverable error
 			return fmt.Errorf("unrecoverable error: %v",
 				err)
-		} else if vr.ErrorCode != nil {
-			// Evaluate errors when ErrorCode is set
+		}
+
+		// Evaluate errors when ErrorCode is set
+		if vr.ErrorCode != nil {
 			switch *vr.ErrorCode {
 			// Silently ignore.
 			case tkv1.VoteErrorTicketAlreadyVoted:
@@ -249,23 +250,23 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 
 				return nil
 			}
-		} else {
-			// Success, log it and exit
-			err = p.jsonLog(successJournal, va.Vote.Token, vr)
-			if err != nil {
-				return fmt.Errorf("3 jsonLog: %v", err)
-			}
-
-			// All done with this vote
-			// Vote completed
-			p.Lock()
-			p.ballotResults = append(p.ballotResults, *vr)
-			fmt.Printf("%v finished bunch %v vote %v -- "+
-				"total progress %v/%v\n", time.Now(), bunchID,
-				voteID, len(p.ballotResults), cap(p.ballotResults))
-			p.Unlock()
-			return nil
 		}
+
+		// Success, log it and exit
+		err = p.jsonLog(successJournal, va.Vote.Token, vr)
+		if err != nil {
+			return fmt.Errorf("3 jsonLog: %v", err)
+		}
+
+		// All done with this vote
+		// Vote completed
+		p.Lock()
+		p.ballotResults = append(p.ballotResults, *vr)
+		fmt.Printf("%v finished bunch %v vote %v -- "+
+			"total progress %v/%v\n", time.Now(), bunchID,
+			voteID, len(p.ballotResults), cap(p.ballotResults))
+		p.Unlock()
+		return nil
 	}
 
 	// Not reached

--- a/politeiawww/cmd/politeiavoter/trickle.go
+++ b/politeiawww/cmd/politeiavoter/trickle.go
@@ -262,10 +262,12 @@ func (p *piv) voteTicket(ectx context.Context, bunchID, voteID, of int, va voteA
 		// Vote completed
 		p.Lock()
 		p.ballotResults = append(p.ballotResults, *vr)
+		p.Unlock()
+
 		fmt.Printf("%v finished bunch %v vote %v -- "+
 			"total progress %v/%v\n", time.Now(), bunchID,
 			voteID, len(p.ballotResults), cap(p.ballotResults))
-		p.Unlock()
+
 		return nil
 	}
 


### PR DESCRIPTION
This commit fixes a bug that was causing politeiavoter to continually
retry casting a vote when a duplicate vote error is returned.

Duplicate vote errors can occur when the first attempt results in a
network error where the vote is actually cast, but politeiavoter reports
it as failed. Example, the client connection drops after the vote has
already been submitted to the backend.  politeiavoter will attempt to
re-submit these votes and duplicate vote errors will be returned.

Previously, a duplicate vote error was considered a success case and the
vote was no longer attempted to be re-cast.

bc7da5b1 introduced a change that prevented the success case code path
from being reached on duplicate vote errors. This resulted in
politeiavoter continually retrying these votes when it should have
simply exited. This commit fixes this bug and reverts it to the previous
behavior.

----

Introduced by #1561.