### PR TITLE
pi: Update proposal status cache logging.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/pi/statusescache.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/statusescache.go
@@ -73,10 +73,15 @@ func (s *proposalStatuses) set(token string, entry statusEntry) {
 
 	// If an entry associated with the proposal already exists in cache
 	// overwrite the proposal status.
-	if s.data[token] != nil {
+	if e, ok := s.data[token]; ok {
+		if e.propStatus == entry.propStatus {
+			// Entry exists, but has not changed. No
+			// need to overwrite the existing entry.
+			return
+		}
 		s.data[token] = &entry
-		log.Debugf("proposalStatuses: entry for proposal %v was overwritten",
-			token)
+		log.Debugf("proposalStatuses: updated entry %v from %v to %v",
+			token, e.propStatus, entry.propStatus)
 		return
 	}
 
@@ -86,11 +91,12 @@ func (s *proposalStatuses) set(token string, entry statusEntry) {
 		t := s.entries.Remove(s.entries.Back()).(string)
 		// Remove oldest status from map.
 		delete(s.data, t)
-		log.Debugf("proposalStatuses: entry for proposal %v was removed", t)
+		log.Debugf("proposalStatuses: removed entry %v", t)
 	}
 
 	// Store new status.
 	s.entries.PushFront(token)
 	s.data[token] = &entry
-	log.Debugf("proposalStatuses: entry for proposal %v was added", token)
+	log.Debugf("proposalStatuses: added entry %v with status %v",
+		token, entry.propStatus)
 }


### PR DESCRIPTION
This commit makes two minor tweaks to the proposal status cache:

1. Only overwrite existing entries if the proposal status has changed.
   The logging was too noisy without this.

2. Add the proposal status to the debug logging along with the token.

Example log statements:

```
2021-12-03 15:23:36.390 [DBG] PLUG: proposalStatuses: updated entry 2f459c359620f942 from unvetted to under-review
2021-12-03 15:30:40.254 [DBG] PLUG: proposalStatuses: added entry 05e06fe789cebf7e with status active
2021-12-03 15:31:40.254 [DBG] PLUG: proposalStatuses: removed entry acafd57e67a0e519
```