### PR TITLE
politeiad: Cleanup deprecated page sizes

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -1858,7 +1858,7 @@ func (p *ticketVotePlugin) cmdTimestamps(token []byte, payload string) (string, 
 		auths   = make([]ticketvote.Timestamp, 0, 32)
 		details *ticketvote.Timestamp
 
-		pageSize = ticketvote.VoteTimestampsPageSize
+		pageSize = p.timestampsPageSize
 		votes    = make([]ticketvote.Timestamp, 0, pageSize)
 	)
 	switch {

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/inventory.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/inventory.go
@@ -372,7 +372,7 @@ func (p *ticketVotePlugin) invByStatusAll(bestBlock, pageSize uint32) (*invBySta
 // inventoryByStatus returns a page of tokens for the provided status. If no
 // status is provided then a page for each status will be returned.
 func (p *ticketVotePlugin) inventoryByStatus(bestBlock uint32, s ticketvote.VoteStatusT, page uint32) (*invByStatus, error) {
-	pageSize := ticketvote.InventoryPageSize
+	pageSize := p.inventoryPageSize
 
 	// If no status is provided a page of tokens for each status should
 	// be returned.

--- a/politeiad/plugins/ticketvote/ticketvote.go
+++ b/politeiad/plugins/ticketvote/ticketvote.go
@@ -653,12 +653,6 @@ type SubmissionsReply struct {
 	Submissions []string `json:"submissions"`
 }
 
-const (
-	// InventoryPageSize is the maximum number of tokens that will be
-	// returned for any single status in an InventoryReply.
-	InventoryPageSize uint32 = 20
-)
-
 // Inventory requests the tokens of public records in the inventory categorized
 // by vote status.
 //
@@ -719,17 +713,6 @@ type Timestamp struct {
 	MerkleRoot string  `json:"merkleroot"`
 	Proofs     []Proof `json:"proofs"`
 }
-
-const (
-	// VoteTimestampsPageSize is the maximum number of vote timestamps
-	// that will be returned for any single request. A vote timestamp
-	// is ~2000 bytes so a page of 100 votes will only be 0.2MB, but
-	// the bottleneck on this call is performance, not size. Its
-	// expensive to retrieve a large number of inclusion proofs from
-	// trillian. A 100 timestamps request will take ~1 second to
-	// complete.
-	VoteTimestampsPageSize uint32 = 100
-)
 
 // Timestamps requests the timestamps for a ticket vote.
 //


### PR DESCRIPTION
This diff ditches the ticketvote plugin page sizes which used to be defined as
constants. It uses the new page sizes which are defined as plugin settings.

This is a leftover from #1604.