### PR TITLE
pictl: `commenttimestamps` improvements.

### DIFF
--- a/politeiawww/cmd/pictl/cmdcomments.go
+++ b/politeiawww/cmd/pictl/cmdcomments.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"fmt"
-
 	cmv1 "github.com/decred/politeia/politeiawww/api/comments/v1"
 	pclient "github.com/decred/politeia/politeiawww/client"
 )
@@ -47,7 +45,7 @@ func (c *cmdComments) Execute(args []string) error {
 	// Print comments
 	for _, v := range cr.Comments {
 		printComment(v)
-		fmt.Printf("\n")
+		printf("\n")
 	}
 
 	return nil

--- a/politeiawww/cmd/pictl/cmdcommenttimestamps.go
+++ b/politeiawww/cmd/pictl/cmdcommenttimestamps.go
@@ -68,8 +68,9 @@ func (c *cmdCommentTimestamps) Execute(args []string) error {
 
 	// Timestamps route is paginated, request timestamps page by page.
 	var (
-		pageStartIdx int
-		fetched      int
+		pageStartIdx        int
+		fetched             int
+		totalNotTimestamped int
 	)
 	for pageStartIdx < len(commentIDs) {
 		pageEndIdx := pageStartIdx + int(pageSize)
@@ -98,11 +99,12 @@ func (c *cmdCommentTimestamps) Execute(args []string) error {
 			return err
 		}
 		if len(notTimestamped) > 0 {
-			printf("Not timestamped yet: %v\n", notTimestamped)
+			totalNotTimestamped = totalNotTimestamped + len(notTimestamped)
 		}
 
-		printf("Fetched timestampes of %v/%v comments \n", fetched,
-			len(commentIDs))
+		printf("Total number of comments: %v, fetched: %v, timestamped: %v, "+
+			"not timestamped: %v \n", len(commentIDs), fetched,
+			fetched-totalNotTimestamped, totalNotTimestamped)
 
 		// Next page start index
 		pageStartIdx = pageEndIdx

--- a/politeiawww/cmd/pictl/cmdcommenttimestamps.go
+++ b/politeiawww/cmd/pictl/cmdcommenttimestamps.go
@@ -55,7 +55,7 @@ func (c *cmdCommentTimestamps) Execute(args []string) error {
 
 	// If the proposal has no comments yet, nothing to do.
 	if len(commentIDs) == 0 {
-		printf("Proposal has no comments yet \n")
+		printf("Proposal has no comments \n")
 		return nil
 	}
 


### PR DESCRIPTION
This diff fixes a bug in `pictl commenttimestamps` where no timestamps
were fetched if the no comment IDs were provided, this is not the
expected behavior as it says in the `commenttimestamps` command help
message:

> If comment IDs are not provided then the timestamps for all comments will be
returned.

In addition, this commit adds pagination to the `commenttimestamps`
command to allow fetching all comment timestamps page by page when
a proposal has more than one page of comments. This also allows users to
request the timestamps of more than one page using the `commentIDs`
command argument.

--- 

Closes #1616.