### PR TITLE
multi: Add routes page sizes as plugin settings.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/comments/comments.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/comments.go
@@ -40,9 +40,11 @@ type commentsPlugin struct {
 	identity *identity.FullIdentity
 
 	// Plugin settings
-	commentLengthMax uint32
-	voteChangesMax   uint32
-	allowExtraData   bool
+	commentLengthMax   uint32
+	voteChangesMax     uint32
+	allowExtraData     bool
+	countPageSize      uint32
+	timestampsPageSize uint32
 }
 
 // Setup performs any plugin setup that is required.
@@ -155,6 +157,14 @@ func (p *commentsPlugin) Settings() []backend.PluginSetting {
 			Key:   comments.SettingKeyAllowExtraData,
 			Value: strconv.FormatBool(p.allowExtraData),
 		},
+		{
+			Key:   comments.SettingKeyCountPageSize,
+			Value: strconv.FormatUint(uint64(p.countPageSize), 10),
+		},
+		{
+			Key:   comments.SettingKeyTimestampsPageSize,
+			Value: strconv.FormatUint(uint64(p.timestampsPageSize), 10),
+		},
 	}
 }
 
@@ -169,9 +179,11 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 
 	// Default plugin settings
 	var (
-		commentLengthMax = comments.SettingCommentLengthMax
-		voteChangesMax   = comments.SettingVoteChangesMax
-		allowExtraData   = comments.SettingAllowExtraData
+		commentLengthMax   = comments.SettingCommentLengthMax
+		voteChangesMax     = comments.SettingVoteChangesMax
+		allowExtraData     = comments.SettingAllowExtraData
+		countPageSize      = comments.SettingCountPageSize
+		timestampsPageSize = comments.SettingTimestampsPageSize
 	)
 
 	// Override defaults with any passed in settings
@@ -198,17 +210,33 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 					v.Key, v.Value, err)
 			}
 			allowExtraData = b
+		case comments.SettingKeyCountPageSize:
+			u, err := strconv.ParseUint(v.Value, 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+					v.Key, v.Value, err)
+			}
+			countPageSize = uint32(u)
+		case comments.SettingKeyTimestampsPageSize:
+			u, err := strconv.ParseUint(v.Value, 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+					v.Key, v.Value, err)
+			}
+			timestampsPageSize = uint32(u)
 		default:
 			return nil, errors.Errorf("invalid comments plugin setting '%v'", v.Key)
 		}
 	}
 
 	return &commentsPlugin{
-		tstore:           tstore,
-		identity:         id,
-		dataDir:          dataDir,
-		commentLengthMax: commentLengthMax,
-		voteChangesMax:   voteChangesMax,
-		allowExtraData:   allowExtraData,
+		tstore:             tstore,
+		identity:           id,
+		dataDir:            dataDir,
+		commentLengthMax:   commentLengthMax,
+		voteChangesMax:     voteChangesMax,
+		allowExtraData:     allowExtraData,
+		countPageSize:      countPageSize,
+		timestampsPageSize: timestampsPageSize,
 	}, nil
 }

--- a/politeiad/backendv2/tstorebe/plugins/pi/pi.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/pi.go
@@ -49,21 +49,23 @@ type piPlugin struct {
 	identity *identity.FullIdentity
 
 	// Plugin settings
-	textFileCountMax        uint32
-	textFileSizeMax         uint32 // In bytes
-	imageFileCountMax       uint32
-	imageFileSizeMax        uint32 // In bytes
-	titleSupportedChars     string // JSON encoded []string
-	titleLengthMin          uint32 // In characters
-	titleLengthMax          uint32 // In characters
-	titleRegexp             *regexp.Regexp
-	proposalAmountMin       uint64 // In cents
-	proposalAmountMax       uint64 // In cents
-	proposalStartDateMin    int64  // Seconds from current time
-	proposalEndDateMax      int64  // Seconds from current time
-	proposalDomainsEncoded  string // JSON encoded []string
-	proposalDomains         map[string]struct{}
-	billingStatusChangesMax uint32
+	textFileCountMax             uint32
+	textFileSizeMax              uint32 // In bytes
+	imageFileCountMax            uint32
+	imageFileSizeMax             uint32 // In bytes
+	titleSupportedChars          string // JSON encoded []string
+	titleLengthMin               uint32 // In characters
+	titleLengthMax               uint32 // In characters
+	titleRegexp                  *regexp.Regexp
+	proposalAmountMin            uint64 // In cents
+	proposalAmountMax            uint64 // In cents
+	proposalStartDateMin         int64  // Seconds from current time
+	proposalEndDateMax           int64  // Seconds from current time
+	proposalDomainsEncoded       string // JSON encoded []string
+	proposalDomains              map[string]struct{}
+	billingStatusChangesMax      uint32
+	summariesPageSize            uint32
+	billingStatusChangesPageSize uint32
 }
 
 // Setup performs any plugin setup that is required.
@@ -180,6 +182,14 @@ func (p *piPlugin) Settings() []backend.PluginSetting {
 			Key:   pi.SettingKeyBillingStatusChangesMax,
 			Value: strconv.FormatUint(uint64(p.billingStatusChangesMax), 10),
 		},
+		{
+			Key:   pi.SettingKeySummariesPageSize,
+			Value: strconv.FormatUint(uint64(p.summariesPageSize), 10),
+		},
+		{
+			Key:   pi.SettingKeyBillingStatusChangesPageSize,
+			Value: strconv.FormatUint(uint64(p.billingStatusChangesPageSize), 10),
+		},
 	}
 }
 
@@ -194,18 +204,20 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 
 	// Setup plugin setting default values
 	var (
-		textFileSizeMax         = pi.SettingTextFileSizeMax
-		imageFileCountMax       = pi.SettingImageFileCountMax
-		imageFileSizeMax        = pi.SettingImageFileSizeMax
-		titleLengthMin          = pi.SettingTitleLengthMin
-		titleLengthMax          = pi.SettingTitleLengthMax
-		titleSupportedChars     = pi.SettingTitleSupportedChars
-		amountMin               = pi.SettingProposalAmountMin
-		amountMax               = pi.SettingProposalAmountMax
-		startDateMin            = pi.SettingProposalStartDateMin
-		endDateMax              = pi.SettingProposalEndDateMax
-		domains                 = pi.SettingProposalDomains
-		billingStatusChangesMax = pi.SettingBillingStatusChangesMax
+		textFileSizeMax              = pi.SettingTextFileSizeMax
+		imageFileCountMax            = pi.SettingImageFileCountMax
+		imageFileSizeMax             = pi.SettingImageFileSizeMax
+		titleLengthMin               = pi.SettingTitleLengthMin
+		titleLengthMax               = pi.SettingTitleLengthMax
+		titleSupportedChars          = pi.SettingTitleSupportedChars
+		amountMin                    = pi.SettingProposalAmountMin
+		amountMax                    = pi.SettingProposalAmountMax
+		startDateMin                 = pi.SettingProposalStartDateMin
+		endDateMax                   = pi.SettingProposalEndDateMax
+		domains                      = pi.SettingProposalDomains
+		billingStatusChangesMax      = pi.SettingBillingStatusChangesMax
+		summariesPageSize            = pi.SettingSummariesPageSize
+		billingStatusChangesPageSize = pi.SettingBillingStatusChangesPageSize
 	)
 
 	// Override defaults with any passed in settings
@@ -291,6 +303,20 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			billingStatusChangesMax = uint32(u)
+		case pi.SettingKeySummariesPageSize:
+			u, err := strconv.ParseUint(v.Value, 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+					v.Key, v.Value, err)
+			}
+			summariesPageSize = uint32(u)
+		case pi.SettingKeyBillingStatusChangesPageSize:
+			u, err := strconv.ParseUint(v.Value, 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+					v.Key, v.Value, err)
+			}
+			billingStatusChangesPageSize = uint32(u)
 
 		default:
 			return nil, errors.Errorf("invalid plugin setting: %v", v.Key)
@@ -327,24 +353,26 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 	}
 
 	return &piPlugin{
-		dataDir:                 dataDir,
-		identity:                id,
-		backend:                 backend,
-		textFileSizeMax:         textFileSizeMax,
-		tstore:                  tstore,
-		imageFileCountMax:       imageFileCountMax,
-		imageFileSizeMax:        imageFileSizeMax,
-		titleLengthMin:          titleLengthMin,
-		titleLengthMax:          titleLengthMax,
-		titleSupportedChars:     titleSupportedCharsString,
-		titleRegexp:             rexp,
-		proposalAmountMin:       amountMin,
-		proposalAmountMax:       amountMax,
-		proposalStartDateMin:    startDateMin,
-		proposalEndDateMax:      endDateMax,
-		proposalDomainsEncoded:  domainsString,
-		proposalDomains:         domainsMap,
-		billingStatusChangesMax: billingStatusChangesMax,
+		dataDir:                      dataDir,
+		identity:                     id,
+		backend:                      backend,
+		textFileSizeMax:              textFileSizeMax,
+		tstore:                       tstore,
+		imageFileCountMax:            imageFileCountMax,
+		imageFileSizeMax:             imageFileSizeMax,
+		titleLengthMin:               titleLengthMin,
+		titleLengthMax:               titleLengthMax,
+		titleSupportedChars:          titleSupportedCharsString,
+		titleRegexp:                  rexp,
+		proposalAmountMin:            amountMin,
+		proposalAmountMax:            amountMax,
+		proposalStartDateMin:         startDateMin,
+		proposalEndDateMax:           endDateMax,
+		proposalDomainsEncoded:       domainsString,
+		proposalDomains:              domainsMap,
+		billingStatusChangesMax:      billingStatusChangesMax,
+		summariesPageSize:            summariesPageSize,
+		billingStatusChangesPageSize: billingStatusChangesPageSize,
 		statuses: proposalStatuses{
 			data:    make(map[string]*statusEntry, statusesCacheLimit),
 			entries: list.New(),

--- a/politeiad/backendv2/tstorebe/plugins/pi/pi.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/pi.go
@@ -230,6 +230,7 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			textFileSizeMax = uint32(u)
+
 		case pi.SettingKeyImageFileCountMax:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
@@ -237,6 +238,7 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			imageFileCountMax = uint32(u)
+
 		case pi.SettingKeyImageFileSizeMax:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
@@ -244,6 +246,7 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			imageFileSizeMax = uint32(u)
+
 		case pi.SettingKeyTitleLengthMin:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
@@ -251,6 +254,7 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			titleLengthMin = uint32(u)
+
 		case pi.SettingKeyTitleLengthMax:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
@@ -258,12 +262,14 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			titleLengthMax = uint32(u)
+
 		case pi.SettingKeyTitleSupportedChars:
 			err := json.Unmarshal([]byte(v.Value), &titleSupportedChars)
 			if err != nil {
 				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
 					v.Key, v.Value, err)
 			}
+
 		case pi.SettingKeyProposalAmountMin:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
@@ -271,6 +277,7 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			amountMin = u
+
 		case pi.SettingKeyProposalAmountMax:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
@@ -278,6 +285,7 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			amountMax = u
+
 		case pi.SettingKeyProposalEndDateMax:
 			u, err := strconv.ParseInt(v.Value, 10, 64)
 			if err != nil {
@@ -290,12 +298,14 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					"must be in the future", v.Key, v.Value)
 			}
 			endDateMax = u
+
 		case pi.SettingKeyProposalDomains:
 			err := json.Unmarshal([]byte(v.Value), &domains)
 			if err != nil {
 				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
 					v.Key, v.Value, err)
 			}
+
 		case pi.SettingKeyBillingStatusChangesMax:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
@@ -303,6 +313,7 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			billingStatusChangesMax = uint32(u)
+
 		case pi.SettingKeySummariesPageSize:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
@@ -310,6 +321,7 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 					v.Key, v.Value, err)
 			}
 			summariesPageSize = uint32(u)
+
 		case pi.SettingKeyBillingStatusChangesPageSize:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -38,6 +38,14 @@ const (
 	// SettingKeyAllowExtraData is the plugin setting key for the
 	// SettingAllowExtraData plugin setting.
 	SettingKeyAllowExtraData = "allowextradata"
+
+	// SettingKeyCountPageSize is the plugin setting key for the
+	// SettingCountPageSize plugin setting.
+	SettingKeyCountPageSize = "countpagesize"
+
+	// SettingKeyTimestampsPageSize is the plugin setting key for the
+	// SettingTimestampsPageSize plugin setting.
+	SettingKeyTimestampsPageSize = "timestampspagesize"
 )
 
 // Plugin setting default values. These can be overridden by providing a plugin
@@ -55,6 +63,14 @@ const (
 	// SettingAllowExtraData is the default value of the bool flag which
 	// determines whether posting extra data along with the comment is allowed.
 	SettingAllowExtraData = false
+
+	// SettingCountPageSize is the default maximum number of comment counts
+	// that can be requested at any one time.
+	SettingCountPageSize uint32 = 10
+
+	// SettingTimestampsPageSize is the default maximum number of comment
+	// timestamps that can be requested at any one time.
+	SettingTimestampsPageSize uint32 = 100
 )
 
 // ErrorCodeT represents a error that was caused by the user.

--- a/politeiad/plugins/pi/pi.go
+++ b/politeiad/plugins/pi/pi.go
@@ -57,11 +57,11 @@ const (
 	// the SettingProposalAmountMax plugin setting.
 	SettingKeyProposalAmountMax = "proposalamountmax"
 
-	// SettingKeyProposalStartDateMin is the plugin settings key for
+	// SettingKeyProposalStartDateMin is the plugin setting key for
 	// the SettingProposalStartDateMin plugin setting.
 	SettingKeyProposalStartDateMin = "proposalstartdatemin"
 
-	// SettingKeyProposalEndDateMax is the plugin settings key for
+	// SettingKeyProposalEndDateMax is the plugin setting key for
 	// the SettingProposalEndDateMax plugin setting.
 	SettingKeyProposalEndDateMax = "proposalenddatemax"
 
@@ -72,6 +72,14 @@ const (
 	// SettingKeyBillingStatusChangesMax is the plugin setting
 	// key for the SettingBillingStatusChangesMax plugin setting.
 	SettingKeyBillingStatusChangesMax = "billingstatuschangesmax"
+
+	// SettingKeySummariesPageSize is the plugin setting key for the
+	// SettingSummariesPageSize plugin setting.
+	SettingKeySummariesPageSize = "summariespagesize"
+
+	// SettingKeyBillingStatusChangesPageSize is the plugin key for
+	// the SettingBillingStatusChangesPageSize plugin setting.
+	SettingKeyBillingStatusChangesPageSize = "billingstatuschangespagesize"
 )
 
 // Plugin setting default values. These can be overridden by providing a plugin
@@ -116,6 +124,14 @@ const (
 	// SettingBillingStatusChangesMax is the default maximum allowed
 	// billing status changes.
 	SettingBillingStatusChangesMax uint32 = 1
+
+	// SettingSummariesPageSize is the default maximum number of proposal
+	// summaries that can be requested at any one time.
+	SettingSummariesPageSize uint32 = 5
+
+	// SettingBillingStatusChangesPageSize is the default maximum number of
+	// billing status changes that can be requested at any one time.
+	SettingBillingStatusChangesPageSize uint32 = 5
 )
 
 var (

--- a/politeiad/plugins/ticketvote/ticketvote.go
+++ b/politeiad/plugins/ticketvote/ticketvote.go
@@ -41,6 +41,18 @@ const (
 	// SettingKeyVoteDurationMax is the plugin setting key for the
 	// SettingVoteDurationMax plugin setting.
 	SettingKeyVoteDurationMax = "votedurationmax"
+
+	// SettingKeySummariesPageSize is the plugin setting key for the
+	// SettingSummariesPageSize plugin setting.
+	SettingKeySummariesPageSize = "summariespagesize"
+
+	// SettingKeyInventoryPageSize is the plugin setting key for the
+	// SettingInventoryPageSize plugin setting.
+	SettingKeyInventoryPageSize = "inventorypagesize"
+
+	// SettingKeyTimestampsPageSize is the plugin setting key for the
+	// SettingTimestampsPageSize plugin setting.
+	SettingKeyTimestampsPageSize = "timestampspagesize"
 )
 
 // Plugin setting default values. These can be overridden by providing a plugin
@@ -84,6 +96,18 @@ const (
 	// SettingTestNetVoteDurationMax is the default maximum vote
 	// duration on testnet in blocks.
 	SettingTestNetVoteDurationMax uint32 = 4032
+
+	// SettingSummariesPageSize is the default maximum number of
+	// vote summaries that can be requested at any one time.
+	SettingSummariesPageSize uint32 = 5
+
+	// SettingInventoryPageSize is the default maximum number of tokens
+	// that will be returned for any single status in an InventoryReply.
+	SettingInventoryPageSize uint32 = 20
+
+	// SettingTimestampsPageSize is the default maximum number of comment
+	// timestamps that can be requested at any one time.
+	SettingTimestampsPageSize uint32 = 100
 )
 
 // ErrorCodeT represents and error that is caused by the user.

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -338,12 +338,6 @@ type DelReply struct {
 	Comment Comment `json:"comment"`
 }
 
-const (
-	// CountPageSize is the maximum number of tokens that can be
-	// included in the Count command.
-	CountPageSize uint32 = 10
-)
-
 // Count requests the number of comments on that have been made on the given
 // records. If a record is not found for a token then it will not be included
 // in the returned map.
@@ -406,12 +400,6 @@ type Timestamp struct {
 	MerkleRoot string  `json:"merkleroot"`
 	Proofs     []Proof `json:"proofs"`
 }
-
-const (
-	// TimestampsPageSize is the maximum number of comment timestamps
-	// that can be requests at any one time.
-	TimestampsPageSize uint32 = 100
-)
 
 // CommentTimestamp contains the timestamps for the full history of a single
 // comment.

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -338,6 +338,15 @@ type DelReply struct {
 	Comment Comment `json:"comment"`
 }
 
+const (
+	// CountPageSize is the maximum number of tokens that can be
+	// included in the Count command.
+	//
+	// NOTE: This is DEPRECATED and will be deleted as part of the next major
+	// release. Use the API's Policy route to retrieve the routes page sizes.
+	CountPageSize uint32 = 10
+)
+
 // Count requests the number of comments on that have been made on the given
 // records. If a record is not found for a token then it will not be included
 // in the returned map.
@@ -400,6 +409,15 @@ type Timestamp struct {
 	MerkleRoot string  `json:"merkleroot"`
 	Proofs     []Proof `json:"proofs"`
 }
+
+const (
+	// TimestampsPageSize is the maximum number of comment timestamps
+	// that can be requests at any one time.
+	//
+	// NOTE: This is DEPRECATED and will be deleted as part of the next major
+	// release. Use the API's Policy route to retrieve the routes page sizes.
+	TimestampsPageSize uint32 = 100
+)
 
 // CommentTimestamp contains the timestamps for the full history of a single
 // comment.

--- a/politeiawww/api/pi/v1/v1.go
+++ b/politeiawww/api/pi/v1/v1.go
@@ -268,12 +268,6 @@ type SetBillingStatusReply struct {
 	Timestamp int64  `json:"timestamp"` // Unix timestamp
 }
 
-const (
-	// BillingStatusChangesPageSize is the maximum number of billing status
-	// changes that can be requested at any one time.
-	BillingStatusChangesPageSize uint32 = 5
-)
-
 // BillingStatusChanges requests the billing status changes for the provided
 // proposal tokens.
 type BillingStatusChanges struct {
@@ -304,12 +298,6 @@ const (
 type ProposalUpdateMetadata struct {
 	Title string `json:"title"`
 }
-
-const (
-	// SummariesPageSize is the maximum number of proposal summaries that
-	// can be requested at any one time.
-	SummariesPageSize uint32 = 5
-)
 
 // Summaries requests the proposal summaries for the provided proposal tokens.
 type Summaries struct {

--- a/politeiawww/api/pi/v1/v1.go
+++ b/politeiawww/api/pi/v1/v1.go
@@ -268,6 +268,15 @@ type SetBillingStatusReply struct {
 	Timestamp int64  `json:"timestamp"` // Unix timestamp
 }
 
+const (
+	// BillingStatusChangesPageSize is the maximum number of billing status
+	// changes that can be requested at any one time.
+	//
+	// NOTE: This is DEPRECATED and will be deleted as part of the next major
+	// release. Use the API's Policy route to retrieve the routes page sizes.
+	BillingStatusChangesPageSize uint32 = 5
+)
+
 // BillingStatusChanges requests the billing status changes for the provided
 // proposal tokens.
 type BillingStatusChanges struct {
@@ -298,6 +307,15 @@ const (
 type ProposalUpdateMetadata struct {
 	Title string `json:"title"`
 }
+
+const (
+	// SummariesPageSize is the maximum number of proposal summaries that
+	// can be requested at any one time.
+	//
+	// NOTE: This is DEPRECATED and will be deleted as part of the next major
+	// release. Use the API's Policy route to retrieve the routes page sizes.
+	SummariesPageSize uint32 = 5
+)
 
 // Summaries requests the proposal summaries for the provided proposal tokens.
 type Summaries struct {

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -565,6 +565,15 @@ type Summary struct {
 	BestBlock uint32 `json:"bestblock"`
 }
 
+const (
+	// SummariesPageSize is the maximum number of vote summaries that
+	// can be requested at any one time.
+	//
+	// NOTE: This is DEPRECATED and will be deleted as part of the next major
+	// release. Use the API's Policy route to retrieve the routes page sizes.
+	SummariesPageSize uint32 = 5
+)
+
 // Summaries requests the vote summaries for the provided record tokens.
 type Summaries struct {
 	Tokens []string `json:"tokens"`
@@ -592,6 +601,15 @@ type Submissions struct {
 type SubmissionsReply struct {
 	Submissions []string `json:"submissions"`
 }
+
+const (
+	// InventoryPageSize is the maximum number of tokens that will be
+	// returned for any single status in an InventoryReply.
+	//
+	// NOTE: This is DEPRECATED and will be deleted as part of the next major
+	// release. Use the API's Policy route to retrieve the routes page sizes.
+	InventoryPageSize uint32 = 20
+)
 
 // Inventory requests the tokens of public records in the inventory
 // categorized by vote status.
@@ -655,6 +673,15 @@ type Timestamp struct {
 	MerkleRoot string  `json:"merkleroot"`
 	Proofs     []Proof `json:"proofs"`
 }
+
+const (
+	// VoteTimestampsPageSize is the maximum number of vote timestamps
+	// that will be returned for any single request.
+	//
+	// NOTE: This is DEPRECATED and will be deleted as part of the next major
+	// release. Use the API's Policy route to retrieve the routes page sizes.
+	VoteTimestampsPageSize uint32 = 100
+)
 
 // Timestamps requests the timestamps for ticket vote data.
 //

--- a/politeiawww/api/ticketvote/v1/v1.go
+++ b/politeiawww/api/ticketvote/v1/v1.go
@@ -565,12 +565,6 @@ type Summary struct {
 	BestBlock uint32 `json:"bestblock"`
 }
 
-const (
-	// SummariesPageSize is the maximum number of vote summaries that
-	// can be requested at any one time.
-	SummariesPageSize uint32 = 5
-)
-
 // Summaries requests the vote summaries for the provided record tokens.
 type Summaries struct {
 	Tokens []string `json:"tokens"`
@@ -598,12 +592,6 @@ type Submissions struct {
 type SubmissionsReply struct {
 	Submissions []string `json:"submissions"`
 }
-
-const (
-	// InventoryPageSize is the maximum number of tokens that will be
-	// returned for any single status in an InventoryReply.
-	InventoryPageSize uint32 = 20
-)
 
 // Inventory requests the tokens of public records in the inventory
 // categorized by vote status.
@@ -667,12 +655,6 @@ type Timestamp struct {
 	MerkleRoot string  `json:"merkleroot"`
 	Proofs     []Proof `json:"proofs"`
 }
-
-const (
-	// VoteTimestampsPageSize is the maximum number of vote timestamps
-	// that will be returned for any single request.
-	VoteTimestampsPageSize uint32 = 100
-)
 
 // Timestamps requests the timestamps for ticket vote data.
 //

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -638,7 +638,8 @@ func (p *piv) inventory() error {
 		}
 		pageTokens := ir.Vetted[tkv1.VoteStatuses[tkv1.VoteStatusStarted]]
 		tokens = append(tokens, pageTokens...)
-		if uint32(len(pageTokens)) < tkv1.InventoryPageSize {
+		// XXX Retrieve inventory page size
+		if uint32(len(pageTokens)) < 20 {
 			break
 		}
 		page++

--- a/politeiawww/cmd/politeiavoter/politeiavoter.go
+++ b/politeiawww/cmd/politeiavoter/politeiavoter.go
@@ -616,6 +616,25 @@ func (p *piv) records(tokens []string, serverPubKey string) (*rcv1.RecordsReply,
 	return &rsr, nil
 }
 
+// votePolicy sends a ticketvote API Policy request and returns the reply.
+func (p *piv) votePolicy() (*tkv1.PolicyReply, error) {
+	// Send request
+	responseBody, err := p.makeRequest(http.MethodPost, tkv1.APIRoute,
+		tkv1.RoutePolicy, tkv1.Policy{})
+	if err != nil {
+		return nil, err
+	}
+
+	var pr tkv1.PolicyReply
+	err = json.Unmarshal(responseBody, &pr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal RecordsReply: %v",
+			err)
+	}
+
+	return &pr, nil
+}
+
 func (p *piv) inventory() error {
 	// Get server public key to verify replies.
 	version, err := p.getVersion()
@@ -623,9 +642,16 @@ func (p *piv) inventory() error {
 		return err
 	}
 	serverPubKey := version.PubKey
+
 	// Inventory route is paginated, therefore we keep fetching
 	// until we receive a patch with number of records smaller than the
-	// ticketvote's declared page size.
+	// ticketvote's declared page size. The page size is retrieved from
+	// the ticketvote API Policy route.
+	vp, err := p.votePolicy()
+	if err != nil {
+		return err
+	}
+	pageSize := vp.InventoryPageSize
 	page := uint32(1)
 	var tokens []string
 	for {
@@ -638,8 +664,7 @@ func (p *piv) inventory() error {
 		}
 		pageTokens := ir.Vetted[tkv1.VoteStatuses[tkv1.VoteStatusStarted]]
 		tokens = append(tokens, pageTokens...)
-		// XXX Retrieve inventory page size
-		if uint32(len(pageTokens)) < 20 {
+		if uint32(len(pageTokens)) < pageSize {
 			break
 		}
 		page++

--- a/politeiawww/legacy/comments/comments.go
+++ b/politeiawww/legacy/comments/comments.go
@@ -251,8 +251,10 @@ func (c *Comments) HandleTimestamps(w http.ResponseWriter, r *http.Request) {
 func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *sessions.Sessions, e *events.Manager, plugins []pdv2.Plugin) (*Comments, error) {
 	// Parse plugin settings
 	var (
-		lengthMax      uint32
-		voteChangesMax uint32
+		lengthMax          uint32
+		voteChangesMax     uint32
+		countPageSize      uint32
+		timestampsPageSize uint32
 	)
 	for _, p := range plugins {
 		if p.ID != comments.PluginID {
@@ -273,6 +275,18 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 					return nil, err
 				}
 				voteChangesMax = uint32(u)
+			case comments.SettingKeyCountPageSize:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				countPageSize = uint32(u)
+			case comments.SettingKeyTimestampsPageSize:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				timestampsPageSize = uint32(u)
 			default:
 				// Skip unknown settings
 				log.Warnf("Unknown plugin setting %v; Skipping...", v.Key)
@@ -288,6 +302,12 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 	case voteChangesMax == 0:
 		return nil, fmt.Errorf("plugin setting not found: %v",
 			comments.SettingKeyVoteChangesMax)
+	case countPageSize == 0:
+		return nil, fmt.Errorf("plugin setting not found: %v",
+			comments.SettingKeyCountPageSize)
+	case timestampsPageSize == 0:
+		return nil, fmt.Errorf("plugin setting not found: %v",
+			comments.SettingKeyTimestampsPageSize)
 	}
 
 	return &Comments{
@@ -299,8 +319,8 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 		policy: &v1.PolicyReply{
 			LengthMax:          lengthMax,
 			VoteChangesMax:     voteChangesMax,
-			CountPageSize:      v1.CountPageSize,
-			TimestampsPageSize: v1.TimestampsPageSize,
+			CountPageSize:      countPageSize,
+			TimestampsPageSize: timestampsPageSize,
 		},
 	}, nil
 }

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -209,10 +209,10 @@ func (c *Comments) processCount(ctx context.Context, ct v1.Count) (*v1.CountRepl
 			Counts: map[string]uint32{},
 		}, nil
 
-	case len(ct.Tokens) > int(v1.CountPageSize):
+	case len(ct.Tokens) > int(c.policy.CountPageSize):
 		return nil, v1.UserErrorReply{
 			ErrorCode:    v1.ErrorCodePageSizeExceeded,
-			ErrorContext: fmt.Sprintf("max page size is %v", v1.CountPageSize),
+			ErrorContext: fmt.Sprintf("max page size is %v", c.policy.CountPageSize),
 		}
 	}
 
@@ -345,11 +345,11 @@ func (c *Comments) processTimestamps(ctx context.Context, t v1.Timestamps, isAdm
 			Comments: map[uint32]v1.CommentTimestamp{},
 		}, nil
 
-	case len(t.CommentIDs) > int(v1.TimestampsPageSize):
+	case len(t.CommentIDs) > int(c.policy.TimestampsPageSize):
 		return nil, v1.UserErrorReply{
 			ErrorCode: v1.ErrorCodePageSizeExceeded,
 			ErrorContext: fmt.Sprintf("max page size is %v",
-				v1.TimestampsPageSize),
+				c.policy.TimestampsPageSize),
 		}
 	}
 

--- a/politeiawww/legacy/pi/pi.go
+++ b/politeiawww/legacy/pi/pi.go
@@ -126,18 +126,20 @@ func (p *Pi) HandleSummaries(w http.ResponseWriter, r *http.Request) {
 func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, m mail.Mailer, s *sessions.Sessions, e *events.Manager, plugins []pdv2.Plugin) (*Pi, error) {
 	// Parse plugin settings
 	var (
-		textFileSizeMax         uint32
-		imageFileCountMax       uint32
-		imageFileSizeMax        uint32
-		titleLengthMin          uint32
-		titleLengthMax          uint32
-		titleSupportedChars     []string
-		amountMin               uint64
-		amountMax               uint64
-		startDateMin            int64
-		endDateMax              int64
-		domains                 []string
-		billingStatusChangesMax uint32
+		textFileSizeMax              uint32
+		imageFileCountMax            uint32
+		imageFileSizeMax             uint32
+		titleLengthMin               uint32
+		titleLengthMax               uint32
+		titleSupportedChars          []string
+		amountMin                    uint64
+		amountMax                    uint64
+		startDateMin                 int64
+		endDateMax                   int64
+		domains                      []string
+		billingStatusChangesMax      uint32
+		summariesPageSize            uint32
+		billingStatusChangesPageSize uint32
 	)
 	for _, p := range plugins {
 		if p.ID != pi.PluginID {
@@ -223,6 +225,18 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, m mail.Mai
 					return nil, err
 				}
 				billingStatusChangesMax = uint32(u)
+			case pi.SettingKeySummariesPageSize:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				summariesPageSize = uint32(u)
+			case pi.SettingKeyBillingStatusChangesPageSize:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				billingStatusChangesPageSize = uint32(u)
 
 			default:
 				// Skip unknown settings
@@ -263,6 +277,12 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, m mail.Mai
 	case len(domains) == 0:
 		return nil, errors.Errorf("plugin setting not found: %v",
 			pi.SettingKeyProposalDomains)
+	case summariesPageSize == 0:
+		return nil, errors.Errorf("plugin setting not found: %v",
+			pi.SettingKeySummariesPageSize)
+	case billingStatusChangesPageSize == 0:
+		return nil, errors.Errorf("plugin setting not found: %v",
+			pi.SettingKeyBillingStatusChangesPageSize)
 	}
 
 	// Setup pi context
@@ -285,8 +305,8 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, m mail.Mai
 			StartDateMin:                 startDateMin,
 			EndDateMax:                   endDateMax,
 			Domains:                      domains,
-			SummariesPageSize:            v1.SummariesPageSize,
-			BillingStatusChangesPageSize: v1.BillingStatusChangesPageSize,
+			SummariesPageSize:            summariesPageSize,
+			BillingStatusChangesPageSize: billingStatusChangesPageSize,
 			BillingStatusChangesMax:      billingStatusChangesMax,
 		},
 	}

--- a/politeiawww/legacy/pi/pi.go
+++ b/politeiawww/legacy/pi/pi.go
@@ -154,59 +154,69 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, m mail.Mai
 					return nil, err
 				}
 				textFileSizeMax = uint32(u)
+
 			case pi.SettingKeyImageFileCountMax:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				imageFileCountMax = uint32(u)
+
 			case pi.SettingKeyImageFileSizeMax:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				imageFileSizeMax = uint32(u)
+
 			case pi.SettingKeyTitleLengthMin:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				titleLengthMin = uint32(u)
+
 			case pi.SettingKeyTitleLengthMax:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				titleLengthMax = uint32(u)
+
 			case pi.SettingKeyTitleSupportedChars:
 				err := json.Unmarshal([]byte(v.Value), &titleSupportedChars)
 				if err != nil {
 					return nil, err
 				}
+
 			case pi.SettingKeyProposalAmountMin:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				amountMin = u
+
 			case pi.SettingKeyProposalAmountMax:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				amountMax = u
+
 			case pi.SettingKeyProposalStartDateMin:
 				u, err := strconv.ParseInt(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				startDateMin = u
+
 			case pi.SettingKeyProposalEndDateMax:
 				u, err := strconv.ParseInt(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				endDateMax = u
+
 			case pi.SettingKeyProposalDomains:
 				err := json.Unmarshal([]byte(v.Value), &domains)
 				if err != nil {
@@ -219,18 +229,21 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, m mail.Mai
 							"string")
 					}
 				}
+
 			case pi.SettingKeyBillingStatusChangesMax:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				billingStatusChangesMax = uint32(u)
+
 			case pi.SettingKeySummariesPageSize:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				summariesPageSize = uint32(u)
+
 			case pi.SettingKeyBillingStatusChangesPageSize:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {

--- a/politeiawww/legacy/pi/process.go
+++ b/politeiawww/legacy/pi/process.go
@@ -49,11 +49,11 @@ func (p *Pi) processBillingStatusChanges(ctx context.Context, bscs v1.BillingSta
 	log.Tracef("processBillingStatusChanges: %v", bscs.Tokens)
 
 	// Verify request size
-	if len(bscs.Tokens) > int(v1.BillingStatusChangesPageSize) {
+	if len(bscs.Tokens) > int(p.policy.BillingStatusChangesPageSize) {
 		return nil, v1.UserErrorReply{
 			ErrorCode: v1.ErrorCodePageSizeExceeded,
 			ErrorContext: fmt.Sprintf("max page size is %v",
-				v1.BillingStatusChangesPageSize),
+				p.policy.BillingStatusChangesPageSize),
 		}
 	}
 
@@ -84,11 +84,11 @@ func (p *Pi) processSummaries(ctx context.Context, s v1.Summaries) (*v1.Summarie
 	log.Tracef("processSummaries: %v", s.Tokens)
 
 	// Verify request size
-	if len(s.Tokens) > int(v1.SummariesPageSize) {
+	if len(s.Tokens) > int(p.policy.SummariesPageSize) {
 		return nil, v1.UserErrorReply{
 			ErrorCode: v1.ErrorCodePageSizeExceeded,
 			ErrorContext: fmt.Sprintf("max page size is %v",
-				v1.SummariesPageSize),
+				p.policy.SummariesPageSize),
 		}
 	}
 

--- a/politeiawww/legacy/ticketvote/process.go
+++ b/politeiawww/legacy/ticketvote/process.go
@@ -182,11 +182,11 @@ func (t *TicketVote) processSummaries(ctx context.Context, s v1.Summaries) (*v1.
 	log.Tracef("processSummaries: %v", s.Tokens)
 
 	// Verify request size
-	if len(s.Tokens) > int(v1.SummariesPageSize) {
+	if len(s.Tokens) > int(t.policy.SummariesPageSize) {
 		return nil, v1.UserErrorReply{
 			ErrorCode: v1.ErrorCodePageSizeExceeded,
 			ErrorContext: fmt.Sprintf("max page size is %v",
-				v1.SummariesPageSize),
+				t.policy.SummariesPageSize),
 		}
 	}
 

--- a/politeiawww/legacy/ticketvote/ticketvote.go
+++ b/politeiawww/legacy/ticketvote/ticketvote.go
@@ -297,42 +297,49 @@ func New(cfg *config.Config, pdc *pdclient.Client, s *sessions.Sessions, e *even
 					return nil, err
 				}
 				linkByPeriodMin = i
+
 			case ticketvote.SettingKeyLinkByPeriodMax:
 				i, err := strconv.ParseInt(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				linkByPeriodMax = i
+
 			case ticketvote.SettingKeyVoteDurationMin:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				voteDurationMin = uint32(u)
+
 			case ticketvote.SettingKeyVoteDurationMax:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				voteDurationMax = uint32(u)
+
 			case ticketvote.SettingKeySummariesPageSize:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				summariesPageSize = uint32(u)
+
 			case ticketvote.SettingKeyInventoryPageSize:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				inventoryPageSize = uint32(u)
+
 			case ticketvote.SettingKeyTimestampsPageSize:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, err
 				}
 				timestampsPageSize = uint32(u)
+
 			default:
 				log.Warnf("Unknown plugin setting %v; Skipping...", v.Key)
 			}

--- a/politeiawww/legacy/ticketvote/ticketvote.go
+++ b/politeiawww/legacy/ticketvote/ticketvote.go
@@ -276,10 +276,13 @@ func (t *TicketVote) HandleTimestamps(w http.ResponseWriter, r *http.Request) {
 func New(cfg *config.Config, pdc *pdclient.Client, s *sessions.Sessions, e *events.Manager, plugins []pdv2.Plugin) (*TicketVote, error) {
 	// Parse plugin settings
 	var (
-		linkByPeriodMin int64
-		linkByPeriodMax int64
-		voteDurationMin uint32
-		voteDurationMax uint32
+		linkByPeriodMin    int64
+		linkByPeriodMax    int64
+		voteDurationMin    uint32
+		voteDurationMax    uint32
+		summariesPageSize  uint32
+		inventoryPageSize  uint32
+		timestampsPageSize uint32
 	)
 	for _, p := range plugins {
 		if p.ID != ticketvote.PluginID {
@@ -312,6 +315,24 @@ func New(cfg *config.Config, pdc *pdclient.Client, s *sessions.Sessions, e *even
 					return nil, err
 				}
 				voteDurationMax = uint32(u)
+			case ticketvote.SettingKeySummariesPageSize:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				summariesPageSize = uint32(u)
+			case ticketvote.SettingKeyInventoryPageSize:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				inventoryPageSize = uint32(u)
+			case ticketvote.SettingKeyTimestampsPageSize:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				timestampsPageSize = uint32(u)
 			default:
 				log.Warnf("Unknown plugin setting %v; Skipping...", v.Key)
 			}
@@ -332,6 +353,15 @@ func New(cfg *config.Config, pdc *pdclient.Client, s *sessions.Sessions, e *even
 	case voteDurationMax == 0:
 		return nil, fmt.Errorf("plugin setting not found: %v",
 			ticketvote.SettingKeyVoteDurationMax)
+	case summariesPageSize == 0:
+		return nil, fmt.Errorf("plugin setting not found: %v",
+			ticketvote.SettingKeySummariesPageSize)
+	case inventoryPageSize == 0:
+		return nil, fmt.Errorf("plugin setting not found: %v",
+			ticketvote.SettingKeyInventoryPageSize)
+	case timestampsPageSize == 0:
+		return nil, fmt.Errorf("plugin setting not found: %v",
+			ticketvote.SettingKeyTimestampsPageSize)
 	}
 
 	return &TicketVote{
@@ -344,9 +374,9 @@ func New(cfg *config.Config, pdc *pdclient.Client, s *sessions.Sessions, e *even
 			LinkByPeriodMax:    linkByPeriodMax,
 			VoteDurationMin:    voteDurationMin,
 			VoteDurationMax:    voteDurationMax,
-			SummariesPageSize:  v1.SummariesPageSize,
-			InventoryPageSize:  v1.InventoryPageSize,
-			TimestampsPageSize: v1.VoteTimestampsPageSize,
+			SummariesPageSize:  summariesPageSize,
+			InventoryPageSize:  inventoryPageSize,
+			TimestampsPageSize: timestampsPageSize,
 		},
 	}, nil
 }


### PR DESCRIPTION
Until this commit we have defined page sizes as global consts in our
plugins, this might result in some duplicated code if the page size is
needed in both `politeiawww` & `politeiad`.

This resolves the issue mentioned above by defining the plugins page
sizes as plugin setting, that way we have it available in both places
and easily configurable by sys admin without any code changes.

---

Closes #1603.