### PR TITLE
comments: Fix empty comments bug.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
+++ b/politeiad/backendv2/tstorebe/plugins/comments/cmds.go
@@ -572,6 +572,12 @@ func (p *commentsPlugin) cmdNew(token []byte, payload string) (string, error) {
 	}
 
 	// Verify comment
+	if len(n.Comment) == 0 {
+		return "", backend.PluginError{
+			PluginID:  comments.PluginID,
+			ErrorCode: uint32(comments.ErrorCodeEmptyComment),
+		}
+	}
 	if len(n.Comment) > int(p.commentLengthMax) {
 		return "", backend.PluginError{
 			PluginID:  comments.PluginID,
@@ -708,6 +714,12 @@ func (p *commentsPlugin) cmdEdit(token []byte, payload string) (string, error) {
 	}
 
 	// Verify comment
+	if len(e.Comment) == 0 {
+		return "", backend.PluginError{
+			PluginID:  comments.PluginID,
+			ErrorCode: uint32(comments.ErrorCodeEmptyComment),
+		}
+	}
 	if len(e.Comment) > int(p.commentLengthMax) {
 		return "", backend.PluginError{
 			PluginID:  comments.PluginID,

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -161,8 +161,14 @@ const (
 	// allowed.
 	ErrorCodeEditNotAllowed = 13
 
-	// ErrorCodeLast unit test only.
-	ErrorCodeLast ErrorCodeT = 14
+	// ErrorCodeEmptyComment is returned when a comment with no comment text
+	// is submitted.
+	ErrorCodeEmptyComment = 14
+
+	// ErrorCodeLast is used by unit tests to verify that all error codes have
+	// a human readable entry in the ErrorCodes map. This error code will never
+	// be returned.
+	ErrorCodeLast ErrorCodeT = 15
 )
 
 var (
@@ -182,6 +188,7 @@ var (
 		ErrorCodeRecordStateInvalid:     "record state invalid",
 		ErrorCodeExtraDataNotAllowed:    "comment extra data not allowed",
 		ErrorCodeEditNotAllowed:         "comment edit is not allowed",
+		ErrorCodeEmptyComment:           "comment is empty",
 	}
 )
 


### PR DESCRIPTION
This commit adds validation to the comments plugin that prevents empty
comments from being accepted.

This bug was introduced by 2e41e04.

Closes #1645.