### PR TITLE
mysql: Improve error handling.

### DIFF
--- a/politeiad/backendv2/tstorebe/store/mysql/encrypt_test.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/encrypt_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2020-2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package mysql
 
 import (

--- a/politeiad/backendv2/tstorebe/store/mysql/mysql_test.go
+++ b/politeiad/backendv2/tstorebe/store/mysql/mysql_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,7 +15,7 @@ import (
 )
 
 // newTestMySQL returns a new mysql structure that has been setup for testing.
-func newTestMySQL(t *testing.T) (*mysql, func()) {
+func newTestMySQL(t *testing.T) (*mysqlCtx, func()) {
 	t.Helper()
 
 	// Setup the mock sql database
@@ -29,7 +29,7 @@ func newTestMySQL(t *testing.T) (*mysql, func()) {
 	}
 
 	// Setup the mysql struct
-	s := &mysql{
+	s := &mysqlCtx{
 		db:      db,
 		testing: true,
 		mock:    mock,
@@ -60,7 +60,7 @@ func TestGet(t *testing.T) {
 
 // testGetSingleQuery tests the mysql Get() method when the number of records
 // being retrieved can be fit into a single MySQL SELECT statement.
-func testGetSingleQuery(t *testing.T, s *mysql) {
+func testGetSingleQuery(t *testing.T, s *mysqlCtx) {
 	var (
 		// Test params
 		key1   = "key1"
@@ -110,7 +110,7 @@ func testGetSingleQuery(t *testing.T, s *mysql) {
 // testGetMultiQuery tests the mysql Get() method when the number of records
 // being retrieved cannot fit into a single MySQL SELECT statement and must
 // be broken up into multiple SELECT statements.
-func testGetMultiQuery(t *testing.T, s *mysql) {
+func testGetMultiQuery(t *testing.T, s *mysqlCtx) {
 	// Prepare the test data. The maximum number of records
 	// that can be returned in a single SELECT statement is
 	// limited by the maxPlaceholders variable. We multiply

--- a/politeiad/backendv2/tstorebe/store/store.go
+++ b/politeiad/backendv2/tstorebe/store/store.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -16,14 +16,19 @@ import (
 )
 
 var (
-	// ErrShutdown is returned when a action is attempted against a
-	// store that is shutdown.
+	// ErrShutdown is returned when a action is attempted against a store that
+	// is shutdown.
 	ErrShutdown = errors.New("store is shutdown")
+
+	// ErrDuplicateEntry is returned when a blob is attempted to be saved using
+	// a key that already exists in the database. Automatic overwrites are not
+	// allowed by the key-value store. When a caller receives this error, it can
+	// decide if it would like to manually delete the entry and save a new one.
+	ErrDuplicateEntry = errors.New("duplicate entry")
 )
 
 const (
-	// DataTypeStructure describes a blob entry that contains a
-	// structure.
+	// DataTypeStructure describes a blob entry that contains a structure.
 	DataTypeStructure = "struct"
 )
 
@@ -90,20 +95,29 @@ func Deblob(blob []byte) (*BlobEntry, error) {
 
 // BlobKV represents a blob key-value store.
 type BlobKV interface {
-	// Put saves the provided key-value pairs to the store. This
-	// operation is performed atomically.
+	// Put saves the provided key-value pairs to the store.
+	//
+	// Overwrites are not allowed by the key-value store. If the caller
+	// attempts to save a blob using a key that already exists in the
+	// key-value store, a ErrDuplicateEntry will be returned. It is up
+	// to the caller to decide if it would like to manually delete the
+	// entry and save a new one.
+	//
+	// This operation is performed atomically.
 	Put(blobs map[string][]byte, encrypt bool) error
 
-	// Del deletes the provided blobs from the store. This operation
-	// is performed atomically.
+	// Del deletes the key-value store entries for the provided keys.
+	//
+	// This operation is performed atomically.
 	Del(keys []string) error
 
-	// Get returns blobs from the store for the provided keys. An entry
-	// will not exist in the returned map if for any blobs that are not
-	// found. It is the responsibility of the caller to ensure a blob
-	// was returned for all provided keys.
+	// Get returns the blob entries from the store for the provided keys.
+	//
+	// An entry will not exist in the returned map if for any blobs that
+	// are not found. It is the responsibility of the caller to ensure a
+	// blob was returned for all provided keys.
 	Get(keys []string) (map[string][]byte, error)
 
-	// Closes closes the store connection.
+	// Close closes the store connection.
 	Close()
 }


### PR DESCRIPTION
This commit improves the error handling of the key-value store mysql
implementation with the following changes:

- Renames the mysql structure to mysqlCtx, so that mysql refers to the
  mysql driver package. This allows us to reference errors from the
  mysql driver package.

- Updates the put() function to returned a ErrDuplicateEntry error when
  the caller is attempting to save data using a key that already exists
  in the database. Automatic overwrites are not allowed by the key-value
  store. Returning this error allows the caller to decide if it would
  like to manually delete the entry and save a newer version of it.

- Replaces fmt.Errorf errors with errors.Errorf errors so that stack
  traces are available.