### PR TITLE
multi: Go 1.19 doc comment formatting.

### DIFF
--- a/politeiad/backend/gitbe/cms.go
+++ b/politeiad/backend/gitbe/cms.go
@@ -103,7 +103,7 @@ func (g *gitBackEnd) initCMSPluginJournals() error {
 	return nil
 }
 
-//SetCMSPluginSetting removes a setting if the value is "" and adds a setting otherwise.
+// SetCMSPluginSetting removes a setting if the value is "" and adds a setting otherwise.
 func setCMSPluginSetting(key, value string) {
 	if value == "" {
 		delete(cmsPluginSettings, key)

--- a/politeiad/backend/gitbe/decred.go
+++ b/politeiad/backend/gitbe/decred.go
@@ -185,7 +185,7 @@ func (g *gitBackEnd) replayAllJournals() error {
 	return nil
 }
 
-//SetDecredPluginSetting removes a setting if the value is "" and adds a setting otherwise.
+// SetDecredPluginSetting removes a setting if the value is "" and adds a setting otherwise.
 func setDecredPluginSetting(key, value string) {
 	if value == "" {
 		delete(decredPluginSettings, key)

--- a/politeiad/backendv2/tstorebe/plugins/ticketvote/fsck.go
+++ b/politeiad/backendv2/tstorebe/plugins/ticketvote/fsck.go
@@ -12,16 +12,16 @@ import (
 // fsck performs the ticketvote plugin file system check. The following checks
 // are performed:
 //
-// 1. Rebuild the vote summaries cache. Records that have finished voting
-//    will have a vote summary saved to the cache. This cache is rebuilt
-//    from scratch.
+//  1. Rebuild the vote summaries cache. Records that have finished voting
+//     will have a vote summary saved to the cache. This cache is rebuilt
+//     from scratch.
 //
-// 2. Rebuild the vote inventory cache. All vetted records are included in the
-//    vote inventory cache. This cache is rebuilt from scratch.
+//  2. Rebuild the vote inventory cache. All vetted records are included in the
+//     vote inventory cache. This cache is rebuilt from scratch.
 //
-// 3. Rebuild the runoff vote submissions cache. The submissions cache contains
-//    the list of runoff vote parent records and all of their runoff vote
-//    submissions. This cache is built from scratch.
+//  3. Rebuild the runoff vote submissions cache. The submissions cache contains
+//     the list of runoff vote parent records and all of their runoff vote
+//     submissions. This cache is built from scratch.
 func (p *ticketVotePlugin) fsck(tokens [][]byte) error {
 	log.Infof("Starting ticketvote fsck for %v records", len(tokens))
 

--- a/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
+++ b/politeiad/backendv2/tstorebe/plugins/usermd/usermd.go
@@ -126,13 +126,13 @@ func (p *usermdPlugin) addMissingRecord(tokens []string, missingRecord *backend.
 //
 // It verifies the user cache using the following process:
 //
-// 1. For each record, get the user metadata file from the db.
-// 2. Get the user cache for the record's author.
-// 3. Verify that the record is listed in the user cache under the
-//    correct category.  If the record is not found in the user
-//    cache, add it.  The tokens listed in the user cache are
-//    ordered by the timestamp of their most recent status change
-//    from oldest to newest.
+//  1. For each record, get the user metadata file from the db.
+//  2. Get the user cache for the record's author.
+//  3. Verify that the record is listed in the user cache under the
+//     correct category.  If the record is not found in the user
+//     cache, add it.  The tokens listed in the user cache are
+//     ordered by the timestamp of their most recent status change
+//     from oldest to newest.
 //
 // This function satisfies the plugins PluginClient interface.
 func (p *usermdPlugin) Fsck(tokens [][]byte) error {

--- a/politeiad/backendv2/tstorebe/tstore/record.go
+++ b/politeiad/backendv2/tstorebe/tstore/record.go
@@ -582,12 +582,12 @@ func (t *Tstore) RecordFreeze(token []byte, rm backend.RecordMetadata, metadata 
 // error, was encoutered prior to the record being saved to the tree. We ignore
 // this edge case because:
 //
-// 1. A user has no way to obtain this token unless the trillian instance has
-//    been opened to the public.
+//  1. A user has no way to obtain this token unless the trillian instance has
+//     been opened to the public.
 //
-// 2. Even if they have the token they cannot do anything with it. Any attempt
-//  	to read from the tree or write to the tree will return a RecordNotFound
-//    error.
+//  2. Even if they have the token they cannot do anything with it. Any attempt
+//     to read from the tree or write to the tree will return a RecordNotFound
+//     error.
 //
 // Pulling the leaves from the tree to see if a record has been saved to the
 // tree adds a large amount of overhead to this call, which should be a very

--- a/politeiad/backendv2/tstorebe/tstore/recordindex.go
+++ b/politeiad/backendv2/tstorebe/tstore/recordindex.go
@@ -29,16 +29,16 @@ import (
 //
 // 1. Record content is saved to the kv store.
 //
-// 2. A trillian leaf is created for each piece of record content. The kv store
-//    key for each piece of content is stuffed into the LogLeaf.ExtraData
-//    field. The leaves are appended onto the trillian tree.
+//  2. A trillian leaf is created for each piece of record content. The kv store
+//     key for each piece of content is stuffed into the LogLeaf.ExtraData
+//     field. The leaves are appended onto the trillian tree.
 //
-// 3. If there are failures in steps 1 or 2 for any of the blobs then the
-//    update will exit without completing. No unwinding is performed. Blobs
-//    will be left in the kv store as orphaned blobs. The trillian tree is
-//    append-only so once a leaf is appended, it's there permanently. If steps
-//    1 and 2 are successful then a recordIndex is created, saved to the kv
-//    store, and appended onto the trillian tree.
+//  3. If there are failures in steps 1 or 2 for any of the blobs then the
+//     update will exit without completing. No unwinding is performed. Blobs
+//     will be left in the kv store as orphaned blobs. The trillian tree is
+//     append-only so once a leaf is appended, it's there permanently. If steps
+//     1 and 2 are successful then a recordIndex is created, saved to the kv
+//     store, and appended onto the trillian tree.
 //
 // Appending a recordIndex onto the trillian tree is the last operation that
 // occurs during a record update. If a recordIndex exists in the tree then the

--- a/politeiad/backendv2/tstorebe/tstorebe.go
+++ b/politeiad/backendv2/tstorebe/tstorebe.go
@@ -797,12 +797,12 @@ func (t *tstoreBackend) RecordSetStatus(token []byte, status backend.StatusT, md
 // error, was encoutered prior to the record being saved to the tree. We ignore
 // this edge case because:
 //
-// 1. A user has no way to obtain this token unless the trillian instance has
-//    been opened to the public.
+//  1. A user has no way to obtain this token unless the trillian instance has
+//     been opened to the public.
 //
-// 2. Even if they have the token they cannot do anything with it. Any attempt
-//  	to read from the tree or write to the tree will return a RecordNotFound
-//    error.
+//  2. Even if they have the token they cannot do anything with it. Any attempt
+//     to read from the tree or write to the tree will return a RecordNotFound
+//     error.
 //
 // Pulling the leaves from the tree to see if a record has been saved to the
 // tree adds a large amount of overhead to this call, which should be a very

--- a/politeiad/cmd/legacypoliteia/cmd_import.go
+++ b/politeiad/cmd/legacypoliteia/cmd_import.go
@@ -216,23 +216,23 @@ func newImportCmd(legacyDir, tlogHost, dbHost, dbPass, importToken string, stubU
 //
 // 2. Retrieve the tstore token inventory.
 //
-// 3. Iterate through each record in the existing tstore inventory and check
-//    if the record corresponds to one of the legacy proposals.
+//  3. Iterate through each record in the existing tstore inventory and check
+//     if the record corresponds to one of the legacy proposals.
 //
-// 4. Perform an fsck on all legacy proposals that already exist in tstore to
-//    verify that the full legacy proposal has been imported. Any missing
-//    legacy proposal content is added to tstore during this step. A partial
-//    import can happen if the import command was being run and was stopped
-//    prior to completion or if it encountered an unexpected error.
+//  4. Perform an fsck on all legacy proposals that already exist in tstore to
+//     verify that the full legacy proposal has been imported. Any missing
+//     legacy proposal content is added to tstore during this step. A partial
+//     import can happen if the import command was being run and was stopped
+//     prior to completion or if it encountered an unexpected error.
 //
-// 5. Add the legacy RFP proposals to tstore. This must be done first so that
-//    the RFP submissions can link to the tstore RFP proposal token.
+//  5. Add the legacy RFP proposals to tstore. This must be done first so that
+//     the RFP submissions can link to the tstore RFP proposal token.
 //
 // 6. Add the remaining legacy proposals to tstore.
 //
-// 7. Add a startRunoffRecord for each RFP proposal vote. The record is added
-//    to the RFP parent's tlog tree. This is required in order to mimic what
-//    would happen under normal operating conditions.
+//  7. Add a startRunoffRecord for each RFP proposal vote. The record is added
+//     to the RFP parent's tlog tree. This is required in order to mimic what
+//     would happen under normal operating conditions.
 func (c *importCmd) importLegacyProposals() error {
 	// 1. Inventory all legacy proposals being imported
 	legacyInv, err := parseLegacyTokens(c.legacyDir)

--- a/politeiad/cmd/legacypoliteia/gitbe/mdstreams.go
+++ b/politeiad/cmd/legacypoliteia/gitbe/mdstreams.go
@@ -105,9 +105,9 @@ type VoteOption struct {
 // The message being signed is the SHA256 digest of the VoteV2 JSON byte slice.
 //
 // Differences between StartVoteV1 and StartVoteV2:
-// * Signature is the signature of a hash of the Vote struct. It was
-//   previously the signature of just the proposal token.
-// * Vote is now a VoteV2. See the VoteV2 comment for more details.
+//   - Signature is the signature of a hash of the Vote struct. It was
+//     previously the signature of just the proposal token.
+//   - Vote is now a VoteV2. See the VoteV2 comment for more details.
 type StartVoteV2 struct {
 	Version   uint   `json:"version"`   // Version of this structure
 	PublicKey string `json:"publickey"` // Key used for signature
@@ -118,10 +118,10 @@ type StartVoteV2 struct {
 // VoteV2 represents the vote options and vote parameters for a StartVoteV2.
 //
 // Differences between VoteV1 and VoteV2:
-// * Added the ProposalVersion field that specifies the version of the proposal
-//   that is being voted on. This was added so that the proposal version is
-//   explicitly included in the StartVote signature.
-// * Added a Type field in order to specify the vote type.
+//   - Added the ProposalVersion field that specifies the version of the proposal
+//     that is being voted on. This was added so that the proposal version is
+//     explicitly included in the StartVote signature.
+//   - Added a Type field in order to specify the vote type.
 type VoteV2 struct {
 	Token            string       `json:"token"`
 	ProposalVersion  uint32       `json:"proposalversion"`

--- a/politeiad/config.go
+++ b/politeiad/config.go
@@ -251,10 +251,10 @@ func newConfigParser(cfg *config, so *serviceOptions, options flags.Options) *fl
 // line options.
 //
 // The configuration proceeds as follows:
-// 	1) Start with a default config with sane settings
-// 	2) Pre-parse the command line to check for an alternative config file
-// 	3) Load configuration file overwriting defaults with any specified options
-// 	4) Parse CLI options and overwrite/add any specified options
+//  1. Start with a default config with sane settings
+//  2. Pre-parse the command line to check for an alternative config file
+//  3. Load configuration file overwriting defaults with any specified options
+//  4. Parse CLI options and overwrite/add any specified options
 //
 // The above results in daemon functioning properly without any config settings
 // while still allowing the user to override settings with config files and

--- a/politeiad/plugins/comments/comments.go
+++ b/politeiad/plugins/comments/comments.go
@@ -263,11 +263,11 @@ type Comment struct {
 // The structure of the signature field depends on whether the CommentAdd is
 // associated with a new comment or a comment edit:
 //
-//   1. When a comment is created it's the user signature of the:
-//   State + Token + ParentID + Comment + ExtraData + ExtraDataHint.
+//  1. When a comment is created it's the user signature of the:
+//     State + Token + ParentID + Comment + ExtraData + ExtraDataHint.
 //
-//   2. When a comment is edited it's the user signature of the:
-//   State + Token + ParentID + CommentID + Comment + ExtraData + ExtraDataHint.
+//  2. When a comment is edited it's the user signature of the:
+//     State + Token + ParentID + CommentID + Comment + ExtraData + ExtraDataHint.
 //
 // Receipt is the server signature of the user signature.
 //

--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -774,7 +774,7 @@ type LoginReply struct {
 	TOTPVerified       bool   `json:"totpverified"`       // Whether current totp secret has been verified with
 }
 
-//Logout attempts to log the user out.
+// Logout attempts to log the user out.
 type Logout struct{}
 
 // LogoutReply indicates whether the Logout command was success or not.

--- a/politeiawww/api/www/v2/v2.go
+++ b/politeiawww/api/www/v2/v2.go
@@ -72,10 +72,10 @@ type AuthorizeVote struct {
 // be considered approved.
 //
 // Differences between v1 and v2:
-// * Added the Version field that specifies the version of the proposal that is
-//   being voted on. This was added so that the proposal version is included in
-//   the StartVote signature.
-// * Added the Type field that specifies the vote type.
+//   - Added the Version field that specifies the version of the proposal that is
+//     being voted on. This was added so that the proposal version is included in
+//     the StartVote signature.
+//   - Added the Type field that specifies the vote type.
 type Vote struct {
 	Token            string       `json:"token"`            // Proposal token
 	ProposalVersion  uint32       `json:"proposalversion"`  // Proposal version of vote
@@ -93,9 +93,9 @@ type Vote struct {
 // encoded v2 Vote struct.
 //
 // Differences between v1 and v2:
-// * Signature has been updated to be a signature of the Vote hash. It was
-//   previously a signature of just the proposal token.
-// * Vote has been updated. See the Vote comment for more details.
+//   - Signature has been updated to be a signature of the Vote hash. It was
+//     previously a signature of just the proposal token.
+//   - Vote has been updated. See the Vote comment for more details.
 //
 // This request is NO LONGER SUPPORTED. Use the pi/v1 API instead.
 type StartVote struct {
@@ -107,9 +107,9 @@ type StartVote struct {
 // StartVoteReply is the reply to the StartVote command.
 //
 // Differences between v1 and v2:
-// * StartBlockHeight was changed from a string to a uint32.
-// * EndBlockHeight was changed from a string to a uint32. It was also renamed
-//   from EndHeight to EndBlockHeight to be consistent with StartBlockHeight.
+//   - StartBlockHeight was changed from a string to a uint32.
+//   - EndBlockHeight was changed from a string to a uint32. It was also renamed
+//     from EndHeight to EndBlockHeight to be consistent with StartBlockHeight.
 //
 // This request is NO LONGER SUPPORTED. Use the pi/v1 API instead.
 type StartVoteReply struct {

--- a/politeiawww/cmd/cmswww/testrun.go
+++ b/politeiawww/cmd/cmswww/testrun.go
@@ -643,15 +643,15 @@ func dccCommentNew(u user, token, parentID, comment string) error {
 //
 // A new cms user must have their contractor type updated before they are able
 // to submit invoices. There are currently two ways for this to happen.
-// 1. An admin can update it manually using the CMSManageUser route.
-// 2. The contractor can undergo the DCC process. The DCC process is where
-//    the new contractor is nominated by an existing contractor then other
-//    existing contractors can support or oppose the DCC nomination. Admins
-//    currently have final say in the approval of a DCC. If a DCC is
-//    contentious, it can be put up for an all contractor vote where existing
-//    contractor votes are weighted by the amount of hours they've billed.
-//    Once a DCC has been approved, the user's ContractorType is automatically
-//    updated and they are able to submit invoices.
+//  1. An admin can update it manually using the CMSManageUser route.
+//  2. The contractor can undergo the DCC process. The DCC process is where
+//     the new contractor is nominated by an existing contractor then other
+//     existing contractors can support or oppose the DCC nomination. Admins
+//     currently have final say in the approval of a DCC. If a DCC is
+//     contentious, it can be put up for an all contractor vote where existing
+//     contractor votes are weighted by the amount of hours they've billed.
+//     Once a DCC has been approved, the user's ContractorType is automatically
+//     updated and they are able to submit invoices.
 //
 // testDCC runs through the full DCC process with the exception of the all
 // contractor vote for contentious DCCs. See testDCCVote() for details on the

--- a/politeiawww/cmd/pictl/ticketvote.go
+++ b/politeiawww/cmd/pictl/ticketvote.go
@@ -93,8 +93,9 @@ func printVoteResults(votes []tkv1.CastVoteDetails) {
 // Eligible Tickets  : 4638 tickets
 // Best Block        : 800051
 // Results
-//   1 yes 0 votes
-//   2 no  60 votes
+//
+//	1 yes 0 votes
+//	2 no  60 votes
 //
 // indentInSpaces can be used to add indentation to each line of the string.
 // The provided number of spaces will be inserted at the beginning of each

--- a/politeiawww/cmd/politeiavoter/config.go
+++ b/politeiawww/cmd/politeiavoter/config.go
@@ -224,10 +224,10 @@ func (e errSuppressUsage) Error() string {
 // line options.
 //
 // The configuration proceeds as follows:
-// 	1) Start with a default config with sane settings
-// 	2) Pre-parse the command line to check for an alternative config file
-// 	3) Load configuration file overwriting defaults with any specified options
-// 	4) Parse CLI options and overwrite/add any specified options
+//  1. Start with a default config with sane settings
+//  2. Pre-parse the command line to check for an alternative config file
+//  3. Load configuration file overwriting defaults with any specified options
+//  4. Parse CLI options and overwrite/add any specified options
 //
 // The above results in daemon functioning properly without any config settings
 // while still allowing the user to override settings with config files and

--- a/politeiawww/cmd/shared/config.go
+++ b/politeiawww/cmd/shared/config.go
@@ -73,10 +73,10 @@ type Config struct {
 // line options.
 //
 // The configuration proceeds as follows:
-// 	1) Start with a default config with sane settings
-// 	2) Pre-parse the command line to check for an alternative config file
-// 	3) Load configuration file overwriting defaults with any specified options
-// 	4) Parse CLI options and overwrite/add any specified options
+//  1. Start with a default config with sane settings
+//  2. Pre-parse the command line to check for an alternative config file
+//  3. Load configuration file overwriting defaults with any specified options
+//  4. Parse CLI options and overwrite/add any specified options
 //
 // The above results in the cli functioning properly without any config
 // settings while still allowing the user to override settings with config

--- a/politeiawww/config/config.go
+++ b/politeiawww/config/config.go
@@ -179,10 +179,10 @@ type Config struct {
 // options.
 //
 // The configuration proceeds as follows:
-// 	1) Start with a default config with sane settings
-// 	2) Pre-parse the command line to check for an alternative config file
-// 	3) Load configuration file overwriting defaults with any specified options
-// 	4) Parse CLI options and overwrite/add any specified options
+//  1. Start with a default config with sane settings
+//  2. Pre-parse the command line to check for an alternative config file
+//  3. Load configuration file overwriting defaults with any specified options
+//  4. Parse CLI options and overwrite/add any specified options
 //
 // The above results in rpc functioning properly without any config settings
 // while still allowing the user to override settings with config files and

--- a/politeiawww/user/user.go
+++ b/politeiawww/user/user.go
@@ -22,14 +22,14 @@ var (
 // own. The user object does not necessarily contain all plugin data for the
 // user. Plugins have two ways to save user data:
 //
-// 1. Update the user object that is provided to them by the backend during the
-//    execution of plugin commands. These updates are saved to the database by
-//    the backend. Plugins have the option of saving data to the user object as
-//    either clear text or encrypted.
+//  1. Update the user object that is provided to them by the backend during the
+//     execution of plugin commands. These updates are saved to the database by
+//     the backend. Plugins have the option of saving data to the user object as
+//     either clear text or encrypted.
 //
-// 2. Plugins can create and manage a database table themselves to store plugin
-//    user data in. This option should be reserved for data that would cause
-//    performance issues if saved to this global user object.
+//  2. Plugins can create and manage a database table themselves to store plugin
+//     user data in. This option should be reserved for data that would cause
+//     performance issues if saved to this global user object.
 type User struct {
 	ID      uuid.UUID             // Unique ID
 	Plugins map[string]PluginData // [pluginID]PluginData


### PR DESCRIPTION
This commit updates the repo with comment formatting required by gofmt
for go 1.19.