### PR TITLE
politeiad: Consistent record entries ordering.

### DIFF
--- a/politeiad/backendv2/tstorebe/tstore/record.go
+++ b/politeiad/backendv2/tstorebe/tstore/record.go
@@ -701,7 +701,7 @@ func (t *Tstore) record(treeID int64, version uint32, filenames []string, omitAl
 			treeID, len(keys), len(blobs))
 	}
 
-	// Decode Blobs.
+	// Decode Blobs
 	entries := make([]store.BlobEntry, 0, len(keys))
 	// Sort the blobs map keys to iterate over it in a deterministic manner,
 	// this ensures that the ordering of the record's files and metadata streams

--- a/politeiad/backendv2/tstorebe/tstore/record.go
+++ b/politeiad/backendv2/tstorebe/tstore/record.go
@@ -701,7 +701,7 @@ func (t *Tstore) record(treeID int64, version uint32, filenames []string, omitAl
 			treeID, len(keys), len(blobs))
 	}
 
-	// Decode Blobs
+	// Decode blobs
 	entries := make([]store.BlobEntry, 0, len(keys))
 	// Sort the blobs map keys to iterate over it in a deterministic manner,
 	// this ensures that the ordering of the record's files and metadata streams

--- a/politeiad/backendv2/tstorebe/tstore/record.go
+++ b/politeiad/backendv2/tstorebe/tstore/record.go
@@ -705,7 +705,7 @@ func (t *Tstore) record(treeID int64, version uint32, filenames []string, omitAl
 	entries := make([]store.BlobEntry, 0, len(keys))
 	// Iterate over the blobs map in a deterministic manner, in order
 	// to keep the ordering of the record's files and metadata streams
-	// consistent. Therefore, sort the blobs maps keys.
+	// consistent. Therefore, sort the blobs map keys.
 	sortedKeys := getSortedKeys(blobs)
 	for _, key := range sortedKeys {
 		v := blobs[key]

--- a/politeiad/backendv2/tstorebe/tstore/record.go
+++ b/politeiad/backendv2/tstorebe/tstore/record.go
@@ -701,11 +701,11 @@ func (t *Tstore) record(treeID int64, version uint32, filenames []string, omitAl
 			treeID, len(keys), len(blobs))
 	}
 
-	// Decode blobs
+	// Decode Blobs.
 	entries := make([]store.BlobEntry, 0, len(keys))
-	// Iterate over the blobs map in a deterministic manner, in order
-	// to keep the ordering of the record's files and metadata streams
-	// consistent. Therefore, sort the blobs map keys.
+	// Sort the blobs map keys to iterate over it in a deterministic manner,
+	// this ensures that the ordering of the record's files and metadata streams
+	// is consistent.
 	sortedKeys := getSortedKeys(blobs)
 	for _, key := range sortedKeys {
 		v := blobs[key]

--- a/politeiad/backendv2/tstorebe/tstore/record.go
+++ b/politeiad/backendv2/tstorebe/tstore/record.go
@@ -705,7 +705,7 @@ func (t *Tstore) record(treeID int64, version uint32, filenames []string, omitAl
 	entries := make([]store.BlobEntry, 0, len(keys))
 	// To ensure that the ordering of the record's files and metadata streams
 	// is always consistent, we need iterate over the blobs map in a
-	// deterministic manner, which requires sorting map keys.
+	// deterministic manner, which requires sorting the map keys.
 	sortedKeys := getSortedKeys(blobs)
 	for _, key := range sortedKeys {
 		v := blobs[key]
@@ -785,7 +785,7 @@ func (t *Tstore) record(treeID int64, version uint32, filenames []string, omitAl
 	}, nil
 }
 
-// getSortedKeys accepts a map of record's blobs indexed by string keys,
+// getSortedKeys accepts a map of record blobs indexed by string keys,
 // and it returns the keys in a sorted slice.
 func getSortedKeys(blobs map[string][]byte) []string {
 	keys := make([]string, 0, len(blobs))

--- a/politeiad/backendv2/tstorebe/tstore/record.go
+++ b/politeiad/backendv2/tstorebe/tstore/record.go
@@ -703,9 +703,9 @@ func (t *Tstore) record(treeID int64, version uint32, filenames []string, omitAl
 
 	// Decode blobs
 	entries := make([]store.BlobEntry, 0, len(keys))
-	// Sort the blobs map keys to iterate over it in a deterministic manner,
-	// this ensures that the ordering of the record's files and metadata streams
-	// is consistent.
+	// To ensure that the ordering of the record's files and metadata streams
+	// is always consistent, we need iterate over the blobs map in a
+	// deterministic manner, which requires sorting map keys.
 	sortedKeys := getSortedKeys(blobs)
 	for _, key := range sortedKeys {
 		v := blobs[key]
@@ -786,7 +786,7 @@ func (t *Tstore) record(treeID int64, version uint32, filenames []string, omitAl
 }
 
 // getSortedKeys accepts a map of record's blobs indexed by string keys,
-// it colects the keys in a slice and returns them sorted.
+// and it returns the keys in a sorted slice.
 func getSortedKeys(blobs map[string][]byte) []string {
 	keys := make([]string, 0, len(blobs))
 	for k := range blobs {


### PR DESCRIPTION
This diff ensures that the ordering of the records entries returned from the
backend is consistent.

---

Closes #1595