### PR TITLE
ticketvote: Cache final timestamps.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/comments/timestamp.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/timestamp.go
@@ -97,7 +97,6 @@ func (p *commentsPlugin) saveTimestamps(token []byte, ts map[uint32]comments.Com
 	// Setup the blob entries
 	blobs := make(map[string][]byte, len(ts))
 	keys := make([]string, 0, len(ts))
-	commentIDs := make([]uint32, 0, len(ts))
 	for cid, v := range ts {
 		k, err := getTimestampKey(token, cid)
 		if err != nil {
@@ -109,7 +108,6 @@ func (p *commentsPlugin) saveTimestamps(token []byte, ts map[uint32]comments.Com
 		}
 		blobs[k] = b
 		keys = append(keys, k)
-		commentIDs = append(commentIDs, cid)
 	}
 
 	// Delete exisiting digests

--- a/politeiad/backendv2/tstorebe/plugins/comments/timestamp.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/timestamp.go
@@ -179,7 +179,7 @@ func getTimestampKey(token []byte, commentID uint32) (string, error) {
 func parseTimestampKey(key string) (uint32, error) {
 	s := strings.Split(key, "-")
 	if len(s) != 3 {
-		return 0, errors.Errorf("invalid timestamp key")
+		return 0, errors.Errorf("invalid comment timestamp key")
 	}
 	cid, err := strconv.ParseUint(s[2], 10, 64)
 	if err != nil {

--- a/politeiad/backendv2/tstorebe/plugins/comments/timestamp_test.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/timestamp_test.go
@@ -74,3 +74,53 @@ func TestGetTimestampKey(t *testing.T) {
 		})
 	}
 }
+
+func TestParseTimestampKey(t *testing.T) {
+	// Setup tests
+	tests := []struct {
+		name        string
+		cacheKey    string
+		shouldError bool
+		commentID   uint32
+	}{
+		{
+			name:        "success case",
+			cacheKey:    "timestamp-45154fb-8",
+			shouldError: false,
+			commentID:   8,
+		},
+		{
+			name:        "invalid key",
+			cacheKey:    "--",
+			shouldError: true,
+			commentID:   0,
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cid, err := parseTimestampKey(tc.cacheKey)
+			switch {
+			case tc.shouldError && err == nil:
+				// Wanted an error but didn't get one
+				t.Errorf("want error got nil")
+				return
+
+			case !tc.shouldError && err != nil:
+				// Wanted success but got an error
+				t.Errorf("want error nil, got '%v'", err)
+				return
+
+			case !tc.shouldError && err == nil:
+				// Verify result
+				if cid != tc.commentID {
+					// Expected key was not found, error
+					t.Errorf("unexpected comment ID; want: %v, got: %v", tc.commentID,
+						cid)
+				}
+				return
+			}
+		})
+	}
+}

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/cmds.go
@@ -1910,12 +1910,11 @@ func (p *ticketVotePlugin) cmdTimestamps(token []byte, payload string) (string, 
 
 			if len(votes) == int(pageSize) {
 				// We have a full page. We're done.
-				goto cachefinalts
+				break
 			}
 		}
 
 		// Cache final vote timestamps
-	cachefinalts:
 		err = p.cacheFinalVoteTimestamps(token, votes, t.VotesPage)
 		if err != nil {
 			return "", err

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/timestamp.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/timestamp.go
@@ -52,7 +52,7 @@ func (p *ticketVotePlugin) cacheFinalVoteTimestamps(token []byte, ts []ticketvot
 	return nil
 }
 
-// saveTimestamps saves a slice of vote timestamps to the key-value cache.
+// saveVoteTimestamps saves a slice of vote timestamps to the key-value cache.
 func (p *ticketVotePlugin) saveVoteTimestamps(token []byte, ts []ticketvote.Timestamp, page uint32) error {
 	// Setup the blob entries
 	blobs := make(map[string][]byte, len(ts))
@@ -116,7 +116,7 @@ func (p *ticketVotePlugin) cachedVoteTimestamps(token []byte, page, pageSize uin
 		ts[idx] = t
 	}
 
-	// XXX add debug statement
+	log.Debugf("Retrieved %v cached final vote timestamps", len(ts))
 	return ts, nil
 }
 
@@ -170,7 +170,7 @@ func (p *ticketVotePlugin) cacheFinalAuthTimestamps(token []byte, ts []ticketvot
 	return nil
 }
 
-// saveTimestamps saves a slice of vote timestamps to the key-value cache.
+// saveAuthTimestamps saves a slice of vote timestamps to the key-value cache.
 func (p *ticketVotePlugin) saveAuthTimestamps(token []byte, ts []ticketvote.Timestamp) error {
 	// Setup the blob entries
 	blobs := make(map[string][]byte, len(ts))
@@ -232,7 +232,7 @@ func (p *ticketVotePlugin) cachedAuthTimestamps(token []byte) ([]ticketvote.Time
 		ts[idx] = t
 	}
 
-	// XXX add debug statement
+	log.Debugf("Retrieved %v cached final auth timestamps", len(ts))
 	return ts, nil
 }
 
@@ -280,7 +280,7 @@ func (p *ticketVotePlugin) cacheFinalDetailsTimestamp(token []byte, t ticketvote
 	return nil
 }
 
-// saveTimestamps saves a slice of vote timestamps to the key-value cache.
+// saveDetailsTimestamp saves a slice of vote timestamps to the key-value cache.
 func (p *ticketVotePlugin) saveDetailsTimestamp(token []byte, t ticketvote.Timestamp) error {
 	// Setup the blob entry
 	blobs := make(map[string][]byte, 1)
@@ -332,8 +332,8 @@ func (p *ticketVotePlugin) cachedDetailsTimestamp(token []byte) (*ticketvote.Tim
 			return nil, err
 		}
 
-		// XXX add debug statement
-		// Return decoded timestamp
+		log.Debugf("Retrieved cached vote details for %v",
+			hex.EncodeToString(token))
 		return &t, nil
 	}
 

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/timestamp.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/timestamp.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ticketvote
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/decred/politeia/politeiad/plugins/ticketvote"
+	"github.com/decred/politeia/util"
+	"github.com/pkg/errors"
+)
+
+const (
+	// timestampKeyVote is the key for a ticket vote timestamp entry in the
+	// key-value store cache.
+	timestampKeyVote = "timestamp-vote-{shorttoken}-{page}-{index}"
+
+	// timestampKeyAuth is the key for a vote auth timestamp entry in the
+	// key-value store cache.
+	timestampKeyAuth = "timestamp-auth-{shorttoken}-{index}"
+
+	// timestampKeyDetails is the key for a vote details timestamp entry in the
+	// key-value store cache.
+	timestampKeyDetails = "timestamp-details-{shorttoken}"
+)
+
+// cacheFinalVoteTimestamps accepts a slice of vote timestamps, it collects the
+// final timestamps then stores them in the key-value store.
+func (p *ticketVotePlugin) cacheFinalVoteTimestamps(token []byte, vts []ticketvote.Timestamp, page uint32) error {
+	// Collect final timestamps
+	fvts := make([]ticketvote.Timestamp, 0, len(vts))
+	for _, ts := range vts {
+		if timestampIsFinal(ts) {
+			fvts = append(fvts, ts)
+		}
+	}
+
+	// Store final timestamp
+	err := p.saveVoteTimestamps(token, fvts, page)
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Cached final vote timestamps of %v/%v",
+		len(fvts), len(vts))
+	return nil
+}
+
+// saveTimestamps saves a slice of vote timestamps to the key-value cache.
+func (p *ticketVotePlugin) saveVoteTimestamps(token []byte, ts []ticketvote.Timestamp, page uint32) error {
+	// Setup the blob entries
+	blobs := make(map[string][]byte, len(ts))
+	keys := make([]string, 0, len(ts))
+	for i, v := range ts {
+		k, err := getVoteTimestampKey(token, page, uint32(i))
+		if err != nil {
+			return err
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		blobs[k] = b
+		keys = append(keys, k)
+	}
+
+	// Delete exisiting digests
+	err := p.tstore.CacheDel(keys)
+	if err != nil {
+		return err
+	}
+
+	// Save the blob entries
+	return p.tstore.CachePut(blobs, false)
+}
+
+// cachedVoteTimestamps returns cached vote timestamps if they exist. It
+// accepts the requested page as the vote timestamps request is paginated and
+// both the page number and the vote index are part of the vote's cache key.
+func (p *ticketVotePlugin) cachedVoteTimestamps(token []byte, page, pageSize uint32) ([]ticketvote.Timestamp, error) {
+	// Setup the timestamps
+	keys := make([]string, 0, pageSize)
+	for i := uint32(1); i <= pageSize; i++ {
+		key, err := getVoteTimestampKey(token, page, i)
+		if err != nil {
+			return nil, err
+		}
+
+		keys = append(keys, key)
+	}
+
+	// Get the timestamp blob entries
+	blobs, err := p.tstore.CacheGet(keys)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode the timestamps
+	ts := make([]ticketvote.Timestamp, 0, pageSize)
+	for k, v := range blobs {
+		var t ticketvote.Timestamp
+		err := json.Unmarshal(v, &t)
+		if err != nil {
+			return nil, err
+		}
+		idx, err := parseVoteTimestampKey(k)
+		if err != nil {
+			return nil, err
+		}
+		ts[idx] = t
+	}
+
+	// XXX add debug statement
+	return ts, nil
+}
+
+// getVoteTimestampVoteKey returns the key for a vote timestamp in the key-value
+// store cache.
+func getVoteTimestampKey(token []byte, page, index uint32) (string, error) {
+	t, err := util.ShortTokenEncode(token)
+	if err != nil {
+		return "", err
+	}
+	pageStr := strconv.FormatUint(uint64(page), 10)
+	indexStr := strconv.FormatUint(uint64(index), 10)
+	key := strings.Replace(timestampKeyVote, "{shorttoken}", t, 1)
+	key = strings.Replace(key, "{page}", pageStr, 1)
+	key = strings.Replace(key, "{index}", indexStr, 1)
+	return key, nil
+}
+
+// parseTimestampKeyVote parses the item index from a vote timestamp key.
+func parseVoteTimestampKey(key string) (uint32, error) {
+	s := strings.Split(key, "-")
+	if len(s) != 5 {
+		return 0, errors.Errorf("invalid timestamp key")
+	}
+	index, err := strconv.ParseUint(s[4], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(index), nil
+}
+
+// timestampIsFinal returns whether the timestamp is considered to be final and
+// will not change in the future. Once the TxID is present then the timestamp
+// is considered to be final since it has been included in a DCR transaction.
+func timestampIsFinal(t ticketvote.Timestamp) bool {
+	return t.TxID != ""
+}

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/timestamp_test.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/timestamp_test.go
@@ -1,0 +1,321 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ticketvote
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestGetVoteTimestampKey(t *testing.T) {
+	token := "45154fb45664714b"
+
+	// Setup tests
+	tests := []struct {
+		name        string
+		token       string
+		page        uint32
+		index       uint32
+		shouldError bool
+		cacheKey    string
+	}{
+		{
+			name:        "success case 1",
+			token:       token,
+			page:        1,
+			index:       0,
+			shouldError: false,
+			cacheKey:    "timestamp-vote-45154fb-1-0",
+		},
+		{
+			name:        "success case 2",
+			token:       token,
+			page:        3,
+			index:       9,
+			shouldError: false,
+			cacheKey:    "timestamp-vote-45154fb-3-9",
+		},
+		{
+			name:        "invalid token",
+			token:       "",
+			page:        1,
+			index:       9,
+			shouldError: true,
+			cacheKey:    "",
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Convert token to []byte if set
+			var (
+				tokenb []byte
+				err    error
+			)
+			if tc.token != "" {
+				tokenb, err = hex.DecodeString(tc.token)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			cacheKey, err := getVoteTimestampKey(tokenb, tc.page, tc.index)
+			switch {
+			case tc.shouldError && err == nil:
+				// Wanted an error but didn't get one
+				t.Errorf("want error got nil")
+				return
+
+			case !tc.shouldError && err != nil:
+				// Wanted success but got an error
+				t.Errorf("want error nil, got '%v'", err)
+				return
+
+			case !tc.shouldError && err == nil:
+				// Verify result
+				if cacheKey != tc.cacheKey {
+					// Expected key was not found, error
+					t.Errorf("unexpected cache key; want: %v, got: %v", tc.cacheKey,
+						cacheKey)
+				}
+				return
+			}
+		})
+	}
+}
+
+func TestGetAuthTimestampKey(t *testing.T) {
+	token := "45154fb45664714b"
+
+	// Setup tests
+	tests := []struct {
+		name        string
+		token       string
+		index       uint32
+		shouldError bool
+		cacheKey    string
+	}{
+		{
+			name:        "success case 1",
+			token:       token,
+			index:       0,
+			shouldError: false,
+			cacheKey:    "timestamp-auth-45154fb-0",
+		},
+		{
+			name:        "success case 2",
+			token:       token,
+			index:       255,
+			shouldError: false,
+			cacheKey:    "timestamp-auth-45154fb-255",
+		},
+		{
+			name:        "invalid token",
+			token:       "",
+			index:       9,
+			shouldError: true,
+			cacheKey:    "",
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Convert token to []byte if set
+			var (
+				tokenb []byte
+				err    error
+			)
+			if tc.token != "" {
+				tokenb, err = hex.DecodeString(tc.token)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			cacheKey, err := getAuthTimestampKey(tokenb, tc.index)
+			switch {
+			case tc.shouldError && err == nil:
+				// Wanted an error but didn't get one
+				t.Errorf("want error got nil")
+				return
+
+			case !tc.shouldError && err != nil:
+				// Wanted success but got an error
+				t.Errorf("want error nil, got '%v'", err)
+				return
+
+			case !tc.shouldError && err == nil:
+				// Verify result
+				if cacheKey != tc.cacheKey {
+					// Expected key was not found, error
+					t.Errorf("unexpected cache key; want: %v, got: %v", tc.cacheKey,
+						cacheKey)
+				}
+				return
+			}
+		})
+	}
+}
+
+func TestGetDetailsTimestampKey(t *testing.T) {
+	token := "45154fb45664714b"
+
+	// Setup tests
+	tests := []struct {
+		name        string
+		token       string
+		shouldError bool
+		cacheKey    string
+	}{
+		{
+			name:        "success case 1",
+			token:       token,
+			shouldError: false,
+			cacheKey:    "timestamp-details-45154fb",
+		},
+		{
+			name:        "invalid token",
+			token:       "",
+			shouldError: true,
+			cacheKey:    "",
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Convert token to []byte if set
+			var (
+				tokenb []byte
+				err    error
+			)
+			if tc.token != "" {
+				tokenb, err = hex.DecodeString(tc.token)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			cacheKey, err := getDetailsTimestampKey(tokenb)
+			switch {
+			case tc.shouldError && err == nil:
+				// Wanted an error but didn't get one
+				t.Errorf("want error got nil")
+				return
+
+			case !tc.shouldError && err != nil:
+				// Wanted success but got an error
+				t.Errorf("want error nil, got '%v'", err)
+				return
+
+			case !tc.shouldError && err == nil:
+				// Verify result
+				if cacheKey != tc.cacheKey {
+					// Expected key was not found, error
+					t.Errorf("unexpected cache key; want: %v, got: %v", tc.cacheKey,
+						cacheKey)
+				}
+				return
+			}
+		})
+	}
+}
+
+func TestParseVoteTimestampKey(t *testing.T) {
+	// Setup tests
+	tests := []struct {
+		name        string
+		cacheKey    string
+		shouldError bool
+		index       uint32
+	}{
+		{
+			name:        "success case",
+			cacheKey:    "timestamp-vote-45154fb-1-8",
+			shouldError: false,
+			index:       8,
+		},
+		{
+			name:        "invalid key",
+			cacheKey:    "--",
+			shouldError: true,
+			index:       0,
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			index, err := parseVoteTimestampKey(tc.cacheKey)
+			switch {
+			case tc.shouldError && err == nil:
+				// Wanted an error but didn't get one
+				t.Errorf("want error got nil")
+				return
+
+			case !tc.shouldError && err != nil:
+				// Wanted success but got an error
+				t.Errorf("want error nil, got '%v'", err)
+				return
+
+			case !tc.shouldError && err == nil:
+				// Verify result
+				if index != tc.index {
+					// Expected key was not found, error
+					t.Errorf("unexpected index; want: %v, got: %v", tc.index, index)
+				}
+				return
+			}
+		})
+	}
+}
+
+func TestParseAuthTimestampKey(t *testing.T) {
+	// Setup tests
+	tests := []struct {
+		name        string
+		cacheKey    string
+		shouldError bool
+		index       uint32
+	}{
+		{
+			name:        "success case",
+			cacheKey:    "timestamp-auth-45154fb-109",
+			shouldError: false,
+			index:       109,
+		},
+		{
+			name:        "invalid key",
+			cacheKey:    "---",
+			shouldError: true,
+			index:       0,
+		},
+	}
+
+	// Run tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			index, err := parseAuthTimestampKey(tc.cacheKey)
+			switch {
+			case tc.shouldError && err == nil:
+				// Wanted an error but didn't get one
+				t.Errorf("want error got nil")
+				return
+
+			case !tc.shouldError && err != nil:
+				// Wanted success but got an error
+				t.Errorf("want error nil, got '%v'", err)
+				return
+
+			case !tc.shouldError && err == nil:
+				// Verify result
+				if index != tc.index {
+					// Expected key was not found, error
+					t.Errorf("unexpected index; want: %v, got: %v", tc.index, index)
+				}
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
This diff improves the performance of retrieving cast vote, vote auth
and vote details timestamps from ticketvote plugin. It uses the
key-value store to cache final timestamps which have been timestamped on
the DCR chain as the performance of evaluating it on runtime is
proportional to the tree size which makes it unacceptably slow in prod
where the trees has ~30k leaves.

**Benchmark:** 

I have tested the performance improvements of this commit locally with a
proposal which has a tlog tree with ~10k leaves(comments) with 5 ticket
votes, and had x5 faster response times.

before:

```
$ pictl votetimestamps 328d27b 1 --timer
---Timer Stats---
  Start  : 27 Jan 2022 5:16:07pm
  Stop   : 27 Jan 2022 5:16:07pm
  Elapsed: 367.31476ms
```

after:
```
$ pictl votetimestamps 328d27b 1 --timer
---Timer Stats---
  Start  : 27 Jan 2022 5:16:11pm
  Stop   : 27 Jan 2022 5:16:11pm
  Elapsed: 70.555078ms
```


---

Part of #1538 