### PR TITLE
politeiavoter: Improve hoursprior UX.

### DIFF
--- a/politeiawww/cmd/politeiavoter/politeiavoter_test.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSetupVoteDuration(t *testing.T) {
+	// Setup piv context
+	p, cleanup := fakePiv(t, 0, 1)
+	defer cleanup()
+
+	// Setup tests
+	var tests = []struct {
+		name           string
+		voteDuration   time.Duration
+		hoursPrior     time.Duration
+		timeLeftInVote time.Duration
+		wantErr        bool
+	}{
+		{
+			"vote duration exceeds remaining time",
+			2 * time.Hour,
+			0,
+			1 * time.Hour,
+			true,
+		},
+		{
+			"calculated vote duration is under 24 hours",
+			0,
+			12 * time.Hour,
+			35 * time.Hour,
+			true,
+		},
+		{
+			"vote duration provided success",
+			1 * time.Hour,
+			0,
+			2 * time.Hour,
+			false,
+		},
+		{
+			"vote duration not provided success",
+			0,
+			12 * time.Hour,
+			36 * time.Hour,
+			false,
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup piv config
+			p.cfg.voteDuration = tc.voteDuration
+			p.cfg.hoursPrior = tc.hoursPrior
+
+			// Run test
+			err := p.setupVoteDuration(tc.timeLeftInVote)
+			switch {
+			case err != nil && tc.wantErr:
+				// Test passes
+				return
+			case err == nil && !tc.wantErr:
+				// Test passes
+				return
+			default:
+				// Test fails
+				t.Errorf("got err %v, want err %v",
+					err == nil, tc.wantErr)
+			}
+		})
+	}
+}

--- a/politeiawww/cmd/politeiavoter/politeiavoter_test.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter_test.go
@@ -23,7 +23,7 @@ func TestSetupVoteDuration(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			"vote duration exceeds remaining time",
+			"provided vote duration exceeds remaining time",
 			2 * time.Hour,
 			0,
 			1 * time.Hour,

--- a/politeiawww/cmd/politeiavoter/trickle_test.go
+++ b/politeiawww/cmd/politeiavoter/trickle_test.go
@@ -61,7 +61,7 @@ func fakePiv(t *testing.T, d time.Duration, x uint, hoursPrior uint64) (*piv, fu
 			HomeDir:      homeDir,
 			voteDir:      filepath.Join(homeDir, defaultVoteDirname),
 			voteDuration: d,
-			HoursPrior:   hoursPrior,
+			HoursPrior:   &hoursPrior,
 			Bunches:      x,
 			testing:      true,
 		},

--- a/politeiawww/cmd/politeiavoter/trickle_test.go
+++ b/politeiawww/cmd/politeiavoter/trickle_test.go
@@ -37,7 +37,7 @@ func fakeTickets(x uint) (*pb.CommittedTicketsResponse, *pb.SignMessagesResponse
 	return &ctres, &smr
 }
 
-func fakePiv(t *testing.T, d time.Duration, x uint, hoursPrior uint64) (*piv, func()) {
+func fakePiv(t *testing.T, d time.Duration, x uint) (*piv, func()) {
 	// Setup temp home dir
 	homeDir, err := ioutil.TempDir("", "politeiavoter.test")
 	if err != nil {
@@ -61,29 +61,15 @@ func fakePiv(t *testing.T, d time.Duration, x uint, hoursPrior uint64) (*piv, fu
 			HomeDir:      homeDir,
 			voteDir:      filepath.Join(homeDir, defaultVoteDirname),
 			voteDuration: d,
-			HoursPrior:   &hoursPrior,
 			Bunches:      x,
 			testing:      true,
 		},
 	}, cleanup
 }
 
-func TestTrickleNotEnoughTime(t *testing.T) {
-	x := uint(10)
-	c, cleanup := fakePiv(t, time.Hour, x, 1)
-	defer cleanup()
-
-	ctres, smr := fakeTickets(x)
-	err := c.alarmTrickler("token", "voteBit", ctres, smr)
-	t.Logf("error received: %v", err)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-}
-
 func TestTrickleWorkers(t *testing.T) {
 	bunches := uint(3)
-	c, cleanup := fakePiv(t, time.Minute, bunches, 0)
+	c, cleanup := fakePiv(t, time.Minute, bunches)
 	defer cleanup()
 
 	nrVotes := uint(20)
@@ -95,7 +81,7 @@ func TestTrickleWorkers(t *testing.T) {
 }
 
 func TestUnrecoverableTrickleWorkers(t *testing.T) {
-	c, cleanup := fakePiv(t, 10*time.Second, 1, 0)
+	c, cleanup := fakePiv(t, 10*time.Second, 1)
 	defer cleanup()
 
 	c.cfg.testingMode = testFailUnrecoverable
@@ -113,7 +99,7 @@ func TestManyTrickleWorkers(t *testing.T) {
 	}
 
 	bunches := uint(10)
-	c, cleanup := fakePiv(t, 2*time.Minute, bunches, 0)
+	c, cleanup := fakePiv(t, 2*time.Minute, bunches)
 	defer cleanup()
 
 	nrVotes := uint(20000)


### PR DESCRIPTION
This commit improves the --hoursprior UX by updating politeiavoter to
the following behavior.

By default, the trickler will trickle in votes for the full duration of
the vote minus 12h.

The --voteduration and the --hoursprior settings are not allowed to be
used at the same time. An error is returned if they are attempted to be
used together.

If a --voteduration is specified, the votes are trickled in over the
specified duration.

If a --hoursprior is specified, the votes are trickled in over the full
duration of the vote minus the specified hours prior.

If the calculated vote duration is less than 24h, the user MUST
manually set the duration using the --voteduration flag.

**Example 1**

A vote has 6 days remaining. The user attempts to trickle in their votes
over a 3h period using --voteduration=3h.

Previously, they would get the following error.

```
not enough time left to trickle votes: -9h0m0s < 12h0m0s, use
--hoursprior to modify this behavior
```

Using this commit, no error is returned and the votes are trickled in
over the 3h period.

**Example 2**

A vote has 6 hours remaining. The user attempts to trickle in their
votes without specifying a --voteduration.

Previously, they would get the following error.

```
not enough time left to trickle votes: -6h0m0s < 12h0m0s, use
--hoursprior to modify this behavior
```

With this commit, they now get the following error.

```
there is only 6h0m0s left in the vote; when the remaining time is this
low you must use --voteduration to manually set the duration that will
be used to trickle in your votes, example --voteduration=6h
```

**Example 3**

There is 28h left in a vote. The user attempts to trickle in their votes
without specifying a --voteduration.

Previously, they would get the following error.

```
not enough time left to trickle votes: 4h0m0s < 12h0m0s, use
--hoursprior to modify this behavior
```

With this commit, the calculated vote duration is 16h (28h left in the
vote minus the default 12h hours prior). 16h is less than the required
24h vote duration so they get the following error.

```
there is only 28h0m0s left in the vote; when the remaining time is this
low you must use --voteduration to manually set the duration that will
be used to trickle in your votes, example --voteduration=6h
```
