### PR TITLE
version: Support single override and add git hash.

### DIFF
--- a/politeiad/config.go
+++ b/politeiad/config.go
@@ -269,7 +269,7 @@ func loadConfig() (*config, []string, error) {
 		LogDir:           defaultLogDir,
 		HTTPSKey:         defaultHTTPSKeyFile,
 		HTTPSCert:        defaultHTTPSCertFile,
-		Version:          version.String(),
+		Version:          version.Version,
 		Backend:          defaultBackend,
 		ReadTimeout:      defaultReadTimeout,
 		WriteTimeout:     defaultWriteTimeout,
@@ -302,7 +302,7 @@ func loadConfig() (*config, []string, error) {
 	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
 	if preCfg.ShowVersion {
 		fmt.Printf("%s version %s (Go version %s %s/%s)\n", appName,
-			version.String(), runtime.Version(), runtime.GOOS,
+			cfg.Version, runtime.Version(), runtime.GOOS,
 			runtime.GOARCH)
 		os.Exit(0)
 	}

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -28,7 +28,6 @@ import (
 	"github.com/decred/politeia/politeiad/backendv2"
 	"github.com/decred/politeia/politeiad/backendv2/tstorebe"
 	"github.com/decred/politeia/util"
-	"github.com/decred/politeia/util/version"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
@@ -393,8 +392,7 @@ func _main() error {
 		}
 	}()
 
-	log.Infof("Version : %v", version.String())
-	log.Infof("Build   : %v", version.BuildMainVersion())
+	log.Infof("Version : %v", cfg.Version)
 	log.Infof("Network : %v", activeNetParams.Params.Name)
 	log.Infof("Home dir: %v", cfg.HomeDir)
 

--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -240,7 +240,7 @@ func loadConfig(appName string) (*config, []string, error) {
 		DebugLevel: defaultLogLevel,
 		LogDir:     defaultLogDir,
 		voteDir:    defaultVoteDir,
-		Version:    version.String(),
+		Version:    version.Version,
 		WalletCert: defaultWalletCert,
 		ClientCert: defaultClientCert,
 		ClientKey:  defaultClientKey,
@@ -274,7 +274,7 @@ func loadConfig(appName string) (*config, []string, error) {
 	// Show the version and exit if the version flag was specified.
 	if preCfg.ShowVersion {
 		fmt.Printf("%s version %s (Go version %s %s/%s)\n", appName,
-			version.String(), runtime.Version(), runtime.GOOS,
+			cfg.Version, runtime.Version(), runtime.GOOS,
 			runtime.GOARCH)
 		os.Exit(0)
 	}

--- a/politeiawww/cmd/shared/config.go
+++ b/politeiawww/cmd/shared/config.go
@@ -91,7 +91,7 @@ func LoadConfig(homeDir, dataDirname, configFilename string) (*Config, error) {
 		WalletHost: defaultWalletHost + ":" + defaultWalletTestnetPort,
 		WalletCert: defaultWalletCertFile,
 		FaucetHost: defaultFaucetHost,
-		Version:    version.String(),
+		Version:    version.Version,
 	}
 
 	// Pre-parse the command line options to see if an alternative config
@@ -110,7 +110,7 @@ func LoadConfig(homeDir, dataDirname, configFilename string) (*Config, error) {
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	if cfg.ShowVersion {
 		fmt.Printf("%s version %s (Go version %s %s/%s)\n", appName,
-			version.String(), runtime.Version(), runtime.GOOS,
+			cfg.Version, runtime.Version(), runtime.GOOS,
 			runtime.GOARCH)
 		os.Exit(0)
 	}

--- a/politeiawww/config/config.go
+++ b/politeiawww/config/config.go
@@ -233,6 +233,8 @@ func Load() (*Config, []string, error) {
 			VoteDurationMax:          defaultVoteDurationMax,
 			MailRateLimit:            defaultMailRateLimit,
 		},
+
+		Version: version.Version,
 	}
 
 	// Service options which are only added on Windows.
@@ -261,7 +263,7 @@ func Load() (*Config, []string, error) {
 	// Show the version and exit if the version flag was specified.
 	if preCfg.ShowVersion {
 		fmt.Printf("%s version %s (Go version %s %s/%s)\n", AppName,
-			version.String(), runtime.Version(), runtime.GOOS,
+			cfg.Version, runtime.Version(), runtime.GOOS,
 			runtime.GOARCH)
 		os.Exit(0)
 	}

--- a/politeiawww/handlers.go
+++ b/politeiawww/handlers.go
@@ -17,7 +17,6 @@ import (
 	"github.com/decred/politeia/politeiawww/logger"
 	plugin "github.com/decred/politeia/politeiawww/plugin/v1"
 	"github.com/decred/politeia/util"
-	"github.com/decred/politeia/util/version"
 	"github.com/gorilla/csrf"
 	"github.com/pkg/errors"
 )
@@ -56,7 +55,7 @@ func (p *politeiawww) handleVersion(w http.ResponseWriter, r *http.Request) {
 	util.RespondWithJSON(w, http.StatusOK,
 		v3.VersionReply{
 			APIVersion:   v3.APIVersion,
-			BuildVersion: version.String(),
+			BuildVersion: p.cfg.Version,
 			Plugins:      plugins,
 		})
 }

--- a/politeiawww/legacy/www.go
+++ b/politeiawww/legacy/www.go
@@ -12,7 +12,6 @@ import (
 	"github.com/decred/politeia/politeiad/api/v1/mime"
 	v1 "github.com/decred/politeia/politeiawww/api/www/v1"
 	"github.com/decred/politeia/util"
-	"github.com/decred/politeia/util/version"
 	"github.com/gorilla/csrf"
 )
 
@@ -24,7 +23,7 @@ func (p *Politeiawww) handleVersion(w http.ResponseWriter, r *http.Request) {
 	versionReply := v1.VersionReply{
 		Version:      v1.PoliteiaWWWAPIVersion,
 		Route:        v1.PoliteiaWWWAPIRoute,
-		BuildVersion: version.BuildMainVersion(),
+		BuildVersion: p.cfg.Version,
 		PubKey:       hex.EncodeToString(p.cfg.Identity.Key[:]),
 		TestNet:      p.cfg.TestNet,
 		Mode:         p.cfg.Mode,
@@ -76,7 +75,7 @@ func (p *Politeiawww) handlePolicy(w http.ResponseWriter, r *http.Request) {
 		ProposalNameSupportedChars: v1.PolicyProposalNameSupportedChars,
 		MaxCommentLength:           v1.PolicyMaxCommentLength,
 		TokenPrefixLength:          v1.TokenPrefixLength,
-		BuildInformation:           version.BuildInformation(),
+		BuildInformation:           []string{p.cfg.Version},
 		IndexFilename:              v1.PolicyIndexFilename,
 		MinLinkByPeriod:            0,
 		MaxLinkByPeriod:            0,

--- a/politeiawww/legacy/www_test.go
+++ b/politeiawww/legacy/www_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	www "github.com/decred/politeia/politeiawww/api/www/v1"
-	"github.com/decred/politeia/util/version"
 	"github.com/go-test/deep"
 )
 
@@ -24,7 +23,7 @@ func TestHandleVersion(t *testing.T) {
 
 	expectedReply := www.VersionReply{
 		Version:      www.PoliteiaWWWAPIVersion,
-		BuildVersion: version.BuildMainVersion(),
+		BuildVersion: p.cfg.Version,
 		Route:        www.PoliteiaWWWAPIRoute,
 		PubKey:       hex.EncodeToString(p.cfg.Identity.Key[:]),
 		TestNet:      p.cfg.TestNet,

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -22,7 +22,6 @@ import (
 	plugin "github.com/decred/politeia/politeiawww/plugin/v1"
 	"github.com/decred/politeia/politeiawww/user"
 	"github.com/decred/politeia/util"
-	"github.com/decred/politeia/util/version"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 )
@@ -74,7 +73,7 @@ func _main() error {
 		logger.CloseLogRotator()
 	}()
 
-	log.Infof("Version : %v", version.String())
+	log.Infof("Version : %v", cfg.Version)
 	log.Infof("Network : %v", cfg.ActiveNet.Name)
 	log.Infof("Home dir: %v", cfg.HomeDir)
 

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,130 +8,143 @@
 package version
 
 import (
-	"bytes"
 	"fmt"
-	"runtime/debug"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
 const (
-	// semanticAlphabet defines the allowed characters for the pre-release
-	// portion of a semantic version string.
-	semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
-
-	// semanticBuildAlphabet defines the allowed characters for the build
-	// portion of a semantic version string.
-	semanticBuildAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
+	// semanticAlphabet defines the allowed characters for the pre-release and
+	// build metadata portions of a semantic version string.
+	semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
 )
 
-// These constants define the application version and follow the semantic
-// versioning 2.0.0 spec (http://semver.org/).
-const (
-	Major uint = 1
-	Minor uint = 4
-	Patch uint = 0
-)
+// semverRE is a regular expression used to parse a semantic version string
+// into its constituent parts.
+var semverRE = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*` +
+	`[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
+// These variables define the application version and follow the semantic
+// versioning 2.0.0 spec (https://semver.org/).
 var (
-	// PreRelease is defined as a variable so it can be overridden during the
-	// build process with:
-	// '-ldflags "-X github.com/decred/politeia/util/version.PreRelease=foo"'
-	// if needed.  It MUST only contain characters from semanticAlphabet per
-	// the semantic versioning spec.
-	PreRelease = "pre"
+	// Note for maintainers:
+	//
+	// The expected process for setting the version in releases is as follows:
+	// - Create a release branch of the form 'release-vMAJOR.MINOR'
+	// - Modify the Version variable below on that branch to:
+	//   - Remove the pre-release portion
+	//   - Set the build metadata to 'release.local'
+	// - Update the Version variable below on the master branch to the next
+	//   expected version while retaining a pre-release of 'pre'
+	//
+	// These steps ensure that building from source produces versions that are
+	// distinct from reproducible builds that override the Version via linker
+	// flags.
 
-	// BuildMetadata is defined as a variable so it can be overridden during the
-	// build process with:
-	// '-ldflags "-X github.com/decred/politeia/util/version.BuildMetadata=foo"'
-	// if needed.  It MUST only contain characters from semanticBuildAlphabet
-	// per the semantic versioning spec.
-	BuildMetadata = "dev"
+	// Version is the application version per the semantic versioning 2.0.0 spec
+	// (https://semver.org/).
+	//
+	// It is defined as a variable so it can be overridden during the build
+	// process with:
+	// '-ldflags "-X main.Version=fullsemver"'
+	// if needed.
+	//
+	// It MUST be a full semantic version per the semantic versioning spec or
+	// the app will panic at runtime.  Of particular note is the pre-release
+	// and build metadata portions MUST only contain characters from
+	// semanticAlphabet.
+	Version = "1.4.0-pre"
+
+	// NOTE: The following values are set via init by parsing the above Version
+	// string.
+
+	// These fields are the individual semantic version components that define
+	// the application version.
+	Major         uint32
+	Minor         uint32
+	Patch         uint32
+	PreRelease    string
+	BuildMetadata string
 )
 
-// String returns the application version as a properly formed string per the
-// semantic versioning 2.0.0 spec (http://semver.org/).
-func String() string {
-	// Start with the major, minor, and patch versions.
-	version := fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
-
-	// Append pre-release version if there is one.  The hyphen called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the pre-release string.  The pre-release version
-	// is not appended if it contains invalid characters.
-	preRelease := NormalizePreRelString(PreRelease)
-	if preRelease != "" {
-		version = fmt.Sprintf("%s-%s", version, preRelease)
+// parseUint32 converts the passed string to an unsigned integer or returns an
+// error if it is invalid.
+func parseUint32(s string, fieldName string) (uint32, error) {
+	val, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("malformed semver %s: %w", fieldName, err)
 	}
-
-	// Append build metadata if there is any.  The plus called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the build metadata string.  The build metadata
-	// string is not appended if it contains invalid characters.
-	build := NormalizeBuildString(BuildMetadata)
-	if build != "" {
-		version = fmt.Sprintf("%s+%s", version, build)
-	}
-
-	return version
+	return uint32(val), err
 }
 
-// BuildMainVersion returns the main module version information from where
-// politeia was builded.
-func BuildMainVersion() string {
-	i, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "No build information available"
-	}
-	return i.Main.Version
-}
-
-// BuildInformation returns the main module plus all dependecies module
-// version informations from where politeia was builded.
-func BuildInformation() []string {
-	var infos []string
-	i, ok := debug.ReadBuildInfo()
-	if !ok {
-		infos = append(infos, "No build information available")
-		return infos
-	}
-
-	// Add main module info
-	full := i.Main.Path + "-" + i.Main.Version
-	infos = append(infos, full)
-
-	// Add dependecies module info
-	for _, dep := range i.Deps {
-		full = dep.Path + "-" + dep.Version
-		infos = append(infos, full)
-	}
-
-	return infos
-}
-
-// normalizeSemString returns the passed string stripped of all characters
-// which are not valid according to the provided semantic versioning alphabet.
-func normalizeSemString(str, alphabet string) string {
-	var result bytes.Buffer
-	for _, r := range str {
-		if strings.ContainsRune(alphabet, r) {
-			result.WriteRune(r)
+// checkSemString returns an error if the passed string contains characters that
+// are not in the provided alphabet.
+func checkSemString(s, alphabet, fieldName string) error {
+	for _, r := range s {
+		if !strings.ContainsRune(alphabet, r) {
+			return fmt.Errorf("malformed semver %s: %q invalid", fieldName, r)
 		}
 	}
-	return result.String()
+	return nil
 }
 
-// NormalizePreRelString returns the passed string stripped of all characters
-// which are not valid according to the semantic versioning guidelines for
-// pre-release strings.  In particular they MUST only contain characters in
-// semanticAlphabet.
-func NormalizePreRelString(str string) string {
-	return normalizeSemString(str, semanticAlphabet)
+// parseSemVer parses various semver components from the provided string.
+func parseSemVer(s string) (uint32, uint32, uint32, string, string, error) {
+	// Parse the various semver component from the version string via a regular
+	// expression.
+	m := semverRE.FindStringSubmatch(s)
+	if m == nil {
+		err := fmt.Errorf("malformed version string %q: does not conform to "+
+			"semver specification", s)
+		return 0, 0, 0, "", "", err
+	}
+
+	major, err := parseUint32(m[1], "major")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	minor, err := parseUint32(m[2], "minor")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	patch, err := parseUint32(m[3], "patch")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	preRel := m[4]
+	err = checkSemString(preRel, semanticAlphabet, "pre-release")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	build := m[5]
+	err = checkSemString(build, semanticAlphabet, "buildmetadata")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	return major, minor, patch, preRel, build, nil
 }
 
-// NormalizeBuildString returns the passed string stripped of all characters
-// which are not valid according to the semantic versioning guidelines for build
-// metadata strings.  In particular they MUST only contain characters in
-// semanticBuildAlphabet.
-func NormalizeBuildString(str string) string {
-	return normalizeSemString(str, semanticBuildAlphabet)
+func init() {
+	var err error
+	Major, Minor, Patch, PreRelease, BuildMetadata, err = parseSemVer(Version)
+	if err != nil {
+		panic(err)
+	}
+	if BuildMetadata == "" {
+		BuildMetadata = vcsCommitID()
+		if BuildMetadata != "" {
+			Version = fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
+			if PreRelease != "" {
+				Version += "-" + PreRelease
+			}
+			Version += "+" + BuildMetadata
+		}
+	}
 }

--- a/util/version/version_buildinfo.go
+++ b/util/version/version_buildinfo.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021-2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build go1.18
+// +build go1.18
+
+package version
+
+import "runtime/debug"
+
+// vcsCommitID attempts to return the version control system short commit hash
+// that was used to build the binary.  It currently only detects git commits.
+func vcsCommitID() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	var vcs, revision string
+	for _, bs := range bi.Settings {
+		switch bs.Key {
+		case "vcs":
+			vcs = bs.Value
+		case "vcs.revision":
+			revision = bs.Value
+		}
+	}
+	if vcs == "" {
+		return ""
+	}
+	if vcs == "git" && len(revision) > 9 {
+		revision = revision[:9]
+	}
+	return revision
+}

--- a/util/version/version_nobuildinfo.go
+++ b/util/version/version_nobuildinfo.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2021-2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build !go1.18
+// +build !go1.18
+
+package version
+
+// vcsCommitID returns an empty string for all Go versions prior to 1.18 since
+// the information is not availalbe in binaries prior to that version.
+func vcsCommitID() string {
+	return ""
+}


### PR DESCRIPTION
This commit adds the version changes from decred/dcrctl#44. 

The original commit message is shown below:

This reworks the way versions are handled internally to reverse the
semantics such that the individual semver components (major, minor,
patch, prerelease, and buildmetadata) are parsed from a full string and
exported at init time.

Also, since the version is now parsed and verified to be accurate, it
updates the pre-release parsing to properly support dots as required by
the spec.

Finally, starting with Go version 1.18, it adds the git commit hash to
the version string as buildmetadata when no buildmetadata is otherwise
specified.

This provides a few main benefits:

- Allows a single linker override to fully specify the version string
  instead of having separate ones that can only override the prerelease
  and build metadata portions
- Provides run-time checks to ensure the full version string is valid
  per the semver spec regardless of whether it was specified directly in
  the source or provided via the linker
- The exact commit used to build non-release versions will be in the
  version string by default

Finally, while here, add some comments regarding the release process to
help maintainers.