### PR TITLE
politeiad: Remove leveldb tstore config option.

### DIFF
--- a/politeiad/backendv2/tstorebe/tstore/testing.go
+++ b/politeiad/backendv2/tstorebe/tstore/testing.go
@@ -23,7 +23,7 @@ func NewTestTstore(t *testing.T, dataDir string) *Tstore {
 	}
 
 	// Setup key-value store
-	fp, err := os.MkdirTemp(dataDir, storeDirname)
+	fp, err := os.MkdirTemp(dataDir, "kv")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/politeiad/backendv2/tstorebe/tstorebe.go
+++ b/politeiad/backendv2/tstorebe/tstorebe.go
@@ -1122,10 +1122,10 @@ func (t *tstoreBackend) setup() error {
 }
 
 // New returns a new tstoreBackend.
-func New(appDir, dataDir string, anp *chaincfg.Params, tlogHost, dbType, dbHost, dbPass, dcrtimeHost, dcrtimeCert string) (*tstoreBackend, error) {
+func New(appDir, dataDir string, anp *chaincfg.Params, tlogHost, dbHost, dbPass, dcrtimeHost, dcrtimeCert string) (*tstoreBackend, error) {
 	// Setup tstore instances
 	ts, err := tstore.New(appDir, dataDir, anp, tlogHost,
-		dbType, dbHost, dbPass, dcrtimeHost, dcrtimeCert)
+		dbHost, dbPass, dcrtimeHost, dcrtimeCert)
 	if err != nil {
 		return nil, fmt.Errorf("new tstore: %v", err)
 	}

--- a/politeiad/config.go
+++ b/politeiad/config.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/decred/dcrd/dcrutil/v3"
 	v1 "github.com/decred/dcrtime/api/v1"
-	"github.com/decred/politeia/politeiad/backendv2/tstorebe/tstore"
 	"github.com/decred/politeia/util"
 	"github.com/decred/politeia/util/version"
 	flags "github.com/jessevdk/go-flags"
@@ -46,7 +45,6 @@ const (
 	defaultBackend = backendTstore
 
 	// Tstore default settings
-	defaultDBType   = tstore.DBTypeLevelDB
 	defaultDBHost   = "localhost:3306" // MySQL default host
 	defaultTlogHost = "localhost:8090"
 
@@ -117,7 +115,6 @@ type config struct {
 	DcrdataHost string `long:"dcrdatahost" description:"Dcrdata ip:port"`
 
 	// Tstore backend options
-	DBType   string `long:"dbtype" description:"Database type"`
 	DBHost   string `long:"dbhost" description:"Database ip:port"`
 	DBPass   string // Provided in env variable "DBPASS"
 	TlogHost string `long:"tloghost" description:"Trillian log ip:port"`
@@ -277,7 +274,6 @@ func loadConfig() (*config, []string, error) {
 		ReadTimeout:      defaultReadTimeout,
 		WriteTimeout:     defaultWriteTimeout,
 		ReqBodySizeLimit: defaultReqBodySizeLimit,
-		DBType:           defaultDBType,
 		DBHost:           defaultDBHost,
 		TlogHost:         defaultTlogHost,
 	}
@@ -582,18 +578,12 @@ func loadConfig() (*config, []string, error) {
 // verifyTstoreSettings verifies the config settings that are specific to the
 // tstore backend.
 func verifyTstoreSettings(cfg *config) error {
-	// Verify tstore backend database choice
-	switch cfg.DBType {
-	case tstore.DBTypeLevelDB:
-		// Allowed; continue
-	case tstore.DBTypeMySQL:
-		// The database password is provided in an env variable
-		cfg.DBPass = os.Getenv(envDBPass)
-		if cfg.DBPass == "" {
-			return fmt.Errorf("dbpass not found; you must provide the " +
-				"database password for the politeiad user in the env " +
-				"variable DBPASS")
-		}
+	// Parse the database password. It is provided in an env variable.
+	cfg.DBPass = os.Getenv(envDBPass)
+	if cfg.DBPass == "" {
+		return fmt.Errorf("dbpass not found; you must provide the " +
+			"database password for the politeiad user in the env " +
+			"variable DBPASS")
 	}
 
 	// Verify tlog options

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -274,9 +274,9 @@ func (p *politeia) setupBackendTstore(anp *chaincfg.Params) error {
 		return errors.Errorf("router must be initialized")
 	}
 
-	b, err := tstorebe.New(p.cfg.HomeDir, p.cfg.DataDir, anp,
-		p.cfg.TlogHost, p.cfg.DBType, p.cfg.DBHost,
-		p.cfg.DBPass, p.cfg.DcrtimeHost, p.cfg.DcrtimeCert)
+	b, err := tstorebe.New(p.cfg.HomeDir, p.cfg.DataDir,
+		anp, p.cfg.TlogHost, p.cfg.DBHost, p.cfg.DBPass,
+		p.cfg.DcrtimeHost, p.cfg.DcrtimeCert)
 	if err != nil {
 		return fmt.Errorf("new tstorebe: %v", err)
 	}


### PR DESCRIPTION
This commit removes the ability to use leveldb as the tstore key-value
store.

tstore already requires a MySQL instance to be running since trillian
uses MySQL. It doesn't make a whole lot of sense to have a config option
to use leveldb as the tstore key-value store since MySQL is already a
requirement. Removing this option simplifies the politeiad setup and
makes the code easier to maintain. MySQL is now used by default.

If we move the trillian functionality into politeia and remove the
trillian dependency at some point in the future, then it may make sense
to add a leveldb key-value store option back in.