### PR TITLE
multi: Add temporary comment edits.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -574,6 +574,8 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	// Ensure no extra data provided if not allowed
 	err = p.verifyExtraData(e.ExtraData, e.ExtraDataHint)
 	if err != nil {
 		return "", err
@@ -588,8 +590,6 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	if err != nil {
 		return "", convertSignatureError(err)
 	}
-
-	fmt.Printf("fdfdfdfdf: %v \n\n\n\n\n", e.Signature)
 
 	// Verify comment
 	if len(e.Comment) > int(p.commentLengthMax) {

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -272,7 +272,7 @@ func (p *commentsPlugin) commentCreationTimestamp(c comments.Comment, cidx comme
 
 	// If comment was edited, we need to get the first version of the
 	// comment in order to determine the creation timestamp.
-	b, err := hex.DecodeString(c.Token)
+	b, err := tokenDecode(c.Token)
 	if err != nil {
 		return 0, err
 	}
@@ -586,8 +586,9 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	// Check if comment edits are allowed
 	if !p.allowEdits {
 		return "", backend.PluginError{
-			PluginID:  comments.PluginID,
-			ErrorCode: uint32(comments.ErrorCodeEditsNotAllowed),
+			PluginID:     comments.PluginID,
+			ErrorCode:    uint32(comments.ErrorCodeEditNotAllowed),
+			ErrorContext: "comments plugin setting 'allowedits' is off",
 		}
 	}
 
@@ -665,11 +666,11 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	}
 
 	// Comment edits are allowed only during the timeframe
-	// set by the editPeriodTime plugin setting.
-	if time.Now().Unix() > cf.Timestamp+int64(p.editPeriodTime) {
+	// set by the editPeriod plugin setting.
+	if time.Now().Unix() > cf.Timestamp+int64(p.editPeriod) {
 		return "", backend.PluginError{
 			PluginID:     comments.PluginID,
-			ErrorCode:    uint32(comments.ErrorCodeEditsNotAllowed),
+			ErrorCode:    uint32(comments.ErrorCodeEditNotAllowed),
 			ErrorContext: "comment edits timeframe expired",
 		}
 	}
@@ -708,8 +709,9 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	// Verify extra data hint
 	if e.ExtraDataHint != existing.ExtraDataHint {
 		return "", backend.PluginError{
-			PluginID:  comments.PluginID,
-			ErrorCode: uint32(comments.ErrorCodeExtraDataHintChangesNotAllowed),
+			PluginID:     comments.PluginID,
+			ErrorCode:    uint32(comments.ErrorCodeEditNotAllowed),
+			ErrorContext: "extra data hint edits are not allowed",
 		}
 	}
 

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -574,8 +574,6 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	// Ensure no extra data provided if not allowed
 	err = p.verifyExtraData(e.ExtraData, e.ExtraDataHint)
 	if err != nil {
 		return "", err
@@ -590,6 +588,8 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	if err != nil {
 		return "", convertSignatureError(err)
 	}
+
+	fmt.Printf("fdfdfdfdf: %v \n\n\n\n\n", e.Signature)
 
 	// Verify comment
 	if len(e.Comment) > int(p.commentLengthMax) {

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -634,7 +634,7 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 
 	// Comment edits are allowed only during the timeframe
 	// set by the editPeriodTime plugin setting.
-	if cf.Timestamp+int64(p.editPeriodTime) > time.Now().Unix() {
+	if time.Now().Unix() > cf.Timestamp+int64(p.editPeriodTime) {
 		return "", backend.PluginError{
 			PluginID:     comments.PluginID,
 			ErrorCode:    uint32(comments.ErrorCodeEditsNotAllowed),
@@ -755,7 +755,7 @@ func (p *commentsPlugin) commentFirstVersion(token []byte, ridx recordIndex, com
 	}
 
 	// Convert comment add
-	c := convertCommentFromCommentAdd(adds[1])
+	c := convertCommentFromCommentAdd(adds[0])
 	c.Downvotes, c.Upvotes = voteScore(cidx)
 
 	return &c, nil

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -671,7 +671,7 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 		return "", backend.PluginError{
 			PluginID:     comments.PluginID,
 			ErrorCode:    uint32(comments.ErrorCodeEditNotAllowed),
-			ErrorContext: "comment edits timeframe expired",
+			ErrorContext: "comment edits timeframe has expired",
 		}
 	}
 

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -246,6 +246,10 @@ func (p *commentsPlugin) comments(token []byte, ridx recordIndex, commentIDs []u
 		}
 		c.Downvotes, c.Upvotes = voteScore(cidx)
 		// Populate creation timestamp
+		c.CreatedAt, err = p.commentCreationTimestamp(c, cidx)
+		if err != nil {
+			return nil, err
+		}
 
 		cs[v.CommentID] = c
 	}

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -705,8 +705,17 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 		}
 	}
 
+	// Verify extra data hint
+	if e.ExtraDataHint != existing.ExtraDataHint {
+		return "", backend.PluginError{
+			PluginID:  comments.PluginID,
+			ErrorCode: uint32(comments.ErrorCodeExtraDataHintChangesNotAllowed),
+		}
+	}
+
 	// Verify comment changes
-	if e.Comment == existing.Comment {
+	if e.Comment == existing.Comment &&
+		e.ExtraData == existing.ExtraData {
 		return "", backend.PluginError{
 			PluginID:  comments.PluginID,
 			ErrorCode: uint32(comments.ErrorCodeNoChanges),

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -764,8 +764,7 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	return string(reply), nil
 }
 
-// commentFirstVersion returns the first version of the specified comment. If
-// a comment is not found for the provided comment ID, a nil is returned. The
+// commentFirstVersion returns the first version of the specified comment. The
 // returned comment does not include the vote score.
 func (p *commentsPlugin) commentFirstVersion(token []byte, commentID uint32, cidx commentIndex) (*comments.Comment, error) {
 	// First version comment add digest

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -706,7 +706,11 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 		}
 	}
 
-	// Verify extra data hint
+	// Verify extra data hint. This doesn't really belong here, and should be
+	// left up to the application plugin (i.e. the pi plugin) to decide. It was
+	// put here to prevent application plugin from needing to pull the prior
+	// version of the comment, which is expensive since it causes a tlog tree
+	// retrieval.
 	if e.ExtraDataHint != existing.ExtraDataHint {
 		return "", backend.PluginError{
 			PluginID:     comments.PluginID,

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -626,6 +626,7 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 		return "", err
 	}
 	if cf == nil {
+		// Comment not found
 		return "", backend.PluginError{
 			PluginID:  comments.PluginID,
 			ErrorCode: uint32(comments.ErrorCodeCommentNotFound),
@@ -733,7 +734,8 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 }
 
 // commentFirstVersion returns the first version of the specified comment. If
-// a comment is not found for the provided comment ID, a nil is returned.
+// a comment is not found for the provided comment ID, a nil is returned. The
+// returned comment does not include the vote score.
 func (p *commentsPlugin) commentFirstVersion(token []byte, ridx recordIndex, commentID uint32) (*comments.Comment, error) {
 	cidx, ok := ridx.Comments[commentID]
 	if !ok {
@@ -756,7 +758,6 @@ func (p *commentsPlugin) commentFirstVersion(token []byte, ridx recordIndex, com
 
 	// Convert comment add
 	c := convertCommentFromCommentAdd(adds[0])
-	c.Downvotes, c.Upvotes = voteScore(cidx)
 
 	return &c, nil
 }

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds_test.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds_test.go
@@ -238,7 +238,7 @@ func TestCmdEdit(t *testing.T) {
 					ExtraDataHint: extraDataHint,
 				}),
 			false,
-			pluginError(comments.ErrorCodeEditsNotAllowed),
+			pluginError(comments.ErrorCodeEditNotAllowed),
 		},
 		{
 			"payload token invalid",

--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds_test.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds_test.go
@@ -1,0 +1,317 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package comments
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/decred/politeia/politeiad/api/v1/identity"
+	backend "github.com/decred/politeia/politeiad/backendv2"
+	"github.com/decred/politeia/politeiad/plugins/comments"
+	"github.com/decred/politeia/politeiad/plugins/pi"
+	"github.com/pkg/errors"
+)
+
+func TestCmdEdit(t *testing.T) {
+	// Setup comments plugin
+	c, cleanup := newTestCommentsPlugin(t)
+	defer cleanup()
+
+	// Setup an identity that will be used to create the payload
+	// signatures.
+	fid, err := identity.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup test data
+	var (
+		// Valid input
+		token         = "45154fb45664714b"
+		userID        = "6dc1c8ca-abb5-4631-8ed4-f991b0169770"
+		state         = comments.RecordStateVetted
+		parentID      = uint32(0)
+		commentID     = uint32(1)
+		comment       = "comment"
+		extraData     = ""
+		extraDataHint = ""
+		publicKey     = fid.Public.String()
+
+		msg = strconv.FormatUint(uint64(state), 10) + token +
+			strconv.FormatUint(uint64(parentID), 10) +
+			strconv.FormatUint(uint64(commentID), 10) +
+			comment + extraData + extraDataHint
+		signatureb = fid.SignMessage([]byte(msg))
+		signature  = hex.EncodeToString(signatureb[:])
+
+		// signatureIsWrong is a valid hex encoded, ed25519 signature,
+		// but that does not correspond to the valid input parameters
+		// listed above.
+		signatureIsWrong = "b387f678e1236ca1784c4bc77912c754c6b122dd8b" +
+			"3e499617706dd0bd09167a113e59339d2ce4b3570af37a092ba88f39e7f" +
+			"c93a5ac7513e52dca3e5e13f705"
+	)
+	tokenb, err := hex.DecodeString(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup tests
+	var tests = []struct {
+		name       string // Test name
+		token      []byte
+		e          comments.Edit
+		allowEdits bool
+		err        error // Expected error output
+	}{
+		{
+			"comment edits not allowed",
+			tokenb,
+			edit(t, fid,
+				comments.Edit{
+					UserID:        userID,
+					State:         state,
+					Token:         token,
+					ParentID:      parentID,
+					CommentID:     commentID,
+					Comment:       comment,
+					ExtraData:     extraData,
+					ExtraDataHint: extraDataHint,
+				}),
+			false,
+			pluginError(comments.ErrorCodeEditsNotAllowed),
+		},
+		{
+			"payload token invalid",
+			tokenb,
+			edit(t, fid,
+				comments.Edit{
+					UserID:        userID,
+					State:         state,
+					Token:         "invalid-token",
+					ParentID:      parentID,
+					CommentID:     commentID,
+					Comment:       comment,
+					ExtraData:     extraData,
+					ExtraDataHint: extraDataHint,
+				}),
+			true,
+			pluginError(comments.ErrorCodeTokenInvalid),
+		},
+		{
+			"payload token does not match cmd token",
+			tokenb,
+			edit(t, fid,
+				comments.Edit{
+					UserID:        userID,
+					State:         state,
+					Token:         "da70d0766348340c",
+					ParentID:      parentID,
+					CommentID:     commentID,
+					Comment:       comment,
+					ExtraData:     extraData,
+					ExtraDataHint: extraDataHint,
+				}),
+			true,
+			pluginError(comments.ErrorCodeTokenInvalid),
+		},
+		{
+			"signature is not hex",
+			tokenb,
+			comments.Edit{
+				UserID:        userID,
+				State:         state,
+				Token:         token,
+				ParentID:      parentID,
+				CommentID:     commentID,
+				Comment:       comment,
+				ExtraData:     extraData,
+				ExtraDataHint: extraDataHint,
+				PublicKey:     publicKey,
+				Signature:     "zzz",
+			},
+			true,
+			pluginError(comments.ErrorCodeSignatureInvalid),
+		},
+		{
+			"signature is the wrong size",
+			tokenb,
+			comments.Edit{
+				UserID:        userID,
+				State:         state,
+				Token:         token,
+				ParentID:      parentID,
+				CommentID:     commentID,
+				Comment:       comment,
+				ExtraData:     extraData,
+				ExtraDataHint: extraDataHint,
+				PublicKey:     publicKey,
+				Signature:     "123456",
+			},
+			true,
+			pluginError(comments.ErrorCodeSignatureInvalid),
+		},
+		{
+			"signature is wrong",
+			tokenb,
+			comments.Edit{
+				UserID:        userID,
+				State:         state,
+				Token:         token,
+				ParentID:      parentID,
+				CommentID:     commentID,
+				Comment:       comment,
+				ExtraData:     extraData,
+				ExtraDataHint: extraDataHint,
+				PublicKey:     publicKey,
+				Signature:     signatureIsWrong,
+			},
+			true,
+			pluginError(comments.ErrorCodeSignatureInvalid),
+		},
+		{
+			"public key is not a hex",
+			tokenb,
+			comments.Edit{
+				UserID:        userID,
+				State:         state,
+				Token:         token,
+				ParentID:      parentID,
+				CommentID:     commentID,
+				Comment:       comment,
+				ExtraData:     extraData,
+				ExtraDataHint: extraDataHint,
+				PublicKey:     "",
+				Signature:     signature,
+			},
+			true,
+			pluginError(comments.ErrorCodePublicKeyInvalid),
+		},
+		{
+			"public key is the wrong length",
+			tokenb,
+			comments.Edit{
+				UserID:        userID,
+				State:         state,
+				Token:         token,
+				ParentID:      parentID,
+				CommentID:     commentID,
+				Comment:       comment,
+				ExtraData:     extraData,
+				ExtraDataHint: extraDataHint,
+				PublicKey:     "123456",
+				Signature:     signature,
+			},
+			true,
+			pluginError(comments.ErrorCodePublicKeyInvalid),
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup command payload
+			b, err := json.Marshal(tc.e)
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload := string(b)
+
+			// Decode the expected error into a PluginError. If
+			// an error is being returned it should always be a
+			// PluginError.
+			var wantErrorCode comments.ErrorCodeT
+			if tc.err != nil {
+				var pe backend.PluginError
+				if !errors.As(tc.err, &pe) {
+					t.Fatalf("error is not a plugin error '%v'", tc.err)
+				}
+				wantErrorCode = comments.ErrorCodeT(pe.ErrorCode)
+			}
+
+			// Run test
+			c.allowEdits = tc.allowEdits
+			_, err = c.cmdEdit(tc.token, payload)
+			switch {
+			case tc.err != nil && err == nil:
+				// Wanted an error but didn't get one
+				t.Errorf("want error '%v', got nil",
+					comments.ErrorCodes[wantErrorCode])
+				return
+
+			case tc.err == nil && err != nil:
+				// Wanted success but got an error
+				t.Errorf("want error nil, got '%v'", err)
+				return
+
+			case tc.err != nil && err != nil:
+				// Wanted an error and got an error. Verify that it's
+				// the correct error. All errors should be backend
+				// plugin errors.
+				var gotErr backend.PluginError
+				if !errors.As(err, &gotErr) {
+					t.Errorf("want plugin error, got '%v'", err)
+					return
+				}
+				if comments.PluginID != gotErr.PluginID {
+					t.Errorf("want plugin error with plugin ID '%v', got '%v'",
+						pi.PluginID, gotErr.PluginID)
+					return
+				}
+
+				gotErrorCode := comments.ErrorCodeT(gotErr.ErrorCode)
+				if wantErrorCode != gotErrorCode {
+					t.Errorf("want error '%v', got '%v'",
+						comments.ErrorCodes[wantErrorCode],
+						comments.ErrorCodes[gotErrorCode])
+				}
+
+				// Success; continue to next test
+				return
+
+			case tc.err == nil && err == nil:
+				// Success; continue to next test
+				return
+			}
+		})
+	}
+}
+
+// edit uses the provided arguments to return an Edit command
+// with a valid PublicKey and Signature.
+func edit(t *testing.T, fid *identity.FullIdentity, e comments.Edit) comments.Edit {
+	t.Helper()
+
+	msg := strconv.FormatUint(uint64(e.State), 10) + e.Token +
+		strconv.FormatUint(uint64(e.ParentID), 10) +
+		strconv.FormatUint(uint64(e.CommentID), 10) +
+		e.Comment + e.ExtraData + e.ExtraDataHint
+	sig := fid.SignMessage([]byte(msg))
+
+	return comments.Edit{
+		UserID:        e.UserID,
+		State:         e.State,
+		Token:         e.Token,
+		ParentID:      e.ParentID,
+		CommentID:     e.CommentID,
+		Comment:       e.Comment,
+		ExtraData:     e.ExtraData,
+		ExtraDataHint: e.ExtraDataHint,
+		PublicKey:     fid.Public.String(),
+		Signature:     hex.EncodeToString(sig[:]),
+	}
+}
+
+// pluginError returns a backend PluginError for the provided comments
+// ErrorCodeT.
+func pluginError(e comments.ErrorCodeT) error {
+	return backend.PluginError{
+		PluginID:  comments.PluginID,
+		ErrorCode: uint32(e),
+	}
+}

--- a/politeiad/backendv2/tstorebe/plugins/comments/comments.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/comments.go
@@ -47,7 +47,7 @@ type commentsPlugin struct {
 	countPageSize      uint32
 	timestampsPageSize uint32
 	allowEdits         bool
-	editPeriodTime     uint32
+	editPeriod         uint32
 }
 
 // Setup performs any plugin setup that is required.
@@ -177,8 +177,8 @@ func (p *commentsPlugin) Settings() []backend.PluginSetting {
 			Value: strconv.FormatBool(p.allowEdits),
 		},
 		{
-			Key:   comments.SettingKeyEditPeriodTime,
-			Value: strconv.FormatUint(uint64(p.editPeriodTime), 10),
+			Key:   comments.SettingKeyEditPeriod,
+			Value: strconv.FormatUint(uint64(p.editPeriod), 10),
 		},
 	}
 }
@@ -201,7 +201,7 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 		countPageSize      = comments.SettingCountPageSize
 		timestampsPageSize = comments.SettingTimestampsPageSize
 		allowEdits         = comments.SettingAllowEdits
-		editPeriodTime     = comments.SettingEditPeriodTime
+		editPeriod         = comments.SettingEditPeriod
 	)
 
 	// Override defaults with any passed in settings
@@ -263,13 +263,13 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 			}
 			allowEdits = b
 
-		case comments.SettingKeyEditPeriodTime:
+		case comments.SettingKeyEditPeriod:
 			u, err := strconv.ParseUint(v.Value, 10, 64)
 			if err != nil {
 				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
 					v.Key, v.Value, err)
 			}
-			editPeriodTime = uint32(u)
+			editPeriod = uint32(u)
 
 		default:
 			return nil, errors.Errorf("invalid comments plugin setting '%v'", v.Key)
@@ -287,6 +287,6 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 		countPageSize:      countPageSize,
 		timestampsPageSize: timestampsPageSize,
 		allowEdits:         allowEdits,
-		editPeriodTime:     editPeriodTime,
+		editPeriod:         editPeriod,
 	}, nil
 }

--- a/politeiad/backendv2/tstorebe/plugins/comments/comments.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/comments.go
@@ -43,6 +43,8 @@ type commentsPlugin struct {
 	commentLengthMax uint32
 	voteChangesMax   uint32
 	allowExtraData   bool
+	allowEdits       bool
+	editPeriodTime   uint32
 }
 
 // Setup performs any plugin setup that is required.
@@ -155,6 +157,14 @@ func (p *commentsPlugin) Settings() []backend.PluginSetting {
 			Key:   comments.SettingKeyAllowExtraData,
 			Value: strconv.FormatBool(p.allowExtraData),
 		},
+		{
+			Key:   comments.SettingKeyAllowEdits,
+			Value: strconv.FormatBool(p.allowEdits),
+		},
+		{
+			Key:   comments.SettingKeyEditPeriodTime,
+			Value: strconv.FormatUint(uint64(p.editPeriodTime), 10),
+		},
 	}
 }
 
@@ -172,6 +182,8 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 		commentLengthMax = comments.SettingCommentLengthMax
 		voteChangesMax   = comments.SettingVoteChangesMax
 		allowExtraData   = comments.SettingAllowExtraData
+		allowEdits       = comments.SettingAllowEdits
+		editPeriodTime   = comments.SettingEditPeriodTime
 	)
 
 	// Override defaults with any passed in settings
@@ -198,6 +210,20 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 					v.Key, v.Value, err)
 			}
 			allowExtraData = b
+		case comments.SettingKeyAllowEdits:
+			b, err := strconv.ParseBool(v.Value)
+			if err != nil {
+				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+					v.Key, v.Value, err)
+			}
+			allowEdits = b
+		case comments.SettingKeyEditPeriodTime:
+			u, err := strconv.ParseUint(v.Value, 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+					v.Key, v.Value, err)
+			}
+			editPeriodTime = uint32(u)
 		default:
 			return nil, errors.Errorf("invalid comments plugin setting '%v'", v.Key)
 		}
@@ -210,5 +236,7 @@ func New(tstore plugins.TstoreClient, settings []backend.PluginSetting, dataDir 
 		commentLengthMax: commentLengthMax,
 		voteChangesMax:   voteChangesMax,
 		allowExtraData:   allowExtraData,
+		allowEdits:       allowEdits,
+		editPeriodTime:   editPeriodTime,
 	}, nil
 }

--- a/politeiad/backendv2/tstorebe/plugins/comments/testing.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/testing.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package comments
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/decred/politeia/politeiad/plugins/comments"
+)
+
+// newTestCommentsPlugin returns a commentsPlugin that has been setup for
+// testing.
+func newTestCommentsPlugin(t *testing.T) (*commentsPlugin, func()) {
+	// Create plugin data directory
+	dataDir, err := ioutil.TempDir("", comments.PluginID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup plugin context
+	c := commentsPlugin{
+		dataDir:          dataDir,
+		commentLengthMax: comments.SettingCommentLengthMax,
+		voteChangesMax:   comments.SettingVoteChangesMax,
+		allowExtraData:   comments.SettingAllowExtraData,
+		allowEdits:       comments.SettingAllowEdits,
+		editPeriodTime:   comments.SettingEditPeriodTime,
+	}
+
+	return &c, func() {
+		err = os.RemoveAll(dataDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/politeiad/backendv2/tstorebe/plugins/comments/testing.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/testing.go
@@ -28,7 +28,7 @@ func newTestCommentsPlugin(t *testing.T) (*commentsPlugin, func()) {
 		voteChangesMax:   comments.SettingVoteChangesMax,
 		allowExtraData:   comments.SettingAllowExtraData,
 		allowEdits:       comments.SettingAllowEdits,
-		editPeriodTime:   comments.SettingEditPeriodTime,
+		editPeriod:       comments.SettingEditPeriod,
 	}
 
 	return &c, func() {

--- a/politeiad/client/comments.go
+++ b/politeiad/client/comments.go
@@ -43,6 +43,36 @@ func (c *Client) CommentNew(ctx context.Context, n comments.New) (*comments.Comm
 	return &nr.Comment, nil
 }
 
+// CommentEdit sends the comments plugin Edit command to the politeiad v2 API.
+func (c *Client) CommentEdit(ctx context.Context, e comments.Edit) (*comments.Comment, error) {
+	// Setup request
+	b, err := json.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+	cmd := pdv2.PluginCmd{
+		Token:   e.Token,
+		ID:      comments.PluginID,
+		Command: comments.CmdEdit,
+		Payload: string(b),
+	}
+
+	// Send request
+	reply, err := c.PluginWrite(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode reply
+	var er comments.EditReply
+	err = json.Unmarshal([]byte(reply), &er)
+	if err != nil {
+		return nil, err
+	}
+
+	return &er.Comment, nil
+}
+
 // CommentVote sends the comments plugin Vote command to the politeiad v2 API.
 func (c *Client) CommentVote(ctx context.Context, v comments.Vote) (*comments.VoteReply, error) {
 	// Setup request

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -55,9 +55,9 @@ const (
 	// SettingAllowEdits plugin setting.
 	SettingKeyAllowEdits = "allowedits"
 
-	// SettingKeyEditPeriodTime is the plugin setting key for the
-	// SettingEditPeriodTime plugin setting.
-	SettingKeyEditPeriodTime = "editperiodtime"
+	// SettingKeyEditPeriod is the plugin setting key for the
+	// SettingEditPeriod plugin setting.
+	SettingKeyEditPeriod = "editperiod"
 )
 
 // Plugin setting default values. These can be overridden by providing a
@@ -93,14 +93,14 @@ const (
 
 	// SettingAllowEdits is the default value of the bool flag which
 	// determines whether comment edits are temporarily allowed during the
-	// timeframe set by SettingEditPeriodTime.
+	// timeframe set by SettingEditPeriod.
 	SettingAllowEdits = false
 
-	// SettingEditPeriodTime is the default maximum amount of time,
+	// SettingEditPeriod is the default maximum amount of time,
 	// in seconds, since the submission of a comment where it's still
 	// editable. It defaults to five minutes which should be enough time
 	// to spot typos and grammar mistakes.
-	SettingEditPeriodTime uint32 = 300
+	SettingEditPeriod uint32 = 300
 )
 
 // ErrorCodeT represents a error that was caused by the user.
@@ -157,16 +157,12 @@ const (
 	// is found while comment plugin setting does not allow it.
 	ErrorCodeExtraDataNotAllowed = 12
 
-	// ErrorCodeEditsNotAllowed is returned when comment edits are not
+	// ErrorCodeEditNotAllowed is returned when comment edit is not
 	// allowed.
-	ErrorCodeEditsNotAllowed = 13
-
-	// ErrorCodeExtraDataHintChangesNotAllowed is returned when an edited
-	// comment includes a different extra data hint than the existing one.
-	ErrorCodeExtraDataHintChangesNotAllowed = 14
+	ErrorCodeEditNotAllowed = 13
 
 	// ErrorCodeLast unit test only.
-	ErrorCodeLast ErrorCodeT = 15
+	ErrorCodeLast ErrorCodeT = 14
 )
 
 var (
@@ -185,9 +181,7 @@ var (
 		ErrorCodeVoteChangesMaxExceeded: "vote changes max exceeded",
 		ErrorCodeRecordStateInvalid:     "record state invalid",
 		ErrorCodeExtraDataNotAllowed:    "comment extra data not allowed",
-		ErrorCodeEditsNotAllowed:        "edits are not allowed",
-		ErrorCodeExtraDataHintChangesNotAllowed: "extra data hint edits are not" +
-			" allowed",
+		ErrorCodeEditNotAllowed:         "comment edit is not allowed",
 	}
 )
 
@@ -259,8 +253,14 @@ type Comment struct {
 //
 // PublicKey is the user's public key that is used to verify the signature.
 //
-// Signature is the user signature of the:
-// State + Token + ParentID + Comment + ExtraData + ExtraDataHint
+// The structure of the signature field depends on whether the CommentAdd is
+// associated with a new comment or a comment edit:
+//
+//   1. When a comment is created it's the user signature of the:
+//   State + Token + ParentID + Comment + ExtraData + ExtraDataHint.
+//
+//   2. When a comment is edited it's the user signature of the:
+//   State + Token + ParentID + CommentID + Comment + ExtraData + ExtraDataHint.
 //
 // Receipt is the server signature of the user signature.
 //

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -38,6 +38,14 @@ const (
 	// SettingKeyAllowExtraData is the plugin setting key for the
 	// SettingAllowExtraData plugin setting.
 	SettingKeyAllowExtraData = "allowextradata"
+
+	// SettingKeyAllowEdits is the plugin setting key for the
+	// SettingAllowEdits plugin setting.
+	SettingKeyAllowEdits = "allowedits"
+
+	// SettingKeyEditPeriodTime is the plugin setting key for the
+	// SettingEditPeriodTime plugin setting.
+	SettingKeyEditPeriodTime = "editperiodtime"
 )
 
 // Plugin setting default values. These can be overridden by providing a plugin
@@ -55,6 +63,17 @@ const (
 	// SettingAllowExtraData is the default value of the bool flag which
 	// determines whether posting extra data along with the comment is allowed.
 	SettingAllowExtraData = false
+
+	// SettingAllowEdits is the default value of the bool flag which
+	// determines whether comment edits are temporarily allowed during the
+	// timeframe set by SettingEditPeriodTime.
+	SettingAllowEdits = false
+
+	// SettingEditPeriodTime is the default maximum amount of time,
+	// in seconds, since the submission of a comment where it's still
+	// editable. It defaults to five minutes which should be enough time
+	// to spot typos and grammar mistakes.
+	SettingEditPeriodTime uint32 = 300
 )
 
 // ErrorCodeT represents a error that was caused by the user.
@@ -111,8 +130,12 @@ const (
 	// is found while comment plugin setting does not allow it.
 	ErrorCodeExtraDataNotAllowed = 12
 
+	// ErrorCodeEditsNotAllowed is returned when comment edits are not
+	// allowed.
+	ErrorCodeEditsNotAllowed = 13
+
 	// ErrorCodeLast unit test only.
-	ErrorCodeLast ErrorCodeT = 13
+	ErrorCodeLast ErrorCodeT = 14
 )
 
 var (
@@ -131,6 +154,7 @@ var (
 		ErrorCodeVoteChangesMaxExceeded: "vote changes max exceeded",
 		ErrorCodeRecordStateInvalid:     "record state invalid",
 		ErrorCodeExtraDataNotAllowed:    "comment extra data not allowed",
+		ErrorCodeEditsNotAllowed:        "edits are not allowed",
 	}
 )
 
@@ -335,7 +359,7 @@ type NewReply struct {
 // PublicKey is the user's public key that is used to verify the signature.
 //
 // Signature is the user signature of the:
-// State + Token + ParentID + Comment + ExtraData + ExtraDataHint
+// State + Token + ParentID + CommentID + Comment + ExtraData + ExtraDataHint
 //
 // Receipt is the server signature of the user signature.
 //

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -161,8 +161,12 @@ const (
 	// allowed.
 	ErrorCodeEditsNotAllowed = 13
 
+	// ErrorCodeExtraDataHintChangesNotAllowed is returned when an edited
+	// comment includes a different extra data hint than the existing one.
+	ErrorCodeExtraDataHintChangesNotAllowed = 14
+
 	// ErrorCodeLast unit test only.
-	ErrorCodeLast ErrorCodeT = 14
+	ErrorCodeLast ErrorCodeT = 15
 )
 
 var (
@@ -182,6 +186,8 @@ var (
 		ErrorCodeRecordStateInvalid:     "record state invalid",
 		ErrorCodeExtraDataNotAllowed:    "comment extra data not allowed",
 		ErrorCodeEditsNotAllowed:        "edits are not allowed",
+		ErrorCodeExtraDataHintChangesNotAllowed: "extra data hint edits are not" +
+			" allowed",
 	}
 )
 

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -234,6 +234,7 @@ type Comment struct {
 	Signature string       `json:"signature"` // Client signature
 	CommentID uint32       `json:"commentid"` // Comment ID
 	Version   uint32       `json:"version"`   // Comment version
+	CreatedAt int64        `json:"createdat"` // UNIX timestamp of creation time
 	Timestamp int64        `json:"timestamp"` // UNIX timestamp of last edit
 	Receipt   string       `json:"receipt"`   // Server sig of client sig
 	Downvotes uint64       `json:"downvotes"` // Tolal downvotes on comment

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -16,6 +16,9 @@ const (
 	// RouteNew adds a new comment.
 	RouteNew = "/new"
 
+	// RouteEdit edits a comment.
+	RouteEdit = "/edit"
+
 	// RouteVote votes on a comment.
 	RouteVote = "/vote"
 
@@ -152,6 +155,8 @@ type PolicyReply struct {
 	VoteChangesMax     uint32 `json:"votechangesmax"`
 	CountPageSize      uint32 `json:"countpagesize"`
 	TimestampsPageSize uint32 `json:"timestampspagesize"`
+	AllowEdits         bool   `json:"allowedits"`
+	EditPeriodTime     uint32 `json:"editperiodtime"`
 }
 
 // RecordStateT represents the state of a record.
@@ -265,6 +270,37 @@ type New struct {
 
 // NewReply is the reply to the New command.
 type NewReply struct {
+	Comment Comment `json:"comment"`
+}
+
+// Edit edits an existing comment.
+//
+// PublicKey is the user's public key that is used to verify the signature.
+//
+// Signature is the user signature of the:
+// State + Token + ParentID + CommentID + Comment + ExtraData + ExtraDataHint
+//
+// Receipt is the server signature of the user signature.
+//
+// The PublicKey, Signature, and Receipt are all hex encoded and use the
+// ed25519 signature scheme.
+type Edit struct {
+	UserID    string       `json:"userid"`    // Unique user ID
+	State     RecordStateT `json:"state"`     // Record state
+	Token     string       `json:"token"`     // Record token
+	ParentID  uint32       `json:"parentid"`  // Parent comment ID
+	CommentID uint32       `json:"commentid"` // Comment ID
+	Comment   string       `json:"comment"`   // Comment text
+	PublicKey string       `json:"publickey"` // Pubkey used for Signature
+	Signature string       `json:"signature"` // Client signature
+
+	// Optional fields to be used freely
+	ExtraData     string `json:"extradata,omitempty"`
+	ExtraDataHint string `json:"extradatahint,omitempty"`
+}
+
+// EditReply is the reply to the Edit command.
+type EditReply struct {
 	Comment Comment `json:"comment"`
 }
 

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -210,6 +210,8 @@ type Comment struct {
 	PublicKey string       `json:"publickey"` // Public key used for Signature
 	Signature string       `json:"signature"` // Client signature
 	CommentID uint32       `json:"commentid"` // Comment ID
+	Version   uint32       `json:"version"`   // Comment version
+	CreatedAt int64        `json:"createdat"` // UNIX timestamp of creation time
 	Timestamp int64        `json:"timestamp"` // UNIX timestamp of last edit
 	Receipt   string       `json:"receipt"`   // Server sig of client sig
 	Downvotes uint64       `json:"downvotes"` // Tolal downvotes on comment

--- a/politeiawww/api/comments/v1/v1.go
+++ b/politeiawww/api/comments/v1/v1.go
@@ -158,7 +158,7 @@ type PolicyReply struct {
 	TimestampsPageSize uint32 `json:"timestampspagesize"`
 	VotesPageSize      uint32 `json:"votespagesize"`
 	AllowEdits         bool   `json:"allowedits"`
-	EditPeriodTime     uint32 `json:"editperiodtime"`
+	EditPeriod         uint32 `json:"editperiod"`
 }
 
 // RecordStateT represents the state of a record.

--- a/politeiawww/client/comments.go
+++ b/politeiawww/client/comments.go
@@ -199,15 +199,16 @@ func commentDelVerify(c cmv1.Comment, serverPublicKey string) error {
 
 // CommentEditVerify verifies the edited comment signature and receipt.
 func CommentEditVerify(c cmv1.Comment, serverPublicKey string) error {
-	// Verify comment. The signature is the client signature of the
-	// State + Token + ParentID + Comment + ExtraData + ExtraDataHint.
+	// Verify comment. The signature is the client signature of the:
+	// State + Token + ParentID + CommentID + Comment +
+	// ExtraData + ExtraDataHint.
 	msg := strconv.FormatUint(uint64(c.State), 10) + c.Token +
 		strconv.FormatUint(uint64(c.ParentID), 10) +
 		strconv.FormatUint(uint64(c.CommentID), 10) +
 		c.Comment + c.ExtraData + c.ExtraDataHint
 	err := util.VerifySignature(c.Signature, c.PublicKey, msg)
 	if err != nil {
-		return fmt.Errorf("unable to verify comment %v signature: %v",
+		return fmt.Errorf("unable to verify edited comment %v signature: %v",
 			c.CommentID, err)
 	}
 
@@ -215,7 +216,7 @@ func CommentEditVerify(c cmv1.Comment, serverPublicKey string) error {
 	// client signature.
 	err = util.VerifySignature(c.Receipt, serverPublicKey, c.Signature)
 	if err != nil {
-		return fmt.Errorf("unable to verify comment %v receipt: %v",
+		return fmt.Errorf("unable to verify edited comment %v receipt: %v",
 			c.CommentID, err)
 	}
 

--- a/politeiawww/client/comments.go
+++ b/politeiawww/client/comments.go
@@ -49,6 +49,23 @@ func (c *Client) CommentNew(n cmv1.New) (*cmv1.NewReply, error) {
 	return &nr, nil
 }
 
+// CommentEdit sends a comments v1 Edit request to politeiawww.
+func (c *Client) CommentEdit(e cmv1.Edit) (*cmv1.EditReply, error) {
+	resBody, err := c.makeReq(http.MethodPost,
+		cmv1.APIRoute, cmv1.RouteEdit, e)
+	if err != nil {
+		return nil, err
+	}
+
+	var er cmv1.EditReply
+	err = json.Unmarshal(resBody, &er)
+	if err != nil {
+		return nil, err
+	}
+
+	return &er, nil
+}
+
 // CommentVote sends a comments v1 Vote request to politeiawww.
 func (c *Client) CommentVote(v cmv1.Vote) (*cmv1.VoteReply, error) {
 	resBody, err := c.makeReq(http.MethodPost,

--- a/politeiawww/cmd/pictl/cmdcommentedit.go
+++ b/politeiawww/cmd/pictl/cmdcommentedit.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+
+	cmv1 "github.com/decred/politeia/politeiawww/api/comments/v1"
+	piv1 "github.com/decred/politeia/politeiawww/api/pi/v1"
+	pclient "github.com/decred/politeia/politeiawww/client"
+	"github.com/decred/politeia/politeiawww/cmd/shared"
+)
+
+// cmdCommentEdit edits a new comment.
+type cmdCommentEdit struct {
+	Args struct {
+		Token     string `positional-arg-name:"token" required:"true"`
+		CommentID uint32 `positional-arg-name:"commentid" required:"true"`
+		Comment   string `positional-arg-name:"comment" required:"true"`
+		ParentID  uint32 `positional-arg-name:"parentid"`
+	} `positional-args:"true"`
+
+	// Unvetted is used to comment on an unvetted record. If this flag
+	// is not used the command assumes the record is vetted.
+	Unvetted bool `long:"unvetted" optional:"true"`
+
+	// UpdateTitle is used to post a new author update.
+	UpdateTitle string `long:"updatetitle" optional:"true"`
+}
+
+// Execute executes the cmdCommentEdit command.
+//
+// This function satisfies the go-flags Commander interface.
+func (c *cmdCommentEdit) Execute(args []string) error {
+	// Unpack args
+	var (
+		token     = c.Args.Token
+		commentID = c.Args.CommentID
+		comment   = c.Args.Comment
+		parentID  = c.Args.ParentID
+	)
+
+	// Check for user identity. A user identity is required to sign
+	// the comment.
+	if cfg.Identity == nil {
+		return shared.ErrUserIdentityNotFound
+	}
+
+	// Setup client
+	opts := pclient.Opts{
+		HTTPSCert:  cfg.HTTPSCert,
+		Cookies:    cfg.Cookies,
+		HeaderCSRF: cfg.CSRF,
+		Verbose:    cfg.Verbose,
+		RawJSON:    cfg.RawJSON,
+	}
+	pc, err := pclient.New(cfg.Host, opts)
+	if err != nil {
+		return err
+	}
+
+	// Setup state
+	var state cmv1.RecordStateT
+	switch {
+	case c.Unvetted:
+		state = cmv1.RecordStateUnvetted
+	default:
+		state = cmv1.RecordStateVetted
+	}
+
+	// Prepare extra data if it's a new author update
+	var (
+		extraData,
+		extraDataHint string
+	)
+	if c.UpdateTitle != "" {
+		extraDataHint = piv1.ProposalUpdateHint
+		pum := piv1.ProposalUpdateMetadata{
+			Title: c.UpdateTitle,
+		}
+		b, err := json.Marshal(pum)
+		if err != nil {
+			return err
+		}
+		extraData = string(b)
+	}
+
+	// Setup request
+	msg := strconv.FormatUint(uint64(state), 10) + token +
+		strconv.FormatUint(uint64(parentID), 10) +
+		strconv.FormatUint(uint64(commentID), 10) +
+		comment + extraData + extraDataHint
+	sig := cfg.Identity.SignMessage([]byte(msg))
+	e := cmv1.Edit{
+		State:         state,
+		Token:         token,
+		ParentID:      parentID,
+		CommentID:     commentID,
+		Comment:       comment,
+		Signature:     hex.EncodeToString(sig[:]),
+		PublicKey:     cfg.Identity.Public.String(),
+		ExtraDataHint: extraDataHint,
+		ExtraData:     extraData,
+	}
+
+	// Send request
+	er, err := pc.CommentEdit(e)
+	if err != nil {
+		return err
+	}
+
+	// Verify receipt
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+	err = pclient.CommentVerify(er.Comment, vr.PubKey)
+	if err != nil {
+		return err
+	}
+
+	// Print receipt
+	printComment(er.Comment)
+
+	return nil
+}
+
+// commentEditHelpMsg is printed to stdout by the help command.
+const commentEditHelpMsg = `commentedit "token" commentid "comment" parentid
+
+Edit a comment. Requires the user to be logged in.
+
+This command assumes the record is a vetted record.
+
+If the record is unvetted, the --unvetted flag must be used. Commenting on
+unvetted records requires admin priviledges.
+
+Proposal's author may edit author update using the --updatetitle flag.
+
+Arguments:
+1. token     (string, required)  Proposal censorship token.
+2. commentid (string, required)  Comment ID. 
+3. comment   (string, required)  Comment text.
+4. parentid  (uint32, optional)  ID of parent commment. Including a parent ID
+                                 indicates that the comment is a reply.
+
+Flags:
+  --unvetted    (bool, optional)   Record is unvetted.
+  --updatetitle (string, optional) Authour update title.
+`

--- a/politeiawww/cmd/pictl/cmdcommentedit.go
+++ b/politeiawww/cmd/pictl/cmdcommentedit.go
@@ -151,7 +151,7 @@ This command assumes the record is a vetted record.
 If the record is unvetted, the --unvetted flag must be used. Commenting on
 unvetted records requires admin priviledges.
 
-Proposal's author may edit author update using the --updatetitle flag.
+Proposal's author may edit an author update using the --updatetitle flag.
 
 Arguments:
 1. token     (string, required)  Proposal censorship token.

--- a/politeiawww/cmd/pictl/cmdhelp.go
+++ b/politeiawww/cmd/pictl/cmdhelp.go
@@ -105,6 +105,8 @@ func (c *cmdHelp) Execute(args []string) error {
 		fmt.Printf("%s\n", commentPolicyHelpMsg)
 	case "commentnew":
 		fmt.Printf("%s\n", commentNewHelpMsg)
+	case "commentedit":
+		fmt.Printf("%s\n", commentEditHelpMsg)
 	case "commentvote":
 		fmt.Printf("%s\n", commentVoteHelpMsg)
 	case "commentcensor":

--- a/politeiawww/cmd/pictl/pictl.go
+++ b/politeiawww/cmd/pictl/pictl.go
@@ -85,6 +85,7 @@ type pictl struct {
 	// Comments commands
 	CommentsPolicy    cmdCommentPolicy     `command:"commentpolicy"`
 	CommentNew        cmdCommentNew        `command:"commentnew"`
+	CommentEdit       cmdCommentEdit       `command:"commentedit"`
 	CommentVote       cmdCommentVote       `command:"commentvote"`
 	CommentCensor     cmdCommentCensor     `command:"commentcensor"`
 	CommentCount      cmdCommentCount      `command:"commentcount"`
@@ -182,6 +183,7 @@ Record commands
 Comment commands
   commentpolicy                (public) Get the comments api policy
   commentnew                   (user)   Submit a new comment
+  commentedit                  (user)   Edit a comment
   commentvote                  (user)   Upvote/downvote a comment
   commentcensor                (admin)  Censor a comment
   commentcount                 (public) Get the number of comments

--- a/politeiawww/legacy/comments/comments.go
+++ b/politeiawww/legacy/comments/comments.go
@@ -6,7 +6,6 @@ package comments
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/decred/politeia/politeiawww/legacy/sessions"
 	"github.com/decred/politeia/politeiawww/legacy/user"
 	"github.com/decred/politeia/util"
+	"github.com/pkg/errors"
 )
 
 // Comments is the context for the comments API.
@@ -67,6 +67,37 @@ func (c *Comments) HandleNew(w http.ResponseWriter, r *http.Request) {
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, nr)
+}
+
+// HandleEdit is the request handler for the comments v1 Edit route.
+func (c *Comments) HandleEdit(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("HandleEdit")
+
+	var v v1.Edit
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&v); err != nil {
+		respondWithError(w, r, "HandleEdit: unmarshal",
+			v1.UserErrorReply{
+				ErrorCode: v1.ErrorCodeInputInvalid,
+			})
+		return
+	}
+
+	u, err := c.sessions.GetSessionUser(w, r)
+	if err != nil {
+		respondWithError(w, r,
+			"HandleEdit: GetSessionUser: %v", err)
+		return
+	}
+
+	vr, err := c.processEdit(r.Context(), v, *u)
+	if err != nil {
+		respondWithError(w, r,
+			"HandleEdit: processEdit: %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, vr)
 }
 
 // HandleVote is the request handler for the comments v1 Vote route.
@@ -253,6 +284,8 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 	var (
 		lengthMax      uint32
 		voteChangesMax uint32
+		allowEdits     bool
+		editPeriodTime uint32
 	)
 	for _, p := range plugins {
 		if p.ID != comments.PluginID {
@@ -273,6 +306,20 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 					return nil, err
 				}
 				voteChangesMax = uint32(u)
+			case comments.SettingKeyAllowEdits:
+				b, err := strconv.ParseBool(v.Value)
+				if err != nil {
+					return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+						v.Key, v.Value, err)
+				}
+				allowEdits = b
+			case comments.SettingKeyEditPeriodTime:
+				u, err := strconv.ParseUint(v.Value, 10, 64)
+				if err != nil {
+					return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+						v.Key, v.Value, err)
+				}
+				editPeriodTime = uint32(u)
 			default:
 				// Skip unknown settings
 				log.Warnf("Unknown plugin setting %v; Skipping...", v.Key)
@@ -283,11 +330,14 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 	// Verify all plugin settings have been provided
 	switch {
 	case lengthMax == 0:
-		return nil, fmt.Errorf("plugin setting not found: %v",
+		return nil, errors.Errorf("plugin setting not found: %v",
 			comments.SettingKeyCommentLengthMax)
 	case voteChangesMax == 0:
-		return nil, fmt.Errorf("plugin setting not found: %v",
+		return nil, errors.Errorf("plugin setting not found: %v",
 			comments.SettingKeyVoteChangesMax)
+	case editPeriodTime == 0:
+		return nil, errors.Errorf("plugin setting not found: %v",
+			comments.SettingKeyEditPeriodTime)
 	}
 
 	return &Comments{
@@ -301,6 +351,8 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 			VoteChangesMax:     voteChangesMax,
 			CountPageSize:      v1.CountPageSize,
 			TimestampsPageSize: v1.TimestampsPageSize,
+			AllowEdits:         allowEdits,
+			EditPeriodTime:     editPeriodTime,
 		},
 	}, nil
 }

--- a/politeiawww/legacy/comments/comments.go
+++ b/politeiawww/legacy/comments/comments.go
@@ -289,7 +289,7 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 		countPageSize      uint32
 		timestampsPageSize uint32
 		allowEdits         bool
-		editPeriodTime     uint32
+		editPeriod         uint32
 	)
 	for _, p := range plugins {
 		if p.ID != comments.PluginID {
@@ -348,13 +348,13 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 				}
 				allowEdits = b
 
-			case comments.SettingKeyEditPeriodTime:
+			case comments.SettingKeyEditPeriod:
 				u, err := strconv.ParseUint(v.Value, 10, 64)
 				if err != nil {
 					return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
 						v.Key, v.Value, err)
 				}
-				editPeriodTime = uint32(u)
+				editPeriod = uint32(u)
 
 			default:
 				// Skip unknown settings
@@ -380,9 +380,9 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 	case timestampsPageSize == 0:
 		return nil, errors.Errorf("plugin setting not found: %v",
 			comments.SettingKeyTimestampsPageSize)
-	case editPeriodTime == 0:
+	case editPeriod == 0:
 		return nil, errors.Errorf("plugin setting not found: %v",
-			comments.SettingKeyEditPeriodTime)
+			comments.SettingKeyEditPeriod)
 	}
 
 	return &Comments{
@@ -399,7 +399,7 @@ func New(cfg *config.Config, pdc *pdclient.Client, udb user.Database, s *session
 			CountPageSize:      countPageSize,
 			TimestampsPageSize: timestampsPageSize,
 			AllowEdits:         allowEdits,
-			EditPeriodTime:     editPeriodTime,
+			EditPeriod:         editPeriod,
 		},
 	}, nil
 }

--- a/politeiawww/legacy/comments/pi.go
+++ b/politeiawww/legacy/comments/pi.go
@@ -25,6 +25,7 @@ func userHasPaid(u user.User) bool {
 	return u.NewUserPaywallTx != ""
 }
 
+// piHookNewPre hook runs before each New command.
 func (c *Comments) piHookNewPre(u user.User) error {
 	if !c.paywallIsEnabled() {
 		return nil
@@ -41,6 +42,24 @@ func (c *Comments) piHookNewPre(u user.User) error {
 	return nil
 }
 
+// piHookEditPre hook runs before each Edit command.
+func (c *Comments) piHookEditPre(u user.User) error {
+	if !c.paywallIsEnabled() {
+		return nil
+	}
+
+	// Verify user has paid registration paywall
+	if !userHasPaid(u) {
+		return v1.PluginErrorReply{
+			PluginID:  user.PiUserPluginID,
+			ErrorCode: user.ErrorCodeUserRegistrationNotPaid,
+		}
+	}
+
+	return nil
+}
+
+// piHookVotePre hook runs before each Vote command.
 func (c *Comments) piHookVotePre(u user.User) error {
 	if !c.paywallIsEnabled() {
 		return nil

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -619,6 +619,8 @@ func convertComment(c comments.Comment) v1.Comment {
 		PublicKey:     c.PublicKey,
 		Signature:     c.Signature,
 		CommentID:     c.CommentID,
+		Version:       c.Version,
+		CreatedAt:     c.CreatedAt,
 		Timestamp:     c.Timestamp,
 		Receipt:       c.Receipt,
 		Downvotes:     c.Downvotes,

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -154,14 +154,6 @@ func (c *Comments) processEdit(ctx context.Context, e v1.Edit, u user.User) (*v1
 	cm := convertComment(*pdc)
 	commentPopulateUserData(&cm, u)
 
-	// Emit event
-	// XXX should we introduce a new event here?
-	c.events.Emit(EventTypeNew,
-		EventNew{
-			State:   e.State,
-			Comment: cm,
-		})
-
 	return &v1.EditReply{
 		Comment: cm,
 	}, nil

--- a/politeiawww/legacy/comments/process.go
+++ b/politeiawww/legacy/comments/process.go
@@ -114,7 +114,8 @@ func (c *Comments) processEdit(ctx context.Context, e v1.Edit, u user.User) (*v1
 		}
 	}
 
-	// Ensure that session user is the comment author
+	// Ensure that session user ID is identical to the user ID included in the
+	// edit request payload.
 	if u.ID.String() != e.UserID {
 		return nil, v1.UserErrorReply{
 			ErrorCode:    v1.ErrorCodeUnauthorized,

--- a/politeiawww/legacy/routes.go
+++ b/politeiawww/legacy/routes.go
@@ -398,6 +398,9 @@ func (p *Politeiawww) setPiRoutes(r *records.Records, c *comments.Comments, t *t
 		cmv1.RouteNew, c.HandleNew,
 		permissionLogin)
 	p.addRoute(http.MethodPost, cmv1.APIRoute,
+		cmv1.RouteEdit, c.HandleEdit,
+		permissionLogin)
+	p.addRoute(http.MethodPost, cmv1.APIRoute,
 		cmv1.RouteVote, c.HandleVote,
 		permissionLogin)
 	p.addRoute(http.MethodPost, cmv1.APIRoute,


### PR DESCRIPTION
This commit adds temporary comment edits feature.

**Implementation:**

 - Add two new settings to the comments plugin:
   - `allowedits` - global flag to enable comments edits.
   - `editperiodtime` - defines the maximum period of time in seconds
     where comments are still editable.

 - Add logic to `politeiad` to ensure edits are allowed only during the
   time interval set by the new `editperiodtime` setting.

 - Add the new settings to the comments API policy route reply.

 - Add an `/edit` route to the comment API.

 - Add a `pictl commentedit` command.
 
 ---
 
 Closes #1597.