### PR TITLE
tstore: Improve blobs not found error.

### DIFF
--- a/politeiad/backendv2/tstorebe/tstore/tstoreclient.go
+++ b/politeiad/backendv2/tstorebe/tstore/tstoreclient.go
@@ -306,14 +306,8 @@ func (t *tstoreClient) BlobsByDataDesc(token []byte, dataDesc []string) ([]store
 	}
 	if len(blobs) != len(keys) {
 		// One or more blobs were not found
-		missing := make([]string, 0, len(keys))
-		for _, v := range keys {
-			_, ok := blobs[v]
-			if !ok {
-				missing = append(missing, v)
-			}
-		}
-		return nil, fmt.Errorf("blobs not found: %v", missing)
+		return nil, fmt.Errorf("%v/%v blobs not found",
+			len(keys)-len(blobs), len(keys))
 	}
 
 	// Prepare reply. The blob entries should be in the same order as


### PR DESCRIPTION
This commit improves the error message that is returned when the
expected number of blobs are not found in the key-value store.

Previously, the keys that were not found were being included in the
error message. This made the error message illegible when a large number
of keys were being requested, like when all of a proposal's cast votes
are being requested.