### PR TITLE
pi: Fix LegacyToken errors.

### DIFF
--- a/politeiad/plugins/pi/pi.go
+++ b/politeiad/plugins/pi/pi.go
@@ -298,10 +298,6 @@ const (
 // proposal signature since it is user specified data. The ProposalMetadata
 // object is saved to politeiad as a file, not as a metadata stream, since it
 // needs to be included in the merkle root that politeiad signs.
-//
-// Only proposals which have been imported from the old gitbe backend would
-// have their legacy token stored in LegacyToken field. This field can not
-// be set during normal proposal submissions.
 type ProposalMetadata struct {
 	Name      string `json:"name"`
 	Amount    uint64 `json:"amount"`    // Funding amount in cents
@@ -309,7 +305,15 @@ type ProposalMetadata struct {
 	EndDate   int64  `json:"enddate"`   // Estimated end date, Unix time
 	Domain    string `json:"domain"`    // Proposal domain
 
-	LegacyToken string `json:"legacytoken"` // Legacy gitbe token
+	// LegacyToken will only be set for legacy proposals that have been imported
+	// from the deprecated git backend into the tstore backend. The LegacyToken
+	// corresponds to the original token that was assigned to the proposal during
+	// submission to the git backed. This token is not used for anything in the
+	// current tstore backend, but can be used to lookup the proposal's original
+	// timestamps in the legacy proposal git repo. The proposal is assigned a
+	// new token by the tstore backend on import. An error is returned if this
+	// field is attempted to be set during normal proposal submissions.
+	LegacyToken string `json:"legacytoken,omitempty"`
 }
 
 // BillingStatusT represents the billing status of a proposal that has been

--- a/politeiawww/api/pi/v1/v1.go
+++ b/politeiawww/api/pi/v1/v1.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -161,6 +161,16 @@ type ProposalMetadata struct {
 	StartDate int64  `json:"startdate"` // Start date, Unix time
 	EndDate   int64  `json:"enddate"`   // Estimated end date, Unix time
 	Domain    string `json:"domain"`    // Proposal domain
+
+	// LegacyToken will only be set for legacy proposals that have been imported
+	// from the deprecated git backend into the tstore backend. The LegacyToken
+	// corresponds to the original token that was assigned to the proposal during
+	// submission to the git backed. This token is not used for anything in the
+	// current tstore backend, but can be used to lookup the proposal's original
+	// timestamps in the legacy proposal git repo. The proposal is assigned a
+	// new token by the tstore backend on import. An error is returned if this
+	// field is attempted to be set during normal proposal submissions.
+	LegacyToken string `json:"legacytoken,omitempty"`
 }
 
 // VoteMetadata is metadata that is specified by the user on proposal


### PR DESCRIPTION
This fixes two issues with commit 38b63bd.

1. LegacyToken should have the omitempty JSON tag since it will only be
   set for certain proposals and the field should not be included in the
   encoded JSON that is saved to disk if it is empty.
2. LegacyToken was not added to the politeiawww pi API.