### PR TITLE
dbutil: Fix mysql flag bug.

### DIFF
--- a/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
+++ b/politeiawww/cmd/politeiawww_dbutil/politeiawww_dbutil.go
@@ -877,7 +877,7 @@ func _main() error {
 		}
 	case *verifyIdentities, *setEmail:
 		// These commands must be run with either -cockroachdb or -mysql.
-		if !*cockroach || *level {
+		if !*cockroach && !*mysql {
 			return fmt.Errorf("invalid database flag; must use " +
 				"either -mysql or -cockroachdb with this command")
 		}


### PR DESCRIPTION
This commit fixes a bug where the dbutil command was suppose to be
checking for the mysql flag, but was not.

This bug was introduced by 0b1982a48.