### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/politeiad/backend/gitbe/git_test.go
+++ b/politeiad/backend/gitbe/git_test.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"bytes"
 	"compress/zlib"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -27,21 +26,16 @@ func (w *testWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func newGitBackEnd() *gitBackEnd {
-	dir, err := os.MkdirTemp("", "politeiad.test")
-	if err != nil {
-		panic(fmt.Sprintf("%v", err))
-	}
+func newGitBackEnd(t *testing.T) *gitBackEnd {
 	return &gitBackEnd{
-		root:     dir,
+		root:     t.TempDir(),
 		gitPath:  "git", // assume installed
 		gitTrace: true,
 	}
 }
 
 func TestVersion(t *testing.T) {
-	g := newGitBackEnd()
-	defer os.RemoveAll(g.root)
+	g := newGitBackEnd(t)
 
 	_, err := g.gitVersion()
 	if err != nil {
@@ -52,8 +46,7 @@ func TestVersion(t *testing.T) {
 func TestInit(t *testing.T) {
 	log := slog.NewBackend(&testWriter{t}).Logger("TEST")
 	UseLogger(log)
-	g := newGitBackEnd()
-	defer os.RemoveAll(g.root)
+	g := newGitBackEnd(t)
 
 	err := g.gitInitRepo(g.root, defaultRepoConfig)
 	if err != nil {
@@ -64,8 +57,7 @@ func TestInit(t *testing.T) {
 func TestLog(t *testing.T) {
 	log := slog.NewBackend(&testWriter{t}).Logger("TEST")
 	UseLogger(log)
-	g := newGitBackEnd()
-	defer os.RemoveAll(g.root)
+	g := newGitBackEnd(t)
 
 	_, err := g.gitInit(g.root)
 	if err != nil {
@@ -82,8 +74,7 @@ func TestFsck(t *testing.T) {
 	// Test git fsck, we build on top of that with a dcrtime fsck
 	log := slog.NewBackend(&testWriter{t}).Logger("TEST")
 	UseLogger(log)
-	g := newGitBackEnd()
-	defer os.RemoveAll(g.root)
+	g := newGitBackEnd(t)
 
 	// Init git repo
 	err := g.gitInitRepo(g.root, defaultRepoConfig)

--- a/politeiad/backend/gitbe/gitbe_test.go
+++ b/politeiad/backend/gitbe/gitbe_test.go
@@ -78,11 +78,7 @@ func TestAnchorWithCommits(t *testing.T) {
 	log := slog.NewBackend(&testWriter{t}).Logger("TEST")
 	UseLogger(log)
 
-	dir, err := os.MkdirTemp("", "politeia.test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Initialize stuff we need
 	g, err := New(chaincfg.TestNet3Params(), dir, "", "", nil,
@@ -403,11 +399,7 @@ func TestAnchorWithCommits(t *testing.T) {
 }
 
 func TestFilePathVersion(t *testing.T) {
-	dir, err := os.MkdirTemp("", "pathversion")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	t.Logf("dir: %v", dir)
 	d, err := _joinLatest(dir)
@@ -468,11 +460,7 @@ func TestFilePathVersion(t *testing.T) {
 }
 
 func TestUpdateReadme(t *testing.T) {
-	dir, err := os.MkdirTemp("", "politeia.test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	g, err := New(chaincfg.TestNet3Params(), dir, "", "", nil,
 		testing.Verbose(), "")
@@ -576,11 +564,7 @@ func TestTokenPrefixGeneration(t *testing.T) {
 	updateTokenPrefixLength(1)
 	defer updateTokenPrefixLength(originalPrefixLength)
 
-	dir, err := os.MkdirTemp("", "politeia.test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	g, err := New(chaincfg.TestNet3Params(), dir, "", "", nil,
 		testing.Verbose(), "")

--- a/politeiad/backend/gitbe/journal_test.go
+++ b/politeiad/backend/gitbe/journal_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -47,24 +46,22 @@ func testExact(j *Journal, filename string, count int) error {
 }
 
 func TestJournalExact(t *testing.T) {
-	dir, err := os.MkdirTemp("", "journal")
+	dir := t.TempDir()
 	t.Logf("TestJournalExact: %v", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	j := NewJournal()
 
 	// Test journal
 	count := 1000
 	filename := filepath.Join(dir, "file1")
 	for i := 0; i < count; i++ {
-		err = j.Journal(filename, fmt.Sprintf("%v", i))
+		err := j.Journal(filename, fmt.Sprintf("%v", i))
 		if err != nil {
 			t.Fatalf("%v: %v", i, err)
 		}
 	}
 
-	err = testExact(j, filename, count)
+	err := testExact(j, filename, count)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,20 +70,14 @@ func TestJournalExact(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	os.RemoveAll(dir)
 }
 
 func TestJournalDoubleOpen(t *testing.T) {
-	dir, err := os.MkdirTemp("", "journal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("TestJournalDoubleOpen: %v", dir)
+	dir := t.TempDir()
 
 	j := NewJournal()
 	filename := filepath.Join(dir, "file1")
-	err = j.Journal(filename, "journal this")
+	err := j.Journal(filename, "journal this")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,20 +91,15 @@ func TestJournalDoubleOpen(t *testing.T) {
 	if !errors.Is(err, ErrBusy) {
 		t.Fatal(err)
 	}
-
-	os.RemoveAll(dir)
 }
 
 func TestJournalDoubleClose(t *testing.T) {
-	dir, err := os.MkdirTemp("", "journal")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	t.Logf("TestJournalDoubleClose: %v", dir)
 
 	j := NewJournal()
 	filename := filepath.Join(dir, "file1")
-	err = j.Journal(filename, "journal this")
+	err := j.Journal(filename, "journal this")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,16 +118,11 @@ func TestJournalDoubleClose(t *testing.T) {
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatal(err)
 	}
-
-	os.RemoveAll(dir)
 }
 
 func TestJournalConcurrent(t *testing.T) {
-	dir, err := os.MkdirTemp("", "journal")
+	dir := t.TempDir()
 	t.Logf("TestJournalConcurrent: %v", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	j := NewJournal()
 	// Test concurrent writes
@@ -190,16 +171,11 @@ func TestJournalConcurrent(t *testing.T) {
 	if err := eg.Wait(); err != nil {
 		t.Fatal(err)
 	}
-
-	os.RemoveAll(dir)
 }
 
 func TestJournalConcurrentSame(t *testing.T) {
-	dir, err := os.MkdirTemp("", "journal")
+	dir := t.TempDir()
 	t.Logf("TestJournalConcurrentSame: %v", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	j := NewJournal()
 
@@ -219,7 +195,7 @@ func TestJournalConcurrentSame(t *testing.T) {
 	}
 
 	// Read back and make sure all entries exist
-	err = j.Open(filename)
+	err := j.Open(filename)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,16 +221,11 @@ func TestJournalConcurrentSame(t *testing.T) {
 	if len(check) != 0 {
 		t.Fatalf("len != 0")
 	}
-
-	os.RemoveAll(dir)
 }
 
 func TestJournalCopy(t *testing.T) {
-	dir, err := os.MkdirTemp("", "journal")
+	dir := t.TempDir()
 	t.Logf("TestJournalConcurrentCopy: %v", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	j := NewJournal()
 
@@ -262,13 +233,13 @@ func TestJournalCopy(t *testing.T) {
 	count := 1000
 	filename := filepath.Join(dir, "file1")
 	for i := 0; i < count; i++ {
-		err = j.Journal(filename, fmt.Sprintf("%v", i))
+		err := j.Journal(filename, fmt.Sprintf("%v", i))
 		if err != nil {
 			t.Fatalf("%v: %v", i, err)
 		}
 	}
 
-	err = testExact(j, filename, count)
+	err := testExact(j, filename, count)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,6 +275,4 @@ func TestJournalCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	os.RemoveAll(dir)
 }


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```