### PR TITLE
pi: Dont rate limit "Voting Started" emails.

### DIFF
--- a/politeiawww/legacy/pi/events.go
+++ b/politeiawww/legacy/pi/events.go
@@ -573,7 +573,7 @@ func (p *Pi) ntfnVoteStarted(sd tkv1.StartDetails, eventUser user.User, authorID
 	)
 
 	// Compile user notification list
-	recipients := make(map[uuid.UUID]string, 1024)
+	var recipients []string
 	err := p.userdb.AllUsers(func(u *user.User) {
 		switch {
 		case u.ID.String() == eventUser.ID.String():
@@ -589,7 +589,7 @@ func (p *Pi) ntfnVoteStarted(sd tkv1.StartDetails, eventUser user.User, authorID
 			return
 		default:
 			// User has notification bit set
-			recipients[u.ID] = u.Email
+			recipients = append(recipients, u.Email)
 		}
 	})
 	if err != nil {

--- a/politeiawww/legacy/pi/mail.go
+++ b/politeiawww/legacy/pi/mail.go
@@ -354,7 +354,7 @@ Voting has started on a Politeia proposal.
 var voteStartedTmpl = template.Must(
 	template.New("voteStarted").Parse(voteStartedText))
 
-func (p *Pi) mailNtfnVoteStarted(token, name string, recipients map[uuid.UUID]string) error {
+func (p *Pi) mailNtfnVoteStarted(token, name string, recipients []string) error {
 	route := strings.Replace(guiRouteRecordDetails, "{token}", token, 1)
 	u, err := url.Parse(p.cfg.WebServerAddress + route)
 	if err != nil {
@@ -371,7 +371,9 @@ func (p *Pi) mailNtfnVoteStarted(token, name string, recipients map[uuid.UUID]st
 		return err
 	}
 
-	return p.mail.SendToUsers(subject, body, recipients)
+	// Don't subject this email to rate limits because proposal voting can only
+	// be started by admins, not regular users.
+	return p.mail.SendTo(subject, body, recipients)
 }
 
 type voteStartedToAuthor struct {


### PR DESCRIPTION
Voting on proposals is often started in batches which can cause the email rate limit to be hit for *all* users at once, despite the users themselves not taking any action. This has happened the last two times proposal voting has started.