### PR TITLE
comments: Allow retrieving all comment votes.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1257,9 +1257,9 @@ func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string,
 		// manner, the user IDs must first be sorted, then the pagination is
 		// applied.
 		default:
-			sortedKeys := getVotesMapKeysSorted(cidx.Votes)
-			for _, k := range sortedKeys {
-				for _, vidx := range cidx.Votes[k] {
+			userIDs := getSortedUserIDs(cidx.Votes)
+			for _, userID := range userIDs {
+				for _, vidx := range cidx.Votes[userID] {
 					// Add digest if it's part of the requested page
 					if isInPageRange(idx, pageFirstIndex, pageLastIndex) {
 						digests = append(digests, vidx.Digest)
@@ -1278,19 +1278,18 @@ func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string,
 	return digests
 }
 
-// getVotesMapKeysSorted accepts a map of a comment vote indexes with the
-// user IDs as keys, it collects the keys, sorts them and finally returns
-// them as sorted slice.
-func getVotesMapKeysSorted(m map[string][]voteIndex) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
+// getSortedUserIDs accepts a map of comment vote indexes indexed by user IDs,
+// it collects the keys, sorts them and finally returns them as sorted slice.
+func getSortedUserIDs(m map[string][]voteIndex) []string {
+	userIDs := make([]string, 0, len(m))
+	for userID := range m {
+		userIDs = append(userIDs, userID)
 	}
 
 	// Sort keys
-	sort.Strings(keys)
+	sort.Strings(userIDs)
 
-	return keys
+	return userIDs
 }
 
 // isInPageRange determines whether the given index is part of the given

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1223,6 +1223,7 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 					idx++
 				}
 			}
+
 		// If user ID filter is applied, collect the requested page of the user's
 		// comment votes.
 		case filterByUserID:

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1240,7 +1240,7 @@ func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string,
 				continue
 			}
 			for _, vidx := range voteIdxs {
-				// Add digest if it's is part of the requested page
+				// Add digest if it's part of the requested page
 				if isInPageRange(idx, pageFirstIndex, pageLastIndex) {
 					digests = append(digests, vidx.Digest)
 
@@ -1252,14 +1252,15 @@ func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string,
 				idx++
 			}
 
-		// No filtering criteria is applied. we need to sort the Votes map keys,
-		// in order to iterate over the comment's votes maps in a deterministic
-		// manner while collecting the requested page.
+		// No filtering criteria is applied. The votes are indexed by user ID and
+		// saved in a map. In order to return a page of votes in a deterministic
+		// manner, the user IDs must first be sorted, then the pagination is
+		// applied.
 		default:
 			sortedKeys := getVotesMapKeysSorted(cidx.Votes)
 			for _, k := range sortedKeys {
 				for _, vidx := range cidx.Votes[k] {
-					// Add digest if it's is part of the requested page
+					// Add digest if it's part of the requested page
 					if isInPageRange(idx, pageFirstIndex, pageLastIndex) {
 						digests = append(digests, vidx.Digest)
 

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1219,7 +1219,7 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 	}
 
 	// If requested page exceeds the number of available pages, reutrn
-	// emptry reply.
+	// an emptry reply.
 	pageSize := comments.VotesPageSize
 	if len(digests) < int((page-1)*pageSize) {
 		return votesReply([]comments.CommentVote{})

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1212,7 +1212,7 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 			}
 		}
 
-		// User has cast votes on this comment
+		// Collect digests
 		for _, vidx := range voteIdxs {
 			digests = append(digests, vidx.Digest)
 		}

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1218,7 +1218,7 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 		}
 	}
 
-	// If requested page exceeds the number of available pages, reutrn
+	// If requested page exceeds the number of available pages, return
 	// an emptry reply.
 	pageSize := p.votesPageSize
 	if len(digests) < int((page-1)*pageSize) {

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1208,10 +1208,11 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 		}
 
 		cidx := ridx.Comments[uint32(commentID)]
-		if !filterByUserID {
-			// If no user ID filter is applied, we need to sort the Votes map keys,
-			// in order to iterate over the comment's votes maps in a deterministic
-			// manner.
+		switch {
+		// If no user ID filter is applied, we need to sort the Votes map keys,
+		// in order to iterate over the comment's votes maps in a deterministic
+		// manner.
+		case !filterByUserID:
 			sortedKeys := getVotesMapKeysSorted(cidx.Votes)
 			for _, k := range sortedKeys {
 				for _, vidx := range cidx.Votes[k] {
@@ -1222,9 +1223,9 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 					idx++
 				}
 			}
-		} else {
-			// If user ID filter is applied, collect the requested page of the user's
-			// comment votes.
+		// If user ID filter is applied, collect the requested page of the user's
+		// comment votes.
+		case filterByUserID:
 			voteIdxs, ok := cidx.Votes[v.UserID]
 			if !ok {
 				// User has not cast any votes for this comment

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1210,7 +1210,7 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 		cidx := ridx.Comments[uint32(commentID)]
 		if !filterByUserID {
 			// If no user ID filter is applied, we need to sort the Votes map keys,
-			// in order to iterate over the comment's votes maps in a determinisitic
+			// in order to iterate over the comment's votes maps in a deterministic
 			// manner.
 			sortedKeys := getVotesMapKeysSorted(cidx.Votes)
 			for _, k := range sortedKeys {

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1161,68 +1161,6 @@ func (p *commentsPlugin) cmdCount(token []byte) (string, error) {
 	return string(reply), nil
 }
 
-// collectVoteDigestsPage accepts a map of all comment indexes with a
-// filtering criteria and it collects the requested page.
-func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string, page, pageSize uint32) [][]byte {
-	// Default to first page if page is not provided
-	if page == 0 {
-		page = 1
-	}
-
-	digests := make([][]byte, 0, pageSize)
-	var (
-		pageFirstIndex uint32 = (page - 1) * pageSize
-		pageLastIndex  uint32 = page * pageSize
-		idx            uint32 = 0
-		filterByUserID        = userID != ""
-	)
-
-	// Iterate over record index comments map deterministically; start from
-	// comment id 1 upwards.
-	for commentID := 1; commentID <= len(commentIdxes); commentID++ {
-		// If digests page is full, then we are done
-		if len(digests) == int(pageSize) {
-			break
-		}
-
-		cidx := commentIdxes[uint32(commentID)]
-		switch {
-		// User ID filtering criteria is applied. Collect the requested page of
-		// the user's comment votes.
-		case filterByUserID:
-			voteIdxs, ok := cidx.Votes[userID]
-			if !ok {
-				// User has not cast any votes for this comment
-				continue
-			}
-			for _, vidx := range voteIdxs {
-				// Add digest if it's is part of the requested page
-				if isInPageRange(idx, pageFirstIndex, pageLastIndex) {
-					digests = append(digests, vidx.Digest)
-				}
-				idx++
-			}
-
-		// No filtering criteria is applied. we need to sort the Votes map keys,
-		// in order to iterate over the comment's votes maps in a deterministic
-		// manner while collecting the requested page.
-		default:
-			sortedKeys := getVotesMapKeysSorted(cidx.Votes)
-			for _, k := range sortedKeys {
-				for _, vidx := range cidx.Votes[k] {
-					// Add digest if it's is part of the requested page
-					if isInPageRange(idx, pageFirstIndex, pageLastIndex) {
-						digests = append(digests, vidx.Digest)
-					}
-					idx++
-				}
-			}
-		}
-	}
-
-	return digests
-}
-
 // cmdVotes retrieves the comment votes that meet the provided filtering
 // criteria.
 func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) {
@@ -1270,6 +1208,74 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 	}
 
 	return string(reply), nil
+}
+
+// collectVoteDigestsPage accepts a map of all comment indexes with a
+// filtering criteria and it collects the requested page.
+func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string, page, pageSize uint32) [][]byte {
+	// Default to first page if page is not provided
+	if page == 0 {
+		page = 1
+	}
+
+	digests := make([][]byte, 0, pageSize)
+	var (
+		pageFirstIndex uint32 = (page - 1) * pageSize
+		pageLastIndex  uint32 = page * pageSize
+		idx            uint32 = 0
+		filterByUserID        = userID != ""
+	)
+
+	// Iterate over record index comments map deterministically; start from
+	// comment id 1 upwards.
+	for commentID := 1; commentID <= len(commentIdxes); commentID++ {
+		cidx := commentIdxes[uint32(commentID)]
+		switch {
+		// User ID filtering criteria is applied. Collect the requested page of
+		// the user's comment votes.
+		case filterByUserID:
+			voteIdxs, ok := cidx.Votes[userID]
+			if !ok {
+				// User has not cast any votes for this comment
+				continue
+			}
+			for _, vidx := range voteIdxs {
+				// Add digest if it's is part of the requested page
+				if isInPageRange(idx, pageFirstIndex, pageLastIndex) {
+					digests = append(digests, vidx.Digest)
+
+					// If digests page is full, then we are done
+					if len(digests) == int(pageSize) {
+						goto done
+					}
+				}
+				idx++
+			}
+
+		// No filtering criteria is applied. we need to sort the Votes map keys,
+		// in order to iterate over the comment's votes maps in a deterministic
+		// manner while collecting the requested page.
+		default:
+			sortedKeys := getVotesMapKeysSorted(cidx.Votes)
+			for _, k := range sortedKeys {
+				for _, vidx := range cidx.Votes[k] {
+					// Add digest if it's is part of the requested page
+					if isInPageRange(idx, pageFirstIndex, pageLastIndex) {
+						digests = append(digests, vidx.Digest)
+
+						// If digests page is full, then we are done
+						if len(digests) == int(pageSize) {
+							goto done
+						}
+					}
+					idx++
+				}
+			}
+		}
+	}
+
+done:
+	return digests
 }
 
 // getVotesMapKeysSorted accepts a map of a comment vote indexes with the

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1246,7 +1246,7 @@ func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string,
 
 					// If digests page is full, then we are done
 					if len(digests) == int(pageSize) {
-						goto done
+						return digests
 					}
 				}
 				idx++
@@ -1265,7 +1265,7 @@ func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string,
 
 						// If digests page is full, then we are done
 						if len(digests) == int(pageSize) {
-							goto done
+							return digests
 						}
 					}
 					idx++
@@ -1274,7 +1274,6 @@ func collectVoteDigestsPage(commentIdxes map[uint32]commentIndex, userID string,
 		}
 	}
 
-done:
 	return digests
 }
 

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1220,7 +1220,7 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 
 	// If requested page exceeds the number of available pages, reutrn
 	// an emptry reply.
-	pageSize := comments.VotesPageSize
+	pageSize := p.votesPageSize
 	if len(digests) < int((page-1)*pageSize) {
 		return votesReply([]comments.CommentVote{})
 	}

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -1222,7 +1222,7 @@ func (p *commentsPlugin) cmdVotes(token []byte, payload string) (string, error) 
 	// emptry reply.
 	pageSize := comments.VotesPageSize
 	if len(digests) < int((page-1)*pageSize) {
-		votesReply([]comments.CommentVote{})
+		return votesReply([]comments.CommentVote{})
 	}
 
 	// Lookup votes

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds_test.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package comments
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/decred/politeia/politeiad/plugins/comments"
+)
+
+func TestCollectVoteDigestsPage(t *testing.T) {
+	// Setup test data
+	userIDs := []string{"user1", "user2", "user3"}
+	commentIDs := []uint32{1, 2, 3}
+	token := "testtoken"
+	// Use page size 2 for testing
+	pageSize := uint32(2)
+
+	// Create a comment indexes map for testing with three comment IDs,
+	// which has one comment vote on the first comment from "user1",
+	// another two comment votes on the second second comment from
+	// "user1" and "user2", and lastly another three comment votes on
+	// the third comment from all three test users.
+	commentIdxes := make(map[uint32]commentIndex, len(commentIDs))
+	for _, commentID := range commentIDs {
+		// Prepare comment index Votes map
+		commentIdx := commentIndex{
+			Votes: make(map[string][]voteIndex, commentID),
+		}
+
+		users := userIDs[:commentID]
+		for _, userID := range users {
+			be, err := convertBlobEntryFromCommentVote(comments.CommentVote{
+				UserID:    userID,
+				State:     comments.RecordStateVetted,
+				Token:     token,
+				CommentID: commentID,
+				Vote:      comments.VoteUpvote,
+				PublicKey: "pubkey",
+				Signature: "signature",
+				Timestamp: 1,
+				Receipt:   "receipt",
+			})
+			if err != nil {
+				t.Error(err)
+			}
+			d, err := hex.DecodeString(be.Digest)
+			if err != nil {
+				t.Error(err)
+			}
+			commentIdx.Votes[userID] = []voteIndex{
+				{
+					Digest: d,
+					Vote:   comments.VoteUpvote,
+				},
+			}
+		}
+
+		commentIdxes[commentID] = commentIdx
+	}
+
+	// Setup tests
+	tests := []struct {
+		name                 string
+		page                 uint32
+		userID               string
+		resultExpectedLength int
+	}{
+		{
+			name:                 "first user's first page",
+			page:                 1,
+			userID:               userIDs[0],
+			resultExpectedLength: 2,
+		},
+		{
+			name:                 "first user's second page",
+			page:                 2,
+			userID:               userIDs[0],
+			resultExpectedLength: 1,
+		},
+		{
+			name:                 "first user's third page",
+			page:                 3,
+			userID:               userIDs[0],
+			resultExpectedLength: 0,
+		},
+		{
+			name:                 "second user's first page",
+			page:                 1,
+			userID:               userIDs[1],
+			resultExpectedLength: 2,
+		},
+		{
+			name:                 "second user's second page",
+			page:                 2,
+			userID:               userIDs[1],
+			resultExpectedLength: 0,
+		},
+		{
+			name:                 "third user's first page",
+			page:                 1,
+			userID:               userIDs[2],
+			resultExpectedLength: 1,
+		},
+		{
+			name:                 "third user's second page",
+			page:                 2,
+			userID:               userIDs[2],
+			resultExpectedLength: 0,
+		},
+		{
+			name:                 "all votes first page",
+			page:                 1,
+			userID:               "",
+			resultExpectedLength: 2,
+		},
+		{
+			name:                 "all votes second page",
+			page:                 2,
+			userID:               "",
+			resultExpectedLength: 2,
+		},
+		{
+			name:                 "all votes third page",
+			page:                 3,
+			userID:               "",
+			resultExpectedLength: 2,
+		},
+		{
+			name:                 "all votes forth page",
+			page:                 4,
+			userID:               "",
+			resultExpectedLength: 0,
+		},
+		{
+			name:                 "default to first page with filtering criteria",
+			page:                 0,
+			userID:               userIDs[2],
+			resultExpectedLength: 1,
+		},
+		{
+			name:                 "default to first page w/o filtering criteria",
+			page:                 0,
+			userID:               "",
+			resultExpectedLength: 2,
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run test
+			digests := collectVoteDigestsPage(commentIdxes, tc.userID, tc.page,
+				pageSize)
+
+			// Verify length of returned page
+			if len(digests) != tc.resultExpectedLength {
+				t.Errorf("unexpected result length; want %v, got %v",
+					commentIdxes, digests)
+			}
+		})
+	}
+}

--- a/politeiad/backendv2/tstorebe/plugins/comments/comments.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/comments.go
@@ -43,6 +43,7 @@ type commentsPlugin struct {
 	commentLengthMax uint32
 	voteChangesMax   uint32
 	allowExtraData   bool
+	votesPageSize    uint32
 }
 
 // Setup performs any plugin setup that is required.
@@ -155,6 +156,10 @@ func (p *commentsPlugin) Settings() []backend.PluginSetting {
 			Key:   comments.SettingKeyAllowExtraData,
 			Value: strconv.FormatBool(p.allowExtraData),
 		},
+		{
+			Key:   comments.SettingKeyVotesPageSize,
+			Value: strconv.FormatUint(uint64(p.votesPageSize), 10),
+		},
 	}
 }
 
@@ -172,6 +177,7 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 		commentLengthMax = comments.SettingCommentLengthMax
 		voteChangesMax   = comments.SettingVoteChangesMax
 		allowExtraData   = comments.SettingAllowExtraData
+		votesPageSize    = comments.SettingVotesPageSize
 	)
 
 	// Override defaults with any passed in settings
@@ -198,6 +204,13 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 					v.Key, v.Value, err)
 			}
 			allowExtraData = b
+		case comments.SettingKeyVotesPageSize:
+			u, err := strconv.ParseUint(v.Value, 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+					v.Key, v.Value, err)
+			}
+			votesPageSize = uint32(u)
 		default:
 			return nil, errors.Errorf("invalid comments plugin setting '%v'", v.Key)
 		}
@@ -210,5 +223,6 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 		commentLengthMax: commentLengthMax,
 		voteChangesMax:   voteChangesMax,
 		allowExtraData:   allowExtraData,
+		votesPageSize:    votesPageSize,
 	}, nil
 }

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -480,8 +480,8 @@ type CountReply struct {
 // page is returned. If the requested page does not exist an empty page
 // is returned.
 type Votes struct {
-	UserID string `json:"userid,omitemty"`
-	Page   uint32 `json:"page,omitemty"`
+	UserID string `json:"userid,omitempty"`
+	Page   uint32 `json:"page,omitempty"`
 }
 
 // VotesReply is the reply to the Votes command.

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -38,6 +38,10 @@ const (
 	// SettingKeyAllowExtraData is the plugin setting key for the
 	// SettingAllowExtraData plugin setting.
 	SettingKeyAllowExtraData = "allowextradata"
+
+	// SettingKeyVotesPageSize is the plugin setting key for the
+	// SettingVotesPageSize plugin setting.
+	SettingKeyVotesPageSize = "votespagesize"
 )
 
 // Plugin setting default values. These can be overridden by providing a plugin
@@ -55,6 +59,10 @@ const (
 	// SettingAllowExtraData is the default value of the bool flag which
 	// determines whether posting extra data along with the comment is allowed.
 	SettingAllowExtraData = false
+
+	// SettingVotesPageSize is the default maximum number of comment votes
+	// that can be requests at any one time.
+	SettingVotesPageSize uint32 = 100
 )
 
 // ErrorCodeT represents a error that was caused by the user.
@@ -462,12 +470,6 @@ type Count struct{}
 type CountReply struct {
 	Count uint32 `json:"count"`
 }
-
-const (
-	// VotesPageSize is the maximum number of comment votes
-	// that can be requests at any one time.
-	VotesPageSize uint32 = 100
-)
 
 // Votes retrieves the record's comment votes that meet the provided filtering
 // criteria. If no filtering criteria is provided then it rerieves all comment

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -463,9 +463,19 @@ type CountReply struct {
 	Count uint32 `json:"count"`
 }
 
-// Votes retrieves the comment votes that meet the provided filtering criteria.
+const (
+	// VotesPageSize is the maximum number of comment votes
+	// that can be requests at any one time.
+	VotesPageSize uint32 = 100
+)
+
+// Votes retrieves the record's comment votes that meet the provided filtering
+// criteria. If no filtering criteria is provided then it rerieves all comment
+// votes. This command is paginated and if no page is provided, then the first
+// page is returned.
 type Votes struct {
-	UserID string `json:"userid"`
+	UserID string `json:"userid,omitemty"`
+	Page   uint32 `json:"page,omitemty"`
 }
 
 // VotesReply is the reply to the Votes command.

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -471,7 +471,7 @@ const (
 
 // Votes retrieves the record's comment votes that meet the provided filtering
 // criteria. If no filtering criteria is provided then it rerieves all comment
-// votes. This command is paginated and if no page is provided, then the first
+// votes. This command is paginated, if no page is provided, then the first
 // page is returned.
 type Votes struct {
 	UserID string `json:"userid,omitemty"`

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -61,10 +61,11 @@ const (
 	SettingAllowExtraData = false
 
 	// SettingVotesPageSize is the default maximum number of comment votes
-	// that can be returned at any one time. It defaults to 200 to limit the
-	// comment votes route payload size to be ~80KB, as each comment vote size
-	// is expected to be around 400 bytes which means 200 * 0.4 = 80KB.
-	SettingVotesPageSize uint32 = 200
+	// that can be returned at any one time. It defaults to 2621 to limit the
+	// comment votes route payload size to be ~1MiB, as each comment vote size
+	// is expected to be around 400 bytes which means:
+	// 2621 * 400 byte = ~1048576 byte = 1MiB.
+	SettingVotesPageSize uint32 = 2621
 )
 
 // ErrorCodeT represents a error that was caused by the user.

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -61,11 +61,11 @@ const (
 	SettingAllowExtraData = false
 
 	// SettingVotesPageSize is the default maximum number of comment votes
-	// that can be returned at any one time. It defaults to 2621 to limit the
+	// that can be returned at any one time. It defaults to 2500 to limit the
 	// comment votes route payload size to be ~1MiB, as each comment vote size
 	// is expected to be around 400 bytes which means:
-	// 2621 * 400 byte = ~1048576 byte = 1MiB.
-	SettingVotesPageSize uint32 = 2621
+	// 2500 * 400 byte = 1000000 byte = ~1MiB.
+	SettingVotesPageSize uint32 = 2500
 )
 
 // ErrorCodeT represents a error that was caused by the user.

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -474,7 +474,8 @@ type CountReply struct {
 // Votes retrieves the record's comment votes that meet the provided filtering
 // criteria. If no filtering criteria is provided then it rerieves all comment
 // votes. This command is paginated, if no page is provided, then the first
-// page is returned.
+// page is returned. If the requested page does not exist an empty page
+// is returned.
 type Votes struct {
 	UserID string `json:"userid,omitemty"`
 	Page   uint32 `json:"page,omitemty"`

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -44,8 +44,8 @@ const (
 	SettingKeyVotesPageSize = "votespagesize"
 )
 
-// Plugin setting default values. These can be overridden by providing a plugin
-// setting key and value to the plugin on startup.
+// Plugin setting default values. These can be overridden by providing a
+// plugin setting key and value to the plugin on startup.
 const (
 	// SettingCommentLengthMax is the default maximum number of
 	// characters that are allowed in a comment.
@@ -61,8 +61,10 @@ const (
 	SettingAllowExtraData = false
 
 	// SettingVotesPageSize is the default maximum number of comment votes
-	// that can be requests at any one time.
-	SettingVotesPageSize uint32 = 100
+	// that can be returned at any one time. It defaults to 200 to limit the
+	// comment votes route payload size to ~80KB, as each comment vote size is
+	// expected to be around 400 bytes which means 200 * 0.4 = 80KB.
+	SettingVotesPageSize uint32 = 200
 )
 
 // ErrorCodeT represents a error that was caused by the user.

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -62,8 +62,8 @@ const (
 
 	// SettingVotesPageSize is the default maximum number of comment votes
 	// that can be returned at any one time. It defaults to 200 to limit the
-	// comment votes route payload size to ~80KB, as each comment vote size is
-	// expected to be around 400 bytes which means 200 * 0.4 = 80KB.
+	// comment votes route payload size to be ~80KB, as each comment vote size
+	// is expected to be around 400 bytes which means 200 * 0.4 = 80KB.
 	SettingVotesPageSize uint32 = 200
 )
 

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -375,7 +375,7 @@ const (
 
 // Votes retrieves the record's comment votes that meet the provided filtering
 // criteria. If no filtering criteria is provided then it rerieves all comment
-// votes. This command is paginated and if no page is provided, then the first
+// votes. This command is paginated, if no page is provided, then the first
 // page is returned.
 type Votes struct {
 	Token  string `json:"token"`

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -370,7 +370,8 @@ type CommentsReply struct {
 // Votes retrieves the record's comment votes that meet the provided filtering
 // criteria. If no filtering criteria is provided then it rerieves all comment
 // votes. This command is paginated, if no page is provided, then the first
-// page is returned.
+// page is returned. If the requested page does not exist an empty page
+// is returned.
 type Votes struct {
 	Token  string `json:"token"`
 	UserID string `json:"userid,omitempty"`

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -398,8 +398,8 @@ type Proof struct {
 // Timestamp contains all of the data required to verify that a piece of data
 // was timestamped onto the decred blockchain.
 //
-// All digests are hex encoded SHA256 digests. The merkle root can be found
-// in the OP_RETURN of the specified DCR transaction.
+// All digests are hex encoded SHA256 digests. The merkle root can be found in
+// the OP_RETURN of the specified DCR transaction.
 //
 // TxID, MerkleRoot, and Proofs will only be populated once the merkle root
 // has been included in a DCR tx and the tx has 6 confirmations. The Data

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -152,6 +152,7 @@ type PolicyReply struct {
 	VoteChangesMax     uint32 `json:"votechangesmax"`
 	CountPageSize      uint32 `json:"countpagesize"`
 	TimestampsPageSize uint32 `json:"timestampspagesize"`
+	VotesPageSize      uint32 `json:"votespagesize"`
 }
 
 // RecordStateT represents the state of a record.
@@ -366,10 +367,20 @@ type CommentsReply struct {
 	Comments []Comment `json:"comments"`
 }
 
-// Votes returns the comment votes that meet the provided filtering criteria.
+const (
+	// VotesPageSize is the maximum number of comment votes
+	// that can be requests at any one time.
+	VotesPageSize uint32 = 100
+)
+
+// Votes retrieves the record's comment votes that meet the provided filtering
+// criteria. If no filtering criteria is provided then it rerieves all comment
+// votes. This command is paginated and if no page is provided, then the first
+// page is returned.
 type Votes struct {
 	Token  string `json:"token"`
-	UserID string `json:"userid"`
+	UserID string `json:"userid,omitempty"`
+	Page   uint32 `json:"page,omitempty"`
 }
 
 // VotesReply is the reply to the Votes command.
@@ -393,12 +404,12 @@ type Proof struct {
 // Timestamp contains all of the data required to verify that a piece of data
 // was timestamped onto the decred blockchain.
 //
-// All digests are hex encoded SHA256 digests. The merkle root can be found in
-// the OP_RETURN of the specified DCR transaction.
+// All digests are hex encoded SHA256 digests. The merkle root can be found
+// in the OP_RETURN of the specified DCR transaction.
 //
-// TxID, MerkleRoot, and Proofs will only be populated once the merkle root has
-// been included in a DCR tx and the tx has 6 confirmations. The Data field
-// will not be populated if the data has been censored.
+// TxID, MerkleRoot, and Proofs will only be populated once the merkle root
+// has been included in a DCR tx and the tx has 6 confirmations. The Data
+// field will not be populated if the data has been censored.
 type Timestamp struct {
 	Data       string  `json:"data"` // JSON encoded
 	Digest     string  `json:"digest"`

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -367,12 +367,6 @@ type CommentsReply struct {
 	Comments []Comment `json:"comments"`
 }
 
-const (
-	// VotesPageSize is the maximum number of comment votes
-	// that can be requests at any one time.
-	VotesPageSize uint32 = 100
-)
-
 // Votes retrieves the record's comment votes that meet the provided filtering
 // criteria. If no filtering criteria is provided then it rerieves all comment
 // votes. This command is paginated, if no page is provided, then the first

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -401,9 +401,9 @@ type Proof struct {
 // All digests are hex encoded SHA256 digests. The merkle root can be found in
 // the OP_RETURN of the specified DCR transaction.
 //
-// TxID, MerkleRoot, and Proofs will only be populated once the merkle root
-// has been included in a DCR tx and the tx has 6 confirmations. The Data
-// field will not be populated if the data has been censored.
+// TxID, MerkleRoot, and Proofs will only be populated once the merkle root has
+// been included in a DCR tx and the tx has 6 confirmations. The Data field
+// will not be populated if the data has been censored.
 type Timestamp struct {
 	Data       string  `json:"data"` // JSON encoded
 	Digest     string  `json:"digest"`

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -60,6 +60,7 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 	if len(vr.Votes) == 0 {
 		if userID != "" {
 			printf("No comment votes found for user %v\n", userID)
+			return nil
 		}
 		printf("No comment votes found for proposal %v\n", token)
 	}

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -69,14 +69,16 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 }
 
 // commentVotesHelpMsg is printed to stdout by the help command.
-const commentVotesHelpMsg = `commentvotes "token" "userid" "page"
+const commentVotesHelpMsg = `commentvotes "token"
 
-Get comment upvote/downvotes for a proposal. User ID can be used to retrieve 
-the votes of a specific user. If no filter criteria provided the returned 
-votes are paginated. If all votes are requested and no page value is provided 
-then the first page is returned.
+Get paginated comment up/downvotes for a proposal. The --userid flag can be 
+used to retrieve the votes of a specific userid. The --page flag can be used 
+to retrieve a specific page, if no page is provided then the first page is 
+returned.
 
 Arguments:
-1. token   (string, required)  Proposal censorship token
-2. userid  (string, optional)  User ID
-3. page    (uint32, optional)  Requested page`
+1. token  (string, required)  Proposal censorship token
+
+Flags:
+  --userid  (string, optional)  User ID
+  --page    (uint32, optional)  Requested page`

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -16,6 +16,7 @@ type cmdCommentVotes struct {
 		Token string `positional-arg-name:"token" required:"true"`
 	} `positional-args:"true"`
 
+	// Filtering options
 	UserID string `long:"userid"`
 	Page   uint32 `long:"page"`
 }
@@ -24,7 +25,7 @@ type cmdCommentVotes struct {
 //
 // This function satisfies the go-flags Commander interface.
 func (c *cmdCommentVotes) Execute(args []string) error {
-	// Unpack args & flags
+	// Unpack args & filtering options
 	var (
 		token  = c.Args.Token
 		userID = c.UserID

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -72,7 +72,7 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 const commentVotesHelpMsg = `commentvotes "token"
 
 Get paginated comment up/downvotes of a proposal. The --userid flag can be 
-used to retrieve the votes of a specific userid. The --page flag can be used 
+used to retrieve the votes of a specific user. The --page flag can be used 
 to retrieve a specific page, if no page is provided then the first page is 
 returned.
 

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"fmt"
-
 	cmv1 "github.com/decred/politeia/politeiawww/api/comments/v1"
 	pclient "github.com/decred/politeia/politeiawww/client"
 )
@@ -17,6 +15,7 @@ type cmdCommentVotes struct {
 	Args struct {
 		Token  string `positional-arg-name:"token" required:"true"`
 		UserID string `positional-arg-name:"userid"`
+		Page   uint32 `positional-arg-name:"page"`
 	} `positional-args:"true"`
 }
 
@@ -28,22 +27,8 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 	var (
 		token  = c.Args.Token
 		userID = c.Args.UserID
+		page   = c.Args.Page
 	)
-
-	// If a user ID was not provided this command assumes the user
-	// is requesting their own comment votes.
-	if userID == "" {
-		// Get user ID of logged in user
-		lr, err := client.Me()
-		if err != nil {
-			if err.Error() == "401" {
-				return fmt.Errorf("no user ID provided and no logged in "+
-					"user found. Command usage: \n\n%v", commentVotesHelpMsg)
-			}
-			return err
-		}
-		userID = lr.UserID
-	}
 
 	// Setup client
 	opts := pclient.Opts{
@@ -62,6 +47,7 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 	v := cmv1.Votes{
 		Token:  token,
 		UserID: userID,
+		Page:   page,
 	}
 	vr, err := pc.CommentVotes(v)
 	if err != nil {
@@ -70,7 +56,10 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 
 	// Print votes
 	if len(vr.Votes) == 0 {
-		printf("No comment votes found for user %v\n", userID)
+		if userID != "" {
+			printf("No comment votes found for user %v\n", userID)
+		}
+		printf("No comment votes found for proposal %v\n", token)
 	}
 	printCommentVotes(vr.Votes)
 
@@ -78,12 +67,14 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 }
 
 // commentVotesHelpMsg is printed to stdout by the help command.
-const commentVotesHelpMsg = `commentvotes "token" "userid"
+const commentVotesHelpMsg = `commentvotes "token" "userid" "page"
 
-Get the provided user comment upvote/downvotes for a proposal. If no user ID
-is provided then the command will assume the logged in user is requesting their
-own comment votes.
+Get comment upvote/downvotes for a proposal. User ID can be used to retrieve 
+the votes of a specific user. If no filter criteria provided the returned 
+votes are paginated. If all votes are requested and no page value is provided 
+then the first page is returned.
 
 Arguments:
 1. token   (string, required)  Proposal censorship token
-2. userid  (string, optional)  User ID`
+2. userid  (string, optional)  User ID
+3. page    (uint32, optional)  Requested page`

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -56,15 +56,16 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 		return err
 	}
 
-	// Print votes
-	if len(vr.Votes) == 0 {
+	// Print votes or an empty message if no votes were found
+	if len(vr.Votes) > 0 {
+		printCommentVotes(vr.Votes)
+	} else {
 		if userID != "" {
 			printf("No comment votes found for user %v\n", userID)
-			return nil
+		} else {
+			printf("No comment votes found for proposal %v\n", token)
 		}
-		printf("No comment votes found for proposal %v\n", token)
 	}
-	printCommentVotes(vr.Votes)
 
 	return nil
 }

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -57,14 +57,15 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 	}
 
 	// Print votes or an empty message if no votes were found
-	if len(vr.Votes) > 0 {
+	switch {
+	case len(vr.Votes) > 0:
 		printCommentVotes(vr.Votes)
-	} else {
-		if userID != "" {
-			printf("No comment votes found for user %v\n", userID)
-		} else {
-			printf("No comment votes found for proposal %v\n", token)
-		}
+
+	case userID != "":
+		printf("No comment votes found for user %v\n", userID)
+
+	case userID == "":
+		printf("No comment votes found for proposal %v\n", token)
 	}
 
 	return nil

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -13,21 +13,22 @@ import (
 // record.
 type cmdCommentVotes struct {
 	Args struct {
-		Token  string `positional-arg-name:"token" required:"true"`
-		UserID string `positional-arg-name:"userid"`
-		Page   uint32 `positional-arg-name:"page"`
+		Token string `positional-arg-name:"token" required:"true"`
 	} `positional-args:"true"`
+
+	UserID string `long:"userid"`
+	Page   uint32 `long:"page"`
 }
 
 // Execute executes the cmdCommentVotes command.
 //
 // This function satisfies the go-flags Commander interface.
 func (c *cmdCommentVotes) Execute(args []string) error {
-	// Unpack args
+	// Unpack args & flags
 	var (
 		token  = c.Args.Token
-		userID = c.Args.UserID
-		page   = c.Args.Page
+		userID = c.UserID
+		page   = c.Page
 	)
 
 	// Setup client

--- a/politeiawww/cmd/pictl/cmdcommentvotes.go
+++ b/politeiawww/cmd/pictl/cmdcommentvotes.go
@@ -71,7 +71,7 @@ func (c *cmdCommentVotes) Execute(args []string) error {
 // commentVotesHelpMsg is printed to stdout by the help command.
 const commentVotesHelpMsg = `commentvotes "token"
 
-Get paginated comment up/downvotes for a proposal. The --userid flag can be 
+Get paginated comment up/downvotes of a proposal. The --userid flag can be 
 used to retrieve the votes of a specific userid. The --page flag can be used 
 to retrieve a specific page, if no page is provided then the first page is 
 returned.

--- a/politeiawww/cmd/pictl/comment.go
+++ b/politeiawww/cmd/pictl/comment.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"sort"
 	"strings"
 
 	cmv1 "github.com/decred/politeia/politeiawww/api/comments/v1"
@@ -60,17 +59,11 @@ func printCommentVotes(votes []cmv1.CommentVote) {
 		return
 	}
 	printf("Token   : %v\n", votes[0].Token)
-	printf("UserID  : %v\n", votes[0].UserID)
-	printf("Username: %v\n", votes[0].Username)
 	printf("Votes\n")
 
-	// Order votes by timestamp. Oldest to newest.
-	sort.SliceStable(votes, func(i, j int) bool {
-		return votes[i].Timestamp < votes[j].Timestamp
-	})
-
 	for _, v := range votes {
-		printf("  %-22v comment %v vote %v\n",
-			dateAndTimeFromUnix(v.Timestamp), v.CommentID, v.Vote)
+		printf("  %-22v userid %v username %v comment %v vote %v \n",
+			dateAndTimeFromUnix(v.Timestamp), v.UserID, v.Username, v.CommentID,
+			v.Vote)
 	}
 }

--- a/politeiawww/legacy/comments/comments.go
+++ b/politeiawww/legacy/comments/comments.go
@@ -301,6 +301,7 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 			VoteChangesMax:     voteChangesMax,
 			CountPageSize:      v1.CountPageSize,
 			TimestampsPageSize: v1.TimestampsPageSize,
+			VotesPageSize:      v1.VotesPageSize,
 		},
 	}, nil
 }

--- a/politeiawww/legacy/comments/comments.go
+++ b/politeiawww/legacy/comments/comments.go
@@ -253,6 +253,7 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 	var (
 		lengthMax      uint32
 		voteChangesMax uint32
+		votesPageSize  uint32
 	)
 	for _, p := range plugins {
 		if p.ID != comments.PluginID {
@@ -273,6 +274,12 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 					return nil, err
 				}
 				voteChangesMax = uint32(u)
+			case comments.SettingKeyVotesPageSize:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				votesPageSize = uint32(u)
 			default:
 				// Skip unknown settings
 				log.Warnf("Unknown plugin setting %v; Skipping...", v.Key)
@@ -288,6 +295,9 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 	case voteChangesMax == 0:
 		return nil, fmt.Errorf("plugin setting not found: %v",
 			comments.SettingKeyVoteChangesMax)
+	case votesPageSize == 0:
+		return nil, fmt.Errorf("plugin setting not found: %v",
+			comments.SettingKeyVotesPageSize)
 	}
 
 	return &Comments{
@@ -301,7 +311,7 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 			VoteChangesMax:     voteChangesMax,
 			CountPageSize:      v1.CountPageSize,
 			TimestampsPageSize: v1.TimestampsPageSize,
-			VotesPageSize:      v1.VotesPageSize,
+			VotesPageSize:      votesPageSize,
 		},
 	}, nil
 }

--- a/politeiawww/legacy/comments/log.go
+++ b/politeiawww/legacy/comments/log.go
@@ -29,5 +29,5 @@ func UseLogger(logger slog.Logger) {
 
 // Initialize the package logger.
 func init() {
-	UseLogger(logger.NewSubsystem("PWWW"))
+	UseLogger(logger.NewSubsystem("COMMENTS"))
 }

--- a/politeiawww/legacy/comments/log.go
+++ b/politeiawww/legacy/comments/log.go
@@ -29,5 +29,5 @@ func UseLogger(logger slog.Logger) {
 
 // Initialize the package logger.
 func init() {
-	UseLogger(logger.NewSubsystem("COMMENTS"))
+	UseLogger(logger.NewSubsystem("CMPL"))
 }

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -367,7 +367,7 @@ func (c *Comments) commentVotesPopulateUserData(votes []v1.CommentVote, userID s
 	}
 
 	// Map user IDs to usernames
-	usernames := make(map[string]string, len(mPubKeys))
+	usernames := make(map[string]string, len(users))
 	for _, u := range users {
 		usernames[u.ID.String()] = u.Username
 	}

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 
 	pdv2 "github.com/decred/politeia/politeiad/api/v2"
 	"github.com/decred/politeia/politeiad/plugins/comments"
@@ -306,6 +305,7 @@ func (c *Comments) processVotes(ctx context.Context, v v1.Votes) (*v1.VotesReply
 	// comments are public.
 	cm := comments.Votes{
 		UserID: v.UserID,
+		Page:   v.Page,
 	}
 	votes, err := c.politeiad.CommentVotes(ctx, v.Token, cm)
 	if err != nil {
@@ -323,11 +323,6 @@ func (c *Comments) processVotes(ctx context.Context, v v1.Votes) (*v1.VotesReply
 		return nil, err
 	}
 	commentVotePopulateUserData(cv, *u)
-
-	// Sort comment votes by timestamp from newest to oldest.
-	sort.SliceStable(cv, func(i, j int) bool {
-		return cv[i].Timestamp > cv[j].Timestamp
-	})
 
 	return &v1.VotesReply{
 		Votes: cv,

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -390,7 +390,7 @@ func (c *Comments) commentVotesPopulateUserData(votes []v1.CommentVote, userID s
 			usernames[u.ID.String()] = u.Username
 		}
 
-		log.Debugf("fetched a batch of %v users out of %v required users",
+		log.Debugf("Fetched a batch of %v users out of %v required users",
 			len(batch), len(pubkeys))
 
 		// Next batch start index

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -367,17 +367,17 @@ func (c *Comments) commentVotesPopulateUserData(votes []v1.CommentVote, userID s
 
 	// Get users from db in batchs to avoid reading too many
 	// users into memory.
-	var startIdx int
+	var batchStartIdx int
 	usernames := make(map[string]string, len(pubkeys))
-	for startIdx < len(pubkeys) {
-		endIdx := startIdx + usersBatchSize
-		if endIdx > len(pubkeys) {
+	for batchStartIdx < len(pubkeys) {
+		batchEndIdx := batchStartIdx + usersBatchSize
+		if batchEndIdx > len(pubkeys) {
 			// We've reached the end of the slice
-			endIdx = len(pubkeys)
+			batchEndIdx = len(pubkeys)
 		}
 
-		// startIdx is included. endIdx is excluded.
-		batch := pubkeys[startIdx:endIdx]
+		// batchStartIdx is included. batchEndIdx is excluded.
+		batch := pubkeys[batchStartIdx:batchEndIdx]
 
 		// Get batch of users
 		users, err := c.userdb.UsersGetByPubKey(batch)
@@ -390,8 +390,11 @@ func (c *Comments) commentVotesPopulateUserData(votes []v1.CommentVote, userID s
 			usernames[u.ID.String()] = u.Username
 		}
 
-		// Update the start index
-		startIdx = endIdx
+		log.Debugf("fetched a batch of %v users out of %v required users",
+			len(batch), len(pubkeys))
+
+		// Next batch start index
+		batchStartIdx = batchEndIdx
 	}
 
 	// Populate comment votes with usernames

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -327,8 +327,8 @@ func (c *Comments) processVotes(ctx context.Context, v v1.Votes) (*v1.VotesReply
 	} else {
 		// If user ID filter is not applied, we need to collect all
 		// the user IDs from comment vote structs.
+		uids = make(map[string]uuid.UUID, len(votes))
 		for _, vote := range votes {
-			uids = make(map[string]uuid.UUID, len(votes))
 			if _, ok := uids[vote.UserID]; ok {
 				// If user uuid already known, skip
 				continue

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -337,7 +337,7 @@ func (c *Comments) processVotes(ctx context.Context, v v1.Votes) (*v1.VotesReply
 			if err != nil {
 				return nil, err
 			}
-			uids[v.UserID] = uid
+			uids[vote.UserID] = uid
 		}
 	}
 	// Map string user ID to the user name - map[userid]username

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -375,6 +375,7 @@ func (c *Comments) commentVotesPopulateUserData(votes []v1.CommentVote, userID s
 		batchLastIndex := int(math.Min(float64(usersBatchSize),
 			float64(len(pubKeys))))
 		batch := pubKeys[:batchLastIndex]
+
 		// Remaining public keys
 		pubKeys = pubKeys[batchLastIndex:]
 

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -314,24 +314,30 @@ func (c *Comments) processVotes(ctx context.Context, v v1.Votes) (*v1.VotesReply
 	cv := convertCommentVotes(votes)
 
 	// Populate comment votes with user data
-	var uids []uuid.UUID
+	var uids map[string]uuid.UUID
 	if v.UserID != "" {
 		// If user ID filter is applied, we have only one user
 		// to fetch.
+		uids = make(map[string]uuid.UUID, 1)
 		uid, err := uuid.Parse(v.UserID)
 		if err != nil {
 			return nil, err
 		}
-		uids = append(uids, uid)
+		uids[v.UserID] = uid
 	} else {
 		// If user ID filter is not applied, we need to collect all
 		// the user IDs from comment vote structs.
 		for _, vote := range votes {
+			uids = make(map[string]uuid.UUID, len(votes))
+			if _, ok := uids[vote.UserID]; ok {
+				// If user uuid already known, skip
+				continue
+			}
 			uid, err := uuid.Parse(vote.UserID)
 			if err != nil {
 				return nil, err
 			}
-			uids = append(uids, uid)
+			uids[v.UserID] = uid
 		}
 	}
 	// Map string user ID to the user name - map[userid]username

--- a/politeiawww/legacy/pi/log.go
+++ b/politeiawww/legacy/pi/log.go
@@ -29,5 +29,5 @@ func UseLogger(logger slog.Logger) {
 
 // Initialize the package logger.
 func init() {
-	UseLogger(logger.NewSubsystem("PI"))
+	UseLogger(logger.NewSubsystem("PIPL"))
 }

--- a/politeiawww/legacy/pi/log.go
+++ b/politeiawww/legacy/pi/log.go
@@ -29,5 +29,5 @@ func UseLogger(logger slog.Logger) {
 
 // Initialize the package logger.
 func init() {
-	UseLogger(logger.NewSubsystem("PWWW"))
+	UseLogger(logger.NewSubsystem("PI"))
 }

--- a/politeiawww/legacy/ticketvote/log.go
+++ b/politeiawww/legacy/ticketvote/log.go
@@ -29,5 +29,5 @@ func UseLogger(logger slog.Logger) {
 
 // Initialize the package logger.
 func init() {
-	UseLogger(logger.NewSubsystem("TICKETVOTE"))
+	UseLogger(logger.NewSubsystem("TVPL"))
 }

--- a/politeiawww/legacy/ticketvote/log.go
+++ b/politeiawww/legacy/ticketvote/log.go
@@ -29,5 +29,5 @@ func UseLogger(logger slog.Logger) {
 
 // Initialize the package logger.
 func init() {
-	UseLogger(logger.NewSubsystem("PWWW"))
+	UseLogger(logger.NewSubsystem("TICKETVOTE"))
 }

--- a/politeiawww/records/log.go
+++ b/politeiawww/records/log.go
@@ -29,5 +29,5 @@ func UseLogger(logger slog.Logger) {
 
 // Initialize the package logger.
 func init() {
-	UseLogger(logger.NewSubsystem("PWWW"))
+	UseLogger(logger.NewSubsystem("RECORDS"))
 }

--- a/politeiawww/records/log.go
+++ b/politeiawww/records/log.go
@@ -29,5 +29,5 @@ func UseLogger(logger slog.Logger) {
 
 // Initialize the package logger.
 func init() {
-	UseLogger(logger.NewSubsystem("RECORDS"))
+	UseLogger(logger.NewSubsystem("RCPL"))
 }


### PR DESCRIPTION
**Background:**

The comment votes endpoint currently only allows you to retrieve comment
votes for a specific user ID. This initial implementation was
restrictive because that was all that politeiagui needs. Opening up the
endpoint to allow a client to retrieve all comment votes made on a
proposal, without needing to provide a user ID, has been requested in
order to help analyze the proposal process. Comment votes are already
public, so there is no reason to not allow this.

**Implementation:**

- Make the user ID field optional.
- Return paginated comment votes. 
- Add A page number field to the command payload, which defaults to 1 if
  not provided.
- Add new `votesPageSize` comments plugin setting to use it in both of
`politeiawww` & `politeiad`
- Add the new `votesPageSize` plugin setting to the comments' policy reply.
- Update comments plugin command in politeiad to reflect the new
  implementation.
- Update `pictl commentvotes` command to reflect new changes.

---

Closes #1591.