### PR TITLE
tstorebe/store: Allow put overwrites.

### DIFF
--- a/politeiad/backendv2/tstorebe/store/localdb/localdb.go
+++ b/politeiad/backendv2/tstorebe/store/localdb/localdb.go
@@ -51,8 +51,10 @@ func (l *localdb) decrypt(data []byte) ([]byte, uint32, error) {
 	return sbox.Decrypt(&l.key, data)
 }
 
-// Put saves the provided key-value pairs to the store. This operation is
-// performed atomically.
+// Put saves the provided key-value entries to the database. New entries are
+// inserted. Existing entries are updated.
+//
+// This operation is atomic.
 //
 // This function satisfies the store BlobKV interface.
 func (l *localdb) Put(blobs map[string][]byte, encrypt bool) error {
@@ -90,8 +92,9 @@ func (l *localdb) Put(blobs map[string][]byte, encrypt bool) error {
 	return nil
 }
 
-// Del deletes the provided blobs from the store. This operation is performed
-// atomically.
+// Del deletes the key-value entries from the database for the provided keys.
+//
+// This operation is atomic.
 //
 // This function satisfies the store BlobKV interface.
 func (l *localdb) Del(keys []string) error {
@@ -121,10 +124,11 @@ func isEncrypted(b []byte) bool {
 	return bytes.HasPrefix(b, []byte("sbox"))
 }
 
-// Get returns blobs from the store for the provided keys. An entry will not
-// exist in the returned map if for any blobs that are not found. It is the
-// responsibility of the caller to ensure a blob was returned for all provided
-// keys.
+// Get retrieves the key-value entries from the database for the provided keys.
+//
+// An entry will not exist in the returned map for any blobs that are not
+// found. It is the responsibility of the caller to ensure a blob was returned
+// for all provided keys.
 //
 // This function satisfies the store BlobKV interface.
 func (l *localdb) Get(keys []string) (map[string][]byte, error) {
@@ -165,7 +169,7 @@ func (l *localdb) Get(keys []string) (map[string][]byte, error) {
 	return blobs, nil
 }
 
-// Closes closes the store connection.
+// Close closes the database connection.
 //
 // This function satisfies the store BlobKV interface.
 func (l *localdb) Close() {

--- a/politeiad/backendv2/tstorebe/store/store.go
+++ b/politeiad/backendv2/tstorebe/store/store.go
@@ -19,12 +19,6 @@ var (
 	// ErrShutdown is returned when a action is attempted against a store that
 	// is shutdown.
 	ErrShutdown = errors.New("store is shutdown")
-
-	// ErrDuplicateEntry is returned when a blob is attempted to be saved using
-	// a key that already exists in the database. Automatic overwrites are not
-	// allowed by the key-value store. When a caller receives this error, it can
-	// decide if it would like to manually delete the entry and save a new one.
-	ErrDuplicateEntry = errors.New("duplicate entry")
 )
 
 const (
@@ -95,29 +89,25 @@ func Deblob(blob []byte) (*BlobEntry, error) {
 
 // BlobKV represents a blob key-value store.
 type BlobKV interface {
-	// Put saves the provided key-value pairs to the store.
+	// Put saves the provided key-value entries to the database. New entries are
+	// inserted. Existing entries are updated.
 	//
-	// Overwrites are not allowed by the key-value store. If the caller
-	// attempts to save a blob using a key that already exists in the
-	// key-value store, a ErrDuplicateEntry will be returned. It is up
-	// to the caller to decide if it would like to manually delete the
-	// entry and save a new one.
-	//
-	// This operation is performed atomically.
+	// This operation is atomic.
 	Put(blobs map[string][]byte, encrypt bool) error
 
-	// Del deletes the key-value store entries for the provided keys.
+	// Del deletes the key-value entries from the database for the provided keys.
 	//
-	// This operation is performed atomically.
+	// This operation is atomic.
 	Del(keys []string) error
 
-	// Get returns the blob entries from the store for the provided keys.
+	// Get retrieves the key-value entries from the database for the provided
+	// keys.
 	//
-	// An entry will not exist in the returned map if for any blobs that
-	// are not found. It is the responsibility of the caller to ensure a
-	// blob was returned for all provided keys.
+	// An entry will not exist in the returned map for any blobs that are not
+	// found. It is the responsibility of the caller to ensure a blob was
+	// returned for all provided keys.
 	Get(keys []string) (map[string][]byte, error)
 
-	// Close closes the store connection.
+	// Close closes the database connection.
 	Close()
 }


### PR DESCRIPTION
This commit updates the tstore backend key-value store to allow for
overwrites when using the Put() method. New entries are inserted.
Existing entries are updated.

After reviewing the tstore architecture, I realized that the duplicate
entry error that was added in 950620c was the wrong way to handle
duplicate key errors.

tstore saves data using a 2-step process. Step 1, save the data to the
key-value store. Step 2, append the hash of the data onto the trillian
tree. If step 2 fails, the key-value store entries are not unwound, they
are simply left in the key-value store. It was originally setup like
this to keep the required database primitives as simple as possible to
allow for flexibility in the database choice. The thought was that, at
some point in the future, it might be possible to drop in a
decentralized storage technology as the backing key-value store.

In the above scenerio where step 2 fails, any attempts to resubmit the
data would result in a duplicate key error if the data was unchanged.
This is why the Put() method is being updated to allow for overwrites.