### PR TITLE
mysql: Batch select queries when required.

### DIFF
--- a/politeiad/backendv2/tstorebe/store/mysql/encrypt_test.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/encrypt_test.go
@@ -3,19 +3,14 @@ package mysql
 import (
 	"bytes"
 	"testing"
-
-	"github.com/decred/politeia/util"
 )
 
 func TestEncryptDecrypt(t *testing.T) {
-	password := "passwordsosikrit"
 	blob := []byte("encryptmeyo")
 
-	// setup fake context
-	s := &mysql{
-		testing: true,
-	}
-	s.argon2idKey(password, util.NewArgon2Params())
+	// Setup a mysql struct
+	s, cleanup := newTestMySQL(t)
+	defer cleanup()
 
 	// Encrypt and make sure cleartext isn't the same as the encypted blob.
 	eb, err := s.encrypt(nil, nil, blob)

--- a/politeiad/backendv2/tstorebe/store/mysql/mysql.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/mysql.go
@@ -35,7 +35,7 @@ const (
 	// maxPlaceholders is the maximum number of placeholders, "(?, ?, ?)", that
 	// can be used in a prepared statement. MySQL uses an uint16 for this, so
 	// the limit is the the maximum value of an uint16.
-	maxPlaceholders = 65536
+	maxPlaceholders = 65535
 )
 
 // tableKeyValue defines the key-value table.

--- a/politeiad/backendv2/tstorebe/store/mysql/mysql.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/mysql.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/decred/politeia/politeiad/backendv2/tstorebe/store"
 	"github.com/decred/politeia/util"
 	"github.com/pkg/errors"
@@ -57,7 +58,10 @@ type mysql struct {
 	shutdown uint64
 	db       *sql.DB
 	key      [32]byte
-	testing  bool // Only set during unit tests
+
+	// The following fields are only used during unit tests.
+	testing bool
+	mock    sqlmock.Sqlmock
 }
 
 func ctxWithTimeout() (context.Context, func()) {
@@ -226,7 +230,6 @@ func (s *mysql) Get(keys []string) (map[string][]byte, error) {
 		defer rows.Close()
 
 		// Unpack the reply
-		reply := make(map[string][]byte, len(keys))
 		for rows.Next() {
 			var k string
 			var v []byte

--- a/politeiad/backendv2/tstorebe/store/mysql/mysql.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/mysql.go
@@ -215,10 +215,13 @@ func (s *mysql) Get(keys []string) (map[string][]byte, error) {
 	// Build the select statements
 	statements := buildSelectStatements(keys, maxPlaceholders)
 
+	log.Debugf("Get %v blobs using %v prepared statements",
+		len(keys), len(statements))
+
 	// Execute the statements
 	reply := make(map[string][]byte, len(keys))
 	for i, e := range statements {
-		log.Debugf("Executing select statement %v/%v", i, len(statements))
+		log.Debugf("Executing select statement %v/%v", i+1, len(statements))
 
 		ctx, cancel := ctxWithTimeout()
 		defer cancel()

--- a/politeiad/backendv2/tstorebe/store/mysql/mysql_test.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/mysql_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/decred/politeia/unittest"
+)
+
+func TestBuildSelectStatements(t *testing.T) {
+	var (
+		// sizeLimit is the max number of placeholders
+		// that the function will include in a single
+		// select statement.
+		sizeLimit = 2
+
+		// Test keys
+		key1 = "key1"
+		key2 = "key2"
+		key3 = "key3"
+		key4 = "key4"
+	)
+	var tests = []struct {
+		name       string
+		keys       []string
+		statements []selectStatement
+	}{
+		{
+			"one statement under the size limit",
+			[]string{key1},
+			[]selectStatement{
+				{
+					Query: buildSelectQuery(1),
+					Args:  []interface{}{key1, key2},
+				},
+			},
+		},
+		{
+			"one statement at the size limit",
+			[]string{key1, key2},
+			[]selectStatement{
+				{
+					Query: buildSelectQuery(2),
+					Args:  []interface{}{key1, key2},
+				},
+			},
+		},
+		{
+			"second statement under the size limit",
+			[]string{key1, key2, key3},
+			[]selectStatement{
+				{
+					Query: buildSelectQuery(2),
+					Args:  []interface{}{key1, key2},
+				},
+				{
+					Query: buildSelectQuery(1),
+					Args:  []interface{}{key3},
+				},
+			},
+		},
+		{
+			"second statement at the size limit",
+			[]string{key1, key2, key3, key4},
+			[]selectStatement{
+				{
+					Query: buildSelectQuery(2),
+					Args:  []interface{}{key1, key2},
+				},
+				{
+					Query: buildSelectQuery(2),
+					Args:  []interface{}{key3, key4},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run the test
+			statements := buildSelectStatements(tc.keys, sizeLimit)
+
+			// Verify the output
+			diff := unittest.DeepEqual(statements, tc.statements)
+			if diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestBuildPlaceholders(t *testing.T) {
+	var tests = []struct {
+		placeholders int
+		output       string
+	}{
+		{0, "()"},
+		{1, "(?)"},
+		{3, "(?,?,?)"},
+	}
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			output := buildPlaceholders(tc.placeholders)
+			if output != tc.output {
+				t.Errorf("got %v, want %v", output, tc.output)
+			}
+		})
+	}
+}

--- a/politeiad/backendv2/tstorebe/store/mysql/mysql_test.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/mysql_test.go
@@ -34,7 +34,7 @@ func TestBuildSelectStatements(t *testing.T) {
 			[]selectStatement{
 				{
 					Query: buildSelectQuery(1),
-					Args:  []interface{}{key1, key2},
+					Args:  []interface{}{key1},
 				},
 			},
 		},

--- a/politeiad/backendv2/tstorebe/store/mysql/mysql_test.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/mysql_test.go
@@ -5,10 +5,100 @@
 package mysql
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/decred/politeia/unittest"
+	"github.com/decred/politeia/util"
 )
+
+// newTestMySQL returns a new mysql structure that has been setup for testing.
+func newTestMySQL(t *testing.T) (*mysql, func()) {
+	t.Helper()
+
+	// Setup the mock sql database
+	opt := sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual)
+	db, mock, err := sqlmock.New(opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup := func() {
+		defer db.Close()
+	}
+
+	// Setup the mysql struct
+	s := &mysql{
+		db:      db,
+		testing: true,
+		mock:    mock,
+	}
+
+	// Derive a test encryption key
+	password := "passwordsosikrit"
+	s.argon2idKey(password, util.NewArgon2Params())
+
+	return s, cleanup
+}
+
+func TestGet(t *testing.T) {
+	// Setup the mysql test struct
+	s, cleanup := newTestMySQL(t)
+	defer cleanup()
+
+	// Test the single query code path
+	testGetSingleQuery(t, s)
+
+	// Test the multiple query code path
+}
+
+// testGetSingleQuery tests the mysql Get() method when the number of records
+// being retrieved can be fit into a single MySQL SELECT statement.
+func testGetSingleQuery(t *testing.T, s *mysql) {
+	var (
+		// Test params
+		key1   = "key1"
+		key2   = "key2"
+		value1 = []byte("value1")
+		value2 = []byte("value2")
+
+		// rows contains the rows that will be returned from the mocked sql query.
+		rows = sqlmock.NewRows([]string{"k", "v"}).
+			AddRow(key1, value1).
+			AddRow(key2, value2)
+	)
+
+	// Setup the sql expectations
+	s.mock.ExpectQuery("SELECT k, v FROM kv WHERE k IN (?,?);").
+		WithArgs(key1, key2).
+		WillReturnRows(rows).
+		RowsWillBeClosed()
+
+	// Run the test
+	blobs, err := s.Get([]string{key1, key2})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify the sql expectations
+	err = s.mock.ExpectationsWereMet()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify the returned value
+	if len(blobs) != 2 {
+		t.Errorf("got %v blobs, want 2", len(blobs))
+	}
+	v1 := blobs[key1]
+	if !bytes.Equal(v1, value1) {
+		t.Errorf("got '%s' for value 1; want '%s'", v1, value1)
+	}
+	v2 := blobs[key2]
+	if !bytes.Equal(v2, value2) {
+		t.Errorf("got '%s' for value 2; want '%s'", v2, value2)
+	}
+}
 
 func TestBuildSelectStatements(t *testing.T) {
 	var (

--- a/politeiad/v2.go
+++ b/politeiad/v2.go
@@ -602,7 +602,7 @@ func (p *politeia) handlePluginReads(w http.ResponseWriter, r *http.Request) {
 			// Internal server error. Log it and return a 500.
 			t := time.Now().Unix()
 			e := fmt.Sprintf("PluginRead %v %v %v: %v",
-				v.cmd.ID, v.cmd.Command, v.cmd.Payload, err)
+				v.cmd.ID, v.cmd.Command, v.cmd.Payload, v.err)
 			log.Errorf("%v %v %v %v Internal error %v: %v",
 				util.RemoteAddr(r), r.Method, r.URL, r.Proto, t, e)
 			log.Errorf("Stacktrace (NOT A REAL CRASH): %s", debug.Stack())

--- a/unittest/unittest.go
+++ b/unittest/unittest.go
@@ -1,12 +1,15 @@
 // Copyright (c) 2021 The Decred developers
-// Use of this source code is governed by an ISC license that can be found in
-// the LICENSE file.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
 
 package unittest
 
 import (
 	"fmt"
 	"reflect"
+	"strings"
+
+	"github.com/go-test/deep"
 )
 
 // TestGenericConstMap tests a map of an error constant type and verifies that
@@ -48,4 +51,26 @@ func TestGenericConstMap(errorsMap interface{}, lastError uint64) error {
 	}
 
 	return nil
+}
+
+// DeepEqual checks for deep equality between the provided structures. An empty
+// string is returned if the structures are deeply equal. A pretty printed
+// string that contains the differences is returned if the structures are not
+// deeply equal. The equality check goes a max of 10 levels deep.
+func DeepEqual(got, want interface{}) string {
+	diffs := deep.Equal(got, want)
+	if diffs == nil {
+		// got and want are deeply equal
+		return ""
+	}
+
+	// Not deeply equal. Pretty print the diffs.
+	var b strings.Builder
+	b.WriteString("value are not deeply equal; got != want: \n")
+	for _, v := range diffs {
+		b.WriteString(v)
+		b.WriteString("\n")
+	}
+
+	return b.String()
 }


### PR DESCRIPTION
Closes #1608 

This commit updates the mysql package to batch SELECT queries if the
number of records being requested exceedes the MySQL limit for the
maximum number placeholders that can be included in a prepared
statement (65,535 placeholders).

As a side note, manually testing this commit required loading a tlog
tree with >65,535 leaves. This was surprisingly difficult to do and
highlights how we're using tlog in a way that it's not really built for.
We will need to write our own append-only log implementation at some
point in order to remove the performance bottlenecks that tlog has.

Log statements from the manual testing are shown below.

```
2021-12-20 09:04:55.964 [DBG] STOR: Get 83698 blobs using 2 prepared statements
2021-12-20 09:04:55.965 [DBG] STOR: Executing select statement 1/2
2021-12-20 09:04:56.925 [DBG] STOR: Executing select statement 2/2
```