### PR TITLE
multi: Expand the API to support retrieving paid amounts.

### DIFF
--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1973,6 +1973,8 @@ Note: This call is public.
 
 **Route:** `GET /v1/proposals/billedstate`
 
+**Params:**
+
 | Parameter | Type | Description | Required |
 |-|-|-|-|
 | token | string | Token for approved proposal. | Yes |

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1962,7 +1962,7 @@ Reply:
 
 ### `Proposal Billed State`
 
-Retrieve proposal's publicly available payment information
+Retrieve proposal's publicly available payment information.
 
 This retrieves the token of proposal that needs to get the payment data and 
 uses that token to search through the database for invoices that have line-items 

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1960,6 +1960,58 @@ Reply:
   }
 ```
 
+### `Proposal Billed State`
+
+Retrieve proposal's publicly available payment information
+
+This retrieves the token of proposal that needs to get the payment data and 
+uses that token to search through the database for invoices that have line-items 
+containing the proposal token. Calculates and return only two pieces of 
+information: amount paid and payment time in the invoices
+
+Note: This call is public.
+
+**Route:** `GET /v1/proposals/billedstate`
+
+| Parameter | Type | Description | Required |
+|-|-|-|-|
+| token | string | Token for approved proposal. | Yes |
+
+**Results:**
+
+| | Type | Description |
+| - | - | - |
+| totalbilled | int64 | Total amount paid for proposal. |
+| paidinvoices | Array of PaidInvoices | Details of amount paid for proposal in invoices. |
+
+**PaidInvoices:**
+
+| | Type | Description |
+| - | - | - |
+| timestamp | int64 | Time paid for invoice. |
+| total | int64 | Amount paid in invoice. |
+
+**Example**
+
+Request:
+``` json
+{
+  "token": "0de5bd82bcccf22f4ccd1881fc9d88159ace56d0c1cfc7dcd86656e738e46a87"
+}
+```
+
+Reply:
+
+```json
+{
+  "totalbilled": 115000,
+  "paidinvoices": [{
+    "timestamp": 1508296860781,
+    "total": 115000
+  }]
+}
+```
+
 ### `User code stats`
 
 Returns all code stats based on provided userid and start/endtime.  

--- a/politeiawww/api/cms/v1/api.md
+++ b/politeiawww/api/cms/v1/api.md
@@ -1964,10 +1964,10 @@ Reply:
 
 Retrieve proposal's publicly available payment information.
 
-This retrieves the token of proposal that needs to get the payment data and 
+This retrieves the proposal token that is needed to get the payment data and 
 uses that token to search through the database for invoices that have line-items 
-containing the proposal token. Calculates and return only two pieces of 
-information: amount paid and payment time in the invoices
+containing the proposal token. Calculates and returns only two pieces of 
+information: amount paid and payment time.
 
 Note: This call is public.
 

--- a/politeiawww/api/cms/v1/v1.go
+++ b/politeiawww/api/cms/v1/v1.go
@@ -54,6 +54,7 @@ const (
 	RouteProposalBilling        = "/proposals/billing"
 	RouteProposalBillingSummary = "/proposals/spendingsummary"
 	RouteProposalBillingDetails = "/proposals/spendingdetails"
+	RouteBilledState            = "/proposals/billedstate"
 	RouteUserCodeStats          = "/user/codestats"
 
 	// Invoice status codes
@@ -1079,4 +1080,17 @@ type CodeStats struct {
 	PRs              []string `json:"prs"`
 	Reviews          []string `json:"reviews"`
 	Commits          []string `json:"commits"`
+}
+
+// RecordBilledStateReply returns the payment status of all invoices for the proposal
+type RecordBilledStateReply struct {
+	TotalBilled  int64                     `json:"totalbilled"` // Total amount paid for proposal
+	PaidInvoices []PublicPaidInvoiceRecord `json:"paidinvoices"`
+}
+
+// PublicPaidInvoiceRecord: Payment information on invoice for proposal
+// Only Timestamp and amount are public
+type PublicPaidInvoiceRecord struct {
+	Timestamp int64 `json:"timestamp"` // Last update of invoice
+	Total     int64 `json:"total"`     // Amount paid for proposal in invoice
 }

--- a/politeiawww/client/records.go
+++ b/politeiawww/client/records.go
@@ -19,6 +19,7 @@ import (
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	backend "github.com/decred/politeia/politeiad/backendv2"
 	"github.com/decred/politeia/politeiad/plugins/usermd"
+	cmsv1 "github.com/decred/politeia/politeiawww/api/cms/v1"
 	rcv1 "github.com/decred/politeia/politeiawww/api/records/v1"
 	v1 "github.com/decred/politeia/politeiawww/api/records/v1"
 	"github.com/decred/politeia/util"
@@ -142,6 +143,23 @@ func (c *Client) Records(r rcv1.Records) (map[string]rcv1.Record, error) {
 	}
 
 	return rr.Records, nil
+}
+
+// GetRecordBilledState sends a record v1 BilledState request to politeiawww.
+func (c *Client) GetRecordBilledState(r cmsv1.ProposalBillingDetails) (*cmsv1.RecordBilledStateReply, error) {
+	resBody, err := c.makeReq(http.MethodGet,
+		cmsv1.APIRoute, cmsv1.RouteBilledState, r)
+	if err != nil {
+		return nil, err
+	}
+
+	var rr cmsv1.RecordBilledStateReply
+	err = json.Unmarshal(resBody, &rr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rr, nil
 }
 
 // RecordInventory sends a records v1 Inventory request to politeiawww.

--- a/politeiawww/legacy/invoices.go
+++ b/politeiawww/legacy/invoices.go
@@ -2547,13 +2547,6 @@ func (p *Politeiawww) processProposalBilledState(pbd cms.ProposalBillingDetails)
 
 	totalSpent := int64(0)
 	for _, dbInv := range propInvoices {
-		u, err := p.db.UserGetByPubKey(dbInv.PublicKey)
-		if err != nil {
-			log.Errorf("getUserByPubKey: token:%v "+
-				"pubKey:%v err:%v", dbInv.PublicKey, err)
-		} else {
-			dbInv.Username = u.Username
-		}
 		// Get payout for proposal
 		payout, err := calculatePayout(dbInv)
 		if err != nil {

--- a/politeiawww/legacy/invoices.go
+++ b/politeiawww/legacy/invoices.go
@@ -2535,3 +2535,38 @@ func (p *Politeiawww) processProposalBillingDetails(pbd cms.ProposalBillingDetai
 	reply.Details = spendingSummary
 	return reply, nil
 }
+
+func (p *Politeiawww) processProposalBilledState(pbd cms.ProposalBillingDetails) (*cms.RecordBilledStateReply, error) {
+	propInvoices, err := p.cmsDB.InvoicesByLineItemsProposalToken(pbd.Token)
+	if err != nil {
+		return nil, err
+	}
+	reply := &cms.RecordBilledStateReply{
+		PaidInvoices: make([]cms.PublicPaidInvoiceRecord, 0),
+	}
+
+	totalSpent := int64(0)
+	for _, dbInv := range propInvoices {
+		u, err := p.db.UserGetByPubKey(dbInv.PublicKey)
+		if err != nil {
+			log.Errorf("getUserByPubKey: token:%v "+
+				"pubKey:%v err:%v", dbInv.PublicKey, err)
+		} else {
+			dbInv.Username = u.Username
+		}
+		// Get payout for proposal
+		payout, err := calculatePayout(dbInv)
+		if err != nil {
+			return nil, err
+		}
+		totalSpent += int64(payout.Total)
+		paidInv := cms.PublicPaidInvoiceRecord{
+			Timestamp: dbInv.Timestamp,
+			Total:     int64(payout.Total),
+		}
+		reply.PaidInvoices = append(reply.PaidInvoices, paidInv)
+	}
+
+	reply.TotalBilled = totalSpent
+	return reply, nil
+}

--- a/politeiawww/legacy/invoices.go
+++ b/politeiawww/legacy/invoices.go
@@ -2541,12 +2541,10 @@ func (p *Politeiawww) processProposalBilledState(pbd cms.ProposalBillingDetails)
 	if err != nil {
 		return nil, err
 	}
-	reply := &cms.RecordBilledStateReply{
-		PaidInvoices: make([]cms.PublicPaidInvoiceRecord, 0),
-	}
 
-	totalSpent := int64(0)
-	for _, dbInv := range propInvoices {
+	var totalSpent int64
+	paidInvoices := make([]cms.PublicPaidInvoiceRecord, len(propInvoices))
+	for i, dbInv := range propInvoices {
 		// Get payout for proposal
 		payout, err := calculatePayout(dbInv)
 		if err != nil {
@@ -2557,9 +2555,11 @@ func (p *Politeiawww) processProposalBilledState(pbd cms.ProposalBillingDetails)
 			Timestamp: dbInv.Timestamp,
 			Total:     int64(payout.Total),
 		}
-		reply.PaidInvoices = append(reply.PaidInvoices, paidInv)
+		paidInvoices[i] = paidInv
 	}
 
-	reply.TotalBilled = totalSpent
-	return reply, nil
+	return &cms.RecordBilledStateReply{
+		PaidInvoices: paidInvoices,
+		TotalBilled: totalSpent,
+	}, nil
 }

--- a/politeiawww/legacy/routes.go
+++ b/politeiawww/legacy/routes.go
@@ -302,6 +302,9 @@ func (p *Politeiawww) setCMSWWWRoutes() {
 	p.addRoute(http.MethodPost, cms.APIRoute,
 		cms.RouteProposalBillingDetails, p.handleProposalBillingDetails,
 		permissionAdmin)
+	p.addRoute(http.MethodGet, cms.APIRoute,
+		cms.RouteBilledState, p.getProposalBilledState,
+		permissionPublic)
 }
 
 // setupPiRoutes sets up the API routes for piwww mode.

--- a/politeiawww/legacy/wwwcms.go
+++ b/politeiawww/legacy/wwwcms.go
@@ -1006,6 +1006,28 @@ func (p *Politeiawww) handlePassThroughBatchProposals(w http.ResponseWriter, r *
 	util.RespondRaw(w, http.StatusOK, data)
 }
 
+func (p *Politeiawww) getProposalBilledState(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("getProposalBilledState")
+	var pbd cms.ProposalBillingDetails
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&pbd); err != nil {
+		RespondWithError(w, r, 0, "HandleRecords: unmarshal",
+			www.UserError{
+				ErrorCode: www.ErrorStatusInvalidInput,
+			})
+		return
+	}
+
+	pbs, err := p.processProposalBilledState(pbd)
+	if err != nil {
+		RespondWithError(w, r, 0,
+			"getProposalBilledState: processProposalBilledState %v", err)
+		return
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, pbs)
+}
+
 func (p *Politeiawww) handleProposalBillingSummary(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleProposalBillingSummary")
 

--- a/politeiawww/legacy/wwwcms.go
+++ b/politeiawww/legacy/wwwcms.go
@@ -1021,7 +1021,7 @@ func (p *Politeiawww) getProposalBilledState(w http.ResponseWriter, r *http.Requ
 	pbs, err := p.processProposalBilledState(pbd)
 	if err != nil {
 		RespondWithError(w, r, 0,
-			"getProposalBilledState: processProposalBilledState %v", err)
+			"getProposalBilledState: processProposalBilledState: %v", err)
 		return
 	}
 

--- a/politeiawww/legacy/wwwcms.go
+++ b/politeiawww/legacy/wwwcms.go
@@ -1011,7 +1011,7 @@ func (p *Politeiawww) getProposalBilledState(w http.ResponseWriter, r *http.Requ
 	var pbd cms.ProposalBillingDetails
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&pbd); err != nil {
-		RespondWithError(w, r, 0, "HandleRecords: unmarshal",
+		RespondWithError(w, r, 0, "getProposalBilledState: unmarshal",
 			www.UserError{
 				ErrorCode: www.ErrorStatusInvalidInput,
 			})


### PR DESCRIPTION
Resoved issue: #1697 

Created API to support getting actual payment data for proposal
**ApiRoute**: /v1/proposals/billedstate
**Type**: Public API
**Input**: proposal token
**Output**: Payment times and amounts paid for proposal
`{ "totalbilled": int64,
  "paidinvoices": [{
       "timestamp": int64,
       "total": int64,
    }]
}`
