### PR TITLE
pi: Fix min start date setting bug.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/pi/pi.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/pi.go
@@ -299,6 +299,14 @@ func New(backend backend.Backend, tstore plugins.TstoreClient, settings []backen
 			}
 			endDateMax = u
 
+		case pi.SettingKeyProposalStartDateMin:
+			i, err := strconv.ParseInt(v.Value, 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("invalid plugin setting %v '%v': %v",
+					v.Key, v.Value, err)
+			}
+			startDateMin = i
+
 		case pi.SettingKeyProposalDomains:
 			err := json.Unmarshal([]byte(v.Value), &domains)
 			if err != nil {


### PR DESCRIPTION
The min start date plugin setting was not being recognized as a plugin
setting.

This bug was introduced by 8c95e6412.