### PR TITLE
mysql: Fix column naming bug.

### DIFF
--- a/politeiawww/legacy/user/mysql/mysql.go
+++ b/politeiawww/legacy/user/mysql/mysql.go
@@ -715,7 +715,7 @@ func (m *mysql) InsertUser(u user.User) error {
 		CreatedAt: time.Now().Unix(),
 	}
 	_, err = m.userDB.ExecContext(ctx,
-		"INSERT INTO users (ID, username, uBlob, createdAt) VALUES (?, ?, ?, ?)",
+		"INSERT INTO users (id, username, u_blob, created_at) VALUES (?, ?, ?, ?)",
 		ur.ID, ur.Username, ur.Blob, ur.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("insert user: %v", err)


### PR DESCRIPTION
This fixes some incorrectly named columns in a sql insert statement. 
The statement was part of a function that is only used during database
migrations, so it does not impact normal operation.

This bug was introduced by 5b5c5ed71.